### PR TITLE
Apply settings via iframe-stamper

### DIFF
--- a/.changeset/five-terms-march.md
+++ b/.changeset/five-terms-march.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/iframe-stamper": minor
+---
+
+Add applySettings.

--- a/examples/wallet-import-export/src/components/Import.tsx
+++ b/examples/wallet-import-export/src/components/Import.tsx
@@ -54,11 +54,7 @@ export function Import(props: ImportProps) {
       box-sizing: border-box;
       width: 400px;
       height: 120px;
-      border-radius: 8px;
-      border-width: 1px;
-      border-style: solid;
-      border-color: rgba(216, 219, 227, 1);
-      padding: 20px;
+      border: none;
     }
     `;
 

--- a/examples/wallet-import-export/src/components/Import.tsx
+++ b/examples/wallet-import-export/src/components/Import.tsx
@@ -35,34 +35,38 @@ export function Import(props: ImportProps) {
         iframeContainer: document.getElementById(TurnkeyIframeContainerId),
         iframeElementId: TurnkeyIframeElementId,
       });
-      iframeStamper.init().then(() => {
-        setIframeStamper(iframeStamper);
-        props.setIframeStamper(iframeStamper);
-        return iframeStamper;
-      }).then((iframeStamper: IframeStamper) => {
-        const styles = {
-          padding: "20px",
-          borderRadius: "8px",
-          borderWidth: "2px",
-          borderStyle: "solid",
-          borderColor: "#ff6961",
-          fontFamily: "monospace",
-          color: "#333",
-          width: "340px",
-          height: "100px",
-          backgroundColor: "#fff3f3",
-          boxShadow: "0px 0px 10px #aaa",
-          overflowWrap: "break-word",
-          wordWrap: "break-word",
-          resize: "none",
-        }
-        return iframeStamper.applySettings({ styles });
-      }).then((settingsApplied: boolean) => {
-        if (settingsApplied !== true) {
-          alert("Unexpected error while applying settings.");
-          return;
-        }
-      });
+      iframeStamper
+        .init()
+        .then(() => {
+          setIframeStamper(iframeStamper);
+          props.setIframeStamper(iframeStamper);
+          return iframeStamper;
+        })
+        .then((iframeStamper: IframeStamper) => {
+          const styles = {
+            padding: "20px",
+            borderRadius: "8px",
+            borderWidth: "2px",
+            borderStyle: "solid",
+            borderColor: "#ff6961",
+            fontFamily: "monospace",
+            color: "#333",
+            width: "340px",
+            height: "100px",
+            backgroundColor: "#fff3f3",
+            boxShadow: "0px 0px 10px #aaa",
+            overflowWrap: "break-word",
+            wordWrap: "break-word",
+            resize: "none",
+          };
+          return iframeStamper.applySettings({ styles });
+        })
+        .then((settingsApplied: boolean) => {
+          if (settingsApplied !== true) {
+            alert("Unexpected error while applying settings.");
+            return;
+          }
+        });
     }
 
     return () => {

--- a/examples/wallet-import-export/src/components/Import.tsx
+++ b/examples/wallet-import-export/src/components/Import.tsx
@@ -38,6 +38,30 @@ export function Import(props: ImportProps) {
       iframeStamper.init().then(() => {
         setIframeStamper(iframeStamper);
         props.setIframeStamper(iframeStamper);
+        return iframeStamper;
+      }).then((iframeStamper: IframeStamper) => {
+        const styles = {
+          padding: "20px",
+          borderRadius: "8px",
+          borderWidth: "2px",
+          borderStyle: "solid",
+          borderColor: "#ff6961",
+          fontFamily: "monospace",
+          color: "#333",
+          width: "340px",
+          height: "100px",
+          backgroundColor: "#fff3f3",
+          boxShadow: "0px 0px 10px #aaa",
+          overflowWrap: "break-word",
+          wordWrap: "break-word",
+          resize: "none",
+        }
+        return iframeStamper.applySettings({ styles });
+      }).then((settingsApplied: boolean) => {
+        if (settingsApplied !== true) {
+          alert("Unexpected error while applying settings.");
+          return;
+        }
       });
     }
 
@@ -53,7 +77,7 @@ export function Import(props: ImportProps) {
     iframe {
       box-sizing: border-box;
       width: 400px;
-      height: 120px;
+      height: 180px;
       border: none;
     }
     `;

--- a/examples/wallet-import-export/src/components/ImportWallet.tsx
+++ b/examples/wallet-import-export/src/components/ImportWallet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import axios from "axios";
-import { SetStateAction, useState } from "react";
+import { SetStateAction, useState, useEffect } from "react";
 
 import styles from "../pages/index.module.css";
 import { IframeStamper } from "@turnkey/iframe-stamper";
@@ -49,6 +49,14 @@ export function ImportWallet(props: ImportWalletProps) {
       return;
     }
 
+    const settingsApplied = await iframeStamper.applySettings(
+      "{\"styles\": {\"padding\": \"20px\", \"borderRadius\": \"8px\", \"borderWidth\": \"1px\", \"borderStyle\": \"solid\", \"borderColor\": \"rgba(216, 219, 227, 1)\", \"fontFamily\": \"monospace\", \"width\": \"340px\", \"height\": \"80px\" }}"
+    );
+    
+    if (settingsApplied !== true) {
+      alert("Unexpected error while applying settings.");
+      return;
+    }
     setStage("import");
     setIframeDisplay("block");
   };

--- a/examples/wallet-import-export/src/components/ImportWallet.tsx
+++ b/examples/wallet-import-export/src/components/ImportWallet.tsx
@@ -49,14 +49,6 @@ export function ImportWallet(props: ImportWalletProps) {
       return;
     }
 
-    const settingsApplied = await iframeStamper.applySettings(
-      "{\"styles\": {\"padding\": \"20px\", \"borderRadius\": \"8px\", \"borderWidth\": \"1px\", \"borderStyle\": \"solid\", \"borderColor\": \"rgba(216, 219, 227, 1)\", \"fontFamily\": \"monospace\", \"width\": \"340px\", \"height\": \"80px\" }}"
-    );
-    
-    if (settingsApplied !== true) {
-      alert("Unexpected error while applying settings.");
-      return;
-    }
     setStage("import");
     setIframeDisplay("block");
   };

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -72,6 +72,34 @@ export type TIframeStamperConfig = {
   iframeContainer: HTMLElement | null | undefined;
 };
 
+export type TIframeStyles = {
+  padding?: string;
+  margin?: string;
+  borderWidth?: string;
+  borderStyle?: string;
+  borderColor?: string;
+  borderRadius?: string;
+  fontSize?: string;
+  fontWeight?: string;
+  fontFamily?: string;
+  color?: string;
+  backgroundColor?: string;
+  width?: string;
+  height?: string;
+  maxWidth?: string;
+  maxHeight?: string;
+  lineHeight?: string;
+  boxShadow?: string;
+  textAlign?: string;
+  overflowWrap?: string;
+  wordWrap?: string;
+  resize?: string;
+};
+
+export type TIframeSettings = {
+  styles?: TIframeStyles;
+};
+
 /**
  * Stamper to use with `@turnkey/http`'s `TurnkeyClient`
  * Creating a stamper inserts an iframe in the current page.
@@ -387,11 +415,12 @@ export class IframeStamper {
    * Function to apply settings on allowed parameters in the iframe
    * This is used to style the HTML element used for plaintext in wallet and private key import.
    */
-  async applySettings(settings: string): Promise<boolean> {
+  async applySettings(settings: TIframeSettings): Promise<boolean> {
+    const settingsStr = JSON.stringify(settings)
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.ApplySettings,
-        value: settings,
+        value: settingsStr,
       },
       "*"
     );

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -416,7 +416,7 @@ export class IframeStamper {
    * This is used to style the HTML element used for plaintext in wallet and private key import.
    */
   async applySettings(settings: TIframeSettings): Promise<boolean> {
-    const settingsStr = JSON.stringify(settings)
+    const settingsStr = JSON.stringify(settings);
     this.iframe.contentWindow?.postMessage(
       {
         type: IframeEventType.ApplySettings,


### PR DESCRIPTION
## Summary & Motivation
ENG-1388. Adds `applySettings` method to the iframe stamper that allows custom settings for surface-level/UI components in the iframe (styles, supported mnemonic lengths, supported private key formats, extra validation, etc.). The first setting we're implementing is `styles`, where CSS styles can be validated, sanitized, and applied to a specific HTML element on import.turnkey.com.

Relevant to https://github.com/tkhq/frames/pull/34

## How I Tested These Changes
using wallet-import-export example against the old and new local instances of import.turnkey.com

## Did you add a changeset?
yes to `iframe-stamper` package

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
