### PR TITLE
Drop `Buffer` usage in `http`

### DIFF
--- a/packages/http/src/__fixtures__/shared.ts
+++ b/packages/http/src/__fixtures__/shared.ts
@@ -8,20 +8,26 @@ export async function readFixture(): Promise<{
   publicKey: string;
   pemPublicKey: string;
 }> {
-  const privateKey = await fs.promises.readFile(
-    path.resolve(FIXTURES_DIR, "api-key.private"),
-    "utf-8"
-  );
+  const privateKey = (
+    await fs.promises.readFile(
+      path.resolve(FIXTURES_DIR, "api-key.private"),
+      "utf-8"
+    )
+  ).trim();
 
   // These two formats represent the same public key
-  const publicKey = await fs.promises.readFile(
-    path.resolve(FIXTURES_DIR, "api-key.public"),
-    "utf-8"
-  );
-  const pemPublicKey = await fs.promises.readFile(
-    path.resolve(FIXTURES_DIR, "api-key.public.pem"),
-    "utf-8"
-  );
+  const publicKey = (
+    await fs.promises.readFile(
+      path.resolve(FIXTURES_DIR, "api-key.public"),
+      "utf-8"
+    )
+  ).trim();
+  const pemPublicKey = (
+    await fs.promises.readFile(
+      path.resolve(FIXTURES_DIR, "api-key.public.pem"),
+      "utf-8"
+    )
+  ).trim();
 
   return {
     privateKey,

--- a/packages/http/src/base.ts
+++ b/packages/http/src/base.ts
@@ -1,7 +1,7 @@
 import fetch from "isomorphic-unfetch";
 import { stamp } from "./stamp";
 import { getConfig } from "./config";
-import { encodeToBase64url } from "./encoding";
+import { stringToBase64urlString } from "./encoding";
 
 type TBasicType = string;
 
@@ -56,7 +56,7 @@ export async function request<
     })
   );
 
-  const xStamp = encodeToBase64url(sealedStamp);
+  const xStamp = stringToBase64urlString(sealedStamp);
 
   const response = await fetch(url.toString(), {
     ...sharedRequestOptions,

--- a/packages/http/src/encoding.ts
+++ b/packages/http/src/encoding.ts
@@ -1,7 +1,7 @@
 /**
  * Code modified from https://github.com/github/webauthn-json/blob/e932b3585fa70b0bd5b5a4012ba7dbad7b0a0d0f/src/webauthn-json/base64url.ts#L23
  */
-export function encodeToBase64url(input: string): string {
+export function stringToBase64urlString(input: string): string {
   // string to base64
   const base64String = btoa(input);
 
@@ -15,9 +15,27 @@ export function encodeToBase64url(input: string): string {
   return base64urlString;
 }
 
-export function toHexString(input: Uint8Array): string {
+export function uint8ArrayToHexString(input: Uint8Array): string {
   return input.reduce(
     (result, x) => result + x.toString(16).padStart(2, "0"),
     ""
+  );
+}
+
+export function hexStringToUint8Array(input: string): Uint8Array {
+  if (
+    input.length === 0 ||
+    input.length % 2 !== 0 ||
+    /[^a-fA-F0-9]/u.test(input)
+  ) {
+    throw new Error(`Invalid hex string: ${JSON.stringify(input)}`);
+  }
+
+  return Uint8Array.from(
+    input
+      .match(
+        /.{2}/g // Split string by every two characters
+      )!
+      .map((byte) => parseInt(byte, 16))
   );
 }

--- a/packages/http/src/stamp.ts
+++ b/packages/http/src/stamp.ts
@@ -1,12 +1,10 @@
 import { webcrypto } from "crypto";
 import { TextEncoder } from "util";
-import { toHexString } from "./encoding";
+import { uint8ArrayToHexString, hexStringToUint8Array } from "./encoding";
 
-// Specific byte-sequence for curve prime256v1 (DER encoding)
-const PRIVATE_KEY_PREFIX = Buffer.from(
-  "308141020100301306072a8648ce3d020106082a8648ce3d030107042730250201010420",
-  "hex"
-);
+// Specific byte-sequence for ECDSA P-256 (DER encoding)
+const PRIVATE_KEY_PREFIX =
+  "308141020100301306072a8648ce3d020106082a8648ce3d030107042730250201010420";
 
 export async function stamp(input: {
   content: string;
@@ -28,11 +26,9 @@ export async function stamp(input: {
 async function importPrivateKey(
   privateKeyHex: string
 ): Promise<webcrypto.CryptoKey> {
-  const privateKeyBuffer = Buffer.from(privateKeyHex, "hex");
-  const privateKeyPkcs8Der = Buffer.concat([
-    PRIVATE_KEY_PREFIX,
-    privateKeyBuffer,
-  ]);
+  const privateKeyPkcs8Der = hexStringToUint8Array(
+    PRIVATE_KEY_PREFIX + privateKeyHex
+  );
 
   return await webcrypto.subtle.importKey(
     "pkcs8",
@@ -63,7 +59,7 @@ async function signMessage(
     new Uint8Array(signatureIeee1363)
   );
 
-  return toHexString(signatureDer);
+  return uint8ArrayToHexString(signatureDer);
 }
 
 /**


### PR DESCRIPTION
## Summary & Motivation
`Buffer` is Node.js only. Fortunately, we only need a subset of it:
- `Buffer.from(...)` can be replaced by `new TextEncoder().encode(...)`
- `Buffer.from(..., "hex")` becomes `hexStringToUint8Array(...)`
- `Buffer#toString("hex")` becomes `uint8ArrayToHexString(...)`
- `Buffer#toString("base64url")` becomes `stringToBase64urlString(...)` — no need to convert to `ArrayBuffer` and back

Will follow up with another PR that adds tests for the new utilities (and the ones in #27)

## How I Tested These Changes
- CI is green
- Ran a few examples locally
