### PR TITLE
Add package name to version string

### DIFF
--- a/.changeset/proud-swans-deny.md
+++ b/.changeset/proud-swans-deny.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/http": patch
+---
+
+Update version string to include package name

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
+    "preinstall": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').name + '@' + require('./package.json').version) + ';'\" > src/version.ts",
     "prepublishOnly": "pnpm -w run clean-all && pnpm -w run build-all",
     "build": "rollup -c",
     "clean": "rimraf ./dist ./.cache",

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "2.5.1";
+export const VERSION = "@turnkey/http@2.5.1";


### PR DESCRIPTION
## Summary & Motivation
I think it'll be useful to have the package name in here instead of just a version. Maybe later we'll end up having multiple SDKs with overlapping versions!

## How I Tested These Changes
Proof is in the pudding: running pnpm i regenerated the version string.

## Did you add a changeset?
Yes ✅ 

