### PR TITLE
Fix links and URLs to follow domain migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![js-build](https://github.com/tkhq/sdk/actions/workflows/js-build.yml/badge.svg)](https://github.com/tkhq/sdk/actions/workflows/js-build.yml)
 
-API Docs: https://turnkey.readme.io/
+API Docs: https://docs.turnkey.com/
 
 ## Packages
 

--- a/examples/deployer/README.md
+++ b/examples/deployer/README.md
@@ -19,7 +19,7 @@ $ cd examples/deployer/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/rebalancer/README.md
+++ b/examples/rebalancer/README.md
@@ -37,7 +37,7 @@ $ cd examples/rebalancer/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/sweeper/README.md
+++ b/examples/sweeper/README.md
@@ -19,7 +19,7 @@ $ cd examples/sweeper/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/trading-runner/README.md
+++ b/examples/trading-runner/README.md
@@ -31,7 +31,7 @@ $ cd examples/trading-runner/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID
@@ -105,7 +105,7 @@ pnpm cli sweep --asset=USDC --amount=1 --key=bob --destination=0xf0609e87Dfa4DA1
 
 ## Understanding policies
 
-First, see our [Policies docs](https://turnkey.readme.io/docs/policy-engine-overview) for a primer on how policies work and are written. You'll notice that the policies used in this demo make use of directly accessing the transaction data of the Ethereum transactions. For example, let's break down the transaction data for an ERC20 `transfer`, specifically USDC ([Etherscan link](https://goerli.etherscan.io/tx/0x11a4f4c0778ddbf7731cab1b07d7db577918397c47bf3270ea9016237c8d4d11)):
+First, see our [Policies docs](https://docs.turnkey.com/managing-policies/overview) for a primer on how policies work and are written. You'll notice that the policies used in this demo make use of directly accessing the transaction data of the Ethereum transactions. For example, let's break down the transaction data for an ERC20 `transfer`, specifically USDC ([Etherscan link](https://goerli.etherscan.io/tx/0x11a4f4c0778ddbf7731cab1b07d7db577918397c47bf3270ea9016237c8d4d11)):
 
 ```
 0xa9059cbb000000000000000000000000d3b433723858612da3260eac465758c7ddfa5e5000000000000000000000000000000000000000000000000000000000000f4240

--- a/examples/with-cosmjs/README.md
+++ b/examples/with-cosmjs/README.md
@@ -19,7 +19,7 @@ $ cd examples/with-cosmjs/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/with-ethers/README.md
+++ b/examples/with-ethers/README.md
@@ -19,7 +19,7 @@ $ cd examples/with-ethers/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/with-federated-passkeys/README.md
+++ b/examples/with-federated-passkeys/README.md
@@ -19,7 +19,7 @@ $ cd examples/with-federated-passkeys/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/with-federated-passkeys/src/pages/index.tsx
+++ b/examples/with-federated-passkeys/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { buffer } from "stream/consumers";
 import { useState } from "react";
 
 browserInit({
-  baseUrl: "https://coordinator-beta.turnkey.io",
+  baseUrl: "https://api.turnkey.com",
 });
 
 type subOrgFormData = {
@@ -116,7 +116,7 @@ export default function Home() {
 
   return (
     <main className={styles.main}>
-      <a href="https://turnkey.io" target="_blank" rel="noopener noreferrer">
+      <a href="https://turnkey.com" target="_blank" rel="noopener noreferrer">
         <Image
           src="/logo.svg"
           alt="Turnkey Logo"

--- a/examples/with-gnosis/README.md
+++ b/examples/with-gnosis/README.md
@@ -19,7 +19,7 @@ $ cd examples/with-gnosis/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/with-nonce-manager/README.md
+++ b/examples/with-nonce-manager/README.md
@@ -19,7 +19,7 @@ $ cd examples/with-nonce-manager/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/with-offline/README.md
+++ b/examples/with-offline/README.md
@@ -25,7 +25,7 @@ $ cd examples/with-offline/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID
@@ -71,12 +71,12 @@ Creating a new Private Key for organization b8d8fa59-e1b7-4897-866a-551c32d061fa
 ? New Private Key Name hello
 Your request details:
 ✅ Route:
-        https://coordinator-beta.turnkey.io/public/v1/submit/create_private_keys
+        https://api.turnkey.com/public/v1/submit/create_private_keys
 ✅ Stamp (goes in X-Stamp HTTP header)
         eyJwdWJsaWNLZXkiOiIwM2JmMTYyNTc2ZWI4ZGZlY2YzM2Q5Mjc1ZDA5NTk1Mjg0ZjZjNGRmMGRiNjE1NmMzYzU4Mjc3Nzg4NmEwZWUwYWMiLCJzY2hlbWUiOiJTSUdOQVRVUkVfU0NIRU1FX1RLX0FQSV9QMjU2Iiwic2lnbmF0dXJlIjoiMzA0NDAyMjA0MjFjNzk0YzAzZDQxNDRhNjkyZmMwN2YxZjZhNGYxNzNhOGRhMGU3NTdiNWNlYWU1ZGQzNmQ2YWZjZmYwMzdkMDIyMDAzZmQ3OWRjYWI4MTYxMDAxYjRiYWQwNjVjMzE4ZWYzNDUxZTViZGVhMTYxM2VlMmNiOTkzMjVmZjVmMjBmNjIifQ
 ✅ POST body:
         {"timestampMs":"1685118651239","type":"ACTIVITY_TYPE_CREATE_PRIVATE_KEYS","organizationId":"b8d8fa59-e1b7-4897-866a-551c32d061fa","parameters":{"privateKeys":[{"privateKeyName":"hello","curve":"CURVE_SECP256K1","addressFormats":["ADDRESS_FORMAT_ETHEREUM"],"privateKeyTags":[]}]}}
 
 For example, you can send this request to Turnkey by running the following cURL command:
-        curl -X POST -d'{"timestampMs":"1685118651239","type":"ACTIVITY_TYPE_CREATE_PRIVATE_KEYS","organizationId":"b8d8fa59-e1b7-4897-866a-551c32d061fa","parameters":{"privateKeys":[{"privateKeyName":"hello","curve":"CURVE_SECP256K1","addressFormats":["ADDRESS_FORMAT_ETHEREUM"],"privateKeyTags":[]}]}}' -H'X-Stamp:eyJwdWJsaWNLZXkiOiIwM2JmMTYyNTc2ZWI4ZGZlY2YzM2Q5Mjc1ZDA5NTk1Mjg0ZjZjNGRmMGRiNjE1NmMzYzU4Mjc3Nzg4NmEwZWUwYWMiLCJzY2hlbWUiOiJTSUdOQVRVUkVfU0NIRU1FX1RLX0FQSV9QMjU2Iiwic2lnbmF0dXJlIjoiMzA0NDAyMjA0MjFjNzk0YzAzZDQxNDRhNjkyZmMwN2YxZjZhNGYxNzNhOGRhMGU3NTdiNWNlYWU1ZGQzNmQ2YWZjZmYwMzdkMDIyMDAzZmQ3OWRjYWI4MTYxMDAxYjRiYWQwNjVjMzE4ZWYzNDUxZTViZGVhMTYxM2VlMmNiOTkzMjVmZjVmMjBmNjIifQ' -v 'https://coordinator-beta.turnkey.io/public/v1/submit/create_private_keys'
+        curl -X POST -d'{"timestampMs":"1685118651239","type":"ACTIVITY_TYPE_CREATE_PRIVATE_KEYS","organizationId":"b8d8fa59-e1b7-4897-866a-551c32d061fa","parameters":{"privateKeys":[{"privateKeyName":"hello","curve":"CURVE_SECP256K1","addressFormats":["ADDRESS_FORMAT_ETHEREUM"],"privateKeyTags":[]}]}}' -H'X-Stamp:eyJwdWJsaWNLZXkiOiIwM2JmMTYyNTc2ZWI4ZGZlY2YzM2Q5Mjc1ZDA5NTk1Mjg0ZjZjNGRmMGRiNjE1NmMzYzU4Mjc3Nzg4NmEwZWUwYWMiLCJzY2hlbWUiOiJTSUdOQVRVUkVfU0NIRU1FX1RLX0FQSV9QMjU2Iiwic2lnbmF0dXJlIjoiMzA0NDAyMjA0MjFjNzk0YzAzZDQxNDRhNjkyZmMwN2YxZjZhNGYxNzNhOGRhMGU3NTdiNWNlYWU1ZGQzNmQ2YWZjZmYwMzdkMDIyMDAzZmQ3OWRjYWI4MTYxMDAxYjRiYWQwNjVjMzE4ZWYzNDUxZTViZGVhMTYxM2VlMmNiOTkzMjVmZjVmMjBmNjIifQ' -v 'https://api.turnkey.com/public/v1/submit/create_private_keys'
 ```

--- a/examples/with-offline/src/index.ts
+++ b/examples/with-offline/src/index.ts
@@ -67,7 +67,7 @@ async function main() {
   httpInit({
     apiPublicKey: process.env.API_PUBLIC_KEY!,
     apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: "https://coordinator-beta.turnkey.io",
+    baseUrl: "https://api.turnkey.com",
   });
 
   const organizationId = process.env.ORGANIZATION_ID;
@@ -85,9 +85,7 @@ async function main() {
 
   console.log("Your request details:");
   console.log("✅ Route:");
-  console.log(
-    `\thttps://coordinator-beta.turnkey.io/public/v1/submit/create_private_keys`
-  );
+  console.log(`\thttps://api.turnkey.com/public/v1/submit/create_private_keys`);
   console.log("✅ Stamp (goes in X-Stamp HTTP header)");
   console.log(`\t${xStamp}`);
   console.log("✅ POST body:");
@@ -97,7 +95,7 @@ async function main() {
     "\nFor example, you can send this request to Turnkey by running the following cURL command:"
   );
   console.log(
-    `\tcurl -X POST -d'${sealedBody}' -H'X-Stamp:${xStamp}' -v 'https://coordinator-beta.turnkey.io/public/v1/submit/create_private_keys'`
+    `\tcurl -X POST -d'${sealedBody}' -H'X-Stamp:${xStamp}' -v 'https://api.turnkey.com/public/v1/submit/create_private_keys'`
   );
 
   console.log(

--- a/examples/with-solana/README.md
+++ b/examples/with-solana/README.md
@@ -24,7 +24,7 @@ $ cd examples/with-solana/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/examples/with-uniswap/README.md
+++ b/examples/with-uniswap/README.md
@@ -19,7 +19,7 @@ $ cd examples/with-uniswap/
 
 ### 2/ Setting up Turnkey
 
-The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://turnkey.readme.io/docs/quickstart) guide, you should have:
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID

--- a/packages/cosmjs/README.md
+++ b/packages/cosmjs/README.md
@@ -2,13 +2,13 @@
 
 [![npm](https://img.shields.io/npm/v/@turnkey/cosmjs?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/cosmjs)
 
-Experimental [Turnkey](https://turnkey.io) Cosmos Signer for [`CosmJS`](https://github.com/cosmos/cosmjs):
+Experimental [Turnkey](https://turnkey.com) Cosmos Signer for [`CosmJS`](https://github.com/cosmos/cosmjs):
 
 - `TurnkeyDirectWallet` is a drop-in replacement for [`DirectSecp256k1Wallet`](https://github.com/cosmos/cosmjs/blob/e8e65aa0c145616ccb58625c32bffe08b46ff574/packages/proto-signing/src/directsecp256k1wallet.ts#LL14C14-L14C35) that conforms to the `OfflineDirectSigner` interface.
 
 If you need a lower-level, fully typed HTTP client for interacting with Turnkey API, check out [`@turnkey/http`](/packages/http/).
 
-API Docs: https://turnkey.readme.io/
+API Docs: https://docs.turnkey.com/
 
 ## Getting started
 

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -12,7 +12,7 @@
   ],
   "author": {
     "name": "Turnkey",
-    "url": "https://turnkey.io/"
+    "url": "https://turnkey.com/"
   },
   "homepage": "https://github.com/tkhq/sdk",
   "bugs": {

--- a/packages/ethers/README.md
+++ b/packages/ethers/README.md
@@ -2,11 +2,11 @@
 
 [![npm](https://img.shields.io/npm/v/@turnkey/ethers?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/ethers)
 
-[Turnkey](https://turnkey.io) Signer for [`Ethers`](https://docs.ethers.org/v5/api/signer/).
+[Turnkey](https://turnkey.com) Signer for [`Ethers`](https://docs.ethers.org/v5/api/signer/).
 
 If you need a lower-level, fully typed HTTP client for interacting with Turnkey API, check out [`@turnkey/http`](/packages/http/).
 
-API Docs: https://turnkey.readme.io/
+API Docs: https://docs.turnkey.com/
 
 ## Getting started
 
@@ -26,7 +26,7 @@ async function main() {
   const turnkeySigner = new TurnkeySigner({
     apiPublicKey: "...",
     apiPrivateKey: "...",
-    baseUrl: "https://coordinator-beta.turnkey.io",
+    baseUrl: "https://api.turnkey.com",
     organizationId: "...",
     privateKeyId: "...",
   });

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -12,7 +12,7 @@
   ],
   "author": {
     "name": "Turnkey",
-    "url": "https://turnkey.io/"
+    "url": "https://turnkey.com/"
   },
   "homepage": "https://github.com/tkhq/sdk",
   "bugs": {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -10,7 +10,7 @@
   ],
   "author": {
     "name": "Turnkey",
-    "url": "https://turnkey.io/"
+    "url": "https://turnkey.com/"
   },
   "homepage": "https://github.com/tkhq/sdk",
   "bugs": {

--- a/packages/http/src/__tests__/async-test.ts
+++ b/packages/http/src/__tests__/async-test.ts
@@ -18,7 +18,7 @@ beforeEach(async () => {
   init({
     apiPublicKey: publicKey,
     apiPrivateKey: privateKey,
-    baseUrl: "https://mocked.turnkey.io",
+    baseUrl: "https://mocked.turnkey.com",
   });
 });
 

--- a/packages/http/src/__tests__/request-test.ts
+++ b/packages/http/src/__tests__/request-test.ts
@@ -11,7 +11,7 @@ test("requests are stamped after initialization", async () => {
   init({
     apiPublicKey: publicKey,
     apiPrivateKey: privateKey,
-    baseUrl: "https://mocked.turnkey.io",
+    baseUrl: "https://mocked.turnkey.com",
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -41,7 +41,7 @@ test("requests return grpc status details as part of their errors", async () => 
   init({
     apiPublicKey: publicKey,
     apiPrivateKey: privateKey,
-    baseUrl: "https://mocked.turnkey.io",
+    baseUrl: "https://mocked.turnkey.com",
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;


### PR DESCRIPTION
## Summary & Motivation

We've migrated our API domain and docs:
- turnkey.io -> turnkey.com
- turnkey.readme.io -> docs.turnkey.com

Don't think it's worth a patch release for this, it'll just be released over time as we release packages.