### PR TITLE
Returns details as part of error

### DIFF
--- a/packages/ethers/src/__tests__/index-test.ts
+++ b/packages/ethers/src/__tests__/index-test.ts
@@ -143,7 +143,7 @@ describe("TurnkeySigner", () => {
             "activityId": null,
             "activityStatus": null,
             "activityType": null,
-            "cause": [Error: Turnkey error 2: unable to execute ruling: ump denied request explicitly (Details: [])],
+            "cause": [TurnkeyRequestError: Turnkey error 2: unable to execute ruling: ump denied request explicitly (Details: [])],
             "message": "Failed to sign: Turnkey error 2: unable to execute ruling: ump denied request explicitly (Details: [])",
           }
         `);

--- a/packages/http/src/__tests__/request-test.ts
+++ b/packages/http/src/__tests__/request-test.ts
@@ -80,7 +80,11 @@ test("requests return grpc status details as part of their errors", async () => 
 
     expect(e.details.length).toEqual(1);
     expect(e.details[0].fieldViolations.length).toEqual(1);
-    expect(e.details[0].fieldViolations[0].field).toEqual("privateKeys.0.privateKeyName");
-    expect(e.details[0].fieldViolations[0].description).toEqual("This field must be unique.")
+    expect(e.details[0].fieldViolations[0].field).toEqual(
+      "privateKeys.0.privateKeyName"
+    );
+    expect(e.details[0].fieldViolations[0].description).toEqual(
+      "This field must be unique."
+    );
   }
 });

--- a/packages/http/src/__tests__/request-test.ts
+++ b/packages/http/src/__tests__/request-test.ts
@@ -77,5 +77,10 @@ test("requests return grpc status details as part of their errors", async () => 
     expect(e.message).toEqual(
       `Turnkey error 1: invalid request (Details: [{\"@type\":\"type.googleapis.com/google.rpc.BadRequest\",\"fieldViolations\":[{\"field\":\"privateKeys.0.privateKeyName\",\"description\":\"This field must be unique.\"}]}])`
     );
+
+    expect(e.details.length).toEqual(1);
+    expect(e.details[0].fieldViolations.length).toEqual(1);
+    expect(e.details[0].fieldViolations[0].field).toEqual("privateKeys.0.privateKeyName");
+    expect(e.details[0].fieldViolations[0].description).toEqual("This field must be unique.")
   }
 });

--- a/packages/http/src/base.ts
+++ b/packages/http/src/base.ts
@@ -72,12 +72,12 @@ export async function request<
   if (!response.ok) {
     // Can't use native `cause` here because it's not well supported on Node v16
     // https://node.green/#ES2022-features-Error-cause-property
-    
-    let res: GrpcStatus
+
+    let res: GrpcStatus;
     try {
       res = await response.json();
     } catch (_) {
-      throw new Error(`${response.status} ${response.statusText}`)
+      throw new Error(`${response.status} ${response.statusText}`);
     }
 
     throw new TurnkeyRequestError(res);

--- a/packages/http/src/shared.ts
+++ b/packages/http/src/shared.ts
@@ -47,13 +47,10 @@ export type GrpcStatus = {
 };
 
 export class TurnkeyRequestError extends Error {
-  details: unknown[] | null;
+  details: any[] | null | undefined;
+  code: number;
 
-  constructor(input: {
-    message: string;
-    code: number;
-    details: unknown[] | null;
-  }) {
+  constructor(input: GrpcStatus) {
     let turnkeyErrorMessage = `Turnkey error ${input.code}: ${input.message}`;
 
     if (input.details != null) {
@@ -64,5 +61,6 @@ export class TurnkeyRequestError extends Error {
 
     this.name = "TurnkeyRequestError";
     this.details = input.details;
+    this.code = input.code;
   }
 }

--- a/packages/http/src/shared.ts
+++ b/packages/http/src/shared.ts
@@ -39,3 +39,30 @@ export type TStamper = (input: {
   scheme: string;
   signature: string;
 }>;
+
+export type GrpcStatus = {
+  message: string;
+  code: number;
+  details: unknown[] | null;
+};
+
+export class TurnkeyRequestError extends Error {
+  details: unknown[] | null;
+
+  constructor(input: {
+    message: string;
+    code: number;
+    details: unknown[] | null;
+  }) {
+    let turnkeyErrorMessage = `Turnkey error ${input.code}: ${input.message}`;
+
+    if (input.details != null) {
+      turnkeyErrorMessage += ` (Details: ${JSON.stringify(input.details)})`;
+    }
+
+    super(turnkeyErrorMessage);
+
+    this.name = "TurnkeyRequestError";
+    this.details = input.details;
+  }
+}


### PR DESCRIPTION
## Summary & Motivation

Adds a details field to the error that is thrown when a request to turnkey returns an error code.

These aren't typed at the moment. Any ideas on the best way to do/expose this?

## How I Tested These Changes
Unit
