### PR TITLE
Release turnkey/api-key-stamper@v0.2.0

### DIFF
--- a/packages/api-key-stamper/CHANGELOG.md
+++ b/packages/api-key-stamper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/api-key-stamper
 
+## 0.2.0
+
+### Minor Changes
+
+- Add ESM support (#154)
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/api-key-stamper/package.json
+++ b/packages/api-key-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/api-key-stamper",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
We never released api-key-stamper after merging #154. This PR fixes this.