### PR TITLE
Fix README link in @turnkey/solana

### DIFF
--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @turnkey/solana
 
+## 0.1.1
+
+- Fix README link
+
 ## 0.1.0
 
 - Initial release

--- a/packages/solana/README.md
+++ b/packages/solana/README.md
@@ -16,6 +16,6 @@ $ npm install @turnkey/solana
 
 ## Examples
 
-| Example                                 | Description                                                                         |
-| --------------------------------------- | ----------------------------------------------------------------------------------- |
-| [`with-solana`](/examples/with-solana/) | Create a new Solana address, then sign and broadcast a transaction on Solana devnet |
+| Example                                      | Description                                                                         |
+| -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [`with-solana`](../../examples/with-solana/) | Create a new Solana address, then sign and broadcast a transaction on Solana devnet |

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
The current link address for the example on https://www.npmjs.com/package/@turnkey/solana is `https://github.com/tkhq/sdk/blob/HEAD/packages/solana/examples/with-solana/`, which is a 404 😢 

Trying with a relative link to see what happens!