### PR TITLE
Migrate the remaining examples to use new `TurnkeyClient`

### DIFF
--- a/examples/deployer/package.json
+++ b/examples/deployer/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@turnkey/api-key-stamper": "workspace:^",
     "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "dotenv": "^16.0.3",

--- a/examples/deployer/src/createNewEthereumPrivateKey.ts
+++ b/examples/deployer/src/createNewEthereumPrivateKey.ts
@@ -41,16 +41,11 @@ export async function createNewEthereumPrivateKey() {
       timestampMs: String(Date.now()), // millisecond timestamp
     });
 
-    const privateKeyId = refineNonNull(
-      activity.result.createPrivateKeysResultV2?.privateKeys?.[0]?.privateKeyId
+    const privateKeys = refineNonNull(
+      activity.result.createPrivateKeysResultV2?.privateKeys
     );
-
-    const keyInfo = await turnkeyClient.getPrivateKey({
-      organizationId: process.env.ORGANIZATION_ID!,
-      privateKeyId,
-    });
-
-    const address = refineNonNull(keyInfo.privateKey.addresses[0]?.address);
+    const privateKeyId = refineNonNull(privateKeys?.[0]?.privateKeyId);
+    const address = refineNonNull(privateKeys?.[0]?.addresses?.[0]?.address);
 
     // Success!
     console.log(

--- a/examples/deployer/src/createNewEthereumPrivateKey.ts
+++ b/examples/deployer/src/createNewEthereumPrivateKey.ts
@@ -1,56 +1,53 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import * as crypto from "crypto";
 
 export async function createNewEthereumPrivateKey() {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
   console.log(
     "`process.env.PRIVATE_KEY_ID` not found; creating a new Ethereum private key on Turnkey...\n"
   );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    request: TurnkeyApi.createPrivateKeys,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createPrivateKeys,
   });
 
   const privateKeyName = `ETH Key ${crypto.randomBytes(2).toString("hex")}`;
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          privateKeys: [
-            {
-              privateKeyName,
-              curve: "CURVE_SECP256K1",
-              addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
-              privateKeyTags: [],
-            },
-          ],
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        privateKeys: [
+          {
+            privateKeyName,
+            curve: "CURVE_SECP256K1",
+            addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
+            privateKeyTags: [],
+          },
+        ],
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const privateKeyId = refineNonNull(
-      activity.result.createPrivateKeysResult?.privateKeyIds?.[0]
+      activity.result.createPrivateKeysResultV2?.privateKeys?.[0]?.privateKeyId
     );
 
-    const keyInfo = await TurnkeyApi.getPrivateKey({
-      body: {
-        organizationId: process.env.ORGANIZATION_ID!,
-        privateKeyId,
-      },
+    const keyInfo = await turnkeyClient.getPrivateKey({
+      organizationId: process.env.ORGANIZATION_ID!,
+      privateKeyId,
     });
 
     const address = refineNonNull(keyInfo.privateKey.addresses[0]?.address);

--- a/examples/rebalancer/README.md
+++ b/examples/rebalancer/README.md
@@ -125,7 +125,7 @@ Next, run the "pollAndBroadcast" command to wait for the tx to be confirmed and 
 pnpm cli pollAndBroadcast --interval=20000
 ```
 
-### 8/ Approve Recyle
+### 8/ Approve Recycle
 
 Finally, approve the recycle txn using the activity ID from above:
 

--- a/examples/rebalancer/package.json
+++ b/examples/rebalancer/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@turnkey/api-key-stamper": "workspace:^",
     "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "dotenv": "^16.0.3",

--- a/examples/rebalancer/src/index.ts
+++ b/examples/rebalancer/src/index.ts
@@ -241,6 +241,7 @@ async function sweepImpl() {
     const connectedSigner = getTurnkeySigner(provider, pk.privateKeyId);
     const balance = await connectedSigner.getBalance();
     const feeData = await connectedSigner.getFeeData();
+    const address = await connectedSigner.getAddress();
 
     feeData.maxFeePerGas = feeData.maxFeePerGas!.mul(GAS_MULTIPLIER);
     feeData.maxPriorityFeePerGas =
@@ -251,14 +252,18 @@ async function sweepImpl() {
       .mul(TRANSFER_GAS_LIMIT); // 21000 is the gas limit for a simple transfer
 
     if (balance.lt(SWEEP_THRESHOLD)) {
-      console.log("Insufficient balance for sweep. Moving on...");
+      console.log(
+        `Address ${address} has an insufficient balance for sweep. Moving on...`
+      );
       continue;
     }
 
     const sweepAmount = balance.sub(gasRequired.mul(2)); // be relatively conservative with sweep amount to prevent overdraft
 
     if (sweepAmount.lt(0)) {
-      console.log("Insufficient balance for sweep. Moving on...");
+      console.log(
+        `Address ${address} has an insufficient balance for sweep. Moving on...`
+      );
       continue;
     }
 

--- a/examples/rebalancer/src/requests/createActivityApproval.ts
+++ b/examples/rebalancer/src/requests/createActivityApproval.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -6,30 +8,27 @@ export default async function approveActivity(
   activityId: string,
   activityFingerprint: string
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    request: TurnkeyApi.approveActivity,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.approveActivity,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_APPROVE_ACTIVITY",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          fingerprint: activityFingerprint,
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_APPROVE_ACTIVITY",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        fingerprint: activityFingerprint,
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const result = refineNonNull(activity);

--- a/examples/rebalancer/src/requests/createActivityApproval.ts
+++ b/examples/rebalancer/src/requests/createActivityApproval.ts
@@ -1,21 +1,13 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function approveActivity(
+  turnkeyClient: TurnkeyClient,
   activityId: string,
   activityFingerprint: string
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.approveActivity,

--- a/examples/rebalancer/src/requests/createActivityRejection.ts
+++ b/examples/rebalancer/src/requests/createActivityRejection.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -6,30 +8,27 @@ export default async function rejectActivity(
   activityId: string,
   activityFingerprint: string
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    request: TurnkeyApi.rejectActivity,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.rejectActivity,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_REJECT_ACTIVITY",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          fingerprint: activityFingerprint,
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_REJECT_ACTIVITY",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        fingerprint: activityFingerprint,
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const result = refineNonNull(activity);

--- a/examples/rebalancer/src/requests/createActivityRejection.ts
+++ b/examples/rebalancer/src/requests/createActivityRejection.ts
@@ -1,21 +1,13 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function rejectActivity(
+  turnkeyClient: TurnkeyClient,
   activityId: string,
   activityFingerprint: string
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.rejectActivity,

--- a/examples/rebalancer/src/requests/createPolicy.ts
+++ b/examples/rebalancer/src/requests/createPolicy.ts
@@ -1,23 +1,15 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createPolicy(
+  turnkeyClient: TurnkeyClient,
   policyName: string,
   effect: "EFFECT_ALLOW" | "EFFECT_DENY",
   consensus: string,
   condition: string
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createPolicy,

--- a/examples/rebalancer/src/requests/createPrivateKeyTag.ts
+++ b/examples/rebalancer/src/requests/createPrivateKeyTag.ts
@@ -1,21 +1,13 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createPrivateKeyTag(
+  turnkeyClient: TurnkeyClient,
   privateKeyTagName: string,
   privateKeyIds: string[]
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createPrivateKeyTag,

--- a/examples/rebalancer/src/requests/createPrivateKeyTag.ts
+++ b/examples/rebalancer/src/requests/createPrivateKeyTag.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -6,32 +8,28 @@ export default async function createPrivateKeyTag(
   privateKeyTagName: string,
   privateKeyIds: string[]
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    // this method doesn't currently support creating private key tags
-    request: TurnkeyApi.createPrivateKeyTag,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createPrivateKeyTag,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          privateKeyTagName,
-          privateKeyIds,
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        privateKeyTagName,
+        privateKeyIds,
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const privateKeyTagId = refineNonNull(

--- a/examples/rebalancer/src/requests/createUser.ts
+++ b/examples/rebalancer/src/requests/createUser.ts
@@ -1,23 +1,15 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createUser(
+  turnkeyClient: TurnkeyClient,
   userName: string,
   userTags: string[],
   apiKeyName: string,
   publicKey: string
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createApiOnlyUsers,

--- a/examples/rebalancer/src/requests/createUser.ts
+++ b/examples/rebalancer/src/requests/createUser.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -8,41 +10,38 @@ export default async function createUser(
   apiKeyName: string,
   publicKey: string
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    request: TurnkeyApi.createApiOnlyUsers,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createApiOnlyUsers,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          apiOnlyUsers: [
-            {
-              userName,
-              userTags,
-              apiKeys: [
-                {
-                  apiKeyName,
-                  publicKey,
-                },
-              ],
-            },
-          ],
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        apiOnlyUsers: [
+          {
+            userName,
+            userTags,
+            apiKeys: [
+              {
+                apiKeyName,
+                publicKey,
+              },
+            ],
+          },
+        ],
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const userId = refineNonNull(

--- a/examples/rebalancer/src/requests/createUserTag.ts
+++ b/examples/rebalancer/src/requests/createUserTag.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -6,32 +8,28 @@ export default async function createUserTag(
   userTagName: string,
   userIds: string[]
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    // this method doesn't currently support creating user tags
-    request: TurnkeyApi.createUserTag,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createUserTag,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_USER_TAG",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          userTagName,
-          userIds,
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_USER_TAG",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        userTagName,
+        userIds,
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const userTagId = refineNonNull(

--- a/examples/rebalancer/src/requests/createUserTag.ts
+++ b/examples/rebalancer/src/requests/createUserTag.ts
@@ -1,21 +1,13 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createUserTag(
+  turnkeyClient: TurnkeyClient,
   userTagName: string,
   userIds: string[]
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createUserTag,

--- a/examples/rebalancer/src/requests/getActivities.ts
+++ b/examples/rebalancer/src/requests/getActivities.ts
@@ -1,18 +1,10 @@
-import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import type { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
 import { refineNonNull } from "./utils";
 
 export default async function getActivities(
+  turnkeyClient: TurnkeyClient,
   limit: string
 ): Promise<TurnkeyApiTypes["v1GetActivitiesResponse"]["activities"]> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const response = await turnkeyClient.getActivities({
     organizationId: process.env.ORGANIZATION_ID!,
     paginationOptions: {

--- a/examples/rebalancer/src/requests/getActivities.ts
+++ b/examples/rebalancer/src/requests/getActivities.ts
@@ -1,22 +1,22 @@
-import { TurnkeyApi, init as httpInit, TurnkeyApiTypes } from "@turnkey/http";
+import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { refineNonNull } from "./utils";
 
 export default async function getActivities(
   limit: string
 ): Promise<TurnkeyApiTypes["v1GetActivitiesResponse"]["activities"]> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  const response = await TurnkeyApi.getActivities({
-    body: {
-      organizationId: process.env.ORGANIZATION_ID!,
-      paginationOptions: {
-        limit: limit,
-      },
+  const response = await turnkeyClient.getActivities({
+    organizationId: process.env.ORGANIZATION_ID!,
+    paginationOptions: {
+      limit: limit,
     },
   });
 

--- a/examples/rebalancer/src/requests/getActivity.ts
+++ b/examples/rebalancer/src/requests/getActivity.ts
@@ -1,18 +1,10 @@
-import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import type { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
 import { refineNonNull } from "./utils";
 
 export default async function getActivity(
+  turnkeyClient: TurnkeyClient,
   activityId: string
 ): Promise<TurnkeyApiTypes["v1ActivityResponse"]["activity"]> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const response = await turnkeyClient.getActivity({
     organizationId: process.env.ORGANIZATION_ID!,
     activityId,

--- a/examples/rebalancer/src/requests/getActivity.ts
+++ b/examples/rebalancer/src/requests/getActivity.ts
@@ -1,19 +1,21 @@
-import { TurnkeyApi, init as httpInit } from "@turnkey/http";
+import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { refineNonNull } from "./utils";
 
-export default async function getActivity(activityId: string): Promise<any> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+export default async function getActivity(
+  activityId: string
+): Promise<TurnkeyApiTypes["v1ActivityResponse"]["activity"]> {
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  const response = await TurnkeyApi.getActivity({
-    body: {
-      organizationId: process.env.ORGANIZATION_ID!,
-      activityId,
-    },
+  const response = await turnkeyClient.getActivity({
+    organizationId: process.env.ORGANIZATION_ID!,
+    activityId,
   });
 
   return refineNonNull(response.activity);

--- a/examples/rebalancer/src/requests/getOrganization.ts
+++ b/examples/rebalancer/src/requests/getOrganization.ts
@@ -1,18 +1,9 @@
-import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import type { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
 import { refineNonNull } from "./utils";
 
-export default async function getOrganization(): Promise<
-  TurnkeyApiTypes["v1OrganizationData"]
-> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
+export default async function getOrganization(
+  turnkeyClient: TurnkeyClient
+): Promise<TurnkeyApiTypes["v1OrganizationData"]> {
   const response = await turnkeyClient.getOrganization({
     organizationId: process.env.ORGANIZATION_ID!,
   });

--- a/examples/rebalancer/src/requests/getOrganization.ts
+++ b/examples/rebalancer/src/requests/getOrganization.ts
@@ -1,20 +1,20 @@
-import { TurnkeyApi, init as httpInit, TurnkeyApiTypes } from "@turnkey/http";
+import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { refineNonNull } from "./utils";
 
 export default async function getOrganization(): Promise<
   TurnkeyApiTypes["v1OrganizationData"]
 > {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  const response = await TurnkeyApi.getOrganization({
-    body: {
-      organizationId: process.env.ORGANIZATION_ID!,
-    },
+  const response = await turnkeyClient.getOrganization({
+    organizationId: process.env.ORGANIZATION_ID!,
   });
 
   return refineNonNull(response.organizationData);

--- a/examples/trading-runner/README.md
+++ b/examples/trading-runner/README.md
@@ -65,7 +65,7 @@ Before executing any txns using Turnkey, you'll first need the "Trading" address
 
 ### 5/ Trade
 
-Once the "Trading" address has funds in it, execute the "trade" command to make a t
+Once the "Trading" address has funds in it, execute the "trade" command to exchange a base asset for the quote asset, for a specified amount.
 
 ```bash
 pnpm cli trade --baseAsset=<SYMBOL> --quoteAsset=<SYMBOL> --baseAmount=<WHOLE AMOUNT> --key=<USER>

--- a/examples/trading-runner/package.json
+++ b/examples/trading-runner/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@turnkey/api-key-stamper": "workspace:^",
     "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@uniswap/sdk-core": "^3.1.1",

--- a/examples/trading-runner/src/index.ts
+++ b/examples/trading-runner/src/index.ts
@@ -4,6 +4,8 @@ import * as dotenv from "dotenv";
 // Load environment variables from `.env.local`
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { ethers } from "ethers";
 import prompts from "prompts";
 import { findPrivateKeys, isKeyOfObject, fromReadableAmount } from "./utils";
@@ -34,6 +36,15 @@ import {
 } from "./uniswap/constants";
 import { prepareV3Trade, executeTrade } from "./uniswap/base";
 import { toReadableAmount } from "./utils";
+
+// For demonstration purposes, create a globally accessible TurnkeyClient
+const turnkeyClient = new TurnkeyClient(
+  { baseUrl: process.env.BASE_URL! },
+  new ApiKeyStamper({
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+  })
+);
 
 async function main() {
   const args = process.argv.slice(2);
@@ -95,29 +106,45 @@ main().catch((error) => {
 
 async function setup(_options: any) {
   // setup user tags
-  const adminTagId = await createUserTag("Admin", []);
-  const traderTagId = await createUserTag("Trader", []);
+  const adminTagId = await createUserTag(turnkeyClient, "Admin", []);
+  const traderTagId = await createUserTag(turnkeyClient, "Trader", []);
 
   // setup users
-  await createUser("Alice", [adminTagId], "Alice key", keys!.alice!.publicKey!);
-  await createUser("Bob", [traderTagId], "Bob key", keys!.bob!.publicKey!);
+  await createUser(
+    turnkeyClient,
+    "Alice",
+    [adminTagId],
+    "Alice key",
+    keys!.alice!.publicKey!
+  );
+  await createUser(
+    turnkeyClient,
+    "Bob",
+    [traderTagId],
+    "Bob key",
+    keys!.bob!.publicKey!
+  );
 
   // setup private key tags
-  const tradingTagId = await createPrivateKeyTag("trading", []);
-  const personal = await createPrivateKeyTag("personal", []);
+  const tradingTagId = await createPrivateKeyTag(turnkeyClient, "trading", []);
+  const personal = await createPrivateKeyTag(turnkeyClient, "personal", []);
   const longTermStorageTagId = await createPrivateKeyTag(
+    turnkeyClient,
     "long-term-storage",
     []
   );
 
   // setup private keys
-  await createPrivateKey("Trading Wallet", [tradingTagId]);
-  await createPrivateKey("Long Term Storage", [longTermStorageTagId]);
-  await createPrivateKey("Personal", [personal]);
+  await createPrivateKey(turnkeyClient, "Trading Wallet", [tradingTagId]);
+  await createPrivateKey(turnkeyClient, "Long Term Storage", [
+    longTermStorageTagId,
+  ]);
+  await createPrivateKey(turnkeyClient, "Personal", [personal]);
 
   // setup policies: grant specific users permissions to use specific private keys
   // ADMIN
   await createPolicy(
+    turnkeyClient,
     "Admin users can do everything",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${adminTagId}'))`,
@@ -130,30 +157,35 @@ async function setup(_options: any) {
 
   // TRADING
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to deposit, aka wrap, ETH",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
     `private_key.tags.contains('${tradingTagId}') && eth.tx.to == '${WETH_TOKEN_GOERLI.address}' && eth.tx.data[0..10] == '${DEPOSIT_SELECTOR}'`
   );
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to withdraw, aka unwrap, WETH",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
     `private_key.tags.contains('${tradingTagId}') && eth.tx.to == '${WETH_TOKEN_GOERLI.address}' && eth.tx.data[0..10] == '${WITHDRAW_SELECTOR}'`
   );
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to make ERC20 token approvals for WETH for usage with Uniswap",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
     `private_key.tags.contains('${tradingTagId}') && eth.tx.to == '${WETH_TOKEN_GOERLI.address}' && eth.tx.data[0..10] == '${APPROVE_SELECTOR}' && eth.tx.data[10..74] == '${paddedRouterAddress}'`
   );
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to make ERC20 token approvals for USDC for usage with Uniswap",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
     `private_key.tags.contains('${tradingTagId}') && eth.tx.to == '${USDC_TOKEN_GOERLI.address}' && eth.tx.data[0..10] == '${APPROVE_SELECTOR}' && eth.tx.data[10..74] == '${paddedRouterAddress}'`
   );
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to make trades using Uniswap",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
@@ -162,7 +194,7 @@ async function setup(_options: any) {
 
   // SENDING
   // first, get long term storage address(es)
-  const organization = await getOrganization();
+  const organization = await getOrganization(turnkeyClient);
   const longTermStoragePrivateKey = findPrivateKeys(
     organization,
     "long-term-storage"
@@ -184,18 +216,21 @@ async function setup(_options: any) {
     .padStart(64, "0");
 
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to send ETH to long term storage addresses",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
     `private_key.tags.contains('${tradingTagId}') && eth.tx.to == '${longTermStorageAddress.address!}'`
   );
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to send WETH to long term storage addresses",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
     `private_key.tags.contains('${tradingTagId}') && eth.tx.to == '${WETH_TOKEN_GOERLI.address}' && eth.tx.data[0..10] == '${TRANSFER_SELECTOR}' && eth.tx.data[10..74] == '${paddedLongTermStorageAddress}'`
   );
   await createPolicy(
+    turnkeyClient,
     "Traders can use trading keys to send USDC to long term storage addresses",
     "EFFECT_ALLOW",
     `approvers.any(user, user.tags.contains('${traderTagId}'))`,
@@ -235,7 +270,7 @@ async function trade(options: { [key: string]: string }) {
 }
 
 async function wrapUnwrapImpl(baseAsset: string, baseAmount: string) {
-  const organization = await getOrganization();
+  const organization = await getOrganization(turnkeyClient);
 
   // find "trading" private key
   const tradingPrivateKey = findPrivateKeys(organization, "trading")[0];
@@ -301,7 +336,7 @@ async function tradeImpl(
   quoteAsset: string,
   baseAmount: string
 ) {
-  const organization = await getOrganization();
+  const organization = await getOrganization(turnkeyClient);
 
   // find "trading" private key
   const tradingPrivateKey = findPrivateKeys(organization, "trading")[0];
@@ -473,7 +508,7 @@ async function sweep(options: any) {
 
 // sweep one asset at a time, and only to long term storage
 async function sweepImpl(asset: string, destination: string, amount: string) {
-  const organization = await getOrganization();
+  const organization = await getOrganization(turnkeyClient);
 
   // find trading private keys
   const tradingPrivateKey = findPrivateKeys(organization, "trading")[0]!;

--- a/examples/trading-runner/src/requests/createPolicy.ts
+++ b/examples/trading-runner/src/requests/createPolicy.ts
@@ -1,23 +1,15 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createPolicy(
+  turnkeyClient: TurnkeyClient,
   policyName: string,
   effect: "EFFECT_ALLOW" | "EFFECT_DENY",
   consensus: string,
   condition: string
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createPolicy,

--- a/examples/trading-runner/src/requests/createPrivateKeyTag.ts
+++ b/examples/trading-runner/src/requests/createPrivateKeyTag.ts
@@ -1,21 +1,13 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createPrivateKeyTag(
+  turnkeyClient: TurnkeyClient,
   privateKeyTagName: string,
   privateKeyIds: string[]
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createPrivateKeyTag,

--- a/examples/trading-runner/src/requests/createPrivateKeyTag.ts
+++ b/examples/trading-runner/src/requests/createPrivateKeyTag.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -6,32 +8,28 @@ export default async function createPrivateKeyTag(
   privateKeyTagName: string,
   privateKeyIds: string[]
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    // this method doesn't currently support creating private key tags
-    request: TurnkeyApi.createPrivateKeyTag,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createPrivateKeyTag,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          privateKeyTagName,
-          privateKeyIds,
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        privateKeyTagName,
+        privateKeyIds,
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const privateKeyTagId = refineNonNull(

--- a/examples/trading-runner/src/requests/createUser.ts
+++ b/examples/trading-runner/src/requests/createUser.ts
@@ -1,23 +1,15 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createUser(
+  turnkeyClient: TurnkeyClient,
   userName: string,
   userTags: string[],
   apiKeyName: string,
   publicKey: string
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createApiOnlyUsers,

--- a/examples/trading-runner/src/requests/createUser.ts
+++ b/examples/trading-runner/src/requests/createUser.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -8,41 +10,38 @@ export default async function createUser(
   apiKeyName: string,
   publicKey: string
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    request: TurnkeyApi.createApiOnlyUsers,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createApiOnlyUsers,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          apiOnlyUsers: [
-            {
-              userName,
-              userTags,
-              apiKeys: [
-                {
-                  apiKeyName,
-                  publicKey,
-                },
-              ],
-            },
-          ],
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        apiOnlyUsers: [
+          {
+            userName,
+            userTags,
+            apiKeys: [
+              {
+                apiKeyName,
+                publicKey,
+              },
+            ],
+          },
+        ],
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const userId = refineNonNull(

--- a/examples/trading-runner/src/requests/createUserTag.ts
+++ b/examples/trading-runner/src/requests/createUserTag.ts
@@ -1,4 +1,6 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
@@ -6,32 +8,28 @@ export default async function createUserTag(
   userTagName: string,
   userIds: string[]
 ): Promise<string> {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    // this method doesn't currently support creating user tags
-    request: TurnkeyApi.createUserTag,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createUserTag,
   });
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_USER_TAG",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          userTagName,
-          userIds,
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_USER_TAG",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        userTagName,
+        userIds,
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const userTagId = refineNonNull(

--- a/examples/trading-runner/src/requests/createUserTag.ts
+++ b/examples/trading-runner/src/requests/createUserTag.ts
@@ -1,21 +1,13 @@
-import { TurnkeyClient } from "@turnkey/http";
+import type { TurnkeyClient } from "@turnkey/http";
 import { createActivityPoller } from "@turnkey/http/dist/async";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createUserTag(
+  turnkeyClient: TurnkeyClient,
   userTagName: string,
   userIds: string[]
 ): Promise<string> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
   const activityPoller = createActivityPoller({
     client: turnkeyClient,
     requestFn: turnkeyClient.createUserTag,

--- a/examples/trading-runner/src/requests/getOrganization.ts
+++ b/examples/trading-runner/src/requests/getOrganization.ts
@@ -1,18 +1,9 @@
-import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import type { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
 import { refineNonNull } from "./utils";
 
-export default async function getOrganization(): Promise<
-  TurnkeyApiTypes["v1OrganizationData"]
-> {
-  const turnkeyClient = new TurnkeyClient(
-    { baseUrl: process.env.BASE_URL! },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
-
+export default async function getOrganization(
+  turnkeyClient: TurnkeyClient
+): Promise<TurnkeyApiTypes["v1OrganizationData"]> {
   const response = await turnkeyClient.getOrganization({
     organizationId: process.env.ORGANIZATION_ID!,
   });

--- a/examples/trading-runner/src/requests/getOrganization.ts
+++ b/examples/trading-runner/src/requests/getOrganization.ts
@@ -1,20 +1,20 @@
-import { TurnkeyApi, init as httpInit, TurnkeyApiTypes } from "@turnkey/http";
+import { TurnkeyClient, TurnkeyApiTypes } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { refineNonNull } from "./utils";
 
 export default async function getOrganization(): Promise<
   TurnkeyApiTypes["v1OrganizationData"]
 > {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  const response = await TurnkeyApi.getOrganization({
-    body: {
-      organizationId: process.env.ORGANIZATION_ID!,
-    },
+  const response = await turnkeyClient.getOrganization({
+    organizationId: process.env.ORGANIZATION_ID!,
   });
 
   return refineNonNull(response.organizationData);

--- a/examples/with-cosmjs/README.md
+++ b/examples/with-cosmjs/README.md
@@ -50,17 +50,17 @@ Visit the explorer links to view your transaction; you have successfully sent yo
 
 ```
 Compressed public key:
-	03be8c88bc5e77aaa9a65ba29f38e892e68d736778fce1bf462d27bfaa3beefc93
+	025adbb33ec36206ae2e022ddc55d3d083aeb9959311227a7699dcb31068286c79
 
 Wallet address:
-	celestia1kaefh2tuh7syp8x0zy9a3wspnhyn50ruw63ynf
+	celestia160pdug04aedlqhfeue5vhjjke5zgmtyruzk6w7
 
 Wallet on explorer:
-	https://testnet.mintscan.io/celestia-incentivized-testnet/account/celestia1kaefh2tuh7syp8x0zy9a3wspnhyn50ruw63ynf
+	https://testnet.mintscan.io/celestia-incentivized-testnet/account/celestia160pdug04aedlqhfeue5vhjjke5zgmtyruzk6w7
 
 Account balance:
-	[{"denom":"utia","amount":"99997600"}]
+	[{"denom":"utia","amount":"4979900"}]
 
 Sent 0.0001 TIA to celestia1vsvx8n7f8dh5udesqqhgrjutyun7zqrgehdq2l:
-	https://testnet.mintscan.io/celestia-incentivized-testnet/txs/A89766D155C51E9F7C1B13DEDCB3E1E00D57F2950490184BC8477F0F081E9E92
+	https://explorer-arabica-9.celestia-arabica.com/arabica-9/tx/933236071C0AFEC756E09F4C2F14F52FAD56971FBD5E83D9E405B4A538D10E63
 ```

--- a/examples/with-cosmjs/package.json
+++ b/examples/with-cosmjs/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@cosmjs/encoding": "^0.31.0",
     "@cosmjs/stargate": "^0.31.0",
+    "@turnkey/api-key-stamper": "workspace:^",
     "@turnkey/cosmjs": "workspace:*",
     "@turnkey/http": "workspace:*",
     "dotenv": "^16.0.3"

--- a/examples/with-cosmjs/src/index.ts
+++ b/examples/with-cosmjs/src/index.ts
@@ -10,8 +10,8 @@ import { TurnkeyDirectWallet } from "@turnkey/cosmjs";
 import { createNewCosmosPrivateKey } from "./createNewCosmosPrivateKey";
 import { print, refineNonNull } from "./shared";
 
-// https://docs.celestia.org/nodes/blockspace-race/#rpc-endpoints
-const ENDPOINT = "https://rpc-celestia-testnet-blockspacerace.keplr.app";
+// https://docs.celestia.org/nodes/arabica-devnet/#rpc-endpoints
+const ENDPOINT = "https://rpc-arabica-9.consensus.celestia-arabica.com";
 
 async function main() {
   if (!process.env.PRIVATE_KEY_ID) {
@@ -70,7 +70,7 @@ async function main() {
     destinationAddress,
     [{ denom: "utia", amount: transactionAmount }],
     {
-      amount: [{ denom: "utia", amount: "500" }],
+      amount: [{ denom: "utia", amount: "20000" }],
       gas: "200000",
     },
     "Hello from Turnkey!"
@@ -80,7 +80,7 @@ async function main() {
     `Sent ${
       Number(transactionAmount) / 1_000_000
     } TIA to ${destinationAddress}:`,
-    `https://testnet.mintscan.io/celestia-incentivized-testnet/txs/${result.transactionHash}`
+    `https://explorer-arabica-9.celestia-arabica.com/arabica-9/tx/${result.transactionHash}`
   );
 
   signingClient.disconnect();

--- a/examples/with-ethers/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-ethers/src/createNewEthereumPrivateKey.ts
@@ -41,7 +41,6 @@ export async function createNewEthereumPrivateKey() {
     const privateKey = refineNonNull(
       completedActivity.result.createPrivateKeysResultV2?.privateKeys?.[0]
     );
-
     const privateKeyId = refineNonNull(privateKey.privateKeyId);
     const address = refineNonNull(privateKey.addresses?.[0]?.address);
 

--- a/examples/with-gnosis/package.json
+++ b/examples/with-gnosis/package.json
@@ -11,6 +11,7 @@
     "@safe-global/safe-core-sdk": "^3.3.2",
     "@safe-global/safe-core-sdk-types": "^1.9.0",
     "@safe-global/safe-ethers-lib": "^1.9.2",
+    "@turnkey/api-key-stamper": "workspace:^",
     "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "dotenv": "^16.0.3",

--- a/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
@@ -14,7 +14,7 @@ export async function createNewEthereumPrivateKey() {
   );
 
   console.log(
-    "`process.env.PRIVATE_KEY_ID` not found; creating a new Ethereum private key on Turnkey...\n"
+    "`process.env.PRIVATE_KEY_ID_{INDEX}` not found; creating a new Ethereum private key on Turnkey...\n"
   );
 
   const activityPoller = createActivityPoller({

--- a/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
@@ -1,54 +1,53 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import * as crypto from "crypto";
 
 export async function createNewEthereumPrivateKey() {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
-  console.log("Creating a new Ethereum private key on Turnkey...\n");
+  console.log(
+    "`process.env.PRIVATE_KEY_ID` not found; creating a new Ethereum private key on Turnkey...\n"
+  );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    request: TurnkeyApi.createPrivateKeys,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createPrivateKeys,
   });
 
   const privateKeyName = `ETH Key ${crypto.randomBytes(2).toString("hex")}`;
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          privateKeys: [
-            {
-              privateKeyName,
-              curve: "CURVE_SECP256K1",
-              addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
-              privateKeyTags: [],
-            },
-          ],
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        privateKeys: [
+          {
+            privateKeyName,
+            curve: "CURVE_SECP256K1",
+            addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
+            privateKeyTags: [],
+          },
+        ],
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const privateKeyId = refineNonNull(
-      activity.result.createPrivateKeysResult?.privateKeyIds?.[0]
+      activity.result.createPrivateKeysResultV2?.privateKeys?.[0]?.privateKeyId
     );
 
-    const keyInfo = await TurnkeyApi.getPrivateKey({
-      body: {
-        organizationId: process.env.ORGANIZATION_ID!,
-        privateKeyId,
-      },
+    const keyInfo = await turnkeyClient.getPrivateKey({
+      organizationId: process.env.ORGANIZATION_ID!,
+      privateKeyId,
     });
 
     const address = refineNonNull(keyInfo.privateKey.addresses[0]?.address);

--- a/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-gnosis/src/createNewEthereumPrivateKey.ts
@@ -41,16 +41,11 @@ export async function createNewEthereumPrivateKey() {
       timestampMs: String(Date.now()), // millisecond timestamp
     });
 
-    const privateKeyId = refineNonNull(
-      activity.result.createPrivateKeysResultV2?.privateKeys?.[0]?.privateKeyId
+    const privateKeys = refineNonNull(
+      activity.result.createPrivateKeysResultV2?.privateKeys
     );
-
-    const keyInfo = await turnkeyClient.getPrivateKey({
-      organizationId: process.env.ORGANIZATION_ID!,
-      privateKeyId,
-    });
-
-    const address = refineNonNull(keyInfo.privateKey.addresses[0]?.address);
+    const privateKeyId = refineNonNull(privateKeys?.[0]?.privateKeyId);
+    const address = refineNonNull(privateKeys?.[0]?.addresses?.[0]?.address);
 
     // Success!
     console.log(

--- a/examples/with-nonce-manager/package.json
+++ b/examples/with-nonce-manager/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@turnkey/api-key-stamper": "workspace:^",
     "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "dotenv": "^16.0.3",

--- a/examples/with-nonce-manager/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-nonce-manager/src/createNewEthereumPrivateKey.ts
@@ -41,16 +41,11 @@ export async function createNewEthereumPrivateKey() {
       timestampMs: String(Date.now()), // millisecond timestamp
     });
 
-    const privateKeyId = refineNonNull(
-      activity.result.createPrivateKeysResultV2?.privateKeys?.[0]?.privateKeyId
+    const privateKeys = refineNonNull(
+      activity.result.createPrivateKeysResultV2?.privateKeys
     );
-
-    const keyInfo = await turnkeyClient.getPrivateKey({
-      organizationId: process.env.ORGANIZATION_ID!,
-      privateKeyId,
-    });
-
-    const address = refineNonNull(keyInfo.privateKey.addresses[0]?.address);
+    const privateKeyId = refineNonNull(privateKeys?.[0]?.privateKeyId);
+    const address = refineNonNull(privateKeys?.[0]?.addresses?.[0]?.address);
 
     // Success!
     console.log(

--- a/examples/with-nonce-manager/src/createNewEthereumPrivateKey.ts
+++ b/examples/with-nonce-manager/src/createNewEthereumPrivateKey.ts
@@ -1,56 +1,53 @@
-import { TurnkeyApi, init as httpInit, withAsyncPolling } from "@turnkey/http";
+import { TurnkeyClient } from "@turnkey/http";
+import { createActivityPoller } from "@turnkey/http/dist/async";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import * as crypto from "crypto";
 
 export async function createNewEthereumPrivateKey() {
-  // Initialize `@turnkey/http` with your credentials
-  httpInit({
-    apiPublicKey: process.env.API_PUBLIC_KEY!,
-    apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    baseUrl: process.env.BASE_URL!,
-  });
+  const turnkeyClient = new TurnkeyClient(
+    { baseUrl: process.env.BASE_URL! },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
 
   console.log(
     "`process.env.PRIVATE_KEY_ID` not found; creating a new Ethereum private key on Turnkey...\n"
   );
 
-  // Use `withAsyncPolling` to handle async activity polling.
-  // In this example, it polls every 250ms until the activity reaches a terminal state.
-  const mutation = withAsyncPolling({
-    request: TurnkeyApi.createPrivateKeys,
-    refreshIntervalMs: 250, // defaults to 500ms
+  const activityPoller = createActivityPoller({
+    client: turnkeyClient,
+    requestFn: turnkeyClient.createPrivateKeys,
   });
 
   const privateKeyName = `ETH Key ${crypto.randomBytes(2).toString("hex")}`;
 
   try {
-    const activity = await mutation({
-      body: {
-        type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
-        organizationId: process.env.ORGANIZATION_ID!,
-        parameters: {
-          privateKeys: [
-            {
-              privateKeyName,
-              curve: "CURVE_SECP256K1",
-              addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
-              privateKeyTags: [],
-            },
-          ],
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+    const activity = await activityPoller({
+      type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+      organizationId: process.env.ORGANIZATION_ID!,
+      parameters: {
+        privateKeys: [
+          {
+            privateKeyName,
+            curve: "CURVE_SECP256K1",
+            addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
+            privateKeyTags: [],
+          },
+        ],
       },
+      timestampMs: String(Date.now()), // millisecond timestamp
     });
 
     const privateKeyId = refineNonNull(
-      activity.result.createPrivateKeysResult?.privateKeyIds?.[0]
+      activity.result.createPrivateKeysResultV2?.privateKeys?.[0]?.privateKeyId
     );
 
-    const keyInfo = await TurnkeyApi.getPrivateKey({
-      body: {
-        organizationId: process.env.ORGANIZATION_ID!,
-        privateKeyId,
-      },
+    const keyInfo = await turnkeyClient.getPrivateKey({
+      organizationId: process.env.ORGANIZATION_ID!,
+      privateKeyId,
     });
 
     const address = refineNonNull(keyInfo.privateKey.addresses[0]?.address);

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -69,7 +69,9 @@ try {
   });
 
   // Success!
-  console.log(activity.result.createPrivateKeysResult?.privateKeyIds?.[0]);
+  console.log(
+    activity.result.createPrivateKeysResultV2?.privateKeys?.[0]?.privateKeyId
+  );
 } catch (error) {
   if (error instanceof TurnkeyActivityError) {
     // In case the activity is rejected, failed, or requires consensus,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
 
   examples/deployer:
     dependencies:
+      '@turnkey/api-key-stamper':
+        specifier: workspace:^
+        version: link:../../packages/api-key-stamper
       '@turnkey/ethers':
         specifier: workspace:*
         version: link:../../packages/ethers
@@ -62,6 +65,9 @@ importers:
 
   examples/rebalancer:
     dependencies:
+      '@turnkey/api-key-stamper':
+        specifier: workspace:^
+        version: link:../../packages/api-key-stamper
       '@turnkey/ethers':
         specifier: workspace:*
         version: link:../../packages/ethers
@@ -105,6 +111,9 @@ importers:
 
   examples/trading-runner:
     dependencies:
+      '@turnkey/api-key-stamper':
+        specifier: workspace:^
+        version: link:../../packages/api-key-stamper
       '@turnkey/ethers':
         specifier: workspace:*
         version: link:../../packages/ethers
@@ -145,6 +154,9 @@ importers:
       '@cosmjs/stargate':
         specifier: ^0.31.0
         version: 0.31.0
+      '@turnkey/api-key-stamper':
+        specifier: workspace:^
+        version: link:../../packages/api-key-stamper
       '@turnkey/cosmjs':
         specifier: workspace:*
         version: link:../../packages/cosmjs
@@ -241,6 +253,9 @@ importers:
       '@safe-global/safe-ethers-lib':
         specifier: ^1.9.2
         version: 1.9.2
+      '@turnkey/api-key-stamper':
+        specifier: workspace:^
+        version: link:../../packages/api-key-stamper
       '@turnkey/ethers':
         specifier: workspace:*
         version: link:../../packages/ethers
@@ -256,6 +271,9 @@ importers:
 
   examples/with-nonce-manager:
     dependencies:
+      '@turnkey/api-key-stamper':
+        specifier: workspace:^
+        version: link:../../packages/api-key-stamper
       '@turnkey/ethers':
         specifier: workspace:*
         version: link:../../packages/ethers


### PR DESCRIPTION
## Summary & Motivation
Counterpart for https://github.com/tkhq/sdk/pull/105.
- $title, for the following:
  - deployer
  - rebalancer
  - sweeper
  - trading-runner
  - with-cosmjs
  - with-gnosis
  - with-nonce-manager
- Fixes some misc typos
- Fix wrapping/unwrapping behavior in `trading-runner`
- Updates `withcosmjs` to use current Celestia testnet + RPC

## How I Tested These Changes
Ran each locally!