### PR TITLE
export DEFAULT_ETHEREUM_ACCOUNT helpers from sdk packages

### DIFF
--- a/packages/sdk-browser/src/index.ts
+++ b/packages/sdk-browser/src/index.ts
@@ -32,6 +32,11 @@ import {
   TurnkeySDKBrowserClient
 } from "./sdk-client";
 
+import {
+  defaultEthereumAccountAtIndex,
+  DEFAULT_ETHEREUM_ACCOUNTS
+} from "./turnkey-helpers";
+
 import type {
   TurnkeySDKClientConfig,
   TurnkeySDKBrowserConfig,
@@ -65,10 +70,16 @@ export type {
 // Functions
 export {
   createActivityPoller,
+  defaultEthereumAccountAtIndex,
   getWebAuthnAttestation,
   sealAndStampRequestBody,
   signWithApiKey,
 };
+
+// Constants
+export {
+  DEFAULT_ETHEREUM_ACCOUNTS
+}
 
 // Enums
 export { IframeEventType };

--- a/packages/sdk-browser/src/turnkey-helpers.ts
+++ b/packages/sdk-browser/src/turnkey-helpers.ts
@@ -1,0 +1,19 @@
+interface WalletAccount {
+  curve: "CURVE_SECP256K1" | "CURVE_ED25519";
+  pathFormat: "PATH_FORMAT_BIP32";
+  path: string;
+  addressFormat: "ADDRESS_FORMAT_ETHEREUM" | "ADDRESS_FORMAT_UNCOMPRESSED" | "ADDRESS_FORMAT_COMPRESSED" | "ADDRESS_FORMAT_SOLANA" | "ADDRESS_FORMAT_COSMOS" | "ADDRESS_FORMAT_TRON";
+}
+
+export const defaultEthereumAccountAtIndex = (pathIndex: number): WalletAccount => {
+  return {
+    curve: "CURVE_SECP256K1",
+    pathFormat: "PATH_FORMAT_BIP32",
+    path: `m/44'/60'/${pathIndex}'/0/0`,
+    addressFormat: "ADDRESS_FORMAT_ETHEREUM"
+  }
+};
+
+export const DEFAULT_ETHEREUM_ACCOUNTS: WalletAccount[] = [
+  defaultEthereumAccountAtIndex(0)
+];

--- a/packages/sdk-server/src/index.ts
+++ b/packages/sdk-server/src/index.ts
@@ -17,6 +17,11 @@ import {
 
 import { TurnkeyServerSDK, TurnkeySDKServerClient } from "./sdk-client";
 
+import {
+  defaultEthereumAccountAtIndex,
+  DEFAULT_ETHEREUM_ACCOUNTS,
+} from "./turnkey-helpers";
+
 import type {
   TurnkeySDKClientConfig,
   TurnkeySDKServerConfig,
@@ -51,10 +56,14 @@ export type {
 export {
   fetch,
   createActivityPoller,
+  defaultEthereumAccountAtIndex,
   getWebAuthnAttestation,
   sealAndStampRequestBody,
   signWithApiKey,
 };
+
+// Constants
+export { DEFAULT_ETHEREUM_ACCOUNTS };
 
 // Base Turnkey API
 export { TurnkeyApi };

--- a/packages/sdk-server/src/turnkey-helpers.ts
+++ b/packages/sdk-server/src/turnkey-helpers.ts
@@ -1,0 +1,19 @@
+interface WalletAccount {
+  curve: "CURVE_SECP256K1" | "CURVE_ED25519";
+  pathFormat: "PATH_FORMAT_BIP32";
+  path: string;
+  addressFormat: "ADDRESS_FORMAT_ETHEREUM" | "ADDRESS_FORMAT_UNCOMPRESSED" | "ADDRESS_FORMAT_COMPRESSED" | "ADDRESS_FORMAT_SOLANA" | "ADDRESS_FORMAT_COSMOS" | "ADDRESS_FORMAT_TRON";
+}
+
+export const defaultEthereumAccountAtIndex = (pathIndex: number): WalletAccount => {
+  return {
+    curve: "CURVE_SECP256K1",
+    pathFormat: "PATH_FORMAT_BIP32",
+    path: `m/44'/60'/${pathIndex}'/0/0`,
+    addressFormat: "ADDRESS_FORMAT_ETHEREUM"
+  }
+};
+
+export const DEFAULT_ETHEREUM_ACCOUNTS: WalletAccount[] = [
+  defaultEthereumAccountAtIndex(0)
+];


### PR DESCRIPTION
Adds default helpers for generating a walletAccount at index and exports the initial configuration as a constant