### PR TITLE
update viem signing

### DIFF
--- a/examples/with-viem/package.json
+++ b/examples/with-viem/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "pnpm -w run build-all && tsx src/index.ts",
+    "start-advanced": "pnpm -w run build-all && tsx src/advanced.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/with-viem/src/advanced.ts
+++ b/examples/with-viem/src/advanced.ts
@@ -1,0 +1,128 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+import { createAccount } from "@turnkey/viem";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import {
+  createWalletClient,
+  http,
+  recoverMessageAddress,
+  recoverTypedDataAddress,
+  stringToHex,
+  hexToBytes,
+  type Account,
+} from "viem";
+import { sepolia } from "viem/chains";
+import { print, assertEqual } from "./util";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    })
+  );
+
+  const turnkeyAccount = await createAccount({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    privateKeyId: process.env.PRIVATE_KEY_ID!,
+  });
+
+  const client = createWalletClient({
+    account: turnkeyAccount as Account,
+    chain: sepolia,
+    transport: http(
+      `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY!}`
+    ),
+  });
+
+  const address = client.account.address;
+  const baseMessage = "Hello Turnkey";
+
+  // 1. Sign a raw hex message
+  const hexMessage = { raw: stringToHex(baseMessage) };
+  let signature = await client.signMessage({
+    message: hexMessage,
+  });
+  let recoveredAddress = await recoverMessageAddress({
+    message: hexMessage,
+    signature,
+  });
+
+  print("Turnkey-powered signature - raw hex message:", `${signature}`);
+  assertEqual(address, recoveredAddress);
+
+  // 2. Sign a raw bytes message
+  const bytesMessage = { raw: hexToBytes(stringToHex(baseMessage)) };
+  signature = await client.signMessage({
+    message: bytesMessage,
+  });
+  recoveredAddress = await recoverMessageAddress({
+    message: bytesMessage,
+    signature,
+  });
+
+  print("Turnkey-powered signature - raw bytes message:", `${signature}`);
+  assertEqual(address, recoveredAddress);
+
+  // 3. Sign typed data (EIP-712)
+  const domain = {
+    name: "Ether Mail",
+    version: "1",
+    chainId: 1,
+    verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+  } as const;
+
+  // The named list of all type definitions
+  const types = {
+    Person: [
+      { name: "name", type: "string" },
+      { name: "wallet", type: "address" },
+    ],
+    Mail: [
+      { name: "from", type: "Person" },
+      { name: "to", type: "Person" },
+      { name: "contents", type: "string" },
+    ],
+  } as const;
+
+  const typedData = {
+    account: turnkeyAccount,
+    domain,
+    types,
+    primaryType: "Mail",
+    message: {
+      from: {
+        name: "Cow",
+        wallet: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+      },
+      to: {
+        name: "Bob",
+        wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+      },
+      contents: "Hello, Bob!",
+    },
+  } as const;
+
+  signature = await client.signTypedData(typedData);
+  recoveredAddress = await recoverTypedDataAddress({
+    ...typedData,
+    signature,
+  });
+
+  print("Turnkey-powered signature - typed data:", `${signature}`);
+  assertEqual(address, recoveredAddress);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-viem/src/util.ts
+++ b/examples/with-viem/src/util.ts
@@ -1,0 +1,9 @@
+export function print(header: string, body: string): void {
+  console.log(`${header}\n\t${body}\n`);
+}
+
+export function assertEqual<T>(left: T, right: T) {
+  if (left !== right) {
+    throw new Error(`${JSON.stringify(left)} !== ${JSON.stringify(right)}`);
+  }
+}

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/viem
 
+## 0.2.4
+
+### Patch Changes
+
+- 0ec2d94: Addresses a bug when signing raw messages (see https://github.com/tkhq/sdk/issues/116)
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary & Motivation
Address https://github.com/tkhq/sdk/issues/116 🛠️👷 

Note: setting up the e2e tests viem will be pulled into a separate PR.

Note/interesting observation:

```node
 const recoveredAddress = await recoverMessageAddress({
    message,
    signature: signMessageSignature,
});
```

When running in the context of a (Go) test harness, this would result in segfaults. Wild! The same was happening for `verifyMessage`, until it was prepended with the wallet client (i.e. `walletClient.verifyMessage({})`). Guessing there's some internals stuff going on with regards to having a (connected) client?

## How I Tested These Changes
ran the scripts!

## Helpful discussions
https://github.com/wagmi-dev/wagmi/discussions/2340
