### PR TITLE
Update federated passkey demo

### DIFF
--- a/examples/with-federated-passkeys/src/pages/index.tsx
+++ b/examples/with-federated-passkeys/src/pages/index.tsx
@@ -113,7 +113,7 @@ export default function Home() {
     // https://www.w3.org/TR/webauthn-2/#sctn-sample-registration
     const attestation = await getWebAuthnAttestation({
       publicKey: {
-         authenticatorSelection: {
+        authenticatorSelection: {
           residentKey: "preferred",
           requireResidentKey: false,
           userVerification: "preferred",

--- a/examples/with-federated-passkeys/src/pages/index.tsx
+++ b/examples/with-federated-passkeys/src/pages/index.tsx
@@ -21,8 +21,9 @@ type privateKeyResult = {
 };
 
 // All algorithms can be found here: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
-// We only support ES256, which is listed here
+// We only support ES256 and RS256, which are listed here
 const es256 = -7;
+const rs256 = -257;
 
 // This constant designates the type of credential we want to create.
 // The enum only supports one value, "public-key"
@@ -112,6 +113,11 @@ export default function Home() {
     // https://www.w3.org/TR/webauthn-2/#sctn-sample-registration
     const attestation = await getWebAuthnAttestation({
       publicKey: {
+         authenticatorSelection: {
+          residentKey: "preferred",
+          requireResidentKey: false,
+          userVerification: "preferred"
+        },
         rp: {
           id: "localhost",
           name: "Turnkey Federated Passkey Demo",
@@ -122,6 +128,10 @@ export default function Home() {
             type: publicKey,
             alg: es256,
           },
+          {
+            type: publicKey,
+            alg: rs256,
+          }
         ],
         user: {
           id: authenticatorUserId,

--- a/examples/with-federated-passkeys/src/pages/index.tsx
+++ b/examples/with-federated-passkeys/src/pages/index.tsx
@@ -116,7 +116,7 @@ export default function Home() {
          authenticatorSelection: {
           residentKey: "preferred",
           requireResidentKey: false,
-          userVerification: "preferred"
+          userVerification: "preferred",
         },
         rp: {
           id: "localhost",

--- a/examples/with-federated-passkeys/src/pages/index.tsx
+++ b/examples/with-federated-passkeys/src/pages/index.tsx
@@ -131,7 +131,7 @@ export default function Home() {
           {
             type: publicKey,
             alg: rs256,
-          }
+          },
         ],
         user: {
           id: authenticatorUserId,


### PR DESCRIPTION
## Summary & Motivation
Added an additional algorithm that is now supported, and added new authenticatorSelection parameters to support android based passkeys that do not support discoverable credentials 

## How I Tested These Changes
Discussed with Max and tested locally that I am able to create and use a passkey with an android phone