### PR TITLE
update ethers + viem types

### DIFF
--- a/.changeset/silent-rocks-cry.md
+++ b/.changeset/silent-rocks-cry.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/ethers": patch
+"@turnkey/viem": patch
+---
+
+Add support for new Turnkey Client types

--- a/examples/with-ethers/README.md
+++ b/examples/with-ethers/README.md
@@ -58,7 +58,7 @@ This script will do the following:
 
 Note that these transactions will all be broadcasted sequentially.
 
-The script constructs a transaction via Turnkey and broadcasts via Infura. If the script exits because your account isn't funded, you can request funds on https://goerlifaucet.com/ or https://faucet.paradigm.xyz/.
+The script constructs a transaction via Turnkey and broadcasts via Infura. If the script exits because your account isn't funded, you can request funds on https://sepoliafaucet.com/ or https://faucet.paradigm.xyz/.
 
 Visit the Etherscan link to view your transaction; you have successfully sent your first transaction with Turnkey!
 
@@ -66,7 +66,7 @@ See the following for a sample output:
 
 ```
 Network:
-	goerli (chain ID 5)
+	sepolia (chain ID 11155111)
 
 Address:
 	0x064c0CfDD7C485Eba21988Ded4dbCD9358556842
@@ -87,13 +87,13 @@ Turnkey-signed transaction:
 	0x02f8668080808080942ad9ea1e677949a536a270cec812d6e868c881088609184e72a00080c001a09881f59e48500ef8960ae1cb94e0c862e7d613f961c250b6f07b546a1b058b1da06ba1871d7aed5eb8ea8cb211a0e3e22a1c6b54b34b4376d0ef5b1daef4100c8f
 
 Sent 0.00001 Ether to 0x2Ad9eA1E677949a536A270CEC812D6e868C88108:
-	https://goerli.etherscan.io/tx/0xe034bdc597766719aef04b1d08998e606e85da1dd73e52fad8586a7d79d659e0
+	https://sepolia.etherscan.io/tx/0xe034bdc597766719aef04b1d08998e606e85da1dd73e52fad8586a7d79d659e0
 
 WETH Balance:
 	0.00007 WETH
 
 Wrapped 0.00001 ETH:
-	https://goerli.etherscan.io/tx/0x7f98c1b2c7ff7f8ab876b27fdcd794653d8b7f728dbeec3b1d403789c38bcb71
+	https://sepolia.etherscan.io/tx/0x7f98c1b2c7ff7f8ab876b27fdcd794653d8b7f728dbeec3b1d403789c38bcb71
 ```
 
 ```bash

--- a/examples/with-ethers/package.json
+++ b/examples/with-ethers/package.json
@@ -13,6 +13,7 @@
     "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*",
+    "@turnkey/sdk-js-server": "workspace:*",
     "dotenv": "^16.0.3",
     "ethers": "^6.10.0"
   }

--- a/examples/with-ethers/package.json
+++ b/examples/with-ethers/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.3",
   "private": true,
   "scripts": {
-    "start": "pnpm -w run build-all && tsx src/index.ts",
-    "start-advanced": "pnpm -w run build-all && tsx src/advanced.ts",
-    "start-sepolia-legacy": "pnpm -w run build-all && tsx src/sepoliaLegacyTx.ts",
+    "start": "tsx src/index.ts",
+    "start-advanced": "tsx src/advanced.ts",
+    "start-sepolia-legacy": "tsx src/sepoliaLegacyTx.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },
@@ -13,7 +13,7 @@
     "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*",
-    "@turnkey/sdk-js-server": "workspace:*",
+    "@turnkey/sdk-server": "workspace:*",
     "dotenv": "^16.0.3",
     "ethers": "^6.10.0"
   }

--- a/examples/with-ethers/src/index.ts
+++ b/examples/with-ethers/src/index.ts
@@ -6,8 +6,7 @@ dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
 import { TurnkeySigner } from "@turnkey/ethers";
 import { ethers } from "ethers";
-import { TurnkeyClient } from "@turnkey/http";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import { TurnkeyServerSDK } from "@turnkey/sdk-js-server";
 import { createNewWallet } from "./createNewWallet";
 import { print, assertEqual } from "./util";
 import WETH_TOKEN_ABI from "./weth-contract-abi.json";
@@ -21,19 +20,16 @@ async function main() {
     return;
   }
 
-  const turnkeyClient = new TurnkeyClient(
-    {
-      baseUrl: process.env.BASE_URL!,
-    },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
+  const turnkeyClient = new TurnkeyServerSDK({
+    apiBaseUrl: process.env.BASE_URL!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    rootOrganizationId: process.env.ORGANIZATION_ID!,
+  });
 
   // Initialize a Turnkey Signer
   const turnkeySigner = new TurnkeySigner({
-    client: turnkeyClient,
+    client: turnkeyClient.api(),
     organizationId: process.env.ORGANIZATION_ID!,
     signWith: process.env.SIGN_WITH!,
   });

--- a/examples/with-ethers/src/index.ts
+++ b/examples/with-ethers/src/index.ts
@@ -6,12 +6,12 @@ dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
 import { TurnkeySigner } from "@turnkey/ethers";
 import { ethers } from "ethers";
-import { TurnkeyServerSDK } from "@turnkey/sdk-js-server";
+import { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
 import { createNewWallet } from "./createNewWallet";
 import { print, assertEqual } from "./util";
 import WETH_TOKEN_ABI from "./weth-contract-abi.json";
 
-const WETH_TOKEN_ADDRESS_GOERLI = "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6";
+const WETH_TOKEN_ADDRESS_SEPOLIA = "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9";
 
 async function main() {
   if (!process.env.SIGN_WITH) {
@@ -24,7 +24,7 @@ async function main() {
     apiBaseUrl: process.env.BASE_URL!,
     apiPrivateKey: process.env.API_PRIVATE_KEY!,
     apiPublicKey: process.env.API_PUBLIC_KEY!,
-    rootOrganizationId: process.env.ORGANIZATION_ID!,
+    defaultOrganizationId: process.env.ORGANIZATION_ID!,
   });
 
   // Initialize a Turnkey Signer
@@ -35,7 +35,7 @@ async function main() {
   });
 
   // Bring your own provider (such as Alchemy or Infura: https://docs.ethers.org/v6/api/providers/)
-  const network = "goerli";
+  const network = "sepolia";
   const provider = new ethers.JsonRpcProvider(
     `https://${network}.infura.io/v3/${process.env.INFURA_KEY}`
   );
@@ -78,9 +78,9 @@ async function main() {
   if (balance === 0) {
     let warningMessage =
       "The transaction won't be broadcasted because your account balance is zero.\n";
-    if (network === "goerli") {
+    if (network === "sepolia") {
       warningMessage +=
-        "Use https://goerlifaucet.com/ to request funds on Goerli, then run the script again.\n";
+        "Use https://sepoliafaucet.com/ to request funds on Sepolia, then run the script again.\n";
     }
 
     console.warn(warningMessage);
@@ -95,10 +95,10 @@ async function main() {
     `https://${network}.etherscan.io/tx/${sentTx.hash}`
   );
 
-  if (network === "goerli") {
-    // https://goerli.etherscan.io/address/0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6
+  if (network === "sepolia") {
+    // https://sepolia.etherscan.io/address/0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6
     const wethContract = new ethers.Contract(
-      WETH_TOKEN_ADDRESS_GOERLI,
+      WETH_TOKEN_ADDRESS_SEPOLIA,
       WETH_TOKEN_ABI,
       connectedSigner
     );

--- a/examples/with-viem/README.md
+++ b/examples/with-viem/README.md
@@ -67,8 +67,14 @@ Fetching Node.js 18.0.0 ...
 > tsc --build tsconfig.mono.json
 
 Source address
-        0xfe81d134AC28b5CAc01E198E5988F449621d960B
+        0xDC608F098255C89B36da905D9132A9Ee3DD266D9
 
 Transaction
-        https://sepolia.etherscan.io/tx/0x91a388d8a6e506bbaeaf21b2914461a0f6125afb3a84a4cf27bdf5e9eb06ffce
+        https://sepolia.etherscan.io/tx/0xf21c98e02dc987c1987da06cab7523c0de6cb3a275064c918001907d9adfc11d
+
+Turnkey-powered signature:
+        0x83d002f3b5b0de4f4532c402efdc8544a1986c73207e63e6b743900ac1387125012b39c0918fafb9cde4293480f670c007c84c6c63e149cb0c8ca9409a36ca351b
+
+Recovered address:
+        0xDC608F098255C89B36da905D9132A9Ee3DD266D9
 ```

--- a/examples/with-viem/package.json
+++ b/examples/with-viem/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*",
+    "@turnkey/sdk-js-server": "workspace:*",
     "@turnkey/viem": "workspace:*",
     "dotenv": "^16.0.3",
     "fetch": "^1.1.0",

--- a/examples/with-viem/package.json
+++ b/examples/with-viem/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "pnpm -w run build-all && tsx src/index.ts",
-    "start-advanced": "pnpm -w run build-all && tsx src/advanced.ts",
-    "start-contracts": "pnpm -w run build-all && tsx src/contracts.ts",
-    "start-legacy": "pnpm -w run build-all && tsx src/legacy/index.ts",
+    "start": "tsx src/index.ts",
+    "start-advanced": "tsx src/advanced.ts",
+    "start-contracts": "tsx src/contracts.ts",
+    "start-legacy": "tsx src/legacy/index.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },
@@ -16,7 +16,7 @@
   "dependencies": {
     "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*",
-    "@turnkey/sdk-js-server": "workspace:*",
+    "@turnkey/sdk-server": "workspace:*",
     "@turnkey/viem": "workspace:*",
     "dotenv": "^16.0.3",
     "fetch": "^1.1.0",

--- a/examples/with-viem/src/index.ts
+++ b/examples/with-viem/src/index.ts
@@ -2,8 +2,7 @@ import * as path from "path";
 import * as dotenv from "dotenv";
 
 import { createAccount } from "@turnkey/viem";
-import { TurnkeyClient } from "@turnkey/http";
-import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import { TurnkeyServerSDK } from "@turnkey/sdk-js-server";
 import {
   createWalletClient,
   http,
@@ -24,18 +23,15 @@ async function main() {
     return;
   }
 
-  const turnkeyClient = new TurnkeyClient(
-    {
-      baseUrl: process.env.BASE_URL!,
-    },
-    new ApiKeyStamper({
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-    })
-  );
+  const turnkeyClient = new TurnkeyServerSDK({
+    apiBaseUrl: process.env.BASE_URL!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    rootOrganizationId: process.env.ORGANIZATION_ID!,
+  });
 
   const turnkeyAccount = await createAccount({
-    client: turnkeyClient,
+    client: turnkeyClient.api(),
     organizationId: process.env.ORGANIZATION_ID!,
     signWith: process.env.SIGN_WITH!,
   });

--- a/examples/with-viem/src/index.ts
+++ b/examples/with-viem/src/index.ts
@@ -56,7 +56,7 @@ async function main() {
   const txHash = await client.sendTransaction(transactionRequest);
 
   print("Source address", client.account.address);
-  print("Transaction", `https://sepolia.etherscan.io/tx/${txHash}`);
+  print("Transaction sent", `https://sepolia.etherscan.io/tx/${txHash}`);
 
   // 2. Sign a simple message
   let address = client.account.address;

--- a/examples/with-viem/src/index.ts
+++ b/examples/with-viem/src/index.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as dotenv from "dotenv";
 
 import { createAccount } from "@turnkey/viem";
-import { TurnkeyServerSDK } from "@turnkey/sdk-js-server";
+import { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
 import {
   createWalletClient,
   http,
@@ -27,7 +27,7 @@ async function main() {
     apiBaseUrl: process.env.BASE_URL!,
     apiPrivateKey: process.env.API_PRIVATE_KEY!,
     apiPublicKey: process.env.API_PUBLIC_KEY!,
-    rootOrganizationId: process.env.ORGANIZATION_ID!,
+    defaultOrganizationId: process.env.ORGANIZATION_ID!,
   });
 
   const turnkeyAccount = await createAccount({

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -54,8 +54,8 @@
   "dependencies": {
     "@turnkey/api-key-stamper": "workspace:*",
     "@turnkey/http": "workspace:*",
-    "@turnkey/sdk-js-browser": "workspace:*",
-    "@turnkey/sdk-js-server": "workspace:*"
+    "@turnkey/sdk-browser": "workspace:*",
+    "@turnkey/sdk-server": "workspace:*"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "3.0.5",

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -53,7 +53,9 @@
   },
   "dependencies": {
     "@turnkey/api-key-stamper": "workspace:*",
-    "@turnkey/http": "workspace:*"
+    "@turnkey/http": "workspace:*",
+    "@turnkey/sdk-js-browser": "workspace:*",
+    "@turnkey/sdk-js-server": "workspace:*"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "3.0.5",

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -11,8 +11,8 @@ import {
 } from "ethers";
 import { TurnkeyActivityError, TurnkeyRequestError } from "@turnkey/http";
 import { TurnkeyClient } from "@turnkey/http";
-import type { TurnkeySDKBrowserClient } from "@turnkey/sdk-js-browser";
-import type { TurnkeySDKServerClient } from "@turnkey/sdk-js-server";
+import type { TurnkeyBrowserClient } from "@turnkey/sdk-browser";
+import type { TurnkeyServerClient } from "@turnkey/sdk-server";
 import {
   type TypedDataDomain,
   type TypedDataField,
@@ -27,7 +27,7 @@ type TConfig = {
   /**
    * Turnkey client
    */
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient;
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient;
   /**
    * Turnkey organization ID
    */
@@ -41,8 +41,8 @@ type TConfig = {
 export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
   private readonly client:
     | TurnkeyClient
-    | TurnkeySDKBrowserClient
-    | TurnkeySDKServerClient;
+    | TurnkeyBrowserClient
+    | TurnkeyServerClient;
 
   public readonly organizationId: string;
   public readonly signWith: string;

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -49,7 +49,8 @@
     "@turnkey/iframe-stamper": "workspace:*",
     "@turnkey/webauthn-stamper": "workspace:*",
     "buffer": "^6.0.3",
-    "elliptic": "^6.5.5"
+    "elliptic": "^6.5.5",
+    "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
     "@types/elliptic": "^6.4.18",

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -57,6 +57,8 @@
   "dependencies": {
     "@turnkey/api-key-stamper": "workspace:*",
     "@turnkey/http": "workspace:*",
+    "@turnkey/sdk-js-browser": "workspace:*",
+    "@turnkey/sdk-js-server": "workspace:*",
     "cross-fetch": "^4.0.0",
     "typescript": "^5.1"
   },

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -57,8 +57,8 @@
   "dependencies": {
     "@turnkey/api-key-stamper": "workspace:*",
     "@turnkey/http": "workspace:*",
-    "@turnkey/sdk-js-browser": "workspace:*",
-    "@turnkey/sdk-js-server": "workspace:*",
+    "@turnkey/sdk-browser": "workspace:*",
+    "@turnkey/sdk-server": "workspace:*",
     "cross-fetch": "^4.0.0",
     "typescript": "^5.1"
   },

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -12,11 +12,11 @@ import type {
 } from "viem";
 import { TurnkeyActivityError, TurnkeyClient } from "@turnkey/http";
 import { ApiKeyStamper } from "@turnkey/api-key-stamper";
-import type { TurnkeySDKBrowserClient } from "@turnkey/sdk-js-browser";
-import type { TurnkeySDKServerClient } from "@turnkey/sdk-js-server";
+import type { TurnkeyBrowserClient } from "@turnkey/sdk-browser";
+import type { TurnkeyServerClient } from "@turnkey/sdk-server";
 
 export async function createAccount(input: {
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient;
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient;
   organizationId: string;
   // This can be a wallet account address, private key address, or private key ID.
   signWith: string;
@@ -195,7 +195,7 @@ export async function createApiKeyAccount(
 }
 
 async function signMessage(
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient,
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient,
   message: SignableMessage,
   organizationId: string,
   signWith: string
@@ -213,7 +213,7 @@ async function signMessage(
 async function signTransaction<
   TTransactionSerializable extends TransactionSerializable
 >(
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient,
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient,
   transaction: TTransactionSerializable,
   serializer: SerializeTransactionFn<TTransactionSerializable>,
   organizationId: string,
@@ -230,7 +230,7 @@ async function signTransaction<
 }
 
 async function signTypedData(
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient,
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient,
   data: TypedData | { [key: string]: unknown },
   organizationId: string,
   signWith: string
@@ -246,7 +246,7 @@ async function signTypedData(
 }
 
 async function signTransactionWithErrorWrapping(
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient,
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient,
   unsignedTransaction: string,
   organizationId: string,
   signWith: string
@@ -274,7 +274,7 @@ async function signTransactionWithErrorWrapping(
 }
 
 async function signTransactionImpl(
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient,
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient,
   unsignedTransaction: string,
   organizationId: string,
   signWith: string
@@ -301,11 +301,10 @@ async function signTransactionImpl(
         activityType: type,
       });
     }
-    
+
     return assertNonNull(
       activity?.result?.signTransactionResult?.signedTransaction
     );
-
   } else {
     // Want to get additional activity details here
     const activity = await client.signTransaction({
@@ -319,7 +318,7 @@ async function signTransactionImpl(
 }
 
 async function signMessageWithErrorWrapping(
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient,
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient,
   message: string,
   organizationId: string,
   signWith: string
@@ -347,7 +346,7 @@ async function signMessageWithErrorWrapping(
 }
 
 async function signMessageImpl(
-  client: TurnkeyClient | TurnkeySDKBrowserClient | TurnkeySDKServerClient,
+  client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient,
   message: string,
   organizationId: string,
   signWith: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -762,6 +762,12 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http
+      '@turnkey/sdk-js-browser':
+        specifier: workspace:*
+        version: link:../sdk-js-browser
+      '@turnkey/sdk-js-server':
+        specifier: workspace:*
+        version: link:../sdk-js-server
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: 3.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,9 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../../packages/http
+      '@turnkey/sdk-js-server':
+        specifier: workspace:*
+        version: link:../../packages/sdk-js-server
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
@@ -665,6 +668,9 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../../packages/http
+      '@turnkey/sdk-js-server':
+        specifier: workspace:*
+        version: link:../../packages/sdk-js-server
       '@turnkey/viem':
         specifier: workspace:*
         version: link:../../packages/viem

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -919,6 +919,12 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http
+      '@turnkey/sdk-js-browser':
+        specifier: workspace:*
+        version: link:../sdk-js-browser
+      '@turnkey/sdk-js-server':
+        specifier: workspace:*
+        version: link:../sdk-js-server
       cross-fetch:
         specifier: ^4.0.0
         version: 4.0.0
@@ -7617,6 +7623,15 @@ packages:
     dependencies:
       '@types/connect': 3.4.35
       '@types/node': 20.3.1
+    dev: true
+
+  /@types/cacheable-request@6.0.3:
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+    dependencies:
+      '@types/http-cache-semantics': 4.0.4
+      '@types/keyv': 3.1.4
+      '@types/node': 20.3.1
+      '@types/responselike': 1.0.3
     dev: true
 
   /@types/cacheable-request@6.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,9 +469,9 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../../packages/http
-      '@turnkey/sdk-js-server':
+      '@turnkey/sdk-server':
         specifier: workspace:*
-        version: link:../../packages/sdk-js-server
+        version: link:../../packages/sdk-server
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
@@ -668,9 +668,9 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../../packages/http
-      '@turnkey/sdk-js-server':
+      '@turnkey/sdk-server':
         specifier: workspace:*
-        version: link:../../packages/sdk-js-server
+        version: link:../../packages/sdk-server
       '@turnkey/viem':
         specifier: workspace:*
         version: link:../../packages/viem
@@ -768,12 +768,12 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http
-      '@turnkey/sdk-js-browser':
+      '@turnkey/sdk-browser':
         specifier: workspace:*
-        version: link:../sdk-js-browser
-      '@turnkey/sdk-js-server':
+        version: link:../sdk-browser
+      '@turnkey/sdk-server':
         specifier: workspace:*
-        version: link:../sdk-js-server
+        version: link:../sdk-server
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: 3.0.5
@@ -852,6 +852,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      cross-fetch:
+        specifier: ^3.1.5
+        version: 3.1.5
       elliptic:
         specifier: ^6.5.5
         version: 6.5.5
@@ -931,12 +934,12 @@ importers:
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http
-      '@turnkey/sdk-js-browser':
+      '@turnkey/sdk-browser':
         specifier: workspace:*
-        version: link:../sdk-js-browser
-      '@turnkey/sdk-js-server':
+        version: link:../sdk-browser
+      '@turnkey/sdk-server':
         specifier: workspace:*
-        version: link:../sdk-js-server
+        version: link:../sdk-server
       cross-fetch:
         specifier: ^4.0.0
         version: 4.0.0
@@ -992,7 +995,7 @@ packages:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.20
     dev: false
 
   /@babel/code-frame@7.22.13:
@@ -1338,7 +1341,7 @@ packages:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
       '@babel/template': 7.20.7
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
@@ -1487,11 +1490,6 @@ packages:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
-    engines: {node: '>=6.9.0'}
-    dev: false
-
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -1537,15 +1535,6 @@ packages:
       '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/highlight@7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: false
 
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
@@ -2769,7 +2758,7 @@ packages:
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2784,7 +2773,7 @@ packages:
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3567,7 +3556,7 @@ packages:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
     dev: false
@@ -3602,7 +3591,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: false
 
@@ -4847,11 +4836,11 @@ packages:
     resolution: {integrity: sha512-W/o/34+wQuXlgqlPYTansOSiBnuxrTv61dEVkA6HNmpcgHLUjfaUbdqt6oVvOzaawwo9IdW9QOtMgQ1ScSZC4A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
       chalk: 4.1.2
-      jest-message-util: 29.4.3
-      jest-util: 29.4.3
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
       slash: 3.0.0
     dev: true
 
@@ -4922,7 +4911,6 @@ packages:
       '@jest/types': 29.6.3
       '@types/node': 20.3.1
       jest-mock: 29.7.0
-    dev: false
 
   /@jest/expect-utils@29.4.3:
     resolution: {integrity: sha512-/6JWbkxHOP8EoS8jeeTd9dTfc9Uawi+43oLKHfp6zzux3U2hqOOVnV3ai4RpDYHOccL6g+5nrxpoc8DmJxtXVQ==}
@@ -4945,12 +4933,12 @@ packages:
     resolution: {integrity: sha512-4Hote2MGcCTWSD2gwl0dwbCpBRHhE6olYEuTj8FMowdg3oQWNKr2YuxenPQYZ7+PfqPY1k98wKDU4Z+Hvd4Tiw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.0.2
       '@types/node': 20.3.1
-      jest-message-util: 29.4.3
-      jest-mock: 29.4.3
-      jest-util: 29.4.3
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
     dev: true
 
   /@jest/fake-timers@29.7.0:
@@ -4963,7 +4951,6 @@ packages:
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
-    dev: false
 
   /@jest/globals@29.4.3:
     resolution: {integrity: sha512-8BQ/5EzfOLG7AaMcDh7yFCbfRLtsc+09E1RQmRBI4D6QQk4m6NSK/MXo+3bJrBN0yU8A2/VIcqhvsOLFmziioA==}
@@ -4990,7 +4977,7 @@ packages:
       '@jest/console': 29.4.3
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.19
       '@types/node': 20.3.1
       chalk: 4.1.2
@@ -5003,8 +4990,8 @@ packages:
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.5
-      jest-message-util: 29.4.3
-      jest-util: 29.4.3
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
       jest-worker: 29.4.3
       slash: 3.0.0
       string-length: 4.0.2
@@ -5019,13 +5006,13 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.25.22
+    dev: true
 
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.27.8
-    dev: false
 
   /@jest/source-map@29.4.3:
     resolution: {integrity: sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==}
@@ -5041,7 +5028,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       collect-v8-coverage: 1.0.1
     dev: true
@@ -5061,7 +5048,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.22.20
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.17
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -5070,7 +5057,7 @@ packages:
       graceful-fs: 4.2.11
       jest-haste-map: 29.4.3
       jest-regex-util: 29.4.3
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       micromatch: 4.0.5
       pirates: 4.0.5
       slash: 3.0.0
@@ -5099,6 +5086,7 @@ packages:
       '@types/node': 20.3.1
       '@types/yargs': 17.0.22
       chalk: 4.1.2
+    dev: true
 
   /@jest/types@29.6.3:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
@@ -5110,7 +5098,6 @@ packages:
       '@types/node': 20.3.1
       '@types/yargs': 17.0.22
       chalk: 4.1.2
-    dev: false
 
   /@jridgewell/gen-mapping@0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
@@ -7457,10 +7444,10 @@ packages:
 
   /@sinclair/typebox@0.25.22:
     resolution: {integrity: sha512-6U6r2L7rnM7EG8G1tWzIjdB3QlsHF4slgcqXNN/SF0xJOAr0nDmT2GedlkyO3mrv8mDTJ24UuOMWR3diBrCvQQ==}
+    dev: true
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
-    dev: false
 
   /@sindresorhus/is@4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -7635,15 +7622,6 @@ packages:
     dependencies:
       '@types/connect': 3.4.35
       '@types/node': 20.3.1
-    dev: true
-
-  /@types/cacheable-request@6.0.3:
-    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
-    dependencies:
-      '@types/http-cache-semantics': 4.0.4
-      '@types/keyv': 3.1.4
-      '@types/node': 20.3.1
-      '@types/responselike': 1.0.3
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -11037,8 +11015,8 @@ packages:
       '@jest/expect-utils': 29.4.3
       jest-get-type: 29.4.3
       jest-matcher-utils: 29.4.3
-      jest-message-util: 29.4.3
-      jest-util: 29.4.3
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
     dev: true
 
   /express@4.19.2:
@@ -12649,10 +12627,10 @@ packages:
     resolution: {integrity: sha512-Vw/bVvcexmdJ7MLmgdT3ZjkJ3LKu8IlpefYokxiqoZy6OCQ2VAm6Vk3t/qHiAGUXbdbJKJWnc8gH3ypTbB/OBw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.4.3
+      '@jest/environment': 29.7.0
       '@jest/expect': 29.4.3
       '@jest/test-result': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
       chalk: 4.1.2
       co: 4.6.0
@@ -12660,12 +12638,12 @@ packages:
       is-generator-fn: 2.1.0
       jest-each: 29.4.3
       jest-matcher-utils: 29.4.3
-      jest-message-util: 29.4.3
+      jest-message-util: 29.7.0
       jest-runtime: 29.4.3
       jest-snapshot: 29.4.3
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       p-limit: 3.1.0
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
     transitivePeerDependencies:
@@ -12714,7 +12692,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.20
       '@jest/test-sequencer': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 18.18.2
       babel-jest: 29.4.3(@babel/core@7.22.20)
       chalk: 4.1.2
@@ -12728,11 +12706,11 @@ packages:
       jest-regex-util: 29.4.3
       jest-resolve: 29.4.3
       jest-runner: 29.4.3
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       jest-validate: 29.4.3
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -12753,7 +12731,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.20
       '@jest/test-sequencer': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
       babel-jest: 29.4.3(@babel/core@7.22.20)
       chalk: 4.1.2
@@ -12767,11 +12745,11 @@ packages:
       jest-regex-util: 29.4.3
       jest-resolve: 29.4.3
       jest-runner: 29.4.3
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       jest-validate: 29.4.3
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -12785,7 +12763,7 @@ packages:
       chalk: 4.1.2
       diff-sequences: 29.4.3
       jest-get-type: 29.4.3
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
     dev: true
 
   /jest-docblock@29.4.3:
@@ -12799,23 +12777,23 @@ packages:
     resolution: {integrity: sha512-1ElHNAnKcbJb/b+L+7j0/w7bDvljw4gTv1wL9fYOczeJrbTbkMGQ5iQPFJ3eFQH19VPTx1IyfePdqSpePKss7Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       chalk: 4.1.2
       jest-get-type: 29.4.3
-      jest-util: 29.4.3
-      pretty-format: 29.4.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-environment-node@29.4.3:
     resolution: {integrity: sha512-gAiEnSKF104fsGDXNkwk49jD/0N0Bqu2K9+aMQXA6avzsA9H3Fiv1PW2D+gzbOSR705bWd2wJZRFEFpV0tXISg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.4.3
-      '@jest/fake-timers': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
-      jest-mock: 29.4.3
-      jest-util: 29.4.3
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
     dev: true
 
   /jest-environment-node@29.7.0:
@@ -12844,14 +12822,14 @@ packages:
     resolution: {integrity: sha512-eZIgAS8tvm5IZMtKlR8Y+feEOMfo2pSQkmNbufdbMzMSn9nitgGxF1waM/+LbryO3OkMcKS98SUb+j/cQxp/vQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.6
       '@types/node': 20.3.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
       jest-regex-util: 29.4.3
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       jest-worker: 29.4.3
       micromatch: 4.0.5
       walker: 1.0.8
@@ -12863,7 +12841,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-get-type: 29.4.3
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
     dev: true
 
   /jest-matcher-utils@29.4.3:
@@ -12873,7 +12851,7 @@ packages:
       chalk: 4.1.2
       jest-diff: 29.4.3
       jest-get-type: 29.4.3
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
     dev: true
 
   /jest-message-util@29.4.3:
@@ -12881,12 +12859,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
       micromatch: 4.0.5
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
     dev: true
@@ -12904,7 +12882,6 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
-    dev: false
 
   /jest-mock@29.4.3:
     resolution: {integrity: sha512-LjFgMg+xed9BdkPMyIJh+r3KeHt1klXPJYBULXVVAkbTaaKjPX1o1uVCAZADMEp/kOxGTwy/Ot8XbvgItOrHEg==}
@@ -12922,7 +12899,6 @@ packages:
       '@jest/types': 29.6.3
       '@types/node': 20.3.1
       jest-util: 29.7.0
-    dev: false
 
   /jest-pnp-resolver@1.2.3(jest-resolve@29.4.3):
     resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
@@ -12958,7 +12934,7 @@ packages:
       graceful-fs: 4.2.11
       jest-haste-map: 29.4.3
       jest-pnp-resolver: 1.2.3(jest-resolve@29.4.3)
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       jest-validate: 29.4.3
       resolve: 1.22.8
       resolve.exports: 2.0.0
@@ -12970,10 +12946,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.4.3
-      '@jest/environment': 29.4.3
+      '@jest/environment': 29.7.0
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
       chalk: 4.1.2
       emittery: 0.13.1
@@ -12982,10 +12958,10 @@ packages:
       jest-environment-node: 29.4.3
       jest-haste-map: 29.4.3
       jest-leak-detector: 29.4.3
-      jest-message-util: 29.4.3
+      jest-message-util: 29.7.0
       jest-resolve: 29.4.3
       jest-runtime: 29.4.3
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       jest-watcher: 29.4.3
       jest-worker: 29.4.3
       p-limit: 3.1.0
@@ -12998,13 +12974,13 @@ packages:
     resolution: {integrity: sha512-F5bHvxSH+LvLV24vVB3L8K467dt3y3dio6V3W89dUz9nzvTpqd/HcT9zfYKL2aZPvD63vQFgLvaUX/UpUhrP6Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.4.3
-      '@jest/fake-timers': 29.4.3
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
       '@jest/globals': 29.4.3
       '@jest/source-map': 29.4.3
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
@@ -13012,12 +12988,12 @@ packages:
       glob: 7.2.3
       graceful-fs: 4.2.11
       jest-haste-map: 29.4.3
-      jest-message-util: 29.4.3
-      jest-mock: 29.4.3
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
       jest-regex-util: 29.4.3
       jest-resolve: 29.4.3
       jest-snapshot: 29.4.3
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -13036,7 +13012,7 @@ packages:
       '@babel/types': 7.23.0
       '@jest/expect-utils': 29.4.3
       '@jest/transform': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/babel__traverse': 7.18.3
       '@types/prettier': 2.7.2
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.22.20)
@@ -13047,10 +13023,10 @@ packages:
       jest-get-type: 29.4.3
       jest-haste-map: 29.4.3
       jest-matcher-utils: 29.4.3
-      jest-message-util: 29.4.3
-      jest-util: 29.4.3
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
       natural-compare: 1.4.0
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -13060,12 +13036,13 @@ packages:
     resolution: {integrity: sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
       picomatch: 2.3.1
+    dev: true
 
   /jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
@@ -13077,18 +13054,17 @@ packages:
       ci-info: 3.8.0
       graceful-fs: 4.2.11
       picomatch: 2.3.1
-    dev: false
 
   /jest-validate@29.4.3:
     resolution: {integrity: sha512-J3u5v7aPQoXPzaar6GndAVhdQcZr/3osWSgTeKg5v574I9ybX/dTyH0AJFb5XgXIB7faVhf+rS7t4p3lL9qFaw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       camelcase: 6.3.0
       chalk: 4.1.2
       jest-get-type: 29.4.3
       leven: 3.1.0
-      pretty-format: 29.4.3
+      pretty-format: 29.7.0
     dev: true
 
   /jest-validate@29.7.0:
@@ -13108,12 +13084,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.6.3
       '@types/node': 20.3.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       string-length: 4.0.2
     dev: true
 
@@ -13122,7 +13098,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@types/node': 20.3.1
-      jest-util: 29.4.3
+      jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -14946,7 +14922,7 @@ packages:
     resolution: {integrity: sha512-cvpcHTc42lcsvOOAzd3XuNWTcvk1Jmnzqeu+WsOuiPmxUJTnkbAcFNsRKvEpBEUFVUgy/GTZLulZDcDEi+CIlA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.4.3
+      '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
@@ -14958,7 +14934,6 @@ packages:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.2.0
-    dev: false
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}


### PR DESCRIPTION
## Summary & Motivation
considerations: viem / ethers become a tiny bit heavier

TODO:
- replace all instances of goerli with sepolia
- test both (update demo-viem-passkeys and demo-ethers-passkeys)

## How I Tested These Changes
- ran examples

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
