### PR TITLE
Revert version export for @turnkey/http (release fix)

### DIFF
--- a/.changeset/small-flowers-serve.md
+++ b/.changeset/small-flowers-serve.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/http": patch
+---
+
+Revert version export

--- a/.changeset/small-flowers-serve.md
+++ b/.changeset/small-flowers-serve.md
@@ -1,5 +1,0 @@
----
-"@turnkey/http": patch
----
-
-Revert version export

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/cosmjs
 
+## 0.5.6
+
+### Patch Changes
+
+- Updated dependencies [52e2389]
+  - @turnkey/http@2.6.1
+
 ## 0.5.5
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/ethers
 
+## 0.19.6
+
+### Patch Changes
+
+- Updated dependencies [52e2389]
+  - @turnkey/http@2.6.1
+
 ## 0.19.5
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/http
 
+## 2.6.1
+
+### Patch Changes
+
+- 52e2389: Revert version export (#186 and #187)
+
 ## 2.6.0
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').name + '@' + require('./package.json').version) + ';'\" > src/version.ts",
+    "preinstall": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "prepublishOnly": "pnpm -w run clean-all && pnpm -w run build-all",
     "build": "rollup -c",
     "clean": "rimraf ./dist ./.cache",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -38,7 +38,6 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "prepublishOnly": "pnpm -w run clean-all && pnpm -w run build-all",
     "build": "rollup -c",
     "clean": "rimraf ./dist ./.cache",

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -20,5 +20,3 @@ const PublicApiService = TurnkeyApi;
 export { PublicApiService };
 
 export { sealAndStampRequestBody } from "./base";
-
-export { VERSION } from "./version";

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,0 @@
-export const VERSION = "2.6.0";

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@2.6.0";
+export const VERSION = "2.6.0";

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/viem
 
+## 0.4.6
+
+### Patch Changes
+
+- Updated dependencies [52e2389]
+  - @turnkey/http@2.6.1
+
 ## 0.4.5
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
Because of the preinstall script introduced in #186 and #187 we're seeing failures to install from npm:
```
npm ERR! command failed
npm ERR! command sh -c node -p "'export const VERSION = ' + JSON.stringify(require('./package.json').name + '@' + require('./package.json').version) + ';'" > src/version.ts
npm ERR! sh: src/version.ts: No such file or directory
```

This PR reverts the two PRs, we'll re-introduce this at a later time!
