### PR TITLE
implement signMessage on Solana TurnkeySigner

### DIFF
--- a/.changeset/hungry-otters-destroy.md
+++ b/.changeset/hungry-otters-destroy.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/solana": minor
+---
+
+implemented signMessage on the Solana TurnkeySigner

--- a/packages/solana/src/__tests__/index-test.ts
+++ b/packages/solana/src/__tests__/index-test.ts
@@ -5,6 +5,9 @@ import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
 
 describe("TurnkeySigner", () => {
+  const organizationId = "4456e4c2-e8b5-4b93-a0cf-1dfae265c12c";
+  const apiPublicKey = "025d374c674fc389c761462f3c59c0acabdcb3a17c599d9e62e5fe78fe984cfbeb";
+  const turnkeySolAddress = 'D8P541wwnertZTgDT14kYJPoFT2eHUFqjTgPxMK5qatM';
   test("can sign a Solana transfer against production", async () => {
     if (!process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY) {
       // This test requires an env var to be set
@@ -17,18 +20,15 @@ describe("TurnkeySigner", () => {
     const client = new TurnkeyClient(
       { baseUrl: "https://api.turnkey.com" },
       new ApiKeyStamper({
-        apiPublicKey:
-          "025d374c674fc389c761462f3c59c0acabdcb3a17c599d9e62e5fe78fe984cfbeb",
+        apiPublicKey,
         apiPrivateKey: process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY,
       })
     );
 
     const signer = new TurnkeySigner({
-      organizationId: "4456e4c2-e8b5-4b93-a0cf-1dfae265c12c",
+      organizationId,
       client,
     });
-
-    const turnkeySolAddress = "D8P541wwnertZTgDT14kYJPoFT2eHUFqjTgPxMK5qatM";
 
     const transferTransaction = new Transaction().add(
       SystemProgram.transfer({
@@ -48,5 +48,31 @@ describe("TurnkeySigner", () => {
     expect(transferTransaction.signatures.length).toBe(0);
     await signer.addSignature(transferTransaction, turnkeySolAddress);
     expect(transferTransaction.signatures.length).toBe(1);
+  });
+
+  test("can sign a message with a Solana account", async () => {
+    if (!process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY) {
+      // This test requires an env var to be set
+      console.warn(
+          "This test is skipped because it cannot run without SOLANA_TEST_ORG_API_PRIVATE_KEY set"
+      );
+      return;
+    }
+
+    const client = new TurnkeyClient(
+        { baseUrl: "https://api.turnkey.com" },
+        new ApiKeyStamper({
+          apiPublicKey,
+          apiPrivateKey: process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY,
+        })
+    );
+
+    const signer = new TurnkeySigner({
+      organizationId,
+      client,
+    });
+
+    const signature = await signer.signMessage('Hello world', turnkeySolAddress);
+    expect(signature).toBeDefined();
   });
 });

--- a/packages/solana/src/index.ts
+++ b/packages/solana/src/index.ts
@@ -1,5 +1,6 @@
 import { PublicKey, type Transaction } from "@solana/web3.js";
 import { TurnkeyActivityError, TurnkeyClient } from "@turnkey/http";
+import type {definitions} from "@turnkey/http/dist/__generated__/services/coordinator/public/v1/public_api.types";
 
 export class TurnkeySigner {
   public readonly organizationId: string;
@@ -20,14 +21,41 @@ export class TurnkeySigner {
     const fromKey = new PublicKey(fromAddress);
     const messageToSign = tx.serializeMessage();
 
+    const signRawPayloadResult = await this.signRawPayload(
+        messageToSign.toString("hex"),
+        "PAYLOAD_ENCODING_HEXADECIMAL",
+        fromAddress,
+    );
+
+    const signature = `${signRawPayloadResult.signRawPayloadResult?.r}${signRawPayloadResult.signRawPayloadResult?.s}`;
+
+    tx.addSignature(fromKey, Buffer.from(signature, "hex"));
+  }
+
+  /**
+   * This function takes a message and returns it after being signed with Turnkey
+   *
+   * @param message The message to sign (string)
+   * @param fromAddress Solana address (base58 encoded)
+   */
+  public async signMessage(message: string, fromAddress: string): Promise<string> {
+    const signRawPayloadResult = await this.signRawPayload(
+        message,
+        "PAYLOAD_ENCODING_TEXT_UTF8",
+        fromAddress,
+    );
+    return `${signRawPayloadResult.signRawPayloadResult?.r}${signRawPayloadResult.signRawPayloadResult?.s}`;
+  }
+
+  private async signRawPayload(payload: string, encoding: definitions["v1PayloadEncoding"], signWith: string) {
     const response = await this.client.signRawPayload({
       type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
       organizationId: this.organizationId,
       timestampMs: String(Date.now()),
       parameters: {
-        signWith: fromAddress,
-        payload: messageToSign.toString("hex"),
-        encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
+        signWith,
+        payload,
+        encoding,
         // Note: unlike ECDSA, EdDSA's API does not support signing raw digests (see RFC 8032).
         // Turnkey's signer requires an explicit value to be passed here to minimize ambiguity.
         hashFunction: "HASH_FUNCTION_NOT_APPLICABLE",
@@ -45,8 +73,6 @@ export class TurnkeySigner {
       });
     }
 
-    const signature = `${result.signRawPayloadResult?.r}${result.signRawPayloadResult?.s}`;
-
-    tx.addSignature(fromKey, Buffer.from(signature, "hex"));
+    return result;
   }
 }


### PR DESCRIPTION
## Summary & Motivation
- Give sign message functionality to solana turnkey wallets
## How I Tested These Changes
- Manually tested using the unit test and hard coded api keys
## Did you add a changeset?
- yes
If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
