### PR TITLE
Export http package version

### DIFF
--- a/.changeset/itchy-elephants-wave.md
+++ b/.changeset/itchy-elephants-wave.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/http": minor
+---
+
+Add VERSION constant

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -38,6 +38,7 @@
     "access": "public"
   },
   "scripts": {
+    "preinstall": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "prepublishOnly": "pnpm -w run clean-all && pnpm -w run build-all",
     "build": "rollup -c",
     "clean": "rimraf ./dist ./.cache",

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -20,3 +20,5 @@ const PublicApiService = TurnkeyApi;
 export { PublicApiService };
 
 export { sealAndStampRequestBody } from "./base";
+
+export { VERSION } from "./version";

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "2.5.1";


### PR DESCRIPTION
## Summary & Motivation
This is step 1 for us to send a header containing @turnkey/http's version when it fetches content from our public API! After that I'll use this new constant inside of the generated client to add a new `X-Version` header containing this value.

I figured this constant is useful on its own: other packages (or apps) may want to use that for debugging purposes.

The idea for the preinstall script is taken straight from [stack overflow](https://stackoverflow.com/questions/41123631/how-to-get-the-version-from-the-package-json-in-typescript)