### PR TITLE
add support for signing solana versioned transactions

### DIFF
--- a/.changeset/sweet-dolphins-agree.md
+++ b/.changeset/sweet-dolphins-agree.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/solana": minor
+---
+
+add support for signing solana versioned transactions

--- a/packages/solana/src/__tests__/index-test.ts
+++ b/packages/solana/src/__tests__/index-test.ts
@@ -2,7 +2,14 @@ import { test, expect, describe } from "@jest/globals";
 import { TurnkeySigner } from "../";
 import { TurnkeyClient } from "@turnkey/http";
 import { ApiKeyStamper } from "@turnkey/api-key-stamper";
-import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import {
+  PublicKey,
+  SIGNATURE_LENGTH_IN_BYTES,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import nacl from "tweetnacl";
 import bs58 from "bs58";
 
@@ -11,6 +18,7 @@ describe("TurnkeySigner", () => {
   const apiPublicKey =
     "025d374c674fc389c761462f3c59c0acabdcb3a17c599d9e62e5fe78fe984cfbeb";
   const turnkeySolAddress = "D8P541wwnertZTgDT14kYJPoFT2eHUFqjTgPxMK5qatM";
+  const defaultSignature = new Uint8Array(SIGNATURE_LENGTH_IN_BYTES);
   test("can sign a Solana transfer against production", async () => {
     if (!process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY) {
       // This test requires an env var to be set
@@ -50,6 +58,73 @@ describe("TurnkeySigner", () => {
     expect(transferTransaction.signatures.length).toBe(0);
     await signer.addSignature(transferTransaction, turnkeySolAddress);
     expect(transferTransaction.signatures.length).toBe(1);
+
+    const isValidSignature = nacl.sign.detached.verify(
+      transferTransaction.serializeMessage(),
+      transferTransaction.signature as Uint8Array,
+      bs58.decode(turnkeySolAddress)
+    );
+    expect(isValidSignature).toBeTruthy();
+  });
+
+  test("can sign a versioned Solana transfer against production", async () => {
+    if (!process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY) {
+      // This test requires an env var to be set
+      throw new Error(
+        "This test requires SOLANA_TEST_ORG_API_PRIVATE_KEY to be set"
+      );
+    }
+
+    const client = new TurnkeyClient(
+      { baseUrl: "https://api.turnkey.com" },
+      new ApiKeyStamper({
+        apiPublicKey,
+        apiPrivateKey: process.env.SOLANA_TEST_ORG_API_PRIVATE_KEY,
+      })
+    );
+
+    const signer = new TurnkeySigner({
+      organizationId,
+      client,
+    });
+
+    const fromKey = new PublicKey(turnkeySolAddress);
+
+    const instructions = [
+      SystemProgram.transfer({
+        fromPubkey: fromKey,
+        // Destination doesn't matter, we set it to the Turnkey war chest!
+        toPubkey: new PublicKey("tkhqC9QX2gkqJtUFk2QKhBmQfFyyqZXSpr73VFRi35C"),
+        lamports: 10,
+      }),
+    ];
+
+    // create v0 compatible message
+    const messageV0 = new TransactionMessage({
+      payerKey: fromKey,
+      // Doesn't really matter since we're not going to broadcast this transaction!
+      recentBlockhash: "GZSq3KvoFVhE22CQsaWSAxBoAvRiZSs7xVNa6yPecMUu",
+      instructions,
+    }).compileToV0Message();
+
+    const transaction = new VersionedTransaction(messageV0);
+
+    // version transactions are initalized with a default signature
+    expect(transaction.signatures.length).toBe(1);
+    expect(transaction.signatures[0]).toEqual(defaultSignature);
+
+    await signer.addSignature(transaction, turnkeySolAddress);
+
+    // after signing the version transaction, the default signature is replaced with the new one
+    expect(transaction.signatures.length).toBe(1);
+    expect(transaction.signatures[0]).not.toEqual(defaultSignature);
+
+    const isValidSignature = nacl.sign.detached.verify(
+      transaction.message.serialize(),
+      transaction.signatures[0] as Uint8Array,
+      bs58.decode(turnkeySolAddress)
+    );
+    expect(isValidSignature).toBeTruthy();
   });
 
   test("can sign a message with a Solana account", async () => {

--- a/packages/solana/src/index.ts
+++ b/packages/solana/src/index.ts
@@ -1,4 +1,8 @@
-import { PublicKey, type Transaction } from "@solana/web3.js";
+import {
+  PublicKey,
+  type Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { TurnkeyActivityError, TurnkeyClient } from "@turnkey/http";
 
 export class TurnkeySigner {
@@ -13,12 +17,21 @@ export class TurnkeySigner {
   /**
    * This function takes a Solana transaction and adds a signature with Turnkey
    *
-   * @param tx Transaction object (native @solana/web3.js type)
+   * @param tx Transaction | VersionedTransaction object (native @solana/web3.js type)
    * @param fromAddress Solana address (base58 encoded)
    */
-  public async addSignature(tx: Transaction, fromAddress: string) {
+  public async addSignature(
+    tx: Transaction | VersionedTransaction,
+    fromAddress: string
+  ) {
     const fromKey = new PublicKey(fromAddress);
-    const messageToSign = tx.serializeMessage();
+
+    let messageToSign: Buffer;
+    if (tx instanceof VersionedTransaction) {
+      messageToSign = Buffer.from(tx.message.serialize());
+    } else {
+      messageToSign = tx.serializeMessage();
+    }
 
     const signRawPayloadResult = await this.signRawPayload(
       messageToSign.toString("hex"),


### PR DESCRIPTION
## Summary & Motivation

Support versioned transactions. Also addresses this https://github.com/tkhq/sdk/issues/215
## How I Tested These Changes

Unit test and manually sent a versioned transaction that was signed by the turnkey testing wallet

https://solscan.io/tx/2pbRDh5wAAxvVPhm432gQVYNaNeWdUZ3UMP7rrKyBBURiFcGHWqhEU18hgNoSRSRkmYA2w4518gnnWQbKSNfRCXv?cluster=devnet

## Did you add a changeset?
Yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
