### PR TITLE
Stop using `require` in universal files

### DIFF
--- a/.changeset/quiet-eyes-work.md
+++ b/.changeset/quiet-eyes-work.md
@@ -1,6 +1,0 @@
----
-"@turnkey/webauthn-stamper": patch
-"@turnkey/http": patch
----
-
-Fix universal files to stop using `require`. Use ES6 imports instead.

--- a/.changeset/quiet-eyes-work.md
+++ b/.changeset/quiet-eyes-work.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/webauthn-stamper": patch
+"@turnkey/http": patch
+---
+
+Fix universal files to stop using `require`. Use ES6 imports instead.

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/cosmjs
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies [f87ced8]
+  - @turnkey/http@2.4.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/ethers
 
+## 0.19.1
+
+### Patch Changes
+
+- Updated dependencies [f87ced8]
+  - @turnkey/http@2.4.1
+
 ## 0.19.0
 
 ### Minor Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/http
 
+## 2.4.1
+
+### Patch Changes
+
+- Fix universal files to stop using `require`. Use ES6 imports instead (#178)
+- Updated dependencies [f87ced8]
+  - @turnkey/webauthn-stamper@0.4.1
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/src/universal.ts
+++ b/packages/http/src/universal.ts
@@ -1,10 +1,11 @@
 /// <reference lib="dom" />
+import { fetch as xFetch } from 'cross-fetch';
 let fetch: typeof globalThis.fetch;
 
 if (typeof globalThis?.fetch !== "undefined") {
   fetch = globalThis.fetch;
 } else {
-  fetch = require("cross-fetch");
+  fetch = xFetch;
 }
 
 export { fetch };

--- a/packages/http/src/universal.ts
+++ b/packages/http/src/universal.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { fetch as xFetch } from 'cross-fetch';
+import { fetch as xFetch } from "cross-fetch";
 let fetch: typeof globalThis.fetch;
 
 if (typeof globalThis?.fetch !== "undefined") {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/viem
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [f87ced8]
+  - @turnkey/http@2.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/webauthn-stamper/CHANGELOG.md
+++ b/packages/webauthn-stamper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/webauthn-stamper
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix universal files to stop using `require`. Use ES6 imports instead (#178)
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/webauthn-stamper/package.json
+++ b/packages/webauthn-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/webauthn-stamper",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/webauthn-stamper/src/universal.ts
+++ b/packages/webauthn-stamper/src/universal.ts
@@ -1,10 +1,11 @@
 /// <reference lib="dom" />
+import { Buffer as nodeBuffer } from "buffer";
 let buffer: typeof globalThis.Buffer;
 
 if (typeof globalThis?.Buffer !== "undefined") {
   buffer = globalThis.Buffer;
 } else {
-  buffer = require("buffer").Buffer;
+  buffer = nodeBuffer;
 }
 
 export { buffer };


### PR DESCRIPTION
## Summary & Motivation
I think #174 broke universal files? Or rather, universal files were never written to work well with modules since they use `require`.

When running the federated passkey demo, the following error happens as a result:
<img width="700" alt="image" src="https://github.com/tkhq/sdk/assets/104520680/ee01982e-0a6d-4d52-9529-f64820eb8cdc">

TODOs:
- [x] green tests
- [x] changeset
- [x] run changeset version (to release as part of this PR)
