### PR TITLE
Adjust logic for signing transactions and versioned transactions to a…

### DIFF
--- a/.changeset/fifty-dingos-mate.md
+++ b/.changeset/fifty-dingos-mate.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/solana": patch
+---
+
+Adjust logic for signing transactions and versioned transactions to avoid typechecks


### PR DESCRIPTION
…void typechecks

## Summary & Motivation
The instanceof check is not being respected when VersionedTransaction tx object is passed to the Turnkey sdk.

Using property check instead to perform this logic.

![image](https://github.com/tkhq/sdk/assets/8083890/3afa79f3-f63a-4645-9ef0-29389ebe642c)



## How I Tested These Changes
Unit tests

## Did you add a changeset?
yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
