### PR TITLE
federated/viem passkey: Add login button leveraging updated Whoami endpoint

### DIFF
--- a/examples/with-federated-passkeys/.env.local.example
+++ b/examples/with-federated-passkeys/.env.local.example
@@ -1,4 +1,4 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-ORGANIZATION_ID="<Turnkey organization ID>"
+NEXT_PUBLIC_ORGANIZATION_ID="<Turnkey organization ID>"
 NEXT_PUBLIC_BASE_URL="https://api.turnkey.com"

--- a/examples/with-federated-passkeys/src/pages/api/subOrg.ts
+++ b/examples/with-federated-passkeys/src/pages/api/subOrg.ts
@@ -45,7 +45,7 @@ export default async function createUser(
     const createSubOrgActivity = await activityPoller({
       type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V2",
       timestampMs: String(Date.now()),
-      organizationId: process.env.ORGANIZATION_ID!,
+      organizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
       parameters: {
         subOrganizationName: createSubOrgRequest.subOrgName,
         rootQuorumThreshold: 1,

--- a/examples/with-viem-and-passkeys/.env.local.example
+++ b/examples/with-viem-and-passkeys/.env.local.example
@@ -1,6 +1,4 @@
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
-
+NEXT_PUBLIC_ORGANIZATION_ID="<Turnkey organization ID>"
 NEXT_PUBLIC_TURNKEY_API_BASE_URL=https://api.turnkey.com
-
-ORGANIZATION_ID="<Turnkey organization ID>"

--- a/examples/with-viem-and-passkeys/src/pages/api/subOrg.ts
+++ b/examples/with-viem-and-passkeys/src/pages/api/subOrg.ts
@@ -42,7 +42,7 @@ export default async function createUser(
     const completedActivity = await activityPoller({
       type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V2",
       timestampMs: String(Date.now()),
-      organizationId: process.env.ORGANIZATION_ID!,
+      organizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
       parameters: {
         subOrganizationName: createSubOrgRequest.subOrgName,
         rootQuorumThreshold: 1,

--- a/examples/with-viem-and-passkeys/src/pages/index.tsx
+++ b/examples/with-viem-and-passkeys/src/pages/index.tsx
@@ -58,6 +58,8 @@ export default function Home() {
   const { register: signingFormRegister, handleSubmit: signingFormSubmit } =
     useForm<signingFormData>();
   const { handleSubmit: privateKeyFormSubmit } = useForm<privateKeyFormData>();
+  const { register: _loginFormRegister, handleSubmit: loginFormSubmit } =
+    useForm();
 
   const stamper = new WebauthnStamper({
     rpId: "localhost",
@@ -164,6 +166,17 @@ export default function Home() {
     setSubOrgId(res.data.subOrgId);
   };
 
+    const login = async () => {
+    // We use the parent org ID, which we know at all times,
+    const res = await passkeyHttpClient.getWhoami({
+      organizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
+    });
+    // to get the sub-org ID, which we don't know at this point because we don't
+    // have a DB. Note that we are able to perform this lookup by using the
+    // credential ID from the users WebAuthn stamp.
+    setSubOrgId(res.organizationId);
+  };
+
   return (
     <main className={styles.main}>
       <a href="https://turnkey.com" target="_blank" rel="noopener noreferrer">
@@ -237,6 +250,27 @@ export default function Home() {
               className={styles.button}
               type="submit"
               value="Create new passkey & sub-org"
+            />
+          </form>
+          <br />
+          <br />
+          <h2>Already created a sub-organization? Log back in</h2>
+          <p className={styles.explainer}>
+            Based on the parent organization ID and a stamp from your passkey used
+            to created the sub-organization, we can look up your
+            sug-organization using the
+            <a href="https://docs.turnkey.com/api#tag/Who-am-I" target="_blank" rel="noopener noreferrer">
+              Whoami endpoint.
+            </a>
+          </p>
+          <form
+            className={styles.form}
+            onSubmit={loginFormSubmit(login)}
+          >
+            <input
+              className={styles.button}
+              type="submit"
+              value="Login to sub-org with existing passkey"
             />
           </form>
         </div>

--- a/examples/with-viem-and-passkeys/src/pages/index.tsx
+++ b/examples/with-viem-and-passkeys/src/pages/index.tsx
@@ -166,7 +166,7 @@ export default function Home() {
     setSubOrgId(res.data.subOrgId);
   };
 
-    const login = async () => {
+  const login = async () => {
     // We use the parent org ID, which we know at all times,
     const res = await passkeyHttpClient.getWhoami({
       organizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
@@ -256,17 +256,18 @@ export default function Home() {
           <br />
           <h2>Already created a sub-organization? Log back in</h2>
           <p className={styles.explainer}>
-            Based on the parent organization ID and a stamp from your passkey used
-            to created the sub-organization, we can look up your
+            Based on the parent organization ID and a stamp from your passkey
+            used to created the sub-organization, we can look up your
             sug-organization using the
-            <a href="https://docs.turnkey.com/api#tag/Who-am-I" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://docs.turnkey.com/api#tag/Who-am-I"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Whoami endpoint.
             </a>
           </p>
-          <form
-            className={styles.form}
-            onSubmit={loginFormSubmit(login)}
-          >
+          <form className={styles.form} onSubmit={loginFormSubmit(login)}>
             <input
               className={styles.button}
               type="submit"


### PR DESCRIPTION
## Summary & Motivation

This updates the federated passkey example to include a login button. Despite the example being stateless, we login by using the updated `whoami` endpoint which now allows lookups for sub-orgs using the parent-org ID + WebAuthN stamp.

## How I Tested These Changes

I developed this against staging. Note the `whoami` endpoint updates have not been deployed to production yet so we should wait until that happens.