### PR TITLE
Add change set instructions to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,8 @@
 
 ## How I Tested These Changes
 
-## Did you update the changeset?
+## Did you add a changeset?
 
-To add a changeset for your pr run [`pnpm changeset`](<https://pnpm.io/using-changesets#adding-new-changesets>). You should write a human friendly message about the changes that will be helpful for sdk consumers. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/).
+To add a changeset for your pr run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changest` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).
 
 These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
 ## Summary & Motivation
 
 ## How I Tested These Changes
+
+## Did you update the changeset?
+
+You should add file to describe the change from this pr that looks like `.changeset/<changename>.md` ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)). Note that at the top it includes the package name along with the type of [semver change (major.minor.patch).](https://semver.org/). These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,6 @@
 
 ## Did you update the changeset?
 
-You should add file to describe the change from this pr that looks like `.changeset/<changename>.md` ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)). Note that at the top it includes the package name along with the type of [semver change (major.minor.patch).](https://semver.org/). These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
+To add a changeset for your pr run [`pnpm changeset`](<https://pnpm.io/using-changesets#adding-new-changesets>). You should write a human friendly message about the changes that will be helpful for sdk consumers. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/).
+
+These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).


### PR DESCRIPTION
## Summary & Motivation

People forget/don't know how to update the change set when making changes to sdk. This PR adds instructions to the PR template that explains how to update the changeset.

## How I Tested These Changes

NA; docs