### PR TITLE
Part 1a/3: Verifiable metadata

### DIFF
--- a/.changeset/chilled-shirts-lay.md
+++ b/.changeset/chilled-shirts-lay.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/iframe-stamper": major
+---
+
+Include organizationId and userId in injected import and export bundles.

--- a/examples/wallet-import-export/src/components/ExportWallet.tsx
+++ b/examples/wallet-import-export/src/components/ExportWallet.tsx
@@ -8,6 +8,7 @@ import { IframeStamper } from "@turnkey/iframe-stamper";
 import { Export } from "@/components/Export";
 
 type ExportWalletProps = {
+  organizationId: string,
   walletId: string;
 };
 
@@ -35,7 +36,8 @@ export function ExportWallet(props: ExportWalletProps) {
     });
 
     let injected = await iframeStamper.injectWalletExportBundle(
-      response.data["exportBundle"]
+      response.data["exportBundle"],
+      props.organizationId,
     );
     if (injected !== true) {
       alert("Unexpected error while injecting export bundle.");

--- a/examples/wallet-import-export/src/components/ExportWallet.tsx
+++ b/examples/wallet-import-export/src/components/ExportWallet.tsx
@@ -8,7 +8,7 @@ import { IframeStamper } from "@turnkey/iframe-stamper";
 import { Export } from "@/components/Export";
 
 type ExportWalletProps = {
-  organizationId: string,
+  organizationId: string;
   walletId: string;
 };
 
@@ -37,7 +37,7 @@ export function ExportWallet(props: ExportWalletProps) {
 
     let injected = await iframeStamper.injectWalletExportBundle(
       response.data["exportBundle"],
-      props.organizationId,
+      props.organizationId
     );
     if (injected !== true) {
       alert("Unexpected error while injecting export bundle.");

--- a/examples/wallet-import-export/src/components/ImportWallet.tsx
+++ b/examples/wallet-import-export/src/components/ImportWallet.tsx
@@ -8,7 +8,7 @@ import { IframeStamper } from "@turnkey/iframe-stamper";
 import { Import } from "@/components/Import";
 
 type ImportWalletProps = {
-  organizationId: string,
+  organizationId: string;
   userId: string;
   getWallets: () => void;
 };
@@ -42,7 +42,7 @@ export function ImportWallet(props: ImportWalletProps) {
     const injected = await iframeStamper.injectImportBundle(
       response.data["importBundle"],
       props.organizationId,
-      props.userId,
+      props.userId
     );
     if (injected !== true) {
       alert("Unexpected error while injecting import bundle.");

--- a/examples/wallet-import-export/src/components/ImportWallet.tsx
+++ b/examples/wallet-import-export/src/components/ImportWallet.tsx
@@ -8,6 +8,7 @@ import { IframeStamper } from "@turnkey/iframe-stamper";
 import { Import } from "@/components/Import";
 
 type ImportWalletProps = {
+  organizationId: string,
   userId: string;
   getWallets: () => void;
 };
@@ -39,7 +40,9 @@ export function ImportWallet(props: ImportWalletProps) {
     });
 
     const injected = await iframeStamper.injectImportBundle(
-      response.data["importBundle"]
+      response.data["importBundle"],
+      props.organizationId,
+      props.userId,
     );
     if (injected !== true) {
       alert("Unexpected error while injecting import bundle.");

--- a/examples/wallet-import-export/src/pages/index.tsx
+++ b/examples/wallet-import-export/src/pages/index.tsx
@@ -86,7 +86,7 @@ export default function ExportPage() {
           show={isImportModalOpen}
           onClose={() => setIsImportModalOpen(false)}
         >
-          <ImportWallet userId={userId} getWallets={getWallets} />
+          <ImportWallet organizationId={process.env.NEXT_PUBLIC_ORGANIZATION_ID!} userId={userId} getWallets={getWallets} />
         </Modal>
       )}
 
@@ -96,7 +96,7 @@ export default function ExportPage() {
           show={isExportModalOpen}
           onClose={() => setIsExportModalOpen(false)}
         >
-          <ExportWallet walletId={selectedWallet} />
+          <ExportWallet organizationId={process.env.NEXT_PUBLIC_ORGANIZATION_ID!} walletId={selectedWallet} />
         </Modal>
       )}
     </main>

--- a/examples/wallet-import-export/src/pages/index.tsx
+++ b/examples/wallet-import-export/src/pages/index.tsx
@@ -86,7 +86,11 @@ export default function ExportPage() {
           show={isImportModalOpen}
           onClose={() => setIsImportModalOpen(false)}
         >
-          <ImportWallet organizationId={process.env.NEXT_PUBLIC_ORGANIZATION_ID!} userId={userId} getWallets={getWallets} />
+          <ImportWallet
+            organizationId={process.env.NEXT_PUBLIC_ORGANIZATION_ID!}
+            userId={userId}
+            getWallets={getWallets}
+          />
         </Modal>
       )}
 
@@ -96,7 +100,10 @@ export default function ExportPage() {
           show={isExportModalOpen}
           onClose={() => setIsExportModalOpen(false)}
         >
-          <ExportWallet organizationId={process.env.NEXT_PUBLIC_ORGANIZATION_ID!} walletId={selectedWallet} />
+          <ExportWallet
+            organizationId={process.env.NEXT_PUBLIC_ORGANIZATION_ID!}
+            walletId={selectedWallet}
+          />
         </Modal>
       )}
     </main>

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -191,13 +191,15 @@ export class IframeStamper {
    */
   async injectKeyExportBundle(
     bundle: string,
-    keyFormat?: KeyFormat
+    organizationId: string,
+    keyFormat?: KeyFormat,
   ): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.InjectKeyExportBundle,
         value: bundle,
-        keyFormat: keyFormat,
+        keyFormat,
+        organizationId,
       },
       "*"
     );
@@ -229,11 +231,12 @@ export class IframeStamper {
    * Encryption should be performed with HPKE (RFC 9180).
    * This is used during the wallet export flow.
    */
-  async injectWalletExportBundle(bundle: string): Promise<boolean> {
+  async injectWalletExportBundle(bundle: string, organizationId: string): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.InjectWalletExportBundle,
         value: bundle,
+        organizationId,
       },
       "*"
     );
@@ -263,11 +266,13 @@ export class IframeStamper {
    * Function to inject an import bundle into the iframe
    * This is used to initiate either the wallet import flow or the private key import flow.
    */
-  async injectImportBundle(bundle: string): Promise<boolean> {
+  async injectImportBundle(bundle: string, organizationId: string, userId: string): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.InjectImportBundle,
         value: bundle,
+        organizationId,
+        userId
       },
       "*"
     );

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -192,7 +192,7 @@ export class IframeStamper {
   async injectKeyExportBundle(
     bundle: string,
     organizationId: string,
-    keyFormat?: KeyFormat,
+    keyFormat?: KeyFormat
   ): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {
@@ -231,7 +231,10 @@ export class IframeStamper {
    * Encryption should be performed with HPKE (RFC 9180).
    * This is used during the wallet export flow.
    */
-  async injectWalletExportBundle(bundle: string, organizationId: string): Promise<boolean> {
+  async injectWalletExportBundle(
+    bundle: string,
+    organizationId: string
+  ): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.InjectWalletExportBundle,
@@ -266,13 +269,17 @@ export class IframeStamper {
    * Function to inject an import bundle into the iframe
    * This is used to initiate either the wallet import flow or the private key import flow.
    */
-  async injectImportBundle(bundle: string, organizationId: string, userId: string): Promise<boolean> {
+  async injectImportBundle(
+    bundle: string,
+    organizationId: string,
+    userId: string
+  ): Promise<boolean> {
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.InjectImportBundle,
         value: bundle,
         organizationId,
-        userId
+        userId,
       },
       "*"
     );


### PR DESCRIPTION
## Summary & Motivation
Addresses ToB findings from ENG-1447 and ENG-1497. Pass the expected  metadata (organization id and user id) to the iframe via the iframe stamper, so the iframe can verify the enclave signature and that that expected metadata matches the metadata contained in the `importBundle` and `exportBundle`.

Part 1a: https://github.com/tkhq/sdk/pull/233
Part 1b:  https://github.com/tkhq/frames/pull/33
Part 1c: https://github.com/tkhq/go-sdk/pull/47
Part 2: https://github.com/tkhq/tkcli/pull/59
Part 3: https://github.com/tkhq/mono/pull/2806

## How I Tested These Changes
tested using the wallet-import-example and local import.turnkey.com and local export.turnkey.com

## Did you add a changeset?
yes (to `iframe-stamper` package)

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
