### PR TITLE
Release packages (2023-06-21)

### DIFF
--- a/.changeset/2023-06-14-sync-protos.md
+++ b/.changeset/2023-06-14-sync-protos.md
@@ -1,7 +1,0 @@
----
-"@turnkey/http": minor
-"@turnkey/cosmjs": minor
-"@turnkey/ethers": minor
----
-
-Sync SDK with latest protos

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/cosmjs
 
+## 0.4.0
+
+### Minor Changes
+
+- No public facing changes
+
+### Patch Changes
+
+- Updated dependencies [9317f51]
+  - @turnkey/http@0.17.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/ethers
 
+## 0.16.0
+
+### Minor Changes
+
+- No public facing changes
+
+### Patch Changes
+
+- Updated dependencies [9317f51]
+  - @turnkey/http@0.17.0
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/http
 
+## 0.17.0
+
+### Minor Changes
+
+- Added support for ed25519
+- New endpoint to programmatically approve or reject activities (`/submit/approve_activity`, `/submit/reject_activity`)
+- New endpoint to programmatically create authenticators (`/submit/create_authenticators`)
+- New endpoints to update Private Key tags (`/submit/update_private_key_tag`)
+- New endpoints to update User tags (`/submit/update_user_tag`)
+- Simplified shape for `AuthenticatorParams` with a new `AuthenticatorParamsV2`. To take advantage of this new shape, use `ACTIVITY_TYPE_CREATE_USERS_V2` and the new `ACTIVITY_TYPE_CREATE_AUTHENTICATORS`.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary & Motivation
Releasing:
* `@turnkey/http@0.17.0`
* `@turnkey/ethers@0.16.0`
* `@turnkey/cosmjs@0.4.0`

## How I Tested These Changes
```
$ corepack enable && pnpm install -r
$ pnpm run clean-all && pnpm run build-all
$ pnpm publish -r --dry-run --no-git-checks
```
...and CI!