### PR TITLE
[easy] Deprecate `PublicApiService`; export API fetchers as `TurnkeyApi`

### DIFF
--- a/examples/deployer/src/createNewEthereumPrivateKey.ts
+++ b/examples/deployer/src/createNewEthereumPrivateKey.ts
@@ -1,8 +1,4 @@
-import {
-  PublicApiService,
-  init as httpInit,
-  withAsyncPolling,
-} from "@turnkey/http";
+import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import * as crypto from "crypto";
 
@@ -21,7 +17,7 @@ export async function createNewEthereumPrivateKey() {
   // Use `withAsyncPolling` to handle async activity polling.
   // In this example, it polls every 250ms until the activity reaches a terminal state.
   const mutation = withAsyncPolling({
-    request: PublicApiService.postCreatePrivateKeys,
+    request: TurnkeyApi.postCreatePrivateKeys,
   });
 
   const privateKeyName = `ETH Key ${crypto.randomBytes(2).toString("hex")}`;

--- a/examples/with-ethers/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-ethers/src/createNewEthereumPrivateKey.ts
@@ -1,8 +1,4 @@
-import {
-  PublicApiService,
-  init as httpInit,
-  withAsyncPolling,
-} from "@turnkey/http";
+import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import * as crypto from "crypto";
 
@@ -21,7 +17,7 @@ export async function createNewEthereumPrivateKey() {
   // Use `withAsyncPolling` to handle async activity polling.
   // In this example, it polls every 250ms until the activity reaches a terminal state.
   const mutation = withAsyncPolling({
-    request: PublicApiService.postCreatePrivateKeys,
+    request: TurnkeyApi.postCreatePrivateKeys,
     refreshIntervalMs: 250, // defaults to 500ms
   });
 

--- a/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
@@ -1,8 +1,4 @@
-import {
-  PublicApiService,
-  init as httpInit,
-  withAsyncPolling,
-} from "@turnkey/http";
+import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import * as crypto from "crypto";
 
@@ -21,7 +17,7 @@ export async function createNewEthereumPrivateKey() {
   // Use `withAsyncPolling` to handle async activity polling.
   // In this example, it polls every 250ms until the activity reaches a terminal state.
   const mutation = withAsyncPolling({
-    request: PublicApiService.postCreatePrivateKeys,
+    request: TurnkeyApi.postCreatePrivateKeys,
   });
 
   const privateKeyName = `ETH Key ${crypto.randomBytes(2).toString("hex")}`;

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -1,6 +1,6 @@
 import { ethers, type UnsignedTransaction, type Bytes } from "ethers";
 import {
-  PublicApiService,
+  TurnkeyApi,
   TurnkeyActivityError,
   init as httpInit,
 } from "@turnkey/http";
@@ -48,7 +48,7 @@ export class TurnkeySigner extends ethers.Signer {
   }
 
   async getAddress(): Promise<string> {
-    const data = await PublicApiService.postGetPrivateKey({
+    const data = await TurnkeyApi.postGetPrivateKey({
       body: {
         privateKeyId: this.config.privateKeyId,
         organizationId: this.config.organizationId,
@@ -69,7 +69,7 @@ export class TurnkeySigner extends ethers.Signer {
   }
 
   private async _signTransactionImpl(message: string): Promise<string> {
-    const { activity } = await PublicApiService.postSignTransaction({
+    const { activity } = await TurnkeyApi.postSignTransaction({
       body: {
         type: "ACTIVITY_TYPE_SIGN_TRANSACTION",
         organizationId: this.config.organizationId,
@@ -163,7 +163,7 @@ export class TurnkeySigner extends ethers.Signer {
   }
 
   async _signMessageImpl(message: string): Promise<string> {
-    const { activity } = await PublicApiService.postSignRawPayload({
+    const { activity } = await TurnkeyApi.postSignRawPayload({
       body: {
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD",
         organizationId: this.config.organizationId,

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -17,7 +17,7 @@ $ npm install @turnkey/http
 Before making http calls, initialize the package with your credentials:
 
 ```typescript
-import { PublicApiService, init } from "@turnkey/http";
+import { TurnkeyApi, init } from "@turnkey/http";
 
 init({
   apiPublicKey: "...",
@@ -26,7 +26,7 @@ init({
 });
 
 // Now you can make authenticated requests!
-const data = await PublicApiService.postGetWhoami({
+const data = await TurnkeyApi.postGetWhoami({
   body: {
     organizationId: "...",
   },
@@ -45,14 +45,14 @@ All Turnkey mutation endpoints are asynchronous (with the exception of signing e
 
 ```typescript
 import {
-  PublicApiService,
+  TurnkeyApi,
   withAsyncPolling,
   TurnkeyActivityError,
 } from "@turnkey/http";
 
 // Use `withAsyncPolling(...)` to wrap & create a fetcher with built-in async polling support
 const fetcher = withAsyncPolling({
-  request: PublicApiService.postCreatePrivateKeys,
+  request: TurnkeyApi.postCreatePrivateKeys,
 });
 
 // The fetcher remains fully typed. After submitting the request,

--- a/packages/http/src/__tests__/async-test.ts
+++ b/packages/http/src/__tests__/async-test.ts
@@ -1,7 +1,7 @@
 import { fetch } from "undici";
 import { test, expect, jest, beforeEach } from "@jest/globals";
 import {
-  PublicApiService,
+  TurnkeyApi,
   init,
   withAsyncPolling,
   TurnkeyActivityError,
@@ -22,28 +22,27 @@ beforeEach(async () => {
   });
 });
 
-const sampleCreatePrivateKeysInput: PublicApiService.TPostCreatePrivateKeysInput =
-  {
-    body: {
-      type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS",
-      parameters: {
-        privateKeys: [
-          {
-            privateKeyName: "hello",
-            curve: "CURVE_SECP256K1",
-            addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
-            privateKeyTags: [],
-          },
-        ],
-      },
-      organizationId: "89881fc7-6ff3-4b43-b962-916698f8ff58",
-      timestampMs: String(Date.now()),
+const sampleCreatePrivateKeysInput: TurnkeyApi.TPostCreatePrivateKeysInput = {
+  body: {
+    type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS",
+    parameters: {
+      privateKeys: [
+        {
+          privateKeyName: "hello",
+          curve: "CURVE_SECP256K1",
+          addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
+          privateKeyTags: [],
+        },
+      ],
     },
-  };
+    organizationId: "89881fc7-6ff3-4b43-b962-916698f8ff58",
+    timestampMs: String(Date.now()),
+  },
+};
 
 test("`withAsyncPolling` should return data after activity completion", async () => {
   const mutation = withAsyncPolling({
-    request: PublicApiService.postCreatePrivateKeys,
+    request: TurnkeyApi.postCreatePrivateKeys,
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -82,7 +81,7 @@ test("`withAsyncPolling` should return data after activity completion", async ()
 
 test("`withAsyncPolling` should throw a rich error when activity requires consensus", async () => {
   const mutation = withAsyncPolling({
-    request: PublicApiService.postCreatePrivateKeys,
+    request: TurnkeyApi.postCreatePrivateKeys,
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -133,7 +132,7 @@ test("`withAsyncPolling` should throw a rich error when activity requires consen
 
 test("`withAsyncPolling` should throw a rich error when activity is rejected", async () => {
   const mutation = withAsyncPolling({
-    request: PublicApiService.postCreatePrivateKeys,
+    request: TurnkeyApi.postCreatePrivateKeys,
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -191,7 +190,7 @@ test("`withAsyncPolling` should throw a rich error when activity is rejected", a
 
 test("`withAsyncPolling` should throw a rich error when activity fails", async () => {
   const mutation = withAsyncPolling({
-    request: PublicApiService.postCreatePrivateKeys,
+    request: TurnkeyApi.postCreatePrivateKeys,
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -235,7 +234,7 @@ test("`withAsyncPolling` should throw a rich error when activity fails", async (
 
 test("`withAsyncPolling` should also work with synchronous activity endpoints", async () => {
   const mutation = withAsyncPolling({
-    request: PublicApiService.postSignTransaction,
+    request: TurnkeyApi.postSignTransaction,
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -274,36 +273,36 @@ test("`withAsyncPolling` should also work with synchronous activity endpoints", 
 
 test("typecheck only: `withAsyncPolling` only works with mutations that return an activity", () => {
   // Legit ones
-  withAsyncPolling({ request: PublicApiService.postCreateApiKeys });
-  withAsyncPolling({ request: PublicApiService.postCreateInvitations });
-  withAsyncPolling({ request: PublicApiService.postCreatePolicy });
-  withAsyncPolling({ request: PublicApiService.postCreatePrivateKeys });
-  withAsyncPolling({ request: PublicApiService.postDeleteApiKeys });
-  withAsyncPolling({ request: PublicApiService.postDeleteInvitation });
-  withAsyncPolling({ request: PublicApiService.postDeletePolicy });
-  withAsyncPolling({ request: PublicApiService.postSignRawPayload });
-  withAsyncPolling({ request: PublicApiService.postSignTransaction });
-  withAsyncPolling({ request: PublicApiService.postGetActivity });
+  withAsyncPolling({ request: TurnkeyApi.postCreateApiKeys });
+  withAsyncPolling({ request: TurnkeyApi.postCreateInvitations });
+  withAsyncPolling({ request: TurnkeyApi.postCreatePolicy });
+  withAsyncPolling({ request: TurnkeyApi.postCreatePrivateKeys });
+  withAsyncPolling({ request: TurnkeyApi.postDeleteApiKeys });
+  withAsyncPolling({ request: TurnkeyApi.postDeleteInvitation });
+  withAsyncPolling({ request: TurnkeyApi.postDeletePolicy });
+  withAsyncPolling({ request: TurnkeyApi.postSignRawPayload });
+  withAsyncPolling({ request: TurnkeyApi.postSignTransaction });
+  withAsyncPolling({ request: TurnkeyApi.postGetActivity });
 
   // Invalid ones
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetOrganization });
+  withAsyncPolling({ request: TurnkeyApi.postGetOrganization });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetPolicy });
+  withAsyncPolling({ request: TurnkeyApi.postGetPolicy });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetUser });
+  withAsyncPolling({ request: TurnkeyApi.postGetUser });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetActivities });
+  withAsyncPolling({ request: TurnkeyApi.postGetActivities });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetPolicies });
+  withAsyncPolling({ request: TurnkeyApi.postGetPolicies });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetPrivateKeys });
+  withAsyncPolling({ request: TurnkeyApi.postGetPrivateKeys });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetUsers });
+  withAsyncPolling({ request: TurnkeyApi.postGetUsers });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetWhoami });
+  withAsyncPolling({ request: TurnkeyApi.postGetWhoami });
   // @ts-expect-error
-  withAsyncPolling({ request: PublicApiService.postGetPrivateKey });
+  withAsyncPolling({ request: TurnkeyApi.postGetPrivateKey });
 });
 
 function createMockResponse(result: { activity: Partial<TActivity> }) {

--- a/packages/http/src/__tests__/request-test.ts
+++ b/packages/http/src/__tests__/request-test.ts
@@ -1,6 +1,6 @@
 import { fetch } from "undici";
 import { test, expect, jest } from "@jest/globals";
-import { PublicApiService, init } from "../index";
+import { TurnkeyApi, init } from "../index";
 import { readFixture } from "../__fixtures__/shared";
 
 jest.mock("undici");
@@ -23,7 +23,7 @@ test("requests are stamped after initialization", async () => {
 
   mockedFetch.mockReturnValue(Promise.resolve(response));
 
-  await PublicApiService.postGetWhoami({
+  await TurnkeyApi.postGetWhoami({
     body: {
       organizationId: "89881fc7-6ff3-4b43-b962-916698f8ff58",
     },

--- a/packages/http/src/async.ts
+++ b/packages/http/src/async.ts
@@ -1,4 +1,4 @@
-import { PublicApiService } from "./__generated__/barrel";
+import { PublicApiService as TurnkeyApi } from "./__generated__/barrel";
 import { TActivity, TActivityResponse, TurnkeyActivityError } from "./shared";
 
 const DEFAULT_REFRESH_INTERVAL_MS = 500;
@@ -73,7 +73,7 @@ export function withAsyncPolling<
       await sleep(refreshIntervalMs);
 
       const pollingResponse: TActivityResponse =
-        await PublicApiService.postGetActivity({
+        await TurnkeyApi.postGetActivity({
           body: {
             activityId: activity.id,
             organizationId: activity.organizationId,

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,7 +1,16 @@
-export * from "./__generated__/barrel";
+import { PublicApiService as TurnkeyApi } from "./__generated__/barrel";
 
 export { init } from "./config";
 
 export { TurnkeyActivityError } from "./shared";
 
 export { withAsyncPolling } from "./async";
+
+export { TurnkeyApi };
+
+/**
+ * @deprecated use `TurnkeyApi` instead
+ */
+const PublicApiService = TurnkeyApi;
+
+export { PublicApiService };


### PR DESCRIPTION
## Summary & Motivation
$title

`PublicApiService` is still available and fully functional, but you'll see a deprecation notice in VSCode

## How I Tested These Changes
<img width="851" alt="image" src="https://user-images.githubusercontent.com/127255904/233226803-6fc9aa99-a0c1-4e63-914a-349f153bd181.png">
