### PR TITLE
changes top-level naming of sdk exports to clients

### DIFF
--- a/examples/rebalancer/src/index.ts
+++ b/examples/rebalancer/src/index.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv";
 // Load environment variables from `.env.local`
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
-import { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import { Turnkey } from "@turnkey/sdk-server";
 import { FeeData } from "ethers";
 import { isKeyOfObject } from "./utils";
 import {
@@ -31,7 +31,7 @@ const GAS_MULTIPLIER = 2n;
 const ACTIVITIES_LIMIT = "100";
 
 // For demonstration purposes, create a globally accessible TurnkeyClient
-const turnkeyClient = new TurnkeyServerSDK({
+const turnkeyClient = new Turnkey({
   apiBaseUrl: process.env.BASE_URL!,
   apiPrivateKey: process.env.API_PRIVATE_KEY!,
   apiPublicKey: process.env.API_PUBLIC_KEY!,

--- a/examples/rebalancer/src/requests/createActivityApproval.ts
+++ b/examples/rebalancer/src/requests/createActivityApproval.ts
@@ -1,9 +1,9 @@
-import type { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function approveActivity(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   activityId: string,
   activityFingerprint: string
 ): Promise<string> {

--- a/examples/rebalancer/src/requests/createActivityRejection.ts
+++ b/examples/rebalancer/src/requests/createActivityRejection.ts
@@ -1,9 +1,9 @@
-import type { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function rejectActivity(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   activityId: string,
   activityFingerprint: string
 ): Promise<string> {

--- a/examples/rebalancer/src/requests/createPolicy.ts
+++ b/examples/rebalancer/src/requests/createPolicy.ts
@@ -1,9 +1,9 @@
-import type { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createPolicy(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   policyName: string,
   effect: "EFFECT_ALLOW" | "EFFECT_DENY",
   consensus: string,

--- a/examples/rebalancer/src/requests/createPrivateKey.ts
+++ b/examples/rebalancer/src/requests/createPrivateKey.ts
@@ -1,9 +1,9 @@
-import type { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createPrivateKey(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   privateKeyName: string,
   privateKeyTags: string[]
 ): Promise<string> {

--- a/examples/rebalancer/src/requests/createPrivateKeyTag.ts
+++ b/examples/rebalancer/src/requests/createPrivateKeyTag.ts
@@ -1,9 +1,9 @@
-import type { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createPrivateKeyTag(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   privateKeyTagName: string,
   privateKeyIds: string[]
 ): Promise<string> {

--- a/examples/rebalancer/src/requests/createUser.ts
+++ b/examples/rebalancer/src/requests/createUser.ts
@@ -1,9 +1,9 @@
-import type { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createUser(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   userName: string,
   userTags: string[],
   apiKeyName: string,

--- a/examples/rebalancer/src/requests/createUserTag.ts
+++ b/examples/rebalancer/src/requests/createUserTag.ts
@@ -1,9 +1,9 @@
-import type { TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeyActivityError } from "@turnkey/ethers";
 import { refineNonNull } from "./utils";
 
 export default async function createUserTag(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   userTagName: string,
   userIds: string[]
 ): Promise<string> {

--- a/examples/rebalancer/src/requests/getActivities.ts
+++ b/examples/rebalancer/src/requests/getActivities.ts
@@ -1,8 +1,8 @@
-import type { TurnkeyServerSDK, TurnkeyApiTypes } from "@turnkey/sdk-server";
+import type { Turnkey, TurnkeyApiTypes } from "@turnkey/sdk-server";
 import { refineNonNull } from "./utils";
 
 export default async function getActivities(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   limit: string
 ): Promise<TurnkeyApiTypes["v1GetActivitiesResponse"]["activities"]> {
   const response = await turnkeyClient.api().getActivities({

--- a/examples/rebalancer/src/requests/getActivity.ts
+++ b/examples/rebalancer/src/requests/getActivity.ts
@@ -1,8 +1,8 @@
-import type { TurnkeyServerSDK, TurnkeyApiTypes } from "@turnkey/sdk-server";
+import type { Turnkey, TurnkeyApiTypes } from "@turnkey/sdk-server";
 import { refineNonNull } from "./utils";
 
 export default async function getActivity(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   activityId: string
 ): Promise<TurnkeyApiTypes["v1ActivityResponse"]["activity"]> {
   const response = await turnkeyClient.api().getActivity({

--- a/examples/rebalancer/src/requests/getPrivateKeysForTag.ts
+++ b/examples/rebalancer/src/requests/getPrivateKeysForTag.ts
@@ -1,4 +1,4 @@
-import type { TurnkeyServerSDK, TurnkeyApiTypes } from "@turnkey/sdk-server";
+import type { Turnkey, TurnkeyApiTypes } from "@turnkey/sdk-server";
 
 /**
  * Get a list of private keys for a given tag
@@ -7,7 +7,7 @@ import type { TurnkeyServerSDK, TurnkeyApiTypes } from "@turnkey/sdk-server";
  * @returns a list of private keys matching the passed in tag
  */
 export default async function getPrivateKeysForTag(
-  turnkeyClient: TurnkeyServerSDK,
+  turnkeyClient: Turnkey,
   tagName: string
 ): Promise<TurnkeyApiTypes["v1PrivateKey"][]> {
   const response = await turnkeyClient.api().listPrivateKeyTags({

--- a/packages/sdk-browser/src/index.ts
+++ b/packages/sdk-browser/src/index.ts
@@ -28,8 +28,9 @@ import {
 
 import {
   TurnkeyBrowserSDK,
-  TurnkeySDKBrowserClient,
-  TurnkeySDKIframeClient,
+  TurnkeyBrowserClient,
+  TurnkeyIframeClient,
+  TurnkeyPasskeyClient,
 } from "./sdk-client";
 
 import {
@@ -51,9 +52,10 @@ export {
   ApiKeyStamper,
   IframeStamper,
   TurnkeyActivityError,
-  TurnkeyBrowserSDK,
-  TurnkeySDKBrowserClient,
-  TurnkeySDKIframeClient,
+  TurnkeyBrowserSDK as Turnkey,
+  TurnkeyBrowserClient,
+  TurnkeyIframeClient,
+  TurnkeyPasskeyClient,
   TurnkeyRequestError,
   WebauthnStamper,
 };

--- a/packages/sdk-react/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react/src/contexts/TurnkeyContext.tsx
@@ -1,21 +1,21 @@
 import { ReactNode, createContext, useState, useEffect, useRef } from "react";
 import {
-  TurnkeyBrowserSDK,
-  TurnkeySDKBrowserClient,
-  TurnkeySDKIframeClient,
+  Turnkey,
+  TurnkeyIframeClient,
+  TurnkeyPasskeyClient,
   TurnkeySDKBrowserConfig,
 } from "@turnkey/sdk-browser";
 
 export interface TurnkeyClientType {
-  turnkeyClient: TurnkeyBrowserSDK | undefined;
-  iframeSigner: TurnkeySDKIframeClient | undefined;
-  passkeySigner: TurnkeySDKBrowserClient | undefined;
+  turnkey: Turnkey | undefined;
+  iframeClient: TurnkeyIframeClient | undefined;
+  passkeyClient: TurnkeyPasskeyClient | undefined;
 }
 
 export const TurnkeyContext = createContext<TurnkeyClientType>({
-  turnkeyClient: undefined,
-  passkeySigner: undefined,
-  iframeSigner: undefined,
+  turnkey: undefined,
+  passkeyClient: undefined,
+  iframeClient: undefined,
 });
 
 interface TurnkeyProviderProps {
@@ -27,14 +27,12 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
   config,
   children,
 }) => {
-  const [turnkeyClient, setTurnkeyClient] = useState<
-    TurnkeyBrowserSDK | undefined
+  const [turnkey, setTurnkey] = useState<Turnkey | undefined>(undefined);
+  const [passkeyClient, setPasskeyClient] = useState<
+    TurnkeyPasskeyClient | undefined
   >(undefined);
-  const [passkeySigner, setPasskeySigner] = useState<
-    TurnkeySDKBrowserClient | undefined
-  >(undefined);
-  const [iframeSigner, setIframeSigner] = useState<
-    TurnkeySDKIframeClient | undefined
+  const [iframeClient, setIframeClient] = useState<
+    TurnkeyIframeClient | undefined
   >(undefined);
   const iframeInit = useRef<boolean>(false);
 
@@ -44,13 +42,13 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
     (async () => {
       if (!iframeInit.current) {
         iframeInit.current = true;
-        const newTurnkeyClient = new TurnkeyBrowserSDK(config);
-        setTurnkeyClient(newTurnkeyClient);
-        setPasskeySigner(await newTurnkeyClient.passkeySigner());
-        const iframeClient = await newTurnkeyClient.iframeSigner(
+        const newTurnkey = new Turnkey(config);
+        setTurnkey(newTurnkey);
+        setPasskeyClient(newTurnkey.passkeyClient());
+        const newIframeClient = await newTurnkey.iframeClient(
           document.getElementById(TurnkeyIframeContainerId)
         );
-        setIframeSigner(iframeClient);
+        setIframeClient(newIframeClient);
       }
     })();
   }, []);
@@ -58,9 +56,9 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
   return (
     <TurnkeyContext.Provider
       value={{
-        turnkeyClient,
-        passkeySigner,
-        iframeSigner,
+        turnkey,
+        passkeyClient,
+        iframeClient,
       }}
     >
       {children}

--- a/packages/sdk-server/README.md
+++ b/packages/sdk-server/README.md
@@ -13,13 +13,13 @@ $ npm install @turnkey/sdk-server
 ```
 
 ```js
-const { TurnkeyServerSDK } = require("@turnkey/sdk-server");
+const { Turnkey } = require("@turnkey/sdk-server");
 
 // This config contains parameters including base URLs, API credentials, and org ID
 const turnkeyConfig = JSON.parse(fs.readFileSync("./turnkey.json"), "utf8");
 
 // Use the config to instantiate a Turnkey Client
-const turnkeyServerClient = new TurnkeyServerSDK(turnkeyConfig);
+const turnkeyServerClient = new Turnkey(turnkeyConfig);
 
 // You're all set to create a server!
 const turnkeyProxyHandler = turnkeyServerClient.expressProxyHandler({});
@@ -33,7 +33,7 @@ app.listen(PORT, () => {
 
 ## Helpers
 
-`@turnkey/sdk-server` provides `TurnkeyServerSDK`, which offers wrappers around commonly used Turnkey API setups. This enables you to easily stand up a minimal backend to proxy end-users' requests to Turnkey. You can also use this to call on the Turnkey API directly from a server setting.
+`@turnkey/sdk-server` provides `Turnkey`, which offers wrappers around commonly used Turnkey API setups. This enables you to easily stand up a minimal backend to proxy end-users' requests to Turnkey. You can also use this to call on the Turnkey API directly from a server setting.
 
 // TODO:
 // - typescript-ify example

--- a/packages/sdk-server/src/__tests__/request-test.ts
+++ b/packages/sdk-server/src/__tests__/request-test.ts
@@ -1,7 +1,7 @@
 import { test, expect, jest } from "@jest/globals";
 
 import { readFixture } from "../__fixtures__/shared";
-import { TurnkeyServerSDK } from "../index";
+import { Turnkey } from "../index";
 import { fetch } from "../universal";
 
 jest.mock("cross-fetch");
@@ -9,7 +9,7 @@ jest.mock("cross-fetch");
 test("requests are stamped after client creation", async () => {
   const { privateKey, publicKey } = await readFixture();
 
-  const turnkeyServerClient = new TurnkeyServerSDK({
+  const turnkeyServerClient = new Turnkey({
     apiBaseUrl: "https://mocked.turnkey.com",
     apiPrivateKey: privateKey,
     apiPublicKey: publicKey,
@@ -38,7 +38,7 @@ test("requests are stamped after client creation", async () => {
 test("requests return grpc status details as part of their errors", async () => {
   const { privateKey, publicKey } = await readFixture();
 
-  const turnkeyServerClient = new TurnkeyServerSDK({
+  const turnkeyServerClient = new Turnkey({
     apiBaseUrl: "https://mocked.turnkey.com",
     apiPrivateKey: privateKey,
     apiPublicKey: publicKey,

--- a/packages/sdk-server/src/__types__/base.ts
+++ b/packages/sdk-server/src/__types__/base.ts
@@ -102,3 +102,8 @@ export type NextApiHandler = (
   req: NextApiRequest,
   res: NextApiResponse
 ) => void | Promise<void>;
+
+export interface ApiCredentials {
+  apiPublicKey: string;
+  apiPrivateKey: string;
+}

--- a/packages/sdk-server/src/index.ts
+++ b/packages/sdk-server/src/index.ts
@@ -15,7 +15,11 @@ import {
   TurnkeyRequestError,
 } from "@turnkey/http";
 
-import { TurnkeyServerSDK, TurnkeySDKServerClient } from "./sdk-client";
+import {
+  TurnkeyServerSDK,
+  TurnkeyServerClient,
+  TurnkeyApiClient,
+} from "./sdk-client";
 
 import {
   defaultEthereumAccountAtIndex,
@@ -36,8 +40,9 @@ import { fetch } from "./universal";
 export {
   ApiKeyStamper,
   TurnkeyActivityError,
-  TurnkeyServerSDK,
-  TurnkeySDKServerClient,
+  TurnkeyApiClient,
+  TurnkeyServerSDK as Turnkey,
+  TurnkeyServerClient,
   TurnkeyRequestError,
 };
 

--- a/packages/sdk-server/src/sdk-client.ts
+++ b/packages/sdk-server/src/sdk-client.ts
@@ -1,6 +1,7 @@
 import { ApiKeyStamper } from "@turnkey/api-key-stamper";
 
 import type {
+  ApiCredentials,
   TurnkeySDKClientConfig,
   TurnkeySDKServerConfig,
   TurnkeyProxyHandlerConfig,
@@ -28,13 +29,13 @@ export class TurnkeyServerSDK {
     this.config = config;
   }
 
-  api = (): TurnkeySDKServerClient => {
+  api = (apiCredentials?: ApiCredentials): TurnkeyApiClient => {
     const apiKeyStamper = new ApiKeyStamper({
-      apiPublicKey: this.config.apiPublicKey,
-      apiPrivateKey: this.config.apiPrivateKey,
+      apiPublicKey: apiCredentials?.apiPublicKey ?? this.config.apiPublicKey,
+      apiPrivateKey: apiCredentials?.apiPrivateKey ?? this.config.apiPrivateKey,
     });
 
-    return new TurnkeySDKServerClient({
+    return new TurnkeyApiClient({
       stamper: apiKeyStamper,
       apiBaseUrl: this.config.apiBaseUrl,
       organizationId: this.config.defaultOrganizationId,
@@ -115,10 +116,16 @@ export class TurnkeyServerSDK {
   };
 }
 
-export class TurnkeySDKServerClient extends TurnkeySDKClientBase {
+export class TurnkeyServerClient extends TurnkeySDKClientBase {
   constructor(config: TurnkeySDKClientConfig) {
     super(config);
   }
 
   [methodName: string]: any;
+}
+
+export class TurnkeyApiClient extends TurnkeyServerClient {
+  constructor(config: TurnkeySDKClientConfig) {
+    super(config);
+  }
 }


### PR DESCRIPTION
Can see the end-result from the PR to `demo-embedded-wallet` https://github.com/tkhq/demo-embedded-wallet/pull/10