### PR TITLE
Minor fixes to env files and Solana example

### DIFF
--- a/examples/deployer/.env.local.example
+++ b/examples/deployer/.env.local.example
@@ -1,6 +1,6 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>"
 INFURA_KEY="<Infura API Key>"

--- a/examples/rebalancer/.env.local.example
+++ b/examples/rebalancer/.env.local.example
@@ -1,5 +1,5 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 INFURA_KEY="<Infura API Key>"

--- a/examples/sweeper/.env.local.example
+++ b/examples/sweeper/.env.local.example
@@ -1,6 +1,6 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>"
 INFURA_KEY="<Infura API Key>"

--- a/examples/trading-runner/.env.local.example
+++ b/examples/trading-runner/.env.local.example
@@ -1,5 +1,5 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 INFURA_KEY="<Infura API Key>"

--- a/examples/with-cosmjs/.env.local.example
+++ b/examples/with-cosmjs/.env.local.example
@@ -1,5 +1,5 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>" # if you leave it blank, we'll create one for you via calling the Turnkey API

--- a/examples/with-ethers/.env.local.example
+++ b/examples/with-ethers/.env.local.example
@@ -1,6 +1,6 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>" # if you leave it blank, we'll create one for you via calling the Turnkey API
 INFURA_KEY="<Infura API Key>"

--- a/examples/with-gnosis/.env.local.example
+++ b/examples/with-gnosis/.env.local.example
@@ -1,6 +1,6 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID_1="<(Crypto) Private key ID>"
 PRIVATE_KEY_ID_2="<(Crypto) Private key ID>"

--- a/examples/with-nonce-manager/.env.local.example
+++ b/examples/with-nonce-manager/.env.local.example
@@ -1,6 +1,6 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>" # if you leave it blank, we'll create one for you via calling the Turnkey API
 INFURA_KEY="<Infura API Key>"

--- a/examples/with-solana/.env.local.example
+++ b/examples/with-solana/.env.local.example
@@ -1,5 +1,5 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<(optional) Turnkey (crypto) Private Key ID>"

--- a/examples/with-solana/src/createSolanaKey.ts
+++ b/examples/with-solana/src/createSolanaKey.ts
@@ -37,7 +37,7 @@ export async function createNewSolanaPrivateKey(turnkeyOrganizationId: string) {
     });
 
     const privateKeyId =
-      activity.result.createPrivateKeysResult?.privateKeyIds?.[0];
+      activity.result.createPrivateKeysResultV2?.privateKeys[0]?.privateKeyId;
     if (!privateKeyId) {
       console.error(
         "activity doesn't contain a valid private key ID",

--- a/examples/with-uniswap/.env.local.example
+++ b/examples/with-uniswap/.env.local.example
@@ -1,6 +1,6 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-BASE_URL="https://coordinator-beta.turnkey.io"
+BASE_URL="https://api.turnkey.com"
 ORGANIZATION_ID="<Turnkey organization ID>"
 PRIVATE_KEY_ID="<Turnkey (crypto) private key ID>"
 INFURA_KEY="<Infura API Key>"


### PR DESCRIPTION
## Summary & Motivation
There are two small fixes in this PR.

1. [Recent examples](https://github.com/tkhq/sdk/blob/bbbe31ff764cc356f6af357de5c343db27467f8a/examples/with-viem/.env.local.example#L3) use `https://api.turnkey.com` as the API base URL. 965c8897200beebf155c55b99c4de3576c6208f3 updates all the example env files to use it.

2. The Solana example contains a bug that causes it to fail after creating a private key. It's caused by the type of call being `ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2` and the result that is read from being `createPrivateKeysResult`, presumbly the V1 API. 076c201fcc8f10fc7868087ac9e94b8505e6fbe2 fixes this.

## How I Tested These Changes
I ran the Solana example project, but otherwise haven't tested this.
