### PR TITLE
Switch sha256 to be synchronous in `@turnkey/webauthn-stamper`

### DIFF
--- a/.changeset/breezy-kangaroos-pay.md
+++ b/.changeset/breezy-kangaroos-pay.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/webauthn-stamper": patch
+---
+
+Make sha256 computation synchronous to resolve ios passkey prompt issues

--- a/examples/with-federated-passkeys/src/pages/index.tsx
+++ b/examples/with-federated-passkeys/src/pages/index.tsx
@@ -184,15 +184,21 @@ export default function Home() {
   );
 
   const login = async () => {
-    // We use the parent org ID, which we know at all times,
-    const res = await turnkeyClient.getWhoami({
-      organizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
-    });
-    // to get the sub-org ID, which we don't know at this point because we don't
-    // have a DB. Note that we are able to perform this lookup by using the
-    // credential ID from the users WebAuthn stamp.
-    setSubOrgId(res.organizationId);
-    await getWallet(res.organizationId);
+    // We use the parent org ID, which we know at all times...
+    try {
+      const res = await turnkeyClient.getWhoami({
+        organizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
+      });
+      // ...to get the sub-org ID, which we don't know at this point because we don't
+      // have a DB. Note that we are able to perform this lookup by using the
+      // credential ID from the users WebAuthn stamp.
+      setSubOrgId(res.organizationId);
+      await getWallet(res.organizationId);
+    } catch (e: any) {
+      const message = `Error caught during login: ${e.toString()}`;
+      console.error(message);
+      alert(message);
+    }
   };
 
   return (

--- a/packages/webauthn-stamper/package.json
+++ b/packages/webauthn-stamper/package.json
@@ -50,6 +50,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "@noble/hashes": "^1.3.2"
   }
 }

--- a/packages/webauthn-stamper/src/index.ts
+++ b/packages/webauthn-stamper/src/index.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 import { get as webauthnCredentialGet } from "./webauthn-json";
 import { buffer as Buffer } from "./universal";
+import { sha256 } from "@noble/hashes/sha256";
 
 // Header name for a webauthn stamp
 const stampHeaderName = "X-Stamp-Webauthn";
@@ -38,7 +39,7 @@ export class WebauthnStamper {
   }
 
   async stamp(payload: string) {
-    const challenge = await getChallengeFromPayload(payload);
+    const challenge = getChallengeFromPayload(payload);
 
     const signingOptions: CredentialRequestOptions = {
       publicKey: {
@@ -67,9 +68,9 @@ export class WebauthnStamper {
   }
 }
 
-async function getChallengeFromPayload(payload: string): Promise<Uint8Array> {
+function getChallengeFromPayload(payload: string): Uint8Array {
   const messageBuffer = new TextEncoder().encode(payload);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", messageBuffer);
+  const hashBuffer = sha256(messageBuffer);
   const hexString = Buffer.from(hashBuffer).toString("hex");
   const hexBuffer = Buffer.from(hexString, "utf8");
   return new Uint8Array(hexBuffer);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,6 +624,9 @@ importers:
 
   packages/webauthn-stamper:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.3.2
+        version: 1.3.2
       buffer:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary & Motivation
Bug discovered by @SimonVillage in https://github.com/tkhq/demo-passkey-wallet/issues/3: on ios/safari, cancelling the passkey prompt results in subsequent prompts automatically failing. The reason why: ios is stricter than other browsers when deciding whether a passkey prompt can be triggered or not. [This blog post](https://fy.blackhats.net.au/blog/2020-08-12-user-gesture-is-not-detected-using-ios-touchid-with-webauthn-rs/) has more information on this, but TL;DR: you need to have a maximum of one async promise between a user gesture (tap, click) and the code triggering a passkey prompt.

In our SDK we use [`crypto.subtle.digest`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) to compute the SHA256 of the message to sign: https://github.com/tkhq/sdk/blob/bed2beaa87fd4b1024207bb450e0847c744a4d2c/packages/webauthn-stamper/src/index.ts#L72

This means we have an async promise between a button click and the call to `navigator.credentials.get`, causing iOS to fail. The fix? Use a synchonous version of sha256. [`@noble/hashes`](https://www.npmjs.com/package/@noble/hashes) is a great one

## How I Tested These Changes
Used the federated passkey example on my localhost, and reached the demo through an ngrok tunnel. I was able to repro the issue to start with, and observe it fixed after I replaced sha256 with the synchronous variant.