### PR TITLE
Quick Docs Fix

### DIFF
--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -34,10 +34,8 @@ const client = new TurnkeyClient(
 );
 
 // Now you can make authenticated requests!
-const data = await TurnkeyApi.getWhoami({
-  body: {
-    organizationId: "...",
-  },
+const data = await client.getWhoami({
+  organizationId: "<Your organization id>",
 });
 ```
 


### PR DESCRIPTION
Something small I noticed when going through the SDK docs -- it's a bit confusing here because the variable that is initialized in the docs is the `client` but then the API call is being made from a variable called `TurnkeyAPI` which isn't initialized anywhere in the README.

My best guess is this is an outdated? way of calling the API and is easier to understand if we are consistent and show the API being called through the instantiated http client. 

Feel free to reject if this is wrong and the client in the README is supposed to be `TurnkeyAPI` @r-n-o @andrewkmin 