### PR TITLE
Add codesandbox CI adhoc build config

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,7 @@
+{
+  "installCommand": "csb:install",
+  "buildCommand": "csb:build",
+  "packages": ["packages/cosmjs", "packages/ethers", "packages/http"],
+  "sandboxes": ["turnkey-speedrun-d0ko4q"],
+  "node": "18"
+}

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,6 +2,6 @@
   "installCommand": "csb:install",
   "buildCommand": "csb:build",
   "packages": ["packages/cosmjs", "packages/ethers", "packages/http"],
-  "sandboxes": ["turnkey-speedrun-d0ko4q"],
+  "sandboxes": [],
   "node": "18"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "changeset": "changeset",
     "build-all": "tsc --build tsconfig.mono.json",
     "build:watch": "tsc --build tsconfig.mono.json --watch",
+    "csb:install": "corepack enable && pnpm install -r",
+    "csb:build": "pnpm run build-all",
     "clean-all": "pnpm run -r clean",
     "prettier-all:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ./.prettierignore",
     "prettier-all:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml}\" --ignore-path ./.prettierignore",
@@ -14,7 +16,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16.0.0",
+    "node": ">=16.0.0",
     "npm": "^8.0.0",
     "pnpm": "^8.0.0"
   },


### PR DESCRIPTION
## Summary & Motivation
https://codesandbox.io/docs/learn/sandboxes/ci

> Whenever a Pull Request is opened it builds a version of the library from that PR. This is published to our registry, so you can immediately test the library in CodeSandbox or locally without publishing to npm or elsewhere.

You shouldn't use these adhoc builds for anything serious, but they're great for quickly verifying changes / fixes.

For instance, say you want to test `http` and `ethers`. For the builds generated by this PR, you can use them via:

```bash
$ npm install https://pkg.csb.dev/tkhq/sdk/commit/2492405d/@turnkey/ethers https://pkg.csb.dev/tkhq/sdk/commit/2492405d/@turnkey/http
```

or in your `package.json`:
```json
{
  "dependencies": {
    "@turnkey/ethers": "https://pkg.csb.dev/tkhq/sdk/commit/2492405d/@turnkey/ethers",
    "@turnkey/http": "https://pkg.csb.dev/tkhq/sdk/commit/2492405d/@turnkey/http",
  }
}
```

## How I Tested These Changes
Test via this PR

<img width="1897" alt="image" src="https://github.com/tkhq/sdk/assets/127255904/86cfe98d-f813-45f2-97fe-bb8c08029702">
