### PR TITLE
Update swagger and generated types to v2024.2.0

### DIFF
--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/cosmjs
 
+## 0.5.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @turnkey/http@2.7.1
+
 ## 0.5.8
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/ethers
 
+## 0.19.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @turnkey/http@2.7.1
+
 ## 0.19.8
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/http
 
+## 2.7.1
+
+### Patch Changes
+
+- Update to v2024.2.0 API types: `mnemonicLength` is now a number instead of a string
+
 ## 2.7.0
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -24,15 +24,15 @@
     },
     {
       "name": "Wallets",
-      "description": "Wallets contain collections of deterministically generated cryptographic public / private key pairs that share a common seed. Turnkey securely holds the common seed, but only you can access it. In most cases, Wallets should be preferred over Private Keys since they can be represented by a mnemonic phrase, used across a variety of cryptographic curves, and can derive many addresses.\n\nDerived addresses can be used to create digital signatures using the corresponding underlying private key. See [Signers](./api#tag/Signers) for more information"
+      "description": "Wallets contain collections of deterministically generated cryptographic public / private key pairs that share a common seed. Turnkey securely holds the common seed, but only you can access it. In most cases, Wallets should be preferred over Private Keys since they can be represented by a mnemonic phrase, used across a variety of cryptographic curves, and can derive many addresses.\n\nDerived addresses can be used to create digital signatures using the corresponding underlying private key. See [Signing](./api#tag/Signing) for more information"
     },
     {
-      "name": "Signers",
-      "description": "Signers allow you to create digitial signatures. Signatures are used to validate the authenticity and integrity of a digital message. Turnkey makes it easy to produce signatures by allowing you to sign with an address. If Turnkey doesn't yet support an address format you need, you can generate and sign with the public key instead by using the address format `ADDRESS_FORMAT_COMPRESSED`."
+      "name": "Signing",
+      "description": "Signers allow you to create digital signatures. Signatures are used to validate the authenticity and integrity of a digital message. Turnkey makes it easy to produce signatures by allowing you to sign with an address. If Turnkey doesn't yet support an address format you need, you can generate and sign with the public key instead by using the address format `ADDRESS_FORMAT_COMPRESSED`."
     },
     {
       "name": "Private Keys",
-      "description": "Private Keys are cryptographic public / private key pairs that can be used for cryptocurrency needs or more generalized encryption. Turnkey securely holds all private key materials for you, but only you can access them.\n\nThe Private Key ID or any derived address can be used to create digital signatures. See [Signers](./api#tag/Signers) for more information"
+      "description": "Private Keys are cryptographic public / private key pairs that can be used for cryptocurrency needs or more generalized encryption. Turnkey securely holds all private key materials for you, but only you can access them.\n\nThe Private Key ID or any derived address can be used to create digital signatures. See [Signing](./api#tag/Signing) for more information"
     },
     {
       "name": "Private Key Tags",
@@ -1537,7 +1537,7 @@
             }
           }
         ],
-        "tags": ["Signers"]
+        "tags": ["Signing"]
       }
     },
     "/public/v1/submit/sign_transaction": {
@@ -1569,7 +1569,7 @@
             }
           }
         ],
-        "tags": ["Signers"]
+        "tags": ["Signing"]
       }
     },
     "/public/v1/submit/update_policy": {
@@ -3237,8 +3237,8 @@
           "description": "A list of wallet Accounts."
         },
         "mnemonicLength": {
-          "type": "string",
-          "format": "uint64",
+          "type": "integer",
+          "format": "int32",
           "description": "Length of mnemonic to generate the Wallet seed. Defaults to 12. Accepted values: 12, 15, 18, 21, 24."
         }
       },
@@ -6234,8 +6234,8 @@
           "description": "A list of wallet Accounts."
         },
         "mnemonicLength": {
-          "type": "string",
-          "format": "uint64",
+          "type": "integer",
+          "format": "int32",
           "description": "Length of mnemonic to generate the Wallet seed. Defaults to 12. Accepted values: 12, 15, 18, 21, 24."
         }
       },
@@ -6311,8 +6311,8 @@
       "tags": ["Organizations", "Invitations", "Policies", "Features"]
     },
     {
-      "name": "PRIVATE KEYS",
-      "tags": ["Wallets", "Signers", "Private Keys", "Private Key Tags"]
+      "name": "WALLETS AND PRIVATE KEYS",
+      "tags": ["Wallets", "Signing", "Private Keys", "Private Key Tags"]
     },
     {
       "name": "USERS",

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -825,10 +825,10 @@ export type definitions = {
     /** @description A list of wallet Accounts. */
     accounts: definitions["v1WalletAccountParams"][];
     /**
-     * Format: uint64
+     * Format: int32
      * @description Length of mnemonic to generate the Wallet seed. Defaults to 12. Accepted values: 12, 15, 18, 21, 24.
      */
-    mnemonicLength?: string;
+    mnemonicLength?: number;
   };
   v1CreateWalletRequest: {
     /** @enum {string} */
@@ -1967,10 +1967,10 @@ export type definitions = {
     /** @description A list of wallet Accounts. */
     accounts: definitions["v1WalletAccountParams"][];
     /**
-     * Format: uint64
+     * Format: int32
      * @description Length of mnemonic to generate the Wallet seed. Defaults to 12. Accepted values: 12, 15, 18, 21, 24.
      */
-    mnemonicLength?: string;
+    mnemonicLength?: number;
   };
   v1WalletResult: {
     walletId: string;

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@2.7.0";
+export const VERSION = "@turnkey/http@2.7.1";

--- a/packages/react-native-passkey-stamper/CHANGELOG.md
+++ b/packages/react-native-passkey-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/react-native-passkey-stamper
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @turnkey/http@2.7.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/react-native-passkey-stamper/package.json
+++ b/packages/react-native-passkey-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-native-passkey-stamper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/solana
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @turnkey/http@2.7.1
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/viem
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @turnkey/http@2.7.1
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
Update to v2024.2.0

The only user-facing change is `number` (new) vs `string` (previously) for `mnemonicLength`.

## Did you add a changeset?
Added a changeset and bumped versions accordingly.
