### PR TITLE
Use the organizationId of the currentUser by default when using readOnlySessions so you don't need to manually pass it in

### DIFF
--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -43,7 +43,7 @@ export class TurnkeyBrowserSDK {
       return new TurnkeyBrowserClient({
         readOnlySession: currentUser?.readOnlySession?.session!,
         apiBaseUrl: this.config.apiBaseUrl,
-        organizationId: this.config.defaultOrganizationId,
+        organizationId: currentUser?.organization?.organizationId ?? this.config.defaultOrganizationId,
       });
     } else {
       this.logoutUser();

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -43,7 +43,9 @@ export class TurnkeyBrowserSDK {
       return new TurnkeyBrowserClient({
         readOnlySession: currentUser?.readOnlySession?.session!,
         apiBaseUrl: this.config.apiBaseUrl,
-        organizationId: currentUser?.organization?.organizationId ?? this.config.defaultOrganizationId,
+        organizationId:
+          currentUser?.organization?.organizationId ??
+          this.config.defaultOrganizationId,
       });
     } else {
       this.logoutUser();


### PR DESCRIPTION
Removes the need to manually pass the `organizationId` into a call for the `currentUserSession()` as it will now infer it automatically

See the associated code change to the `demo-embedded-wallet` here: https://github.com/tkhq/demo-embedded-wallet/pull/12