### PR TITLE
release v2023.10.2

### DIFF
--- a/.changeset/long-falcons-peel.md
+++ b/.changeset/long-falcons-peel.md
@@ -1,5 +1,0 @@
----
-"@turnkey/viem": patch
----
-
-Unpin typescript

--- a/.changeset/rude-turtles-refuse.md
+++ b/.changeset/rude-turtles-refuse.md
@@ -1,5 +1,0 @@
----
-"@turnkey/viem": patch
----
-
-Bump Viem dependency to fix `getAddresses()` for LocalAccount

--- a/examples/with-federated-passkeys/src/pages/api/createSubOrg.ts
+++ b/examples/with-federated-passkeys/src/pages/api/createSubOrg.ts
@@ -44,10 +44,10 @@ export default async function createUser(
   });
 
   try {
-    const privateKeyName = `Default ETH Key`;
+    const walletName = `Default Wallet`;
 
     const completedActivity = await activityPoller({
-      type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V3",
+      type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V4",
       timestampMs: String(Date.now()),
       organizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
       parameters: {
@@ -66,14 +66,17 @@ export default async function createUser(
             ],
           },
         ],
-        privateKeys: [
-          {
-            privateKeyName,
-            curve: "CURVE_SECP256K1",
-            addressFormats: ["ADDRESS_FORMAT_ETHEREUM"],
-            privateKeyTags: [],
-          },
-        ],
+        wallet: {
+          walletName,
+          accounts: [
+            {
+              curve: "CURVE_SECP256K1",
+              pathFormat: "PATH_FORMAT_BIP32",
+              path: "m/44'/60'/0'/0/0",
+              addressFormat: "ADDRESS_FORMAT_ETHEREUM",
+            },
+          ],
+        },
       },
     });
 

--- a/examples/with-solana/src/createSolanaTransfer.ts
+++ b/examples/with-solana/src/createSolanaTransfer.ts
@@ -46,11 +46,11 @@ export async function createAndSignTransfer(input: {
   const messageToSign = transferTransaction.serializeMessage();
 
   const activity = await client.signRawPayload({
-    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD",
+    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
     organizationId: turnkeyOrganizationId,
     timestampMs: String(Date.now()),
     parameters: {
-      privateKeyId: turnkeyPrivateKeyId,
+      signWith: turnkeyPrivateKeyId,
       payload: messageToSign.toString("hex"),
       encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
       // Note: unlike ECDSA, EdDSA's API does not support signing raw digests (see RFC 8032).

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/cosmjs
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @turnkey/http@1.4.0
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/cosmjs/src/index.ts
+++ b/packages/cosmjs/src/index.ts
@@ -141,11 +141,11 @@ export class TurnkeyDirectWallet implements OfflineDirectSigner {
   ): Promise<ExtendedSecp256k1Signature> {
     const { activity } = await TurnkeyApi.signRawPayload({
       body: {
-        type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD",
+        type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
         organizationId: this.organizationId,
         timestampMs: String(Date.now()),
         parameters: {
-          privateKeyId: this.privateKeyId,
+          signWith: this.privateKeyId,
           payload: toHex(message),
           encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
           hashFunction: "HASH_FUNCTION_SHA256",

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/ethers
 
+## 0.17.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @turnkey/http@1.4.0
+
 ## 0.17.2
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -72,10 +72,10 @@ export class TurnkeySigner extends ethers.Signer implements TypedDataSigner {
 
   private async _signTransactionImpl(message: string): Promise<string> {
     const { activity } = await this.client.signTransaction({
-      type: "ACTIVITY_TYPE_SIGN_TRANSACTION",
+      type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
       organizationId: this.organizationId,
       parameters: {
-        privateKeyId: this.privateKeyId,
+        signWith: this.privateKeyId,
         type: "TRANSACTION_TYPE_ETHEREUM",
         unsignedTransaction: message,
       },
@@ -181,10 +181,10 @@ export class TurnkeySigner extends ethers.Signer implements TypedDataSigner {
 
   async _signMessageImpl(message: string): Promise<string> {
     const { activity } = await this.client.signRawPayload({
-      type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD",
+      type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
       organizationId: this.organizationId,
       parameters: {
-        privateKeyId: this.privateKeyId,
+        signWith: this.privateKeyId,
         payload: message,
         encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
         hashFunction: "HASH_FUNCTION_NO_OP",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/http
 
+## 1.4.0
+
+### Minor Changes
+
+- Synced protos from mono
+- Consolidated signing routes:
+  - We now have a single route, `/api/v1/submit/sign_raw_payload` for `SignRawPayload` activities (previously this was split into `SignRawPayload` and `SignRawPayloadV2`)
+  - This extends to `/api/v1/submit/sign_transaction` as well. `SignTransaction` and `SignTransactionV2` now have a unified activity: `SignTransaction`
+  - Under the hood, these routes stay largely the same: you can sign raw payloads and transactions with an address (from a wallet account), or a private key ID
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -145,16 +145,8 @@ import type {
   TSignRawPayloadResponse,
 } from "./public_api.fetcher";
 import type {
-  TSignRawPayloadV2Body,
-  TSignRawPayloadV2Response,
-} from "./public_api.fetcher";
-import type {
   TSignTransactionBody,
   TSignTransactionResponse,
-} from "./public_api.fetcher";
-import type {
-  TSignTransactionV2Body,
-  TSignTransactionV2Response,
 } from "./public_api.fetcher";
 import type {
   TUpdateAllowedOriginsBody,
@@ -1370,38 +1362,6 @@ export class TurnkeyClient {
   };
 
   /**
-   * Sign a raw payload with a Private Key id or address
-   *
-   * Sign the provided `TSignRawPayloadV2Body` with the client's `stamp` function, and submit the request (POST /public/v1/submit/sign_raw_payload_v2).
-   *
-   * See also {@link stampSignRawPayloadV2}.
-   */
-  signRawPayloadV2 = async (
-    input: TSignRawPayloadV2Body
-  ): Promise<TSignRawPayloadV2Response> => {
-    return this.request("/public/v1/submit/sign_raw_payload_v2", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TSignRawPayloadV2Body` by using the client's `stamp` function.
-   *
-   * See also {@link SignRawPayloadV2}.
-   */
-  stampSignRawPayloadV2 = async (
-    input: TSignRawPayloadV2Body
-  ): Promise<TSignedRequest> => {
-    const fullUrl =
-      this.config.baseUrl + "/public/v1/submit/sign_raw_payload_v2";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
    * Sign a transaction with a Private Key
    *
    * Sign the provided `TSignTransactionBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/sign_transaction).
@@ -1423,38 +1383,6 @@ export class TurnkeyClient {
     input: TSignTransactionBody
   ): Promise<TSignedRequest> => {
     const fullUrl = this.config.baseUrl + "/public/v1/submit/sign_transaction";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
-   * Sign a transaction with a Private Key id or address
-   *
-   * Sign the provided `TSignTransactionV2Body` with the client's `stamp` function, and submit the request (POST /public/v1/submit/sign_transaction_v2).
-   *
-   * See also {@link stampSignTransactionV2}.
-   */
-  signTransactionV2 = async (
-    input: TSignTransactionV2Body
-  ): Promise<TSignTransactionV2Response> => {
-    return this.request("/public/v1/submit/sign_transaction_v2", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TSignTransactionV2Body` by using the client's `stamp` function.
-   *
-   * See also {@link SignTransactionV2}.
-   */
-  stampSignTransactionV2 = async (
-    input: TSignTransactionV2Body
-  ): Promise<TSignedRequest> => {
-    const fullUrl =
-      this.config.baseUrl + "/public/v1/submit/sign_transaction_v2";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -1806,58 +1806,6 @@ export const signSignRawPayload = (
   });
 
 /**
- * `POST /public/v1/submit/sign_raw_payload_v2`
- */
-export type TSignRawPayloadV2Response =
-  operations["PublicApiService_SignRawPayloadV2"]["responses"]["200"]["schema"];
-
-/**
- * `POST /public/v1/submit/sign_raw_payload_v2`
- */
-export type TSignRawPayloadV2Input = { body: TSignRawPayloadV2Body };
-
-/**
- * `POST /public/v1/submit/sign_raw_payload_v2`
- */
-export type TSignRawPayloadV2Body =
-  operations["PublicApiService_SignRawPayloadV2"]["parameters"]["body"]["body"];
-
-/**
- * Sign Raw Payload
- *
- * Sign a raw payload with a Private Key id or address
- *
- * `POST /public/v1/submit/sign_raw_payload_v2`
- */
-export const signRawPayloadV2 = (input: TSignRawPayloadV2Input) =>
-  request<
-    TSignRawPayloadV2Response,
-    TSignRawPayloadV2Body,
-    never,
-    never,
-    never
-  >({
-    uri: "/public/v1/submit/sign_raw_payload_v2",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `SignRawPayloadV2` request, ready to be POSTed to Turnkey.
- *
- * See {@link SignRawPayloadV2}
- */
-export const signSignRawPayloadV2 = (
-  input: TSignRawPayloadV2Input,
-  options?: TurnkeyCredentialRequestOptions
-) =>
-  signedRequest<TSignRawPayloadV2Body, never, never>({
-    uri: "/public/v1/submit/sign_raw_payload_v2",
-    body: input.body,
-    options,
-  });
-
-/**
  * `POST /public/v1/submit/sign_transaction`
  */
 export type TSignTransactionResponse =
@@ -1899,58 +1847,6 @@ export const signSignTransaction = (
 ) =>
   signedRequest<TSignTransactionBody, never, never>({
     uri: "/public/v1/submit/sign_transaction",
-    body: input.body,
-    options,
-  });
-
-/**
- * `POST /public/v1/submit/sign_transaction_v2`
- */
-export type TSignTransactionV2Response =
-  operations["PublicApiService_SignTransactionV2"]["responses"]["200"]["schema"];
-
-/**
- * `POST /public/v1/submit/sign_transaction_v2`
- */
-export type TSignTransactionV2Input = { body: TSignTransactionV2Body };
-
-/**
- * `POST /public/v1/submit/sign_transaction_v2`
- */
-export type TSignTransactionV2Body =
-  operations["PublicApiService_SignTransactionV2"]["parameters"]["body"]["body"];
-
-/**
- * Sign Transaction
- *
- * Sign a transaction with a Private Key id or address
- *
- * `POST /public/v1/submit/sign_transaction_v2`
- */
-export const signTransactionV2 = (input: TSignTransactionV2Input) =>
-  request<
-    TSignTransactionV2Response,
-    TSignTransactionV2Body,
-    never,
-    never,
-    never
-  >({
-    uri: "/public/v1/submit/sign_transaction_v2",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `SignTransactionV2` request, ready to be POSTed to Turnkey.
- *
- * See {@link SignTransactionV2}
- */
-export const signSignTransactionV2 = (
-  input: TSignTransactionV2Input,
-  options?: TurnkeyCredentialRequestOptions
-) =>
-  signedRequest<TSignTransactionV2Body, never, never>({
-    uri: "/public/v1/submit/sign_transaction_v2",
     body: input.body,
     options,
   });

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -1244,38 +1244,6 @@
         "tags": ["Private Keys"]
       }
     },
-    "/public/v1/submit/sign_raw_payload_v2": {
-      "post": {
-        "summary": "Sign Raw Payload",
-        "description": "Sign a raw payload with a Private Key id or address",
-        "operationId": "PublicApiService_SignRawPayloadV2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ActivityResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1SignRawPayloadV2Request"
-            }
-          }
-        ],
-        "tags": ["PublicApiService"]
-      }
-    },
     "/public/v1/submit/sign_transaction": {
       "post": {
         "summary": "Sign Transaction",
@@ -1306,38 +1274,6 @@
           }
         ],
         "tags": ["Private Keys"]
-      }
-    },
-    "/public/v1/submit/sign_transaction_v2": {
-      "post": {
-        "summary": "Sign Transaction",
-        "description": "Sign a transaction with a Private Key id or address",
-        "operationId": "PublicApiService_SignTransactionV2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ActivityResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1SignTransactionV2Request"
-            }
-          }
-        ],
-        "tags": ["PublicApiService"]
       }
     },
     "/public/v1/submit/update_allowed_origins": {
@@ -2034,7 +1970,8 @@
         "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
         "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
         "ACTIVITY_TYPE_EXPORT_PRIVATE_KEY",
-        "ACTIVITY_TYPE_EXPORT_WALLET"
+        "ACTIVITY_TYPE_EXPORT_WALLET",
+        "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V4"
       ]
     },
     "v1ApiKey": {
@@ -2872,6 +2809,37 @@
         "privateKeys"
       ]
     },
+    "v1CreateSubOrganizationIntentV4": {
+      "type": "object",
+      "properties": {
+        "subOrganizationName": {
+          "type": "string",
+          "description": "Name for this sub-organization"
+        },
+        "rootUsers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RootUserParams"
+          },
+          "description": "Root users to create within this sub-organization"
+        },
+        "rootQuorumThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The threshold of unique approvals to reach root quorum. This value must be less than or equal to the number of root users"
+        },
+        "wallet": {
+          "$ref": "#/definitions/v1WalletParams",
+          "description": "The wallet to create for the sub-organization"
+        },
+        "disableEmailRecovery": {
+          "type": "boolean",
+          "description": "Disable email recovery for the sub-organization"
+        }
+      },
+      "required": ["subOrganizationName", "rootUsers", "rootQuorumThreshold"]
+    },
     "v1CreateSubOrganizationRequest": {
       "type": "object",
       "properties": {
@@ -2888,7 +2856,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1CreateSubOrganizationIntentV3"
+          "$ref": "#/definitions/v1CreateSubOrganizationIntentV4"
         }
       },
       "required": ["type", "timestampMs", "organizationId", "parameters"]
@@ -2918,6 +2886,18 @@
         }
       },
       "required": ["subOrganizationId", "privateKeys"]
+    },
+    "v1CreateSubOrganizationResultV4": {
+      "type": "object",
+      "properties": {
+        "subOrganizationId": {
+          "type": "string"
+        },
+        "wallet": {
+          "$ref": "#/definitions/v1WalletResult"
+        }
+      },
+      "required": ["subOrganizationId"]
     },
     "v1CreateUserTagIntent": {
       "type": "object",
@@ -4119,6 +4099,9 @@
         },
         "exportWalletIntent": {
           "$ref": "#/definitions/v1ExportWalletIntent"
+        },
+        "createSubOrganizationIntentV4": {
+          "$ref": "#/definitions/v1CreateSubOrganizationIntentV4"
         }
       },
       "required": ["createOrganizationIntent"]
@@ -4777,6 +4760,9 @@
         },
         "exportWalletResult": {
           "$ref": "#/definitions/v1ExportWalletResult"
+        },
+        "createSubOrganizationResultV4": {
+          "$ref": "#/definitions/v1CreateSubOrganizationResultV4"
         }
       }
     },
@@ -4998,7 +4984,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_SIGN_RAW_PAYLOAD"]
+          "enum": ["ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -5009,7 +4995,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1SignRawPayloadIntent"
+          "$ref": "#/definitions/v1SignRawPayloadIntentV2"
         }
       },
       "required": ["type", "timestampMs", "organizationId", "parameters"]
@@ -5031,27 +5017,6 @@
         }
       },
       "required": ["r", "s", "v"]
-    },
-    "v1SignRawPayloadV2Request": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2"]
-        },
-        "timestampMs": {
-          "type": "string",
-          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
-        },
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given Organization."
-        },
-        "parameters": {
-          "$ref": "#/definitions/v1SignRawPayloadIntentV2"
-        }
-      },
-      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1SignTransactionIntent": {
       "type": "object",
@@ -5092,36 +5057,6 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_SIGN_TRANSACTION"]
-        },
-        "timestampMs": {
-          "type": "string",
-          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
-        },
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given Organization."
-        },
-        "parameters": {
-          "$ref": "#/definitions/v1SignTransactionIntent"
-        }
-      },
-      "required": ["type", "timestampMs", "organizationId", "parameters"]
-    },
-    "v1SignTransactionResult": {
-      "type": "object",
-      "properties": {
-        "signedTransaction": {
-          "type": "string"
-        }
-      },
-      "required": ["signedTransaction"]
-    },
-    "v1SignTransactionV2Request": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
           "enum": ["ACTIVITY_TYPE_SIGN_TRANSACTION_V2"]
         },
         "timestampMs": {
@@ -5137,6 +5072,15 @@
         }
       },
       "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1SignTransactionResult": {
+      "type": "object",
+      "properties": {
+        "signedTransaction": {
+          "type": "string"
+        }
+      },
+      "required": ["signedTransaction"]
     },
     "v1SimpleClientExtensionResults": {
       "type": "object",
@@ -5735,6 +5679,40 @@
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]
+    },
+    "v1WalletParams": {
+      "type": "object",
+      "properties": {
+        "walletName": {
+          "type": "string",
+          "description": "Human-readable name for a Wallet."
+        },
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1WalletAccountParams"
+          },
+          "description": "A list of wallet Accounts."
+        }
+      },
+      "required": ["walletName", "accounts"]
+    },
+    "v1WalletResult": {
+      "type": "object",
+      "properties": {
+        "walletId": {
+          "type": "string"
+        },
+        "addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of account addresses."
+        }
+      },
+      "required": ["walletId", "addresses"]
     },
     "v1WebAuthnStamp": {
       "type": "object",

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -152,17 +152,9 @@ export type paths = {
     /** Sign a raw payload with a Private Key */
     post: operations["PublicApiService_SignRawPayload"];
   };
-  "/public/v1/submit/sign_raw_payload_v2": {
-    /** Sign a raw payload with a Private Key id or address */
-    post: operations["PublicApiService_SignRawPayloadV2"];
-  };
   "/public/v1/submit/sign_transaction": {
     /** Sign a transaction with a Private Key */
     post: operations["PublicApiService_SignTransaction"];
-  };
-  "/public/v1/submit/sign_transaction_v2": {
-    /** Sign a transaction with a Private Key id or address */
-    post: operations["PublicApiService_SignTransactionV2"];
   };
   "/public/v1/submit/update_allowed_origins": {
     /** Update the allowable origins for credentials and requests */
@@ -455,7 +447,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2"
     | "ACTIVITY_TYPE_SIGN_TRANSACTION_V2"
     | "ACTIVITY_TYPE_EXPORT_PRIVATE_KEY"
-    | "ACTIVITY_TYPE_EXPORT_WALLET";
+    | "ACTIVITY_TYPE_EXPORT_WALLET"
+    | "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V4";
   v1ApiKey: {
     /** @description A User credential that can be used to authenticate to Turnkey. */
     credential: definitions["externaldatav1Credential"];
@@ -768,6 +761,21 @@ export type definitions = {
     /** @description A list of Private Keys. */
     privateKeys: definitions["v1PrivateKeyParams"][];
   };
+  v1CreateSubOrganizationIntentV4: {
+    /** @description Name for this sub-organization */
+    subOrganizationName: string;
+    /** @description Root users to create within this sub-organization */
+    rootUsers: definitions["v1RootUserParams"][];
+    /**
+     * Format: int32
+     * @description The threshold of unique approvals to reach root quorum. This value must be less than or equal to the number of root users
+     */
+    rootQuorumThreshold: number;
+    /** @description The wallet to create for the sub-organization */
+    wallet?: definitions["v1WalletParams"];
+    /** @description Disable email recovery for the sub-organization */
+    disableEmailRecovery?: boolean;
+  };
   v1CreateSubOrganizationRequest: {
     /** @enum {string} */
     type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V3";
@@ -775,7 +783,7 @@ export type definitions = {
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1CreateSubOrganizationIntentV3"];
+    parameters: definitions["v1CreateSubOrganizationIntentV4"];
   };
   v1CreateSubOrganizationResult: {
     subOrganizationId: string;
@@ -784,6 +792,10 @@ export type definitions = {
     subOrganizationId: string;
     /** @description A list of Private Key IDs and addresses. */
     privateKeys: definitions["v1PrivateKeyResult"][];
+  };
+  v1CreateSubOrganizationResultV4: {
+    subOrganizationId: string;
+    wallet?: definitions["v1WalletResult"];
   };
   v1CreateUserTagIntent: {
     /** @description Human-readable name for a User Tag. */
@@ -1234,6 +1246,7 @@ export type definitions = {
     signTransactionIntentV2?: definitions["v1SignTransactionIntentV2"];
     exportPrivateKeyIntent?: definitions["v1ExportPrivateKeyIntent"];
     exportWalletIntent?: definitions["v1ExportWalletIntent"];
+    createSubOrganizationIntentV4?: definitions["v1CreateSubOrganizationIntentV4"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -1460,6 +1473,7 @@ export type definitions = {
     removeOrganizationFeatureResult?: definitions["v1RemoveOrganizationFeatureResult"];
     exportPrivateKeyResult?: definitions["v1ExportPrivateKeyResult"];
     exportWalletResult?: definitions["v1ExportWalletResult"];
+    createSubOrganizationResultV4?: definitions["v1CreateSubOrganizationResultV4"];
   };
   v1RootUserParams: {
     /** @description Human-readable name for a User. */
@@ -1547,12 +1561,12 @@ export type definitions = {
   };
   v1SignRawPayloadRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD";
+    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1SignRawPayloadIntent"];
+    parameters: definitions["v1SignRawPayloadIntentV2"];
   };
   v1SignRawPayloadResult: {
     /** @description Component of an ECSDA signature. */
@@ -1561,15 +1575,6 @@ export type definitions = {
     s: string;
     /** @description Component of an ECSDA signature. */
     v: string;
-  };
-  v1SignRawPayloadV2Request: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1SignRawPayloadIntentV2"];
   };
   v1SignTransactionIntent: {
     /** @description Unique identifier for a given Private Key. */
@@ -1587,24 +1592,15 @@ export type definitions = {
   };
   v1SignTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_SIGN_TRANSACTION";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1SignTransactionIntent"];
-  };
-  v1SignTransactionResult: {
-    signedTransaction: string;
-  };
-  v1SignTransactionV2Request: {
-    /** @enum {string} */
     type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
     parameters: definitions["v1SignTransactionIntentV2"];
+  };
+  v1SignTransactionResult: {
+    signedTransaction: string;
   };
   v1SimpleClientExtensionResults: {
     appid?: boolean;
@@ -1830,6 +1826,17 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["immutablecommonv1AddressFormat"];
+  };
+  v1WalletParams: {
+    /** @description Human-readable name for a Wallet. */
+    walletName: string;
+    /** @description A list of wallet Accounts. */
+    accounts: definitions["v1WalletAccountParams"][];
+  };
+  v1WalletResult: {
+    walletId: string;
+    /** @description A list of account addresses. */
+    addresses: string[];
   };
   v1WebAuthnStamp: {
     /** @description A base64 url encoded Unique identifier for a given credential. */
@@ -2510,47 +2517,11 @@ export type operations = {
       };
     };
   };
-  /** Sign a raw payload with a Private Key id or address */
-  PublicApiService_SignRawPayloadV2: {
-    parameters: {
-      body: {
-        body: definitions["v1SignRawPayloadV2Request"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
   /** Sign a transaction with a Private Key */
   PublicApiService_SignTransaction: {
     parameters: {
       body: {
         body: definitions["v1SignTransactionRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Sign a transaction with a Private Key id or address */
-  PublicApiService_SignTransactionV2: {
-    parameters: {
-      body: {
-        body: definitions["v1SignTransactionV2Request"];
       };
     };
     responses: {

--- a/packages/http/src/__tests__/async-test.ts
+++ b/packages/http/src/__tests__/async-test.ts
@@ -243,16 +243,16 @@ test("`withAsyncPolling` should also work with synchronous activity endpoints", 
     {
       activity: {
         status: "ACTIVITY_STATUS_COMPLETED",
-        type: "ACTIVITY_TYPE_SIGN_TRANSACTION",
+        type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
       },
     },
   ]);
 
   const result = await mutation({
     body: {
-      type: "ACTIVITY_TYPE_SIGN_TRANSACTION",
+      type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
       parameters: {
-        privateKeyId: "9725c4f7-8387-4990-9128-1d2218bef256",
+        signWith: "9725c4f7-8387-4990-9128-1d2218bef256",
         type: "TRANSACTION_TYPE_ETHEREUM",
         unsignedTransaction:
           "02e801808459682f008509d4ae542e8252089440f008f4c17075efca092ae650655f6693aeced00180c0",

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/viem
 
+## 0.2.6
+
+### Patch Changes
+
+- 59dcd2f: Unpin typescript
+- da7c960: Bump Viem dependency to fix `getAddresses()` for LocalAccount
+- Updated dependencies
+  - @turnkey/http@1.4.0
+
 ## 0.2.5
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -268,10 +268,10 @@ async function signTransactionImpl(
   privateKeyId: string
 ): Promise<string> {
   const { activity } = await client.signTransaction({
-    type: "ACTIVITY_TYPE_SIGN_TRANSACTION",
+    type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
     organizationId: organizationId,
     parameters: {
-      privateKeyId: privateKeyId,
+      signWith: privateKeyId,
       type: "TRANSACTION_TYPE_ETHEREUM",
       unsignedTransaction: unsignedTransaction,
     },
@@ -329,10 +329,10 @@ async function signMessageImpl(
   privateKeyId: string
 ): Promise<string> {
   const { activity } = await client.signRawPayload({
-    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD",
+    type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
     organizationId: organizationId,
     parameters: {
-      privateKeyId: privateKeyId,
+      signWith: privateKeyId,
       payload: message,
       encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
       hashFunction: "HASH_FUNCTION_NO_OP",


### PR DESCRIPTION
## Summary & Motivation
Main updates:

@turnkey/http
- Consolidated signing routes:
  - We now have a single route, `/api/v1/submit/sign_raw_payload` for `SignRawPayload` activities (previously this was split into `SignRawPayload` and `SignRawPayloadV2`)
  - This extends to `/api/v1/submit/sign_transaction` as well. `SignTransaction` and `SignTransactionV2` now have a unified activity: `SignTransaction`
  - Under the hood, these routes stay largely the same: you can sign raw payloads and transactions with an address (from a wallet account), or a private key ID

@turnkey/viem
- 59dcd2f: Unpin typescript
- da7c960: Bump Viem dependency to fix `getAddresses()` for LocalAccount


## How I Tested These Changes
