### PR TITLE
Polyfill Window object on Browser SDK

### DIFF
--- a/packages/sdk-browser/src/__polyfills__/window.ts
+++ b/packages/sdk-browser/src/__polyfills__/window.ts
@@ -1,0 +1,21 @@
+const loadWindow = () => {
+  if (typeof window !== 'undefined') {
+    return window;
+  } else {
+    return {
+      localStorage: {
+        getItem: (_key: string): string | null => { return null; },
+        setItem: (_key: string, _value: string) => {},
+        removeItem: (_key: string) => {},
+        clear: () => {},
+        key: (_index: number): string | null => { return null; },
+        length: 0
+      },
+      location: {
+        hostname: ''
+      }
+    }
+  }
+}
+
+export default loadWindow();

--- a/packages/sdk-browser/src/__polyfills__/window.ts
+++ b/packages/sdk-browser/src/__polyfills__/window.ts
@@ -1,21 +1,25 @@
 const loadWindow = () => {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== "undefined") {
     return window;
   } else {
     return {
       localStorage: {
-        getItem: (_key: string): string | null => { return null; },
+        getItem: (_key: string): string | null => {
+          return null;
+        },
         setItem: (_key: string, _value: string) => {},
         removeItem: (_key: string) => {},
         clear: () => {},
-        key: (_index: number): string | null => { return null; },
-        length: 0
+        key: (_index: number): string | null => {
+          return null;
+        },
+        length: 0,
       },
       location: {
-        hostname: ''
-      }
-    }
+        hostname: "",
+      },
+    };
   }
-}
+};
 
 export default loadWindow();

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -52,7 +52,8 @@ export class TurnkeyBrowserSDK {
   };
 
   passkeyClient = (rpId?: string): TurnkeyPasskeyClient => {
-    const targetRpId = rpId ?? this.config.rpId ?? WindowWrapper.location.hostname;
+    const targetRpId =
+      rpId ?? this.config.rpId ?? WindowWrapper.location.hostname;
 
     if (!targetRpId) {
       throw new Error(

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -3,6 +3,7 @@ import { IframeStamper } from "@turnkey/iframe-stamper";
 import { getWebAuthnAttestation } from "@turnkey/http";
 
 import { VERSION } from "./__generated__/version";
+import WindowWrapper from "./__polyfills__/window";
 
 import type {
   GrpcStatus,
@@ -51,7 +52,7 @@ export class TurnkeyBrowserSDK {
   };
 
   passkeyClient = (rpId?: string): TurnkeyPasskeyClient => {
-    const targetRpId = rpId ?? this.config.rpId ?? window.location.hostname;
+    const targetRpId = rpId ?? this.config.rpId ?? WindowWrapper.location.hostname;
 
     if (!targetRpId) {
       throw new Error(

--- a/packages/sdk-browser/src/storage.ts
+++ b/packages/sdk-browser/src/storage.ts
@@ -1,4 +1,5 @@
 import type { User } from "./models";
+import WindowWrapper from "./__polyfills__/window";
 
 export enum StorageKeys {
   CurrentUser = "@turnkey/current_user",
@@ -19,9 +20,9 @@ const STORAGE_VALUE_LOCATIONS: Record<StorageKeys, StorageLocation> = {
 };
 
 const STORAGE_LOCATIONS = {
-  [StorageLocation.Local]: localStorage,
-  [StorageLocation.Secure]: localStorage,
-  [StorageLocation.Session]: localStorage,
+  [StorageLocation.Local]: WindowWrapper.localStorage,
+  [StorageLocation.Secure]: WindowWrapper.localStorage,
+  [StorageLocation.Session]: WindowWrapper.localStorage,
 };
 
 export const getStorageValue = async <K extends StorageKeys>(


### PR DESCRIPTION
This PR adds a polyfill to reference the window object through in the browser-sdk. The polyfill will render a mock object if the browser-sdk happens to be rendered in a server environment.

The browser-sdk usually should not be rendered in a server environment, but there are apparently next.js flows that make this possible, so this enables those flows to function correctly.