### PR TITLE
[NOT FOR MERGE] Test `JsonRpcProvider` compatibility

### DIFF
--- a/examples/with-ethers/src/index.ts
+++ b/examples/with-ethers/src/index.ts
@@ -29,7 +29,10 @@ async function main() {
 
   // Bring your own provider (such as Alchemy or Infura: https://docs.ethers.org/v5/api/providers/)
   const network = "goerli";
-  const provider = new ethers.providers.InfuraProvider(network);
+  const provider = new ethers.providers.JsonRpcProvider(
+    "https://goerli.infura.io/v3/84842078b09946638c03157f83405213", // using the default community project
+    network
+  );
   const connectedSigner = turnkeySigner.connect(provider);
 
   const chainId = await connectedSigner.getChainId();

--- a/packages/ethers/src/__tests__/index-test.ts
+++ b/packages/ethers/src/__tests__/index-test.ts
@@ -1,5 +1,4 @@
 import { Eip1193Bridge } from "@ethersproject/experimental";
-import { setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import { ethers } from "ethers";
 import hre from "hardhat";
 import { test, expect, beforeEach, describe } from "@jest/globals";
@@ -60,8 +59,10 @@ describe("TurnkeySigner", () => {
       `process.env.BANNED_TO_ADDRESS`
     );
 
-    // @ts-ignore
-    const provider = hre.ethers.provider;
+    const provider = new ethers.providers.JsonRpcProvider(
+      hre.config.networks.localhost.url,
+      hre.config.networks.localhost.chainId
+    );
 
     connectedSigner = new TurnkeySigner({
       apiPublicKey,
@@ -75,7 +76,10 @@ describe("TurnkeySigner", () => {
 
     eip1193 = new Eip1193Bridge(connectedSigner, provider);
 
-    setBalance(expectedEthAddress, ethers.utils.parseEther("999999"));
+    await provider.send("hardhat_setBalance", [
+      expectedEthAddress,
+      "0xffffffffffffffffffffffff",
+    ]);
   });
 
   testCase("basics", async () => {


### PR DESCRIPTION
Internal note: to run the Jest test
```bash
$ pwd # sdk/
$ cd packages/ethers
$ pnpm exec hardhat node # Start local hardhat node

# Then in another terminal
$ pwd # mono/src/go/e2e/
$ make filter=Ethers test
```

## Outputs

Jest test ✅ :

```
PASS src/__tests__/index-test.ts
  TurnkeySigner
    ✓ basics (28 ms)
    ✓ it signs transactions (107 ms)
    ✓ it allows (and drops) `tx.from` (110 ms)
    ✓ it sends transactions (330 ms)
    ✓ it throws when there's a deny policy on the transaction (83 ms)
    ✓ it signs messages, `eth_sign` style (204 ms)
    ✓ it signs typed data (EIP-712) (205 ms)
    ✓ ERC-721 (812 ms)
    it signs walletconnect v1 payloads, bridged via EIP-1193
      ✓ Uniswap payload (250 ms)
```

`with-ethers` script ✅ :

```
Network:
	goerli (chain ID 5)

Address:
	0x064c0CfDD7C485Eba21988Ded4dbCD9358556842

Balance:
	0.146428817757239884 Ether

Transaction count:
	147

Turnkey-powered signature:
	0x97da598ac1ad566e77be7c7d9cc77339730e48c557c5d6f32f93d9fdeeed13472b1faf20f1e457a897a409f31b9e680ad6b02086ac4fb9aa693ce10374976b201c

Recovered address:
	0x064c0CfDD7C485Eba21988Ded4dbCD9358556842

Turnkey-signed transaction:
	0x02f8668080808080942ad9ea1e677949a536a270cec812d6e868c881088609184e72a00080c001a09881f59e48500ef8960ae1cb94e0c862e7d613f961c250b6f07b546a1b058b1da06ba1871d7aed5eb8ea8cb211a0e3e22a1c6b54b34b4376d0ef5b1daef4100c8f

Sent 0.00001 Ether to 0x2Ad9eA1E677949a536A270CEC812D6e868C88108:
	https://goerli.etherscan.io/tx/0x193e280878505cdccb88b117ddbba6512fe893e21b4876418db0c89f1ff9d35b

WETH Balance:
	0.00061001202 WETH

Wrapped 0.00001 ETH:
	https://goerli.etherscan.io/tx/0x799489bb9bb57aafab90ed556533aff3cca48a0c5436d43661c2b90e7a9cba2b
```