### PR TITLE
[easy] Explain the difference between two public packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ API Docs: https://turnkey.readme.io/
 
 ## Packages
 
-| Package                               | NPM                                                                                                                   | Description                                        | Changelog                                  |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------ |
-| [`@turnkey/ethers`](/packages/ethers) | [![npm](https://img.shields.io/npm/v/@turnkey/ethers?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/ethers) | Turnkey Signer for Ethers                          | [CHANGELOG](/packages/ethers/CHANGELOG.md) |
-| [`@turnkey/http`](/packages/http)     | [![npm](https://img.shields.io/npm/v/@turnkey/http?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/http)     | Typed HTTP client for interacting with Turnkey API | [CHANGELOG](/packages/http/CHANGELOG.md)   |
+| Package                               | NPM                                                                                                                   | Description                                                           | Changelog                                  |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------ |
+| [`@turnkey/ethers`](/packages/ethers) | [![npm](https://img.shields.io/npm/v/@turnkey/ethers?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/ethers) | Turnkey Signer for Ethers                                             | [CHANGELOG](/packages/ethers/CHANGELOG.md) |
+| [`@turnkey/http`](/packages/http)     | [![npm](https://img.shields.io/npm/v/@turnkey/http?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/http)     | Lower-level, fully typed HTTP client for interacting with Turnkey API | [CHANGELOG](/packages/http/CHANGELOG.md)   |
 
 ## Examples
 

--- a/packages/ethers/README.md
+++ b/packages/ethers/README.md
@@ -4,6 +4,8 @@
 
 [Turnkey](https://turnkey.io) Signer for [`Ethers`](https://docs.ethers.org/v5/api/signer/).
 
+If you need a lower-level, fully typed HTTP client for interacting with Turnkey API, check out [`@turnkey/http`](/packages/http/).
+
 API Docs: https://turnkey.readme.io/
 
 ## Getting started

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -2,7 +2,9 @@
 
 [![npm](https://img.shields.io/npm/v/@turnkey/http?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/http)
 
-Typed HTTP client for interacting with [Turnkey](https://turnkey.io) API.
+A lower-level, fully typed HTTP client for interacting with [Turnkey](https://turnkey.io) API.
+
+For signing transactions and messages, check out the higher-level [`@turnkey/ethers`](/packages/ethers/) Signer.
 
 API Docs: https://turnkey.readme.io/
 


### PR DESCRIPTION
## Summary & Motivation
On npm you can only see a package's own README, so we need to make it more clear everywhere

## How I Tested These Changes
Rendered:
- https://github.com/tkhq/sdk/tree/keyan/readme/packages/ethers
- https://github.com/tkhq/sdk/tree/keyan/readme/packages/http
- https://github.com/tkhq/sdk/tree/keyan/readme/