### PR TITLE
support login management using new readonly endpoint

### DIFF
--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -108,6 +108,10 @@ import type {
   TCreatePrivateKeysResponse,
 } from "./public_api.fetcher";
 import type {
+  TCreateReadOnlySessionBody,
+  TCreateReadOnlySessionResponse,
+} from "./public_api.fetcher";
+import type {
   TCreateSubOrganizationBody,
   TCreateSubOrganizationResponse,
 } from "./public_api.fetcher";
@@ -1147,6 +1151,38 @@ export class TurnkeyClient {
   ): Promise<TSignedRequest> => {
     const fullUrl =
       this.config.baseUrl + "/public/v1/submit/create_private_keys";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Create a read only session for a user (valid for 1 hour)
+   *
+   * Sign the provided `TCreateReadOnlySessionBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_read_only_session).
+   *
+   * See also {@link stampCreateReadOnlySession}.
+   */
+  createReadOnlySession = async (
+    input: TCreateReadOnlySessionBody
+  ): Promise<TCreateReadOnlySessionResponse> => {
+    return this.request("/public/v1/submit/create_read_only_session", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TCreateReadOnlySessionBody` by using the client's `stamp` function.
+   *
+   * See also {@link CreateReadOnlySession}.
+   */
+  stampCreateReadOnlySession = async (
+    input: TCreateReadOnlySessionBody
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/submit/create_read_only_session";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -1396,6 +1396,58 @@ export const signCreatePrivateKeys = (
   });
 
 /**
+ * `POST /public/v1/submit/create_read_only_session`
+ */
+export type TCreateReadOnlySessionResponse =
+  operations["PublicApiService_CreateReadOnlySession"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/create_read_only_session`
+ */
+export type TCreateReadOnlySessionInput = { body: TCreateReadOnlySessionBody };
+
+/**
+ * `POST /public/v1/submit/create_read_only_session`
+ */
+export type TCreateReadOnlySessionBody =
+  operations["PublicApiService_CreateReadOnlySession"]["parameters"]["body"]["body"];
+
+/**
+ * Create Read Only Session
+ *
+ * Create a read only session for a user (valid for 1 hour)
+ *
+ * `POST /public/v1/submit/create_read_only_session`
+ */
+export const createReadOnlySession = (input: TCreateReadOnlySessionInput) =>
+  request<
+    TCreateReadOnlySessionResponse,
+    TCreateReadOnlySessionBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/submit/create_read_only_session",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `CreateReadOnlySession` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link CreateReadOnlySession}
+ */
+export const signCreateReadOnlySession = (
+  input: TCreateReadOnlySessionInput,
+  options?: TurnkeyCredentialRequestOptions
+) =>
+  signedRequest<TCreateReadOnlySessionBody, never, never>({
+    uri: "/public/v1/submit/create_read_only_session",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/submit/create_sub_organization`
  */
 export type TCreateSubOrganizationResponse =

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -996,6 +996,38 @@
         "tags": ["Private Keys"]
       }
     },
+    "/public/v1/submit/create_read_only_session": {
+      "post": {
+        "summary": "Create Read Only Session",
+        "description": "Create a read only session for a user (valid for 1 hour)",
+        "operationId": "PublicApiService_CreateReadOnlySession",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateReadOnlySessionRequest"
+            }
+          }
+        ],
+        "tags": ["Sessions"]
+      }
+    },
     "/public/v1/submit/create_sub_organization": {
       "post": {
         "summary": "Create Sub-Organization",
@@ -2417,7 +2449,8 @@
         "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
         "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY",
         "ACTIVITY_TYPE_CREATE_POLICIES",
-        "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS"
+        "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS",
+        "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION"
       ]
     },
     "v1AddressFormat": {
@@ -3259,6 +3292,68 @@
         }
       },
       "required": ["privateKeys"]
+    },
+    "v1CreateReadOnlySessionIntent": {
+      "type": "object"
+    },
+    "v1CreateReadOnlySessionRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateReadOnlySessionResult": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization. If the request is being made by a user and their Sub-Organization ID is unknown, this can be the Parent Organization ID. However, using the Sub-Organization ID is preferred due to performance reasons."
+        },
+        "organizationName": {
+          "type": "string",
+          "description": "Human-readable name for an Organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "username": {
+          "type": "string",
+          "description": "Human-readable name for a User."
+        },
+        "session": {
+          "type": "string",
+          "description": "String representing a read only session"
+        },
+        "sessionExpiry": {
+          "type": "string",
+          "format": "uint64",
+          "description": "UTC timestamp in seconds representing the expiry time for the read only session."
+        }
+      },
+      "required": [
+        "organizationId",
+        "organizationName",
+        "userId",
+        "username",
+        "session",
+        "sessionExpiry"
+      ]
     },
     "v1CreateSubOrganizationIntent": {
       "type": "object",
@@ -5301,6 +5396,9 @@
         },
         "signRawPayloadsIntent": {
           "$ref": "#/definitions/v1SignRawPayloadsIntent"
+        },
+        "createReadOnlySessionIntent": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionIntent"
         }
       },
       "required": ["createOrganizationIntent"]
@@ -6037,6 +6135,9 @@
         },
         "signRawPayloadsResult": {
           "$ref": "#/definitions/v1SignRawPayloadsResult"
+        },
+        "createReadOnlySessionResult": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionResult"
         }
       }
     },

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -120,6 +120,10 @@ export type paths = {
     /** Create new Private Keys */
     post: operations["PublicApiService_CreatePrivateKeys"];
   };
+  "/public/v1/submit/create_read_only_session": {
+    /** Create a read only session for a user (valid for 1 hour) */
+    post: operations["PublicApiService_CreateReadOnlySession"];
+  };
   "/public/v1/submit/create_sub_organization": {
     /** Create a new Sub-Organization */
     post: operations["PublicApiService_CreateSubOrganization"];
@@ -432,7 +436,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY"
     | "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY"
     | "ACTIVITY_TYPE_CREATE_POLICIES"
-    | "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS";
+    | "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS"
+    | "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -753,6 +758,33 @@ export type definitions = {
   v1CreatePrivateKeysResultV2: {
     /** @description A list of Private Key IDs and addresses. */
     privateKeys: definitions["v1PrivateKeyResult"][];
+  };
+  v1CreateReadOnlySessionIntent: { [key: string]: unknown };
+  v1CreateReadOnlySessionRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateReadOnlySessionIntent"];
+  };
+  v1CreateReadOnlySessionResult: {
+    /** @description Unique identifier for a given Organization. If the request is being made by a user and their Sub-Organization ID is unknown, this can be the Parent Organization ID. However, using the Sub-Organization ID is preferred due to performance reasons. */
+    organizationId: string;
+    /** @description Human-readable name for an Organization. */
+    organizationName: string;
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Human-readable name for a User. */
+    username: string;
+    /** @description String representing a read only session */
+    session: string;
+    /**
+     * Format: uint64
+     * @description UTC timestamp in seconds representing the expiry time for the read only session.
+     */
+    sessionExpiry: string;
   };
   v1CreateSubOrganizationIntent: {
     /** @description Name for this sub-organization */
@@ -1549,6 +1581,7 @@ export type definitions = {
     importPrivateKeyIntent?: definitions["v1ImportPrivateKeyIntent"];
     createPoliciesIntent?: definitions["v1CreatePoliciesIntent"];
     signRawPayloadsIntent?: definitions["v1SignRawPayloadsIntent"];
+    createReadOnlySessionIntent?: definitions["v1CreateReadOnlySessionIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -1815,6 +1848,7 @@ export type definitions = {
     importPrivateKeyResult?: definitions["v1ImportPrivateKeyResult"];
     createPoliciesResult?: definitions["v1CreatePoliciesResult"];
     signRawPayloadsResult?: definitions["v1SignRawPayloadsResult"];
+    createReadOnlySessionResult?: definitions["v1CreateReadOnlySessionResult"];
   };
   v1RootUserParams: {
     /** @description Human-readable name for a User. */
@@ -2740,6 +2774,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreatePrivateKeysRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a read only session for a user (valid for 1 hour) */
+  PublicApiService_CreateReadOnlySession: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateReadOnlySessionRequest"];
       };
     };
     responses: {

--- a/packages/sdk-browser/scripts/codegen.js
+++ b/packages/sdk-browser/scripts/codegen.js
@@ -262,14 +262,21 @@ export class TurnkeySDKClientBase {
   ): Promise<TResponseType> {
     const fullUrl = this.config.apiBaseUrl + url;
     const stringifiedBody = JSON.stringify(body);
-    const stamp = await this.config.stamper.stamp(stringifiedBody);
+    var headers: Record<string, string> = {
+      "X-Client-Version": VERSION
+    }
+    if (this.config.stamper) {
+      const stamp = await this.config.stamper.stamp(stringifiedBody);
+      headers[stamp.stampHeaderName] = stamp.stampHeaderValue
+    }
+    
+    if (this.config.readOnlySession){
+      headers["X-Session"] = this.config.readOnlySession
+    }
 
     const response = await fetch(fullUrl, {
       method: "POST",
-      headers: {
-        [stamp.stampHeaderName]: stamp.stampHeaderValue,
-        "X-Client-Version": VERSION
-      },
+      headers: headers,
       body: stringifiedBody,
       redirect: "follow"
     });

--- a/packages/sdk-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-browser/src/__generated__/sdk_api_types.ts
@@ -178,6 +178,12 @@ export type TCreatePrivateKeysInput = { body: TCreatePrivateKeysBody };
 
 export type TCreatePrivateKeysBody = operations["PublicApiService_CreatePrivateKeys"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
 
+export type TCreateReadOnlySessionResponse = operations["PublicApiService_CreateReadOnlySession"]["responses"]["200"]["schema"]["activity"]["result"]["createReadOnlySessionResult"] & ActivityMetadata;
+
+export type TCreateReadOnlySessionInput = { body: TCreateReadOnlySessionBody };
+
+export type TCreateReadOnlySessionBody = operations["PublicApiService_CreateReadOnlySession"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
+
 export type TCreateSubOrganizationResponse = operations["PublicApiService_CreateSubOrganization"]["responses"]["200"]["schema"]["activity"]["result"]["createSubOrganizationResultV4"] & ActivityMetadata;
 
 export type TCreateSubOrganizationInput = { body: TCreateSubOrganizationBody };

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -996,6 +996,38 @@
         "tags": ["Private Keys"]
       }
     },
+    "/public/v1/submit/create_read_only_session": {
+      "post": {
+        "summary": "Create Read Only Session",
+        "description": "Create a read only session for a user (valid for 1 hour)",
+        "operationId": "PublicApiService_CreateReadOnlySession",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateReadOnlySessionRequest"
+            }
+          }
+        ],
+        "tags": ["Sessions"]
+      }
+    },
     "/public/v1/submit/create_sub_organization": {
       "post": {
         "summary": "Create Sub-Organization",
@@ -2417,7 +2449,8 @@
         "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
         "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY",
         "ACTIVITY_TYPE_CREATE_POLICIES",
-        "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS"
+        "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS",
+        "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION"
       ]
     },
     "v1AddressFormat": {
@@ -3259,6 +3292,68 @@
         }
       },
       "required": ["privateKeys"]
+    },
+    "v1CreateReadOnlySessionIntent": {
+      "type": "object"
+    },
+    "v1CreateReadOnlySessionRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateReadOnlySessionResult": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization. If the request is being made by a user and their Sub-Organization ID is unknown, this can be the Parent Organization ID. However, using the Sub-Organization ID is preferred due to performance reasons."
+        },
+        "organizationName": {
+          "type": "string",
+          "description": "Human-readable name for an Organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "username": {
+          "type": "string",
+          "description": "Human-readable name for a User."
+        },
+        "session": {
+          "type": "string",
+          "description": "String representing a read only session"
+        },
+        "sessionExpiry": {
+          "type": "string",
+          "format": "uint64",
+          "description": "UTC timestamp in seconds representing the expiry time for the read only session."
+        }
+      },
+      "required": [
+        "organizationId",
+        "organizationName",
+        "userId",
+        "username",
+        "session",
+        "sessionExpiry"
+      ]
     },
     "v1CreateSubOrganizationIntent": {
       "type": "object",
@@ -5301,6 +5396,9 @@
         },
         "signRawPayloadsIntent": {
           "$ref": "#/definitions/v1SignRawPayloadsIntent"
+        },
+        "createReadOnlySessionIntent": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionIntent"
         }
       },
       "required": ["createOrganizationIntent"]
@@ -6037,6 +6135,9 @@
         },
         "signRawPayloadsResult": {
           "$ref": "#/definitions/v1SignRawPayloadsResult"
+        },
+        "createReadOnlySessionResult": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionResult"
         }
       }
     },

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -120,6 +120,10 @@ export type paths = {
     /** Create new Private Keys */
     post: operations["PublicApiService_CreatePrivateKeys"];
   };
+  "/public/v1/submit/create_read_only_session": {
+    /** Create a read only session for a user (valid for 1 hour) */
+    post: operations["PublicApiService_CreateReadOnlySession"];
+  };
   "/public/v1/submit/create_sub_organization": {
     /** Create a new Sub-Organization */
     post: operations["PublicApiService_CreateSubOrganization"];
@@ -432,7 +436,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY"
     | "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY"
     | "ACTIVITY_TYPE_CREATE_POLICIES"
-    | "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS";
+    | "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS"
+    | "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -753,6 +758,33 @@ export type definitions = {
   v1CreatePrivateKeysResultV2: {
     /** @description A list of Private Key IDs and addresses. */
     privateKeys: definitions["v1PrivateKeyResult"][];
+  };
+  v1CreateReadOnlySessionIntent: { [key: string]: unknown };
+  v1CreateReadOnlySessionRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateReadOnlySessionIntent"];
+  };
+  v1CreateReadOnlySessionResult: {
+    /** @description Unique identifier for a given Organization. If the request is being made by a user and their Sub-Organization ID is unknown, this can be the Parent Organization ID. However, using the Sub-Organization ID is preferred due to performance reasons. */
+    organizationId: string;
+    /** @description Human-readable name for an Organization. */
+    organizationName: string;
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Human-readable name for a User. */
+    username: string;
+    /** @description String representing a read only session */
+    session: string;
+    /**
+     * Format: uint64
+     * @description UTC timestamp in seconds representing the expiry time for the read only session.
+     */
+    sessionExpiry: string;
   };
   v1CreateSubOrganizationIntent: {
     /** @description Name for this sub-organization */
@@ -1549,6 +1581,7 @@ export type definitions = {
     importPrivateKeyIntent?: definitions["v1ImportPrivateKeyIntent"];
     createPoliciesIntent?: definitions["v1CreatePoliciesIntent"];
     signRawPayloadsIntent?: definitions["v1SignRawPayloadsIntent"];
+    createReadOnlySessionIntent?: definitions["v1CreateReadOnlySessionIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -1815,6 +1848,7 @@ export type definitions = {
     importPrivateKeyResult?: definitions["v1ImportPrivateKeyResult"];
     createPoliciesResult?: definitions["v1CreatePoliciesResult"];
     signRawPayloadsResult?: definitions["v1SignRawPayloadsResult"];
+    createReadOnlySessionResult?: definitions["v1CreateReadOnlySessionResult"];
   };
   v1RootUserParams: {
     /** @description Human-readable name for a User. */
@@ -2740,6 +2774,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreatePrivateKeysRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a read only session for a user (valid for 1 hour) */
+  PublicApiService_CreateReadOnlySession: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateReadOnlySessionRequest"];
       };
     };
     responses: {

--- a/packages/sdk-browser/src/__types__/base.ts
+++ b/packages/sdk-browser/src/__types__/base.ts
@@ -55,8 +55,7 @@ export interface ActivityMetadata {
   status: string;
 }
 
-export interface TurnkeySDKClientConfig {
-  stamper: TStamper;
+interface BaseSDKClientConfig {
   apiBaseUrl: string;
   organizationId: string;
   activityPoller?: {
@@ -64,6 +63,20 @@ export interface TurnkeySDKClientConfig {
     timeout: number;
   };
 }
+
+interface SDKClientConfigWithStamper extends BaseSDKClientConfig {
+  stamper: TStamper;
+  readOnlySession?: never;
+}
+
+interface SDKClientConfigWithReadOnlySession extends BaseSDKClientConfig {
+  stamper?: never;
+  readOnlySession: string;
+}
+
+export type TurnkeySDKClientConfig =
+  | SDKClientConfigWithStamper
+  | SDKClientConfigWithReadOnlySession;
 
 export interface TurnkeySDKBrowserConfig {
   apiBaseUrl: string;

--- a/packages/sdk-browser/src/models.ts
+++ b/packages/sdk-browser/src/models.ts
@@ -1,6 +1,13 @@
 export interface User {
   userId: string;
   username: string;
+  organization: SubOrganization;
+  readOnlySession?: ReadOnlySession;
+}
+
+export interface ReadOnlySession {
+  session: string;
+  sessionExpiry: number;
 }
 
 export interface SubOrganization {

--- a/packages/sdk-react/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react/src/contexts/TurnkeyContext.tsx
@@ -5,7 +5,7 @@ import {
   TurnkeySDKBrowserConfig
 } from '@turnkey/sdk-browser';
 
-interface TurnkeyClientType {
+export interface TurnkeyClientType {
   turnkeyClient: TurnkeyBrowserSDK | undefined;
   iframeSigner: TurnkeySDKBrowserClient | undefined;
   passkeySigner: TurnkeySDKBrowserClient | undefined;

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -370,6 +370,17 @@ export class TurnkeySDKClientBase {
   }
 
 
+	createReadOnlySession = async (input: SdkApiTypes.TCreateReadOnlySessionBody): Promise<SdkApiTypes.TCreateReadOnlySessionResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command("/public/v1/submit/create_read_only_session", {
+      parameters: rest,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION"
+    }, "createReadOnlySessionResult");
+  }
+
+
 	createSubOrganization = async (input: SdkApiTypes.TCreateSubOrganizationBody): Promise<SdkApiTypes.TCreateSubOrganizationResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
     return this.command("/public/v1/submit/create_sub_organization", {

--- a/packages/sdk-server/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-server/src/__generated__/sdk_api_types.ts
@@ -178,6 +178,12 @@ export type TCreatePrivateKeysInput = { body: TCreatePrivateKeysBody };
 
 export type TCreatePrivateKeysBody = operations["PublicApiService_CreatePrivateKeys"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
 
+export type TCreateReadOnlySessionResponse = operations["PublicApiService_CreateReadOnlySession"]["responses"]["200"]["schema"]["activity"]["result"]["createReadOnlySessionResult"] & ActivityMetadata;
+
+export type TCreateReadOnlySessionInput = { body: TCreateReadOnlySessionBody };
+
+export type TCreateReadOnlySessionBody = operations["PublicApiService_CreateReadOnlySession"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams;
+
 export type TCreateSubOrganizationResponse = operations["PublicApiService_CreateSubOrganization"]["responses"]["200"]["schema"]["activity"]["result"]["createSubOrganizationResultV4"] & ActivityMetadata;
 
 export type TCreateSubOrganizationInput = { body: TCreateSubOrganizationBody };

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -996,6 +996,38 @@
         "tags": ["Private Keys"]
       }
     },
+    "/public/v1/submit/create_read_only_session": {
+      "post": {
+        "summary": "Create Read Only Session",
+        "description": "Create a read only session for a user (valid for 1 hour)",
+        "operationId": "PublicApiService_CreateReadOnlySession",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateReadOnlySessionRequest"
+            }
+          }
+        ],
+        "tags": ["Sessions"]
+      }
+    },
     "/public/v1/submit/create_sub_organization": {
       "post": {
         "summary": "Create Sub-Organization",
@@ -2417,7 +2449,8 @@
         "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
         "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY",
         "ACTIVITY_TYPE_CREATE_POLICIES",
-        "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS"
+        "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS",
+        "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION"
       ]
     },
     "v1AddressFormat": {
@@ -3259,6 +3292,68 @@
         }
       },
       "required": ["privateKeys"]
+    },
+    "v1CreateReadOnlySessionIntent": {
+      "type": "object"
+    },
+    "v1CreateReadOnlySessionRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateReadOnlySessionResult": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization. If the request is being made by a user and their Sub-Organization ID is unknown, this can be the Parent Organization ID. However, using the Sub-Organization ID is preferred due to performance reasons."
+        },
+        "organizationName": {
+          "type": "string",
+          "description": "Human-readable name for an Organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "username": {
+          "type": "string",
+          "description": "Human-readable name for a User."
+        },
+        "session": {
+          "type": "string",
+          "description": "String representing a read only session"
+        },
+        "sessionExpiry": {
+          "type": "string",
+          "format": "uint64",
+          "description": "UTC timestamp in seconds representing the expiry time for the read only session."
+        }
+      },
+      "required": [
+        "organizationId",
+        "organizationName",
+        "userId",
+        "username",
+        "session",
+        "sessionExpiry"
+      ]
     },
     "v1CreateSubOrganizationIntent": {
       "type": "object",
@@ -5301,6 +5396,9 @@
         },
         "signRawPayloadsIntent": {
           "$ref": "#/definitions/v1SignRawPayloadsIntent"
+        },
+        "createReadOnlySessionIntent": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionIntent"
         }
       },
       "required": ["createOrganizationIntent"]
@@ -6037,6 +6135,9 @@
         },
         "signRawPayloadsResult": {
           "$ref": "#/definitions/v1SignRawPayloadsResult"
+        },
+        "createReadOnlySessionResult": {
+          "$ref": "#/definitions/v1CreateReadOnlySessionResult"
         }
       }
     },

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -120,6 +120,10 @@ export type paths = {
     /** Create new Private Keys */
     post: operations["PublicApiService_CreatePrivateKeys"];
   };
+  "/public/v1/submit/create_read_only_session": {
+    /** Create a read only session for a user (valid for 1 hour) */
+    post: operations["PublicApiService_CreateReadOnlySession"];
+  };
   "/public/v1/submit/create_sub_organization": {
     /** Create a new Sub-Organization */
     post: operations["PublicApiService_CreateSubOrganization"];
@@ -432,7 +436,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY"
     | "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY"
     | "ACTIVITY_TYPE_CREATE_POLICIES"
-    | "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS";
+    | "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS"
+    | "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -753,6 +758,33 @@ export type definitions = {
   v1CreatePrivateKeysResultV2: {
     /** @description A list of Private Key IDs and addresses. */
     privateKeys: definitions["v1PrivateKeyResult"][];
+  };
+  v1CreateReadOnlySessionIntent: { [key: string]: unknown };
+  v1CreateReadOnlySessionRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateReadOnlySessionIntent"];
+  };
+  v1CreateReadOnlySessionResult: {
+    /** @description Unique identifier for a given Organization. If the request is being made by a user and their Sub-Organization ID is unknown, this can be the Parent Organization ID. However, using the Sub-Organization ID is preferred due to performance reasons. */
+    organizationId: string;
+    /** @description Human-readable name for an Organization. */
+    organizationName: string;
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Human-readable name for a User. */
+    username: string;
+    /** @description String representing a read only session */
+    session: string;
+    /**
+     * Format: uint64
+     * @description UTC timestamp in seconds representing the expiry time for the read only session.
+     */
+    sessionExpiry: string;
   };
   v1CreateSubOrganizationIntent: {
     /** @description Name for this sub-organization */
@@ -1549,6 +1581,7 @@ export type definitions = {
     importPrivateKeyIntent?: definitions["v1ImportPrivateKeyIntent"];
     createPoliciesIntent?: definitions["v1CreatePoliciesIntent"];
     signRawPayloadsIntent?: definitions["v1SignRawPayloadsIntent"];
+    createReadOnlySessionIntent?: definitions["v1CreateReadOnlySessionIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -1815,6 +1848,7 @@ export type definitions = {
     importPrivateKeyResult?: definitions["v1ImportPrivateKeyResult"];
     createPoliciesResult?: definitions["v1CreatePoliciesResult"];
     signRawPayloadsResult?: definitions["v1SignRawPayloadsResult"];
+    createReadOnlySessionResult?: definitions["v1CreateReadOnlySessionResult"];
   };
   v1RootUserParams: {
     /** @description Human-readable name for a User. */
@@ -2740,6 +2774,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreatePrivateKeysRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a read only session for a user (valid for 1 hour) */
+  PublicApiService_CreateReadOnlySession: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateReadOnlySessionRequest"];
       };
     };
     responses: {


### PR DESCRIPTION
## Summary & Motivation
Create a login fxn that uses the new read only session creation activity

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
