### PR TITLE
Remove public key param for key export

### DIFF
--- a/.changeset/eight-ants-tease.md
+++ b/.changeset/eight-ants-tease.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/iframe-stamper": minor
+---
+
+Add key format and remove public key from injectKeyExportBundle.

--- a/.changeset/eight-ants-tease.md
+++ b/.changeset/eight-ants-tease.md
@@ -1,5 +1,0 @@
----
-"@turnkey/iframe-stamper": minor
----
-
-Add key format and remove public key from injectKeyExportBundle.

--- a/.changeset/polite-eagles-press.md
+++ b/.changeset/polite-eagles-press.md
@@ -1,5 +1,0 @@
----
-"@turnkey/iframe-stamper": minor
----
-
-Add optional keyFormat and publicKey parameters to injectKeyExportBundle. Add extractKeyEncryptedBundle.

--- a/packages/iframe-stamper/CHANGELOG.md
+++ b/packages/iframe-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/iframe-stamper
 
+## 1.2.0
+
+### Minor Changes
+
+- 0281b88: Remove optional publicKey parameter from injectKeyExportBundle.
+- 0e3584a: Add optional keyFormat and publicKey parameters to injectKeyExportBundle. Add extractKeyEncryptedBundle.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/iframe-stamper/package.json
+++ b/packages/iframe-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/iframe-stamper",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -191,7 +191,7 @@ export class IframeStamper {
    */
   async injectKeyExportBundle(
     bundle: string,
-    keyFormat?: KeyFormat,
+    keyFormat?: KeyFormat
   ): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -187,20 +187,17 @@ export class IframeStamper {
    * The bundle should be encrypted to the iframe's initial public key
    * Encryption should be performed with HPKE (RFC 9180).
    * The key format to encode the private key in after it's exported and decrypted: HEXADECIMAL or SOLANA. Defaults to HEXADECIMAL.
-   * The public key of the exported private key. Required when the key format is SOLANA.
    * This is used during the private key export flow.
    */
   async injectKeyExportBundle(
     bundle: string,
     keyFormat?: KeyFormat,
-    publicKey?: string
   ): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.InjectKeyExportBundle,
         value: bundle,
         keyFormat: keyFormat,
-        publicKey: publicKey,
       },
       "*"
     );


### PR DESCRIPTION
## Summary & Motivation
Remove `publicKey` param from `injectKeyExportBundle` now that export.turnkey.com can derive it. (https://github.com/tkhq/frames/pull/28, https://github.com/tkhq/frames/pull/29)

## How I Tested These Changes
Ran local example for importing and exporting private keys.

## Did you add a changeset?
Yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
