### PR TITLE
Pull Solana API private key in Github workflow

### DIFF
--- a/packages/solana/src/__tests__/index-test.ts
+++ b/packages/solana/src/__tests__/index-test.ts
@@ -8,10 +8,7 @@ describe("TurnkeySigner", () => {
   test("can sign a Solana transfer against production", async () => {
     if (!process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY) {
       // This test requires an env var to be set
-      console.warn(
-        "This test is skipped because it cannot run without SOLANA_TEST_ORG_API_PRIVATE_KEY set"
-      );
-      return;
+      throw new Error("This test requires SOLANA_TEST_ORG_API_PRIVATE_KEY to be set");
     }
 
     const client = new TurnkeyClient(

--- a/packages/solana/src/__tests__/index-test.ts
+++ b/packages/solana/src/__tests__/index-test.ts
@@ -8,7 +8,9 @@ describe("TurnkeySigner", () => {
   test("can sign a Solana transfer against production", async () => {
     if (!process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY) {
       // This test requires an env var to be set
-      throw new Error("This test requires SOLANA_TEST_ORG_API_PRIVATE_KEY to be set");
+      throw new Error(
+        "This test requires SOLANA_TEST_ORG_API_PRIVATE_KEY to be set"
+      );
     }
 
     const client = new TurnkeyClient(


### PR DESCRIPTION
## Summary & Motivation
Our workflows have been throwing warnings this whole time 😮‍💨 

For example: https://github.com/tkhq/sdk/actions/runs/7628473532/job/20779615804 (on main):
```
packages/viem test$ jest
packages/cosmjs test: No tests found, exiting with code 0
packages/cosmjs test: Done
packages/solana test:   console.warn
packages/solana test:     This test is skipped because it cannot run without SOLANA_TEST_ORG_API_PRIVATE_KEY set
packages/solana test:        9 |     if (!process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY) {
packages/solana test:       10 |       // This test requires an env var to be set
packages/solana test:     > 11 |       console.warn(
packages/solana test:          |               ^
packages/solana test:       12 |         "This test is skipped because it cannot run without SOLANA_TEST_ORG_API_PRIVATE_KEY set"
packages/solana test:       13 |       );
packages/solana test:       14 |       return;
packages/solana test:       at Object.warn (src/__tests__/index-test.ts:11:15)
packages/solana test: PASS src/__tests__/index-test.ts
```

## How I Tested These Changes
CI!
