### PR TITLE
New viem package + example

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,7 +1,12 @@
 {
   "installCommand": "csb:install",
   "buildCommand": "csb:build",
-  "packages": ["packages/cosmjs", "packages/ethers", "packages/http", "packages/viem"],
+  "packages": [
+    "packages/cosmjs",
+    "packages/ethers",
+    "packages/http",
+    "packages/viem"
+  ],
   "sandboxes": [],
   "node": "18"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,7 +1,7 @@
 {
   "installCommand": "csb:install",
   "buildCommand": "csb:build",
-  "packages": ["packages/cosmjs", "packages/ethers", "packages/http"],
+  "packages": ["packages/cosmjs", "packages/ethers", "packages/http", "packages/viem"],
   "sandboxes": [],
   "node": "18"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ typings/
 .env
 .env.*
 !.env.local.example
+!.env.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ API Docs: https://turnkey.readme.io/
 | Package                               | NPM                                                                                                                   | Description                                                           | Changelog                                  |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------ |
 | [`@turnkey/ethers`](/packages/ethers) | [![npm](https://img.shields.io/npm/v/@turnkey/ethers?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/ethers) | Turnkey Signer for Ethers                                             | [CHANGELOG](/packages/ethers/CHANGELOG.md) |
+| [`@turnkey/viem`](/packages/viem) | [![npm](https://img.shields.io/npm/v/@turnkey/viem?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/viem) | (Experimental) Turnkey Helpers to work with Viem                                             | [CHANGELOG](/packages/viem/CHANGELOG.md) |
 | [`@turnkey/cosmjs`](/packages/cosmjs) | [![npm](https://img.shields.io/npm/v/@turnkey/cosmjs?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/cosmjs) | (Experimental) Turnkey Cosmos Signer for CosmJS                       | [CHANGELOG](/packages/cosmjs/CHANGELOG.md) |
 | [`@turnkey/http`](/packages/http)     | [![npm](https://img.shields.io/npm/v/@turnkey/http?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/http)     | Lower-level, fully typed HTTP client for interacting with Turnkey API | [CHANGELOG](/packages/http/CHANGELOG.md)   |
 
@@ -17,6 +18,7 @@ API Docs: https://turnkey.readme.io/
 | Example                                                                | Description                                                                                                        |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | [`with-ethers`](/examples/with-ethers/)                                | Create a new Ethereum address, then sign and broadcast a transaction using the Ethers signer with Infura           |
+| [`with-viem`](/examples/with-viem/)                                | Sign and broadcast a transaction using the Turnkey Custom Account and Infura           |
 | [`with-cosmjs`](/examples/with-cosmjs/)                                | Create a new Cosmos address, then sign and broadcast a transaction on Celestia testnet using the CosmJS signer     |
 | [`with-solana`](/examples/with-solana/)                                | Create a new Solana address, then sign and broadcast a transaction on Solana's devnet                              |
 | [`with-gnosis`](/examples/with-gnosis/)                                | Create new Ethereum addresses, configure a 3/3 Gnosis safe, and create + execute a transaction from it             |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ API Docs: https://turnkey.readme.io/
 | Package                               | NPM                                                                                                                   | Description                                                           | Changelog                                  |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------ |
 | [`@turnkey/ethers`](/packages/ethers) | [![npm](https://img.shields.io/npm/v/@turnkey/ethers?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/ethers) | Turnkey Signer for Ethers                                             | [CHANGELOG](/packages/ethers/CHANGELOG.md) |
-| [`@turnkey/viem`](/packages/viem) | [![npm](https://img.shields.io/npm/v/@turnkey/viem?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/viem) | (Experimental) Turnkey Helpers to work with Viem                                             | [CHANGELOG](/packages/viem/CHANGELOG.md) |
+| [`@turnkey/viem`](/packages/viem)     | [![npm](https://img.shields.io/npm/v/@turnkey/viem?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/viem)     | (Experimental) Turnkey Helpers to work with Viem                      | [CHANGELOG](/packages/viem/CHANGELOG.md)   |
 | [`@turnkey/cosmjs`](/packages/cosmjs) | [![npm](https://img.shields.io/npm/v/@turnkey/cosmjs?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/cosmjs) | (Experimental) Turnkey Cosmos Signer for CosmJS                       | [CHANGELOG](/packages/cosmjs/CHANGELOG.md) |
 | [`@turnkey/http`](/packages/http)     | [![npm](https://img.shields.io/npm/v/@turnkey/http?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/http)     | Lower-level, fully typed HTTP client for interacting with Turnkey API | [CHANGELOG](/packages/http/CHANGELOG.md)   |
 
@@ -18,7 +18,7 @@ API Docs: https://turnkey.readme.io/
 | Example                                                                | Description                                                                                                        |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | [`with-ethers`](/examples/with-ethers/)                                | Create a new Ethereum address, then sign and broadcast a transaction using the Ethers signer with Infura           |
-| [`with-viem`](/examples/with-viem/)                                | Sign and broadcast a transaction using the Turnkey Custom Account and Infura           |
+| [`with-viem`](/examples/with-viem/)                                    | Sign and broadcast a transaction using the Turnkey Custom Account and Infura                                       |
 | [`with-cosmjs`](/examples/with-cosmjs/)                                | Create a new Cosmos address, then sign and broadcast a transaction on Celestia testnet using the CosmJS signer     |
 | [`with-solana`](/examples/with-solana/)                                | Create a new Solana address, then sign and broadcast a transaction on Solana's devnet                              |
 | [`with-gnosis`](/examples/with-gnosis/)                                | Create new Ethereum addresses, configure a 3/3 Gnosis safe, and create + execute a transaction from it             |

--- a/examples/with-viem/.env.local.example
+++ b/examples/with-viem/.env.local.example
@@ -3,4 +3,6 @@ API_PRIVATE_KEY="<Turnkey API Private Key>"
 BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>"
-INFURA_API_KEY="<your infura API key>"
+# This is the community Infura API key. Don't abuse it.
+# If you run a production app, sign up and subsitute your own API key below.
+INFURA_API_KEY="84842078b09946638c03157f83405213"

--- a/examples/with-viem/.env.local.example
+++ b/examples/with-viem/.env.local.example
@@ -1,0 +1,6 @@
+API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
+API_PRIVATE_KEY="<Turnkey API Private Key>"
+BASE_URL="https://api.turnkey.com"
+ORGANIZATION_ID="<Turnkey organization ID>"
+PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>"
+INFURA_API_KEY="<your infura API key>"

--- a/examples/with-viem/.npmrc
+++ b/examples/with-viem/.npmrc
@@ -1,0 +1,1 @@
+use-node-version=18.0.0

--- a/examples/with-viem/README.md
+++ b/examples/with-viem/README.md
@@ -1,0 +1,71 @@
+# Example: `with-viem`
+
+This example shows how to construct and sign a transaction using [`Viem`](https://viem.sh/) with Turnkey.
+
+## Getting started
+
+### 1/ Cloning the example
+
+Make sure you have `Node.js` installed locally; we recommend using Node v16+.
+
+```bash
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/with-viem/
+```
+
+### 2/ Setting up Turnkey
+
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
+
+- A public/private API key pair for Turnkey
+- An organization ID
+- A (crypto) private key ID
+
+Once you've gathered these values, add them to a new `.env.local` file. Notice that your private key should be securely managed and **_never_** be committed to git.
+
+```bash
+$ cp .env.local.example .env.local
+```
+
+Now open `.env.local` and add the missing environment variables:
+
+- `API_PUBLIC_KEY`
+- `API_PRIVATE_KEY`
+- `BASE_URL`
+- `ORGANIZATION_ID`
+- `PRIVATE_KEY_ID`
+
+### 3/ Running the scripts
+
+```bash
+$ pnpm start
+```
+
+This script will do the following:
+
+1. construct a new transaction
+2. sign it with Turnkey
+3. broadcast it via Infura
+
+Sample output from a successful execution:
+```
+$ pnpm start
+Fetching Node.js 18.0.0 ...
+
+> @turnkey/example-with-viem@0.0.0 start /Users/rno/tkhq/code/sdk/examples/with-viem
+> pnpm -w run build-all && tsx src/index.ts
+
+
+> @turnkey/oss@ build-all /Users/rno/tkhq/code/sdk
+> tsc --build tsconfig.mono.json
+
+Source address
+        0xfe81d134AC28b5CAc01E198E5988F449621d960B
+
+Transaction
+        https://sepolia.etherscan.io/tx/0x91a388d8a6e506bbaeaf21b2914461a0f6125afb3a84a4cf27bdf5e9eb06ffce
+```

--- a/examples/with-viem/README.md
+++ b/examples/with-viem/README.md
@@ -52,6 +52,7 @@ This script will do the following:
 3. broadcast it via Infura
 
 Sample output from a successful execution:
+
 ```
 $ pnpm start
 Fetching Node.js 18.0.0 ...

--- a/examples/with-viem/package.json
+++ b/examples/with-viem/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@turnkey/example-with-viem",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "pnpm -w run build-all && tsx src/index.ts",
+    "clean": "rimraf ./dist ./.cache",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@turnkey/viem": "workspace:*",
+    "dotenv": "^16.0.3",
+    "fetch": "^1.1.0",
+    "typescript": "5.1",
+    "viem": "^1.5.3"
+  }
+}

--- a/examples/with-viem/src/index.ts
+++ b/examples/with-viem/src/index.ts
@@ -1,0 +1,49 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+import { createApiKeyAccount } from "@turnkey/viem";
+import { createWalletClient, http } from "viem";
+import { sepolia } from "viem/chains";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  const turnkeyAccount = await createApiKeyAccount({
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    baseUrl: process.env.BASE_URL!,
+    organizationId: process.env.ORGANIZATION_ID!,
+    privateKeyId: process.env.PRIVATE_KEY_ID!,
+  });
+
+  const client = createWalletClient({
+    account: turnkeyAccount,
+    chain: sepolia,
+    transport: http(
+      `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY!}`
+    ),
+  });
+
+  // This demo sends ETH back to our faucet (we keep a bunch of Sepolia ETH at this address)
+  const turnkeyFaucet = "0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7";
+
+  const transactionRequest = {
+    to: turnkeyFaucet as `0x${string}`,
+    value: 1000000000000000n,
+  };
+
+  const txHash = await client.sendTransaction(transactionRequest);
+
+  print("Source address", client.account.address);
+  print("Transaction", `https://sepolia.etherscan.io/tx/${txHash}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+function print(header: string, body: string): void {
+  console.log(`${header}\n\t${body}\n`);
+}

--- a/examples/with-viem/tsconfig.json
+++ b/examples/with-viem/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo",
+    "ignoreDeprecations": "5.0"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"]
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettier": "^2.8.4",
     "rimraf": "^3.0.2",
     "tsx": "^3.12.7",
-    "typescript": "^4.9.4"
+    "typescript": "^5.1.4"
   },
   "packageManager": "pnpm@8.4.0",
   "pnpm": {

--- a/packages/viem/.env.example
+++ b/packages/viem/.env.example
@@ -1,0 +1,6 @@
+# If you want to run unit tests, populate these values and save this file as a new `.env` file
+API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
+API_PRIVATE_KEY="<Turnkey API Private Key>"
+BASE_URL="https://api.turnkey.com"
+ORGANIZATION_ID="<Turnkey organization ID>"
+PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>"

--- a/packages/viem/.npmrc
+++ b/packages/viem/.npmrc
@@ -1,0 +1,1 @@
+use-node-version=18.0.0

--- a/packages/viem/LICENSE
+++ b/packages/viem/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Turnkey
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/viem/README.md
+++ b/packages/viem/README.md
@@ -1,0 +1,52 @@
+# @turnkey/ethers
+
+[![npm](https://img.shields.io/npm/v/@turnkey/viem?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/viem)
+
+[Turnkey](https://turnkey.com) Custom Account for [`Viem`](https://viem.sh/docs/accounts/custom.html#custom-account).
+
+If you need a lower-level, fully typed HTTP client for interacting with Turnkey API, check out [`@turnkey/http`](/packages/http/).
+
+## Getting started
+
+```bash
+$ npm install viem @turnkey/viem
+```
+
+```typescript
+import { createWalletClient, http } from "viem";
+import { createAccount } from "@turnkey/viem";
+
+async function main() {
+  const turnkeyAccount = createAccount({
+    organizationId: "...",
+    privateKeyId: "...",
+    apiPublicKey: "...",
+    apiPrivateKey: "...",
+    baseUrl: "https://api.turnkey.com",
+  });
+
+  const client = createWalletClient({
+    account: turnkeyAccount,
+    chain: sepolia,
+    transport: http(`https://sepolia.infura.io/v3/$(YOUR_INFURA_API_KEY)`),
+  });
+
+  const transactionRequest = {
+    to: "0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7" as `0x${string}`,
+    value: 1000000000000000n, // 0.001 ETH
+  };
+
+  const txHash = await client.sendTransaction(transactionRequest);
+  console.log(`Success! Transaction broadcast with hash ${txHash}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+```
+
+## See also
+
+- [`@turnkey/example-with-viem`](/examples/with-viem/): example using this package to create, sign, and broadcast a transaction on Sepolia (Ethereum testnet)
+- [`@turnkey/http`](/packages/http/): lower-level fully typed HTTP client for interacting with Turnkey API

--- a/packages/viem/jest.config.js
+++ b/packages/viem/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@jest/types").Config.InitialOptions} */
+const config = {
+  transform: {
+    "\\.[jt]sx?$": "@turnkey/jest-config/transformer.js",
+  },
+  testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/node_modules/"],
+};
+
+module.exports = config;

--- a/packages/viem/jest.config.js
+++ b/packages/viem/jest.config.js
@@ -4,6 +4,7 @@ const config = {
     "\\.[jt]sx?$": "@turnkey/jest-config/transformer.js",
   },
   testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/node_modules/"],
+  setupFiles: ['dotenv/config']
 };
 
 module.exports = config;

--- a/packages/viem/jest.config.js
+++ b/packages/viem/jest.config.js
@@ -4,7 +4,7 @@ const config = {
     "\\.[jt]sx?$": "@turnkey/jest-config/transformer.js",
   },
   testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/node_modules/"],
-  setupFiles: ['dotenv/config']
+  setupFiles: ["dotenv/config"],
 };
 
 module.exports = config;

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -48,6 +48,8 @@
     "typescript": "5.1"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "jest": "^29.3.1",
     "viem": "^1.5.3"
   },
   "engines": {

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@turnkey/viem",
+  "version": "0.1.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "license": "Apache-2.0",
+  "description": "Turnkey Helpers to work with Viem",
+  "keywords": [
+    "Turnkey",
+    "Viem",
+    "custom account",
+    "account",
+    "wallet",
+    "signer"
+  ],
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com/"
+  },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tkhq/sdk.git",
+    "directory": "packages/viem"
+  },
+  "files": [
+    "dist/",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prepublishOnly": "pnpm -w run clean-all && pnpm -w run build-all",
+    "build": "tsc",
+    "clean": "rimraf ./dist ./.cache",
+    "test": "jest",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
+  },
+  "peerDependencies": {
+    "viem": "^1.5.0"
+  },
+  "dependencies": {
+    "@turnkey/http": "workspace:*",
+    "typescript": "5.1"
+  },
+  "devDependencies": {
+    "viem": "^1.5.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/viem/src/__tests__/index-test.ts
+++ b/packages/viem/src/__tests__/index-test.ts
@@ -3,8 +3,7 @@ import { sepolia } from "viem/chains";
 
 import { createApiKeyAccount } from "../";
 
-import {expect, beforeEach, describe, test } from "@jest/globals";
-
+import { expect, beforeEach, describe, test } from "@jest/globals";
 
 describe("createApiKeyAccount", () => {
   let client: WalletClient;
@@ -44,7 +43,7 @@ describe("createApiKeyAccount", () => {
       organizationId,
       privateKeyId,
     });
-  
+
     client = createWalletClient({
       account: turnkeyAccount,
       chain: sepolia,
@@ -60,8 +59,10 @@ describe("createApiKeyAccount", () => {
     const signature = await client.signMessage({
       message: "rno was here",
       account: client.account!,
-    })
-    expect(signature).toEqual("0x42ea50d0e54726f9ce0eabf2823381a89ee9131eb2095f431ced65087213a1b767c112bd892dd9221cd269364a9938bbe63c65eea4794abbb7b7d355eadeb9131c")
+    });
+    expect(signature).toEqual(
+      "0x42ea50d0e54726f9ce0eabf2823381a89ee9131eb2095f431ced65087213a1b767c112bd892dd9221cd269364a9938bbe63c65eea4794abbb7b7d355eadeb9131c"
+    );
   });
 });
 

--- a/packages/viem/src/__tests__/index-test.ts
+++ b/packages/viem/src/__tests__/index-test.ts
@@ -1,0 +1,74 @@
+import { WalletClient, createWalletClient, http } from "viem";
+import { sepolia } from "viem/chains";
+
+import { createApiKeyAccount } from "../";
+
+import {expect, beforeEach, describe, test } from "@jest/globals";
+
+
+describe("createApiKeyAccount", () => {
+  let client: WalletClient;
+  let expectedEthAddress: string;
+
+  beforeEach(async () => {
+    const apiPublicKey = assertNonEmptyString(
+      process.env.API_PUBLIC_KEY,
+      `process.env.API_PUBLIC_KEY`
+    );
+    const apiPrivateKey = assertNonEmptyString(
+      process.env.API_PRIVATE_KEY,
+      `process.env.API_PRIVATE_KEY`
+    );
+    const baseUrl = assertNonEmptyString(
+      process.env.BASE_URL,
+      `process.env.BASE_URL`
+    );
+    const organizationId = assertNonEmptyString(
+      process.env.ORGANIZATION_ID,
+      `process.env.ORGANIZATION_ID`
+    );
+    const privateKeyId = assertNonEmptyString(
+      process.env.PRIVATE_KEY_ID,
+      `process.env.PRIVATE_KEY_ID`
+    );
+
+    expectedEthAddress = assertNonEmptyString(
+      process.env.EXPECTED_ETH_ADDRESS,
+      `process.env.EXPECTED_ETH_ADDRESS`
+    );
+
+    const turnkeyAccount = await createApiKeyAccount({
+      apiPublicKey,
+      apiPrivateKey,
+      baseUrl,
+      organizationId,
+      privateKeyId,
+    });
+  
+    client = createWalletClient({
+      account: turnkeyAccount,
+      chain: sepolia,
+      transport: http(),
+    });
+  });
+
+  // Create a .env file with credentials and modify this to "test(" to run tests
+  // TODO: make this work on CI
+  test.skip("basics", async () => {
+    expect(client.account?.address).toEqual(expectedEthAddress);
+
+    const signature = await client.signMessage({
+      message: "rno was here",
+      account: client.account!,
+    })
+    expect(signature).toEqual("0x42ea50d0e54726f9ce0eabf2823381a89ee9131eb2095f431ced65087213a1b767c112bd892dd9221cd269364a9938bbe63c65eea4794abbb7b7d355eadeb9131c")
+  });
+});
+
+function assertNonEmptyString(input: unknown, name: string): string {
+  if (typeof input !== "string" || !input) {
+    throw new Error(`Expected non empty string for "${name}", got ${input}`);
+  }
+
+  return input;
+}

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -1,0 +1,291 @@
+import { hashTypedData, serializeTransaction, signatureToHex } from "viem";
+import { toAccount } from "viem/accounts";
+import { keccak256 } from "viem";
+import type {
+  HashTypedDataParameters,
+  LocalAccount,
+  SerializeTransactionFn,
+  SignableMessage,
+  TransactionSerializable,
+  TypedData,
+} from "viem";
+import {
+  TurnkeyApi,
+  TurnkeyActivityError,
+  init as httpInit,
+} from "@turnkey/http";
+
+/**
+ * Type bundling configuration for an API Key Viem account creation
+ */
+type TApiKeyAccountConfig = {
+  /**
+   * Turnkey API public key
+   */
+  apiPublicKey: string;
+  /**
+   * Turnkey API private key
+   */
+  apiPrivateKey: string;
+  /**
+   * Turnkey API base URL
+   */
+  baseUrl: string;
+  /**
+   * Turnkey organization ID
+   */
+  organizationId: string;
+  /**
+   * Turnkey private key ID
+   */
+  privateKeyId: string;
+};
+
+/**
+ * Creates a new Custom Account backed by a Turnkey API key.
+ */
+export async function createApiKeyAccount(
+  config: TApiKeyAccountConfig
+): Promise<LocalAccount> {
+  const { apiPublicKey, apiPrivateKey, baseUrl, organizationId, privateKeyId } =
+    config;
+
+  httpInit({
+    apiPublicKey,
+    apiPrivateKey,
+    baseUrl,
+  });
+
+  const data = await TurnkeyApi.getPrivateKey({
+    body: {
+      privateKeyId: privateKeyId,
+      organizationId: organizationId,
+    },
+  });
+
+  const ethereumAddress = data.privateKey.addresses.find(
+    (item: any) => item.format === "ADDRESS_FORMAT_ETHEREUM"
+  )?.address;
+
+  if (typeof ethereumAddress !== "string" || !ethereumAddress) {
+    throw new TurnkeyActivityError({
+      message: `Unable to find Ethereum address for key ${privateKeyId} under organization ${organizationId}`,
+    });
+  }
+
+  return toAccount({
+    address: ethereumAddress as `0x${string}`,
+    signMessage: function ({
+      message,
+    }: {
+      message: SignableMessage;
+    }): Promise<`0x${string}`> {
+      return signMessage(message, organizationId, privateKeyId);
+    },
+    signTransaction: function <
+      TTransactionSerializable extends TransactionSerializable
+    >(
+      transaction: TTransactionSerializable,
+      args?:
+        | { serializer?: SerializeTransactionFn<TTransactionSerializable> }
+        | undefined
+    ): Promise<`0x${string}`> {
+      const serializer = !args?.serializer
+        ? serializeTransaction
+        : args.serializer;
+
+      return signTransaction(
+        transaction,
+        serializer,
+        organizationId,
+        privateKeyId
+      );
+    },
+    signTypedData: function (
+      typedData: TypedData | { [key: string]: unknown }
+    ): Promise<`0x${string}`> {
+      return signTypedData(typedData, organizationId, privateKeyId);
+    },
+  });
+}
+
+async function signMessage(
+  message: SignableMessage,
+  organizationId: string,
+  privateKeyId: string
+): Promise<`0x${string}`> {
+  const hashedMessage = keccak256(message as `0x${string}`);
+  const signedMessage = await signMessageWithErrorWrapping(
+    hashedMessage,
+    organizationId,
+    privateKeyId
+  );
+  return `${signedMessage}` as `0x${string}`;
+}
+
+async function signTransaction<
+  TTransactionSerializable extends TransactionSerializable
+>(
+  transaction: TTransactionSerializable,
+  serializer: SerializeTransactionFn<TTransactionSerializable>,
+  organizationId: string,
+  privateKeyId: string
+): Promise<`0x${string}`> {
+  const serializedTx = serializer(transaction);
+  const nonHexPrefixedSerializedTx = serializedTx.replace(/^0x/, "");
+  return await signTransactionWithErrorWrapping(
+    nonHexPrefixedSerializedTx,
+    organizationId,
+    privateKeyId
+  );
+}
+
+async function signTypedData(
+  data: TypedData | { [key: string]: unknown },
+  organizationId: string,
+  privateKeyId: string
+): Promise<`0x${string}`> {
+  const hashToSign = hashTypedData(data as HashTypedDataParameters);
+
+  return await signMessageWithErrorWrapping(
+    hashToSign,
+    organizationId,
+    privateKeyId
+  );
+}
+
+async function signTransactionWithErrorWrapping(
+  unsignedTransaction: string,
+  organizationId: string,
+  privateKeyId: string
+): Promise<`0x${string}`> {
+  let signedTx: string;
+  try {
+    signedTx = await signTransactionImpl(
+      unsignedTransaction,
+      organizationId,
+      privateKeyId
+    );
+  } catch (error) {
+    if (error instanceof TurnkeyActivityError) {
+      throw error;
+    }
+
+    throw new TurnkeyActivityError({
+      message: `Failed to sign transaction: ${(error as Error).message}`,
+      cause: error as Error,
+    });
+  }
+
+  return `0x${signedTx}`;
+}
+
+async function signTransactionImpl(
+  unsignedTransaction: string,
+  organizationId: string,
+  privateKeyId: string
+): Promise<string> {
+  const { activity } = await TurnkeyApi.signTransaction({
+    body: {
+      type: "ACTIVITY_TYPE_SIGN_TRANSACTION",
+      organizationId: organizationId,
+      parameters: {
+        privateKeyId: privateKeyId,
+        type: "TRANSACTION_TYPE_ETHEREUM",
+        unsignedTransaction: unsignedTransaction,
+      },
+      timestampMs: String(Date.now()), // millisecond timestamp
+    },
+  });
+
+  const { id, status, type } = activity;
+
+  if (activity.status === "ACTIVITY_STATUS_COMPLETED") {
+    return assertNonNull(
+      activity?.result?.signTransactionResult?.signedTransaction
+    );
+  }
+
+  throw new TurnkeyActivityError({
+    message: `Invalid activity status: ${activity.status}`,
+    activityId: id,
+    activityStatus: status,
+    activityType: type,
+  });
+}
+
+async function signMessageWithErrorWrapping(
+  message: string,
+  organizationId: string,
+  privateKeyId: string
+): Promise<`0x${string}`> {
+  let signedMessage: string;
+  try {
+    signedMessage = await signMessageImpl(
+      message,
+      organizationId,
+      privateKeyId
+    );
+  } catch (error) {
+    if (error instanceof TurnkeyActivityError) {
+      throw error;
+    }
+
+    throw new TurnkeyActivityError({
+      message: `Failed to sign: ${(error as Error).message}`,
+      cause: error as Error,
+    });
+  }
+
+  return signedMessage as `0x${string}`;
+}
+
+async function signMessageImpl(
+  message: string,
+  organizationId: string,
+  privateKeyId: string
+): Promise<string> {
+  const { activity } = await TurnkeyApi.signRawPayload({
+    body: {
+      type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD",
+      organizationId: organizationId,
+      parameters: {
+        privateKeyId: privateKeyId,
+        payload: message,
+        encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
+        hashFunction: "HASH_FUNCTION_NO_OP",
+      },
+      timestampMs: String(Date.now()), // millisecond timestamp
+    },
+  });
+
+  const { id, status, type } = activity;
+
+  if (activity.status === "ACTIVITY_STATUS_COMPLETED") {
+    let result = assertNonNull(activity?.result?.signRawPayloadResult);
+
+    let assembled = signatureToHex({
+      r: `0x${result.r}`,
+      s: `0x${result.s}`,
+      v: result.v === "00" ? 27n : 28n,
+    });
+
+    // Assemble the hex
+    return assertNonNull(assembled);
+  }
+
+  throw new TurnkeyActivityError({
+    message: `Invalid activity status: ${activity.status}`,
+    activityId: id,
+    activityStatus: status,
+    activityType: type,
+  });
+}
+
+function assertNonNull<T>(input: T | null | undefined): T {
+  if (input == null) {
+    throw new Error(`Got unexpected ${JSON.stringify(input)}`);
+  }
+
+  return input;
+}

--- a/packages/viem/tsconfig.json
+++ b/packages/viem/tsconfig.json
@@ -9,6 +9,11 @@
     "isolatedModules": true,
     "noPropertyAccessFromIndexSignature": false,
     "resolveJsonModule": true,
-    "sourceMap": true
-  }
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"],
+  "exclude": ["**/__tests__/**/*", "**/__fixtures__/**/*"]
 }

--- a/packages/viem/tsconfig.typecheck.json
+++ b/packages/viem/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.typecheck.tsbuildinfo",
+    "ignoreDeprecations": "5.0"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
       typescript:
-        specifier: ^4.9.4
-        version: 4.9.5
+        specifier: ^5.1.4
+        version: 5.1.5
 
   examples/deployer:
     dependencies:
@@ -94,7 +94,7 @@ importers:
         version: 5.7.2
       hardhat:
         specifier: ^2.12.7
-        version: 2.12.7(typescript@4.9.5)
+        version: 2.12.7(typescript@5.1.5)
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -281,10 +281,31 @@ importers:
         version: 5.7.2
       hardhat:
         specifier: ^2.12.7
-        version: 2.12.7(typescript@4.9.5)
+        version: 2.12.7(typescript@5.1.5)
       jsbi:
         specifier: ^3.2.5
         version: 3.2.5
+
+  examples/with-viem:
+    dependencies:
+      '@turnkey/http':
+        specifier: workspace:*
+        version: link:../../packages/http
+      '@turnkey/viem':
+        specifier: workspace:*
+        version: link:../../packages/viem
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.0.3
+      fetch:
+        specifier: ^1.1.0
+        version: 1.1.0
+      typescript:
+        specifier: '5.1'
+        version: 5.1.3
+      viem:
+        specifier: ^1.5.3
+        version: 1.5.3(typescript@5.1.3)
 
   internal/jest-config:
     dependencies:
@@ -352,7 +373,7 @@ importers:
         version: 5.7.2
       hardhat:
         specifier: ^2.12.7
-        version: 2.12.7(typescript@4.9.5)
+        version: 2.12.7(typescript@5.1.5)
 
   packages/http:
     dependencies:
@@ -360,12 +381,28 @@ importers:
         specifier: ^3.1.5
         version: 3.1.5
 
+  packages/viem:
+    dependencies:
+      '@turnkey/http':
+        specifier: workspace:*
+        version: link:../http
+      typescript:
+        specifier: '5.1'
+        version: 5.1.3
+    devDependencies:
+      viem:
+        specifier: ^1.5.3
+        version: 1.5.3(typescript@5.1.3)
+
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
     dev: false
+
+  /@adraffy/ens-normalize@1.9.0:
+    resolution: {integrity: sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==}
 
   /@ampproject/remapping@2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
@@ -3105,6 +3142,11 @@ packages:
     dev: false
     optional: true
 
+  /@noble/curves@1.0.0:
+    resolution: {integrity: sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==}
+    dependencies:
+      '@noble/hashes': 1.3.0
+
   /@noble/curves@1.1.0:
     resolution: {integrity: sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==}
     dependencies:
@@ -3114,10 +3156,12 @@ packages:
   /@noble/hashes@1.2.0:
     resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
 
+  /@noble/hashes@1.3.0:
+    resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
+
   /@noble/hashes@1.3.1:
     resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}
     engines: {node: '>= 16'}
-    dev: false
 
   /@noble/secp256k1@1.7.1:
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
@@ -3274,7 +3318,7 @@ packages:
       hardhat: ^2.9.5
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.12.7(typescript@4.9.5)
+      hardhat: 2.12.7(typescript@5.1.5)
     dev: true
 
   /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0:
@@ -3379,7 +3423,7 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.12.7(typescript@4.9.5)
+      hardhat: 2.12.7(typescript@5.1.5)
     dev: true
 
   /@openzeppelin/contracts@3.4.1-solc-0.7-2:
@@ -3511,10 +3555,23 @@ packages:
       '@noble/secp256k1': 1.7.1
       '@scure/base': 1.1.1
 
+  /@scure/bip32@1.3.0:
+    resolution: {integrity: sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==}
+    dependencies:
+      '@noble/curves': 1.0.0
+      '@noble/hashes': 1.3.1
+      '@scure/base': 1.1.1
+
   /@scure/bip39@1.1.1:
     resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
     dependencies:
       '@noble/hashes': 1.2.0
+      '@scure/base': 1.1.1
+
+  /@scure/bip39@1.2.0:
+    resolution: {integrity: sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==}
+    dependencies:
+      '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
 
   /@sentry/core@5.30.0:
@@ -3791,6 +3848,11 @@ packages:
       '@types/node': 16.18.12
     dev: false
 
+  /@types/ws@8.5.5:
+    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
+    dependencies:
+      '@types/node': 16.18.12
+
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
 
@@ -3958,6 +4020,16 @@ packages:
       '@uniswap/v3-periphery': 1.4.3
     dev: false
 
+  /@wagmi/chains@1.6.0(typescript@5.1.3):
+    resolution: {integrity: sha512-5FRlVxse5P4ZaHG3GTvxwVANSmYJas1eQrTBHhjxVtqXoorm0aLmCHbhmN8Xo1yu09PaWKlleEvfE98yH4AgIw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
+
   /JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -3965,6 +4037,19 @@ packages:
       jsonparse: 1.3.1
       through: 2.3.8
     dev: false
+
+  /abitype@0.9.3(typescript@5.1.3):
+    resolution: {integrity: sha512-dz4qCQLurx97FQhnb/EIYTk/ldQ+oafEDUqC0VVIeQS1Q48/YWt/9YNfMmp9SLFqN41ktxny3c8aYxHjmFIB/w==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
 
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -4371,6 +4456,13 @@ packages:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
     dependencies:
       file-uri-to-path: 1.0.0
+    dev: false
+
+  /biskviit@1.0.1:
+    resolution: {integrity: sha512-VGCXdHbdbpEkFgtjkeoBN8vRlbj1ZRX2/mxhE8asCCRalUx2nBzOomLJv8Aw/nRt5+ccDb+tPKidg4XxcfGW4w==}
+    engines: {node: '>=1.0.0'}
+    dependencies:
+      psl: 1.9.0
     dev: false
 
   /blakejs@1.2.1:
@@ -5018,6 +5110,12 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: false
+
+  /encoding@0.1.12:
+    resolution: {integrity: sha512-bl1LAgiQc4ZWr++pNYUdRe/alecaHFeHxIJ/pNciqGdKXghaTCOwKkbKp6ye7pKZGu/GcaSXFk8PBVhgs+dJdA==}
+    dependencies:
+      iconv-lite: 0.4.24
     dev: false
 
   /encoding@0.1.13:
@@ -5719,6 +5817,13 @@ packages:
     dependencies:
       bser: 2.1.1
 
+  /fetch@1.1.0:
+    resolution: {integrity: sha512-5O8TwrGzoNblBG/jtK4NFuZwNCkZX6s5GfRNOaGtm+QGJEuNakSC/i2RW0R93KX6E0jVjNXm6O3CRN4Ql3K+yA==}
+    dependencies:
+      biskviit: 1.0.1
+      encoding: 0.1.12
+    dev: false
+
   /figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -6015,10 +6120,10 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       chokidar: 3.5.3
-      hardhat: 2.12.7(typescript@4.9.5)
+      hardhat: 2.12.7(typescript@5.1.5)
     dev: false
 
-  /hardhat@2.12.7(typescript@4.9.5):
+  /hardhat@2.12.7(typescript@5.1.5):
     resolution: {integrity: sha512-voWoN6zn5d8BOEaczSyK/1PyfdeOeI3SbGCFb36yCHTJUt6OIqLb+ZDX30VhA1UsYKzLqG7UnWl3fKJUuANc6A==}
     engines: {node: ^14.0.0 || ^16.0.0 || ^18.0.0}
     hasBin: true
@@ -6078,7 +6183,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 4.9.5
+      typescript: 5.1.5
       undici: 5.19.1
       uuid: 8.3.2
       ws: 7.5.9
@@ -6499,6 +6604,13 @@ packages:
     dependencies:
       ws: 7.5.9
     dev: false
+
+  /isomorphic-ws@5.0.0(ws@8.12.0):
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.12.0
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -7941,6 +8053,10 @@ packages:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
 
+  /psl@1.9.0:
+    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: false
+
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -8815,16 +8931,15 @@ packages:
       is-typedarray: 1.0.0
     dev: false
 
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
   /typescript@5.1.3:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: false
+
+  /typescript@5.1.5:
+    resolution: {integrity: sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -8936,6 +9051,30 @@ packages:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: true
+
+  /viem@1.5.3(typescript@5.1.3):
+    resolution: {integrity: sha512-oImpSDDvm8Y72qxXV0pCAGAqQLYgo8YENdz9EKS8ExnnOJLascpex4LNazNyp9cksjm3ORpVpbqGMr9Cy1z2mg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.9.0
+      '@noble/curves': 1.0.0
+      '@noble/hashes': 1.3.0
+      '@scure/bip32': 1.3.0
+      '@scure/bip39': 1.2.0
+      '@types/ws': 8.5.5
+      '@wagmi/chains': 1.6.0(typescript@5.1.3)
+      abitype: 0.9.3(typescript@5.1.3)
+      isomorphic-ws: 5.0.0(ws@8.12.0)
+      typescript: 5.1.3
+      ws: 8.12.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -9190,6 +9329,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  /ws@8.12.0:
+    resolution: {integrity: sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,9 +288,6 @@ importers:
 
   examples/with-viem:
     dependencies:
-      '@turnkey/http':
-        specifier: workspace:*
-        version: link:../../packages/http
       '@turnkey/viem':
         specifier: workspace:*
         version: link:../../packages/viem

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,12 @@ importers:
         specifier: '5.1'
         version: 5.1.3
     devDependencies:
+      '@types/jest':
+        specifier: ^29.5.3
+        version: 29.5.3
+      jest:
+        specifier: ^29.3.1
+        version: 29.4.3(@types/node@16.18.12)
       viem:
         specifier: ^1.5.3
         version: 1.5.3(typescript@5.1.3)
@@ -3758,6 +3764,13 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+
+  /@types/jest@29.5.3:
+    resolution: {integrity: sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==}
+    dependencies:
+      expect: 29.4.3
+      pretty-format: 29.4.3
+    dev: true
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}

--- a/tsconfig.mono.json
+++ b/tsconfig.mono.json
@@ -2,7 +2,8 @@
   "references": [
     { "path": "./packages/cosmjs" },
     { "path": "./packages/ethers" },
-    { "path": "./packages/http" }
+    { "path": "./packages/http" },
+    { "path": "./packages/viem" }
   ],
   "files": []
 }


### PR DESCRIPTION
## Summary & Motivation

This PR introduces a new `@turnkey/viem` package with (for now) a single helper function to create a Viem Custom Account backed by a Turnkey API key. I'll work on making a helper to work with passkeys next, this is a warmup!

The associated `with-viem` example demonstrates sending a transaction on Sepolia using this new helper. It works 🎉 

A problem I ran into: `viem` expects typescript >5.1 (for cutting edge typing features) and node >18 (for `fetch`). Does that mean we need to upgrade all of our packages? I tried to mandate this only in the new packages, but there are warnings when running `typecheck` now:
```
examples/with-viem                       |  WARN  Unsupported engine: wanted: {"node":">=18.0.0"} (current: {"node":"v16.16.0","pnpm":"8.4.0"})
packages/viem                            |  WARN  Unsupported engine: wanted: {"node":">=18.0.0"} (current: {"node":"v16.16.0","pnpm":"8.4.0"})
```
I put 2 `.npmrc` files in both `with-viem` and `viem` packages so `pnpm run <foo>` does the right thing and uses node 18, but still uses node 16 everywhere else. Not sure if it's worth supporting 2 versions of node? 