### PR TITLE
update codegen

### DIFF
--- a/packages/sdk-js-browser/scripts/codegen.js
+++ b/packages/sdk-js-browser/scripts/codegen.js
@@ -65,7 +65,46 @@ function methodTypeFromMethodName(methodName) {
   if (methodName.startsWith("get") || methodName.startsWith("list")) {
     return "query";
   }
+  // Rename to submit?
   return "command";
+}
+
+// Helper that takes in swagger definitions and returns a map containing the latest version of a field.
+// The intent is to consolidate a field with multiple versions (e.g. v1CreateSubOrganizationResult, v1CreateSubOrganizationResultV2...)
+// in order to get just the latest (v1CreateSubOrganizationResultV4).
+function extractLatestVersions(definitions) {
+  const latestVersions = {};
+
+  // Regex to separate the version prefix, base activity details, and (optional) activity version
+  const keyVersionRegex = /^(v\d+)([A-Z][a-z]+(?:[A-Z][a-z]+)*)(V\d+)?$/; 
+
+  Object.keys(definitions).forEach((key) => {
+    const match = key.match(keyVersionRegex);
+    if (match) {
+      const fullName = match[0];
+      const _defaultPrefix = match[1]; // This is simply the namespace prefix; every field has this "v1"
+      const baseName = match[2]; // Field without any version-related prefixes or suffixes
+      const versionSuffix = match[3]; // Version (optional)
+      const formattedKeyName =
+        baseName.charAt(0).toLowerCase() +
+        baseName.slice(1) +
+        (versionSuffix || ""); // Reconstruct the original key with version
+
+      // Determine if this version is newer or if no version was previously stored
+      if (
+        !latestVersions[baseName] ||
+        versionSuffix > (latestVersions[baseName].versionSuffix || "")
+      ) {
+        latestVersions[baseName] = {
+          fullName,
+          formattedKeyName,
+          versionSuffix,
+        };
+      }
+    }
+  });
+
+  return latestVersions;
 }
 
 // Generators
@@ -86,6 +125,8 @@ const generateApiTypesFromSwagger = async (swaggerSpec, targetPath) => {
     'import type { queryOverrideParams, commandOverrideParams, ActivityMetadata } from "../__types__/base";'
   );
 
+  const latestVersions = extractLatestVersions(swaggerSpec.definitions);
+
   for (const endpointPath in swaggerSpec.paths) {
     const methodMap = swaggerSpec.paths[endpointPath];
     const operation = methodMap.post;
@@ -96,20 +137,21 @@ const generateApiTypesFromSwagger = async (swaggerSpec, targetPath) => {
       ""
     );
 
-    const isEndpointDeprecated = Boolean(operation.deprecated);
-
     const methodName = `${
       operationNameWithoutNamespace.charAt(0).toLowerCase() +
       operationNameWithoutNamespace.slice(1)
     }`;
 
     const methodType = methodTypeFromMethodName(methodName);
-    const signedRequestGeneratorName = `sign${methodName}`;
+
     const parameterList = operation["parameters"] ?? [];
 
     let responseValue = "void";
     if (methodType === "command") {
-      responseValue = `operations["${operationId}"]["responses"]["200"]["schema"]["activity"]["result"]["${methodName}Result"] & ActivityMetadata`;
+      const resultKey = operationNameWithoutNamespace + "Result";
+      const versionedMethodName = latestVersions[resultKey].formattedKeyName;
+
+      responseValue = `operations["${operationId}"]["responses"]["200"]["schema"]["activity"]["result"]["${versionedMethodName}"] & ActivityMetadata`;
     } else if (["noop", "query"].includes(methodType)) {
       responseValue = `operations["${operationId}"]["responses"]["200"]["schema"]`;
     } else if (methodType === "activityDecision") {
@@ -206,8 +248,6 @@ const generateSDKClientFromSwagger = async (swaggerSpec, targetPath) => {
 
   imports.push('import type * as SdkApiTypes from "./sdk_api_types";');
 
-  imports.push('import { StorageKeys, getStorageValue } from "../storage";');
-
   codeBuffer.push(`
 export class TurnkeySDKClientBase {
   config: TurnkeySDKClientConfig;
@@ -257,13 +297,13 @@ export class TurnkeySDKClientBase {
     const POLLING_DURATION = this.config.activityPoller?.duration ?? 1000;
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-    const initialData = await this.request<TBodyType, TResponseType>(url, body) as ActivityResponse;
-    const activityId = initialData["activity"]["id"];
-    let activityStatus = initialData["activity"]["status"];
+    const responseData = await this.request<TBodyType, TResponseType>(url, body) as ActivityResponse;
+    const activityId = responseData["activity"]["id"];
+    const activityStatus = responseData["activity"]["status"];
 
     if (activityStatus !== "ACTIVITY_STATUS_PENDING") {
       return {
-        ...initialData["activity"]["result"][\`\${resultKey}\`],
+        ...responseData["activity"]["result"][\`\${resultKey}\`],
         activity: {
           id: activityId,
           status: activityStatus
@@ -325,8 +365,6 @@ export class TurnkeySDKClientBase {
       continue;
     }
 
-    const isEndpointDeprecated = Boolean(operation.deprecated);
-
     const methodName = `${
       operationNameWithoutNamespace.charAt(0).toLowerCase() +
       operationNameWithoutNamespace.slice(1)
@@ -343,10 +381,9 @@ export class TurnkeySDKClientBase {
             ? " = {}"
             : ""
         }): Promise<SdkApiTypes.${responseType}> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("${endpointPath}", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }`
       );
@@ -362,10 +399,9 @@ export class TurnkeySDKClientBase {
       codeBuffer.push(
         `\n\t${methodName} = async (input: SdkApiTypes.${inputType}): Promise<SdkApiTypes.${responseType}> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("${endpointPath}", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "${versionedActivityType ?? unversionedActivityType}"
     }, "${methodName}Result${versionSuffix ? versionSuffix[1] : ""}");
@@ -375,10 +411,10 @@ export class TurnkeySDKClientBase {
       codeBuffer.push(
         `\n\t${methodName} = async (input: SdkApiTypes.${inputType}): Promise<SdkApiTypes.${responseType}> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
-    return this.activityDecision("${endpointPath}", {
+    return this.activityDecision("${endpointPath}",
+      {
         parameters: rest,
-        organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+        organizationId: organizationId ?? this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_${operationNameWithoutNamespace
           .replace(/([a-z])([A-Z])/g, "$1_$2")

--- a/packages/sdk-js-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-js-browser/src/__generated__/sdk-client-base.ts
@@ -6,8 +6,6 @@ import { VERSION } from "../__generated__/version";
 
 import type * as SdkApiTypes from "./sdk_api_types";
 
-import { StorageKeys, getStorageValue } from "../storage";
-
 
 export class TurnkeySDKClientBase {
   config: TurnkeySDKClientConfig;
@@ -57,13 +55,13 @@ export class TurnkeySDKClientBase {
     const POLLING_DURATION = this.config.activityPoller?.duration ?? 1000;
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-    const initialData = await this.request<TBodyType, TResponseType>(url, body) as ActivityResponse;
-    const activityId = initialData["activity"]["id"];
-    let activityStatus = initialData["activity"]["status"];
+    const responseData = await this.request<TBodyType, TResponseType>(url, body) as ActivityResponse;
+    const activityId = responseData["activity"]["id"];
+    const activityStatus = responseData["activity"]["status"];
 
     if (activityStatus !== "ACTIVITY_STATUS_PENDING") {
       return {
-        ...initialData["activity"]["result"][`${resultKey}`],
+        ...responseData["activity"]["result"][`${resultKey}`],
         activity: {
           id: activityId,
           status: activityStatus
@@ -109,195 +107,175 @@ export class TurnkeySDKClientBase {
     } as TResponseType;
   }
 
-
+  
 
 
 	getActivity = async (input: SdkApiTypes.TGetActivityBody): Promise<SdkApiTypes.TGetActivityResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_activity", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getApiKey = async (input: SdkApiTypes.TGetApiKeyBody): Promise<SdkApiTypes.TGetApiKeyResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_api_key", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getApiKeys = async (input: SdkApiTypes.TGetApiKeysBody = {}): Promise<SdkApiTypes.TGetApiKeysResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_api_keys", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getAuthenticator = async (input: SdkApiTypes.TGetAuthenticatorBody): Promise<SdkApiTypes.TGetAuthenticatorResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_authenticator", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getAuthenticators = async (input: SdkApiTypes.TGetAuthenticatorsBody): Promise<SdkApiTypes.TGetAuthenticatorsResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_authenticators", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getOrganization = async (input: SdkApiTypes.TGetOrganizationBody = {}): Promise<SdkApiTypes.TGetOrganizationResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_organization", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getPolicy = async (input: SdkApiTypes.TGetPolicyBody): Promise<SdkApiTypes.TGetPolicyResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_policy", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getPrivateKey = async (input: SdkApiTypes.TGetPrivateKeyBody): Promise<SdkApiTypes.TGetPrivateKeyResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_private_key", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getUser = async (input: SdkApiTypes.TGetUserBody): Promise<SdkApiTypes.TGetUserResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_user", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getWallet = async (input: SdkApiTypes.TGetWalletBody): Promise<SdkApiTypes.TGetWalletResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/get_wallet", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getActivities = async (input: SdkApiTypes.TGetActivitiesBody = {}): Promise<SdkApiTypes.TGetActivitiesResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_activities", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getPolicies = async (input: SdkApiTypes.TGetPoliciesBody = {}): Promise<SdkApiTypes.TGetPoliciesResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_policies", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	listPrivateKeyTags = async (input: SdkApiTypes.TListPrivateKeyTagsBody): Promise<SdkApiTypes.TListPrivateKeyTagsResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_private_key_tags", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getPrivateKeys = async (input: SdkApiTypes.TGetPrivateKeysBody = {}): Promise<SdkApiTypes.TGetPrivateKeysResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_private_keys", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getSubOrgIds = async (input: SdkApiTypes.TGetSubOrgIdsBody = {}): Promise<SdkApiTypes.TGetSubOrgIdsResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_suborgs", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	listUserTags = async (input: SdkApiTypes.TListUserTagsBody = {}): Promise<SdkApiTypes.TListUserTagsResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_user_tags", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getUsers = async (input: SdkApiTypes.TGetUsersBody = {}): Promise<SdkApiTypes.TGetUsersResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_users", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getWalletAccounts = async (input: SdkApiTypes.TGetWalletAccountsBody): Promise<SdkApiTypes.TGetWalletAccountsResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_wallet_accounts", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getWallets = async (input: SdkApiTypes.TGetWalletsBody = {}): Promise<SdkApiTypes.TGetWalletsResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/list_wallets", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	getWhoami = async (input: SdkApiTypes.TGetWhoamiBody = {}): Promise<SdkApiTypes.TGetWhoamiResponse> => {
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.request("/public/v1/query/whoami", {
       ...input,
-      organizationId: input.organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId)
+      organizationId: input.organizationId ?? this.config.organizationId
     });
   }
 
 
 	approveActivity = async (input: SdkApiTypes.TApproveActivityBody): Promise<SdkApiTypes.TApproveActivityResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
-    return this.activityDecision("/public/v1/submit/approve_activity", {
+    return this.activityDecision("/public/v1/submit/approve_activity",
+      {
         parameters: rest,
-        organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+        organizationId: organizationId ?? this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_APPROVE_ACTIVITY"
       });
@@ -306,10 +284,9 @@ export class TurnkeySDKClientBase {
 
 	createApiKeys = async (input: SdkApiTypes.TCreateApiKeysBody): Promise<SdkApiTypes.TCreateApiKeysResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_api_keys", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_API_KEYS"
     }, "createApiKeysResult");
@@ -318,10 +295,9 @@ export class TurnkeySDKClientBase {
 
 	createApiOnlyUsers = async (input: SdkApiTypes.TCreateApiOnlyUsersBody): Promise<SdkApiTypes.TCreateApiOnlyUsersResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_api_only_users", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS"
     }, "createApiOnlyUsersResult");
@@ -330,10 +306,9 @@ export class TurnkeySDKClientBase {
 
 	createAuthenticators = async (input: SdkApiTypes.TCreateAuthenticatorsBody): Promise<SdkApiTypes.TCreateAuthenticatorsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_authenticators", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_AUTHENTICATORS_V2"
     }, "createAuthenticatorsResultV2");
@@ -342,10 +317,9 @@ export class TurnkeySDKClientBase {
 
 	createInvitations = async (input: SdkApiTypes.TCreateInvitationsBody): Promise<SdkApiTypes.TCreateInvitationsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_invitations", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_INVITATIONS"
     }, "createInvitationsResult");
@@ -354,10 +328,9 @@ export class TurnkeySDKClientBase {
 
 	createPolicies = async (input: SdkApiTypes.TCreatePoliciesBody): Promise<SdkApiTypes.TCreatePoliciesResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_policies", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_POLICIES"
     }, "createPoliciesResult");
@@ -366,10 +339,9 @@ export class TurnkeySDKClientBase {
 
 	createPolicy = async (input: SdkApiTypes.TCreatePolicyBody): Promise<SdkApiTypes.TCreatePolicyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_policy", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_POLICY_V3"
     }, "createPolicyResultV3");
@@ -378,10 +350,9 @@ export class TurnkeySDKClientBase {
 
 	createPrivateKeyTag = async (input: SdkApiTypes.TCreatePrivateKeyTagBody): Promise<SdkApiTypes.TCreatePrivateKeyTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_private_key_tag", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG"
     }, "createPrivateKeyTagResult");
@@ -390,10 +361,9 @@ export class TurnkeySDKClientBase {
 
 	createPrivateKeys = async (input: SdkApiTypes.TCreatePrivateKeysBody): Promise<SdkApiTypes.TCreatePrivateKeysResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_private_keys", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2"
     }, "createPrivateKeysResultV2");
@@ -402,10 +372,9 @@ export class TurnkeySDKClientBase {
 
 	createSubOrganization = async (input: SdkApiTypes.TCreateSubOrganizationBody): Promise<SdkApiTypes.TCreateSubOrganizationResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_sub_organization", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V4"
     }, "createSubOrganizationResultV4");
@@ -414,10 +383,9 @@ export class TurnkeySDKClientBase {
 
 	createUserTag = async (input: SdkApiTypes.TCreateUserTagBody): Promise<SdkApiTypes.TCreateUserTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_user_tag", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_USER_TAG"
     }, "createUserTagResult");
@@ -426,10 +394,9 @@ export class TurnkeySDKClientBase {
 
 	createUsers = async (input: SdkApiTypes.TCreateUsersBody): Promise<SdkApiTypes.TCreateUsersResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_users", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_USERS_V2"
     }, "createUsersResultV2");
@@ -438,10 +405,9 @@ export class TurnkeySDKClientBase {
 
 	createWallet = async (input: SdkApiTypes.TCreateWalletBody): Promise<SdkApiTypes.TCreateWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_wallet", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_WALLET"
     }, "createWalletResult");
@@ -450,10 +416,9 @@ export class TurnkeySDKClientBase {
 
 	createWalletAccounts = async (input: SdkApiTypes.TCreateWalletAccountsBody): Promise<SdkApiTypes.TCreateWalletAccountsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/create_wallet_accounts", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS"
     }, "createWalletAccountsResult");
@@ -462,10 +427,9 @@ export class TurnkeySDKClientBase {
 
 	deleteApiKeys = async (input: SdkApiTypes.TDeleteApiKeysBody): Promise<SdkApiTypes.TDeleteApiKeysResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/delete_api_keys", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_API_KEYS"
     }, "deleteApiKeysResult");
@@ -474,10 +438,9 @@ export class TurnkeySDKClientBase {
 
 	deleteAuthenticators = async (input: SdkApiTypes.TDeleteAuthenticatorsBody): Promise<SdkApiTypes.TDeleteAuthenticatorsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/delete_authenticators", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_AUTHENTICATORS"
     }, "deleteAuthenticatorsResult");
@@ -486,10 +449,9 @@ export class TurnkeySDKClientBase {
 
 	deleteInvitation = async (input: SdkApiTypes.TDeleteInvitationBody): Promise<SdkApiTypes.TDeleteInvitationResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/delete_invitation", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_INVITATION"
     }, "deleteInvitationResult");
@@ -498,10 +460,9 @@ export class TurnkeySDKClientBase {
 
 	deletePolicy = async (input: SdkApiTypes.TDeletePolicyBody): Promise<SdkApiTypes.TDeletePolicyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/delete_policy", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_POLICY"
     }, "deletePolicyResult");
@@ -510,10 +471,9 @@ export class TurnkeySDKClientBase {
 
 	deletePrivateKeyTags = async (input: SdkApiTypes.TDeletePrivateKeyTagsBody): Promise<SdkApiTypes.TDeletePrivateKeyTagsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/delete_private_key_tags", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_PRIVATE_KEY_TAGS"
     }, "deletePrivateKeyTagsResult");
@@ -522,10 +482,9 @@ export class TurnkeySDKClientBase {
 
 	deleteUserTags = async (input: SdkApiTypes.TDeleteUserTagsBody): Promise<SdkApiTypes.TDeleteUserTagsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/delete_user_tags", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_USER_TAGS"
     }, "deleteUserTagsResult");
@@ -534,10 +493,9 @@ export class TurnkeySDKClientBase {
 
 	deleteUsers = async (input: SdkApiTypes.TDeleteUsersBody): Promise<SdkApiTypes.TDeleteUsersResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/delete_users", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_USERS"
     }, "deleteUsersResult");
@@ -546,10 +504,9 @@ export class TurnkeySDKClientBase {
 
 	emailAuth = async (input: SdkApiTypes.TEmailAuthBody): Promise<SdkApiTypes.TEmailAuthResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/email_auth", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_EMAIL_AUTH"
     }, "emailAuthResult");
@@ -558,10 +515,9 @@ export class TurnkeySDKClientBase {
 
 	exportPrivateKey = async (input: SdkApiTypes.TExportPrivateKeyBody): Promise<SdkApiTypes.TExportPrivateKeyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/export_private_key", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_EXPORT_PRIVATE_KEY"
     }, "exportPrivateKeyResult");
@@ -570,10 +526,9 @@ export class TurnkeySDKClientBase {
 
 	exportWallet = async (input: SdkApiTypes.TExportWalletBody): Promise<SdkApiTypes.TExportWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/export_wallet", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_EXPORT_WALLET"
     }, "exportWalletResult");
@@ -582,10 +537,9 @@ export class TurnkeySDKClientBase {
 
 	exportWalletAccount = async (input: SdkApiTypes.TExportWalletAccountBody): Promise<SdkApiTypes.TExportWalletAccountResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/export_wallet_account", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_EXPORT_WALLET_ACCOUNT"
     }, "exportWalletAccountResult");
@@ -594,10 +548,9 @@ export class TurnkeySDKClientBase {
 
 	importPrivateKey = async (input: SdkApiTypes.TImportPrivateKeyBody): Promise<SdkApiTypes.TImportPrivateKeyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/import_private_key", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY"
     }, "importPrivateKeyResult");
@@ -606,10 +559,9 @@ export class TurnkeySDKClientBase {
 
 	importWallet = async (input: SdkApiTypes.TImportWalletBody): Promise<SdkApiTypes.TImportWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/import_wallet", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_IMPORT_WALLET"
     }, "importWalletResult");
@@ -618,10 +570,9 @@ export class TurnkeySDKClientBase {
 
 	initImportPrivateKey = async (input: SdkApiTypes.TInitImportPrivateKeyBody): Promise<SdkApiTypes.TInitImportPrivateKeyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/init_import_private_key", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY"
     }, "initImportPrivateKeyResult");
@@ -630,10 +581,9 @@ export class TurnkeySDKClientBase {
 
 	initImportWallet = async (input: SdkApiTypes.TInitImportWalletBody): Promise<SdkApiTypes.TInitImportWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/init_import_wallet", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_INIT_IMPORT_WALLET"
     }, "initImportWalletResult");
@@ -642,10 +592,9 @@ export class TurnkeySDKClientBase {
 
 	initUserEmailRecovery = async (input: SdkApiTypes.TInitUserEmailRecoveryBody): Promise<SdkApiTypes.TInitUserEmailRecoveryResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/init_user_email_recovery", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_INIT_USER_EMAIL_RECOVERY"
     }, "initUserEmailRecoveryResult");
@@ -654,10 +603,9 @@ export class TurnkeySDKClientBase {
 
 	recoverUser = async (input: SdkApiTypes.TRecoverUserBody): Promise<SdkApiTypes.TRecoverUserResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/recover_user", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_RECOVER_USER"
     }, "recoverUserResult");
@@ -666,10 +614,10 @@ export class TurnkeySDKClientBase {
 
 	rejectActivity = async (input: SdkApiTypes.TRejectActivityBody): Promise<SdkApiTypes.TRejectActivityResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
-    return this.activityDecision("/public/v1/submit/reject_activity", {
+    return this.activityDecision("/public/v1/submit/reject_activity",
+      {
         parameters: rest,
-        organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+        organizationId: organizationId ?? this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_REJECT_ACTIVITY"
       });
@@ -678,10 +626,9 @@ export class TurnkeySDKClientBase {
 
 	removeOrganizationFeature = async (input: SdkApiTypes.TRemoveOrganizationFeatureBody): Promise<SdkApiTypes.TRemoveOrganizationFeatureResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/remove_organization_feature", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_REMOVE_ORGANIZATION_FEATURE"
     }, "removeOrganizationFeatureResult");
@@ -690,10 +637,9 @@ export class TurnkeySDKClientBase {
 
 	setOrganizationFeature = async (input: SdkApiTypes.TSetOrganizationFeatureBody): Promise<SdkApiTypes.TSetOrganizationFeatureResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/set_organization_feature", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_SET_ORGANIZATION_FEATURE"
     }, "setOrganizationFeatureResult");
@@ -702,10 +648,9 @@ export class TurnkeySDKClientBase {
 
 	signRawPayload = async (input: SdkApiTypes.TSignRawPayloadBody): Promise<SdkApiTypes.TSignRawPayloadResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/sign_raw_payload", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2"
     }, "signRawPayloadResultV2");
@@ -714,10 +659,9 @@ export class TurnkeySDKClientBase {
 
 	signRawPayloads = async (input: SdkApiTypes.TSignRawPayloadsBody): Promise<SdkApiTypes.TSignRawPayloadsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/sign_raw_payloads", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS"
     }, "signRawPayloadsResult");
@@ -726,10 +670,9 @@ export class TurnkeySDKClientBase {
 
 	signTransaction = async (input: SdkApiTypes.TSignTransactionBody): Promise<SdkApiTypes.TSignTransactionResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/sign_transaction", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2"
     }, "signTransactionResultV2");
@@ -738,10 +681,9 @@ export class TurnkeySDKClientBase {
 
 	updatePolicy = async (input: SdkApiTypes.TUpdatePolicyBody): Promise<SdkApiTypes.TUpdatePolicyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/update_policy", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_POLICY"
     }, "updatePolicyResult");
@@ -750,10 +692,9 @@ export class TurnkeySDKClientBase {
 
 	updatePrivateKeyTag = async (input: SdkApiTypes.TUpdatePrivateKeyTagBody): Promise<SdkApiTypes.TUpdatePrivateKeyTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/update_private_key_tag", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_PRIVATE_KEY_TAG"
     }, "updatePrivateKeyTagResult");
@@ -762,10 +703,9 @@ export class TurnkeySDKClientBase {
 
 	updateRootQuorum = async (input: SdkApiTypes.TUpdateRootQuorumBody): Promise<SdkApiTypes.TUpdateRootQuorumResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/update_root_quorum", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_ROOT_QUORUM"
     }, "updateRootQuorumResult");
@@ -774,10 +714,9 @@ export class TurnkeySDKClientBase {
 
 	updateUser = async (input: SdkApiTypes.TUpdateUserBody): Promise<SdkApiTypes.TUpdateUserResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/update_user", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_USER"
     }, "updateUserResult");
@@ -786,10 +725,9 @@ export class TurnkeySDKClientBase {
 
 	updateUserTag = async (input: SdkApiTypes.TUpdateUserTagBody): Promise<SdkApiTypes.TUpdateUserTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
-    const currentSubOrganization = await getStorageValue(StorageKeys.CurrentSubOrganization);
     return this.command("/public/v1/submit/update_user_tag", {
       parameters: rest,
-      organizationId: organizationId ?? (currentSubOrganization?.organizationId ?? this.config.organizationId),
+      organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_USER_TAG"
     }, "updateUserTagResult");

--- a/packages/sdk-js-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-js-browser/src/__generated__/sdk_api_types.ts
@@ -172,13 +172,13 @@ export type TCreatePrivateKeyTagInput = { body: TCreatePrivateKeyTagBody };
 
 export type TCreatePrivateKeyTagBody = operations["PublicApiService_CreatePrivateKeyTag"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
 
-export type TCreatePrivateKeysResponse = operations["PublicApiService_CreatePrivateKeys"]["responses"]["200"]["schema"]["activity"]["result"]["createPrivateKeysResult"] & ActivityMetadata;
+export type TCreatePrivateKeysResponse = operations["PublicApiService_CreatePrivateKeys"]["responses"]["200"]["schema"]["activity"]["result"]["createPrivateKeysResultV2"] & ActivityMetadata;
 
 export type TCreatePrivateKeysInput = { body: TCreatePrivateKeysBody };
 
 export type TCreatePrivateKeysBody = operations["PublicApiService_CreatePrivateKeys"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
 
-export type TCreateSubOrganizationResponse = operations["PublicApiService_CreateSubOrganization"]["responses"]["200"]["schema"]["activity"]["result"]["createSubOrganizationResult"] & ActivityMetadata;
+export type TCreateSubOrganizationResponse = operations["PublicApiService_CreateSubOrganization"]["responses"]["200"]["schema"]["activity"]["result"]["createSubOrganizationResultV4"] & ActivityMetadata;
 
 export type TCreateSubOrganizationInput = { body: TCreateSubOrganizationBody };
 

--- a/packages/sdk-js-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-js-server/src/__generated__/sdk-client-base.ts
@@ -55,13 +55,13 @@ export class TurnkeySDKClientBase {
     const POLLING_DURATION = this.config.activityPoller?.duration ?? 1000;
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-    const initialData = await this.request<TBodyType, TResponseType>(url, body) as ActivityResponse;
-    const activityId = initialData["activity"]["id"];
-    let activityStatus = initialData["activity"]["status"];
+    const responseData = await this.request<TBodyType, TResponseType>(url, body) as ActivityResponse;
+    const activityId = responseData["activity"]["id"];
+    const activityStatus = responseData["activity"]["status"];
 
     if (activityStatus !== "ACTIVITY_STATUS_PENDING") {
       return {
-        ...initialData["activity"]["result"][`${resultKey}`],
+        ...responseData["activity"]["result"][`${resultKey}`],
         activity: {
           id: activityId,
           status: activityStatus

--- a/packages/sdk-js-server/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-js-server/src/__generated__/sdk_api_types.ts
@@ -172,13 +172,13 @@ export type TCreatePrivateKeyTagInput = { body: TCreatePrivateKeyTagBody };
 
 export type TCreatePrivateKeyTagBody = operations["PublicApiService_CreatePrivateKeyTag"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
 
-export type TCreatePrivateKeysResponse = operations["PublicApiService_CreatePrivateKeys"]["responses"]["200"]["schema"]["activity"]["result"]["createPrivateKeysResult"] & ActivityMetadata;
+export type TCreatePrivateKeysResponse = operations["PublicApiService_CreatePrivateKeys"]["responses"]["200"]["schema"]["activity"]["result"]["createPrivateKeysResultV2"] & ActivityMetadata;
 
 export type TCreatePrivateKeysInput = { body: TCreatePrivateKeysBody };
 
 export type TCreatePrivateKeysBody = operations["PublicApiService_CreatePrivateKeys"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
 
-export type TCreateSubOrganizationResponse = operations["PublicApiService_CreateSubOrganization"]["responses"]["200"]["schema"]["activity"]["result"]["createSubOrganizationResult"] & ActivityMetadata;
+export type TCreateSubOrganizationResponse = operations["PublicApiService_CreateSubOrganization"]["responses"]["200"]["schema"]["activity"]["result"]["createSubOrganizationResultV4"] & ActivityMetadata;
 
 export type TCreateSubOrganizationInput = { body: TCreateSubOrganizationBody };
 

--- a/packages/sdk-js-server/src/__tests__/request-test.ts
+++ b/packages/sdk-js-server/src/__tests__/request-test.ts
@@ -13,7 +13,7 @@ test("requests are stamped after client creation", async () => {
     apiBaseUrl: "https://mocked.turnkey.com",
     apiPrivateKey: privateKey,
     apiPublicKey: publicKey,
-    rootOrganizationId: "89881fc7-6ff3-4b43-b962-916698f8ff58",
+    defaultOrganizationId: "89881fc7-6ff3-4b43-b962-916698f8ff58",
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -42,7 +42,7 @@ test("requests return grpc status details as part of their errors", async () => 
     apiBaseUrl: "https://mocked.turnkey.com",
     apiPrivateKey: privateKey,
     apiPublicKey: publicKey,
-    rootOrganizationId: "89881fc7-6ff3-4b43-b962-916698f8ff58",
+    defaultOrganizationId: "89881fc7-6ff3-4b43-b962-916698f8ff58",
   });
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;


### PR DESCRIPTION
## Summary & Motivation
Update codegen scripts (addressing some nits), and run them for `sdk-js-server` and `sdk-js-browser`. This corrects the ability to fetch the proper result versions for relevant activities (i.e. CreateSubOrganization and CreatePrivateKeys)

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
