### PR TITLE
add signTypedData to ethers implementation

### DIFF
--- a/examples/with-gnosis/README.md
+++ b/examples/with-gnosis/README.md
@@ -49,16 +49,18 @@ $ pnpm start
 
 By default, this script will do the following:
 
-1. create a new Gnosis Safe (e.g. 3/3 multisig)
-2. initiate a Safe transaction
-3. approve transaction onchain using each signer
-4. execute transaction once all approvals have been obtained
+1. Create a new Gnosis Safe (e.g. 3/3 multisig)
+2. Initiate a Safe transaction
+3. Approve transaction using offchain EIP-712 signature
+4. Approve transaction using offchain raw signed message signature
+5. Approve transaction onchain
+6. Execute transaction once all approvals have been obtained
 
-Note that these transactions will all be broadcasted sequentially.
+NOTES:
 
-The script constructs a transaction via Turnkey and broadcasts via Infura. If the script exits because your account isn't funded, you can request funds on https://goerlifaucet.com/ or https://faucet.paradigm.xyz/.
-
-Visit the Etherscan link to view your transaction; you have successfully sent your first transaction with Turnkey!
+- If the script exits because your account isn't funded, you can request funds via https://goerlifaucet.com/, https://faucet.paradigm.xyz/, or Coinbase Wallet (developer settings).
+- Transactions will all be broadcasted sequentially.
+- Sepolia users: the Alchemy provider in Ethers v5 does not support Sepolia. Either use an alternative provider, or switch networks.
 
 See the following for a sample output:
 
@@ -67,44 +69,44 @@ Address 1:
         0x1Bce4a8De35Cf22aCaA4D167C722dD80C14Eb0Ee
 
 Balance 1:
-        0.030020215203400146 Ether
+        0.034412557714194554 Ether
 
 Transaction count 1:
-        10
+        20
 
 Address 2:
         0xf285510B55f62d6787399409418590c9B6d246Fe
 
 Balance 2:
-        0.017074551136338144 Ether
+        0.0135694405114308 Ether
 
 Transaction count 2:
-        2
+        4
 
 Address 3:
         0xE69b8ede844DB94fe726Cf2537992e61A6a6Ea2e
 
 Balance 3:
-        0.066817774846202992 Ether
+        0.06095101662527444 Ether
 
 Transaction count 3:
-        2
+        5
 
-Gnosis Safe Address:
-		https://goerli.etherscan.io/address/0xd49b176D26529AC14046C14A023eEDfDa0a4d878
+New Gnosis Safe Address:
+        0x804ceF3146150033515EE212f13cd4fbEAE52f2a
 
-Sent 0.00001 Ether to 0xd49b176D26529AC14046C14A023eEDfDa0a4d878:
-        https://goerli.etherscan.io/tx/0x47b4ec32b8aa5b9f12594f74f49652bf0f6e4e19d7f0d14e3bde1ea0a2aa0d8e
+Sent 0.00001 Ether to 0x804ceF3146150033515EE212f13cd4fbEAE52f2a:
+        https://goerli.etherscan.io/tx/0x7d40034d769257cae94b990bfb979c7dc1328910765e55c38b698477e53d2fb2
 
-Approved transaction using signer 1
-		https://goerli.etherscan.io/tx/0x80552f02c54eabd15e02504fefd017b315e2fba4b7d754f144e5464b48285f3e
+Signed transaction offchain using signer 1. Signature:
+        0x1b0c320ee49ceda13712cfef4ac57b8c7a03fe7033f0e5f45ca2f9015455a65158e344753afe4253dbbe7dfc8b9b67c9076ffedde485585562b291f6489126c61b
 
-Approved transaction using signer 2
-		https://goerli.etherscan.io/tx/0x3647430001093726876c5ac6d2fe567c01640175f9d7723395c2fc83793104f6
+Signed transaction hash offchain using signer 2. Signature:
+        0x7059168da2f2c10776b9aa7797aa9dc2d18e78c20b3b481f1428a8c099592b6f6599080ddacc8fe49bded3e133ba0d6d7be3de7ce633e7bfa225aba894b580481f
 
-Approved transaction using signer 3
-		https://goerli.etherscan.io/tx/0xe6cd8f037bc42d5ad9f3ce27f546a4b0022940bea9ef70990aad7c3c8afa7b89
+Approved transaction onchain using signer 3. Etherscan link:
+        https://goerli.etherscan.io/tx/0xdd9a42defdc7533856c33cb2bf69f05049667896c860ed1b17b3b2af5d0e0523
 
-Executed transaction using signer 3
-		https://goerli.etherscan.io/tx/0xbbe05de0734aa602e7d972865fdc14bbcf59fc5c7b05354fd8f0c69a24b77cfb
+Executed transaction using signer 3. Etherscan link:
+        https://goerli.etherscan.io/tx/0xf67d40a06e068409fd2a4698f54a1cdf0311f6be33aae08c9f4740a944d92001
 ```

--- a/examples/with-gnosis/src/index.ts
+++ b/examples/with-gnosis/src/index.ts
@@ -125,14 +125,14 @@ async function main() {
   const safeAccountConfig: SafeAccountConfig = {
     owners,
     threshold,
-    // ...
+    // ... other options
   };
 
   const safeSdk1: Safe = await safeFactory.deploySafe({ safeAccountConfig });
   const safeAddress = safeSdk1.getAddress();
   print("New Gnosis Safe Address:", safeAddress);
 
-  // have other signers connect to deployed Safe
+  // Have other signers connect to deployed Safe
   const safeSdk2 = await safeSdk1.connect({
     ethAdapter: ethAdapter2,
     safeAddress,
@@ -142,7 +142,7 @@ async function main() {
     safeAddress,
   });
 
-  // fund the safe using signer 1
+  // Fund the safe using signer 1
   const fundingRequest = {
     to: safeAddress,
     value: ethers.utils.parseEther(transactionAmount),
@@ -154,45 +154,44 @@ async function main() {
     `https://${network}.etherscan.io/tx/${sentTx.hash}`
   );
 
-  // create Safe transaction using signer 1
-  const safeTransaction = await safeSdk1.createTransaction({
+  // Create Safe transaction using signer 1
+  let safeTransaction = await safeSdk1.createTransaction({
     safeTransactionData,
   });
 
-  // obtain onchain signature from signer 1
+  // Obtain *offchain* signature from signer 1 using EIP-712
   let txHash = await safeSdk1.getTransactionHash(safeTransaction);
-  let approveTxResponse = await safeSdk1.approveTransactionHash(txHash);
-  await approveTxResponse.transactionResponse?.wait();
+  safeTransaction = await safeSdk1.signTransaction(safeTransaction, "eth_signTypedData");
   print(
-    `Approved transaction using signer 1:`,
-    `https://${network}.etherscan.io/tx/${approveTxResponse.hash}`
+    `Signed transaction offchain using signer 1. Signature:`, safeTransaction.signatures.get(address1.toLowerCase())?.data ?? ""
   );
 
-  // obtain onchain signature from signer 2
+  // Obtain *offchain* signature from signer 2 using standard raw message signing, and attach it to the safeTransaction
+  // let's try an offchain signature next time
   txHash = await safeSdk2.getTransactionHash(safeTransaction);
-  approveTxResponse = await safeSdk2.approveTransactionHash(txHash);
-  await approveTxResponse.transactionResponse?.wait();
+  let signTransactionHashResponse = await safeSdk2.signTransactionHash(txHash);
   print(
-    `Approved transaction using signer 2:`,
-    `https://${network}.etherscan.io/tx/${approveTxResponse.hash}`
-  );
+    `Signed transaction hash offchain using signer 2. Signature:`,
+    signTransactionHashResponse.data
+    );
+  safeTransaction.addSignature(signTransactionHashResponse);
 
-  // obtain onchain signature from signer 3
-  // this is technically redundant given this signer will go on to execute the transaction,
+  // Obtain onchain signature from signer 3.
+  // This is technically redundant given this signer will go on to execute the transaction,
   // but is left in for demonstration purposes.
   txHash = await safeSdk3.getTransactionHash(safeTransaction);
-  approveTxResponse = await safeSdk3.approveTransactionHash(txHash);
+  let approveTxResponse = await safeSdk3.approveTransactionHash(txHash);
   await approveTxResponse.transactionResponse?.wait();
   print(
-    `Approved transaction using signer 3:`,
+    `Approved transaction onchain using signer 3. Etherscan link:`,
     `https://${network}.etherscan.io/tx/${approveTxResponse.hash}`
   );
 
-  // execute using last signer
+  // Execute transaction using last signer
   const executeTxResponse = await safeSdk3.executeTransaction(safeTransaction);
   await executeTxResponse.transactionResponse?.wait();
   print(
-    `Executed transaction using signer 3:`,
+    `Executed transaction using signer 3. Etherscan link:`,
     `https://${network}.etherscan.io/tx/${executeTxResponse.hash}`
   );
 }

--- a/examples/with-gnosis/src/index.ts
+++ b/examples/with-gnosis/src/index.ts
@@ -161,9 +161,13 @@ async function main() {
 
   // Obtain *offchain* signature from signer 1 using EIP-712
   let txHash = await safeSdk1.getTransactionHash(safeTransaction);
-  safeTransaction = await safeSdk1.signTransaction(safeTransaction, "eth_signTypedData");
+  safeTransaction = await safeSdk1.signTransaction(
+    safeTransaction,
+    "eth_signTypedData"
+  );
   print(
-    `Signed transaction offchain using signer 1. Signature:`, safeTransaction.signatures.get(address1.toLowerCase())?.data ?? ""
+    `Signed transaction offchain using signer 1. Signature:`,
+    safeTransaction.signatures.get(address1.toLowerCase())?.data ?? ""
   );
 
   // Obtain *offchain* signature from signer 2 using standard raw message signing, and attach it to the safeTransaction
@@ -173,7 +177,7 @@ async function main() {
   print(
     `Signed transaction hash offchain using signer 2. Signature:`,
     signTransactionHashResponse.data
-    );
+  );
   safeTransaction.addSignature(signTransactionHashResponse);
 
   // Obtain onchain signature from signer 3.

--- a/packages/ethers/src/__tests__/index-test.ts
+++ b/packages/ethers/src/__tests__/index-test.ts
@@ -104,10 +104,35 @@ test("TurnkeySigner", async () => {
 
   // Test message (raw payload) signing, `eth_sign` style
   const message = "Hello Turnkey";
-  const sig = await signer.signMessage(message);
+  const signMessageSignature = await signer.signMessage(message);
 
-  expect(sig).toMatch(/^0x/);
-  expect(ethers.utils.verifyMessage(message, sig)).toEqual(expectedEthAddress);
+  expect(signMessageSignature).toMatch(/^0x/);
+  expect(ethers.utils.verifyMessage(message, signMessageSignature)).toEqual(expectedEthAddress);
+
+  // Test typed data signing (EIP-712)
+  const typedData = {
+    types: {
+      // Note that we do not need to include `EIP712Domain` as a type here, as Ethers will automatically inject it for us
+      Person: [
+        { name: 'name', type: 'string' },
+        { name: 'wallet', type: 'address' },
+      ],
+    },
+    domain: {
+      name: 'EIP712 Test',
+      version: '1',
+    },
+    primaryType: 'Person',
+    message: {
+      name: 'Alice',
+      wallet: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+    },
+  };
+
+  const signTypedDataSignature = await signer.signTypedData(typedData.domain, typedData.types, typedData.message);
+
+  expect(signTypedDataSignature).toMatch(/^0x/);
+  expect(ethers.utils.verifyTypedData(typedData.domain, typedData.types, typedData.message, signTypedDataSignature)).toEqual(expectedEthAddress);
 });
 
 function assertNonEmptyString(input: unknown, name: string): string {

--- a/packages/ethers/src/__tests__/index-test.ts
+++ b/packages/ethers/src/__tests__/index-test.ts
@@ -107,32 +107,45 @@ test("TurnkeySigner", async () => {
   const signMessageSignature = await signer.signMessage(message);
 
   expect(signMessageSignature).toMatch(/^0x/);
-  expect(ethers.utils.verifyMessage(message, signMessageSignature)).toEqual(expectedEthAddress);
+  expect(ethers.utils.verifyMessage(message, signMessageSignature)).toEqual(
+    expectedEthAddress
+  );
 
   // Test typed data signing (EIP-712)
   const typedData = {
     types: {
       // Note that we do not need to include `EIP712Domain` as a type here, as Ethers will automatically inject it for us
       Person: [
-        { name: 'name', type: 'string' },
-        { name: 'wallet', type: 'address' },
+        { name: "name", type: "string" },
+        { name: "wallet", type: "address" },
       ],
     },
     domain: {
-      name: 'EIP712 Test',
-      version: '1',
+      name: "EIP712 Test",
+      version: "1",
     },
-    primaryType: 'Person',
+    primaryType: "Person",
     message: {
-      name: 'Alice',
-      wallet: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      name: "Alice",
+      wallet: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
     },
   };
 
-  const signTypedDataSignature = await signer.signTypedData(typedData.domain, typedData.types, typedData.message);
+  const signTypedDataSignature = await signer.signTypedData(
+    typedData.domain,
+    typedData.types,
+    typedData.message
+  );
 
   expect(signTypedDataSignature).toMatch(/^0x/);
-  expect(ethers.utils.verifyTypedData(typedData.domain, typedData.types, typedData.message, signTypedDataSignature)).toEqual(expectedEthAddress);
+  expect(
+    ethers.utils.verifyTypedData(
+      typedData.domain,
+      typedData.types,
+      typedData.message,
+      signTypedDataSignature
+    )
+  ).toEqual(expectedEthAddress);
 });
 
 function assertNonEmptyString(input: unknown, name: string): string {

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -1,4 +1,10 @@
-import { ethers, type UnsignedTransaction, type Bytes } from "ethers";
+import {
+  ethers,
+  type UnsignedTransaction,
+  type Bytes,
+  type TypedDataDomain,
+  type TypedDataField,
+} from "ethers";
 import {
   TurnkeyApi,
   TurnkeyActivityError,
@@ -188,7 +194,7 @@ export class TurnkeySigner extends ethers.Signer {
         v: parseInt(result.v) + 27,
       });
 
-      // assemble the hex
+      // Assemble the hex
       return assertNonNull(assembled);
     }
 
@@ -199,6 +205,22 @@ export class TurnkeySigner extends ethers.Signer {
       activityType: type,
     });
   }
+
+  async signTypedData(domain: TypedDataDomain, types: Record<string, Array<TypedDataField>>, value: Record<string, any>): Promise<string> {
+    // Populate any ENS names
+    const populated = await ethers.utils._TypedDataEncoder.resolveNames(domain, types, value, async (name: string) => {
+      assertNonNull(this.provider);
+
+      const address = await this.provider?.resolveName(name);
+      assertNonNull(address);
+
+      return address ?? "";
+    });
+
+     return this._signMessageWithErrorWrapping(ethers.utils._TypedDataEncoder.hash(populated.domain, types, populated.value));
+  }
+
+  _signTypedData = this.signTypedData.bind(this);
 }
 
 export { TurnkeyActivityError };

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -206,18 +206,33 @@ export class TurnkeySigner extends ethers.Signer {
     });
   }
 
-  async signTypedData(domain: TypedDataDomain, types: Record<string, Array<TypedDataField>>, value: Record<string, any>): Promise<string> {
+  async signTypedData(
+    domain: TypedDataDomain,
+    types: Record<string, Array<TypedDataField>>,
+    value: Record<string, any>
+  ): Promise<string> {
     // Populate any ENS names
-    const populated = await ethers.utils._TypedDataEncoder.resolveNames(domain, types, value, async (name: string) => {
-      assertNonNull(this.provider);
+    const populated = await ethers.utils._TypedDataEncoder.resolveNames(
+      domain,
+      types,
+      value,
+      async (name: string) => {
+        assertNonNull(this.provider);
 
-      const address = await this.provider?.resolveName(name);
-      assertNonNull(address);
+        const address = await this.provider?.resolveName(name);
+        assertNonNull(address);
 
-      return address ?? "";
-    });
+        return address ?? "";
+      }
+    );
 
-     return this._signMessageWithErrorWrapping(ethers.utils._TypedDataEncoder.hash(populated.domain, types, populated.value));
+    return this._signMessageWithErrorWrapping(
+      ethers.utils._TypedDataEncoder.hash(
+        populated.domain,
+        types,
+        populated.value
+      )
+    );
   }
 
   _signTypedData = this.signTypedData.bind(this);


### PR DESCRIPTION
## Summary & Motivation
- Add support for signing typed data (per EIP-712) to Turnkey Ethers implementation
- Update Gnosis example to make use of offchain signatures, with two flavors: (1) using signed typed data, and (2) using raw message signing, in addition to the standard onchain flow

## How I Tested These Changes
- Unit
- Testnet

Some helpful documentation/references:
- https://github.com/ethers-io/ethers.js/issues/830
- https://ethereum.stackexchange.com/questions/117631/as-in-web3-js-get-the-same-signature-as-the-signature-from-the-signtypeddata-v4
- Not relevant for JS/TS implementations, but noting some gotchas around encoding:
  - https://ethereum.stackexchange.com/questions/137491/inconsistency-in-recovered-account-when-verifying-eip-712-javascript-python
  - https://ethereum.stackexchange.com/questions/125425/solidity-cannot-verify-ethers-js-signed-data-signtypeddata
