### PR TITLE
Updated iFrame Client Syntax

### DIFF
--- a/packages/sdk-browser/src/__types__/base.ts
+++ b/packages/sdk-browser/src/__types__/base.ts
@@ -82,7 +82,6 @@ export type TurnkeySDKClientConfig =
 
 export interface TurnkeySDKBrowserConfig {
   apiBaseUrl: string;
-  iframeUrl?: string;
   defaultOrganizationId: string;
   rpId?: string;
   serverSignUrl?: string;

--- a/packages/sdk-browser/src/__types__/base.ts
+++ b/packages/sdk-browser/src/__types__/base.ts
@@ -96,3 +96,9 @@ export type commandOverrideParams = {
   organizationId?: string;
   timestampMs?: string;
 };
+
+export interface IframeClientParams {
+  iframeContainer: HTMLElement | null | undefined;
+  iframeUrl: string;
+  iframeElementId?: string;
+}

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -9,6 +9,7 @@ import type {
   GrpcStatus,
   TurnkeySDKClientConfig,
   TurnkeySDKBrowserConfig,
+  IframeClientParams,
 } from "./__types__/base";
 
 import { TurnkeyRequestError } from "./__types__/base";
@@ -73,23 +74,21 @@ export class TurnkeyBrowserSDK {
   };
 
   iframeClient = async (
-    iframeContainer: HTMLElement | null | undefined,
-    iframeUrl?: string
+    params: IframeClientParams
   ): Promise<TurnkeyIframeClient> => {
-    const targetIframeUrl = iframeUrl ?? this.config.iframeUrl;
-
-    if (!targetIframeUrl) {
+    if (!params.iframeUrl) {
       throw new Error(
-        "Tried to initialize iframeSigner with no iframeUrl defined"
+        "Tried to initialize iframeClient with no iframeUrl defined"
       );
     }
 
-    const TurnkeyIframeElementId = "turnkey-default-iframe-element-id";
+    const TurnkeyIframeElementId =
+      params.iframeElementId ?? "turnkey-default-iframe-element-id";
 
     const iframeStamper = new IframeStamper({
-      iframeUrl: targetIframeUrl,
+      iframeContainer: params.iframeContainer,
+      iframeUrl: params.iframeUrl,
       iframeElementId: TurnkeyIframeElementId,
-      iframeContainer: iframeContainer,
     });
 
     await iframeStamper.init();
@@ -262,5 +261,41 @@ export class TurnkeyIframeClient extends TurnkeyBrowserClient {
   ): Promise<boolean> => {
     const stamper = this.config.stamper as IframeStamper;
     return await stamper.injectCredentialBundle(credentialBundle);
+  };
+
+  injectWalletExportBundle = async (
+    credentialBundle: string,
+    organizationId: string
+  ): Promise<boolean> => {
+    const stamper = this.config.stamper as IframeStamper;
+    return await stamper.injectWalletExportBundle(
+      credentialBundle,
+      organizationId
+    );
+  };
+
+  injectKeyExportBundle = async (
+    credentialBundle: string,
+    organizationId: string
+  ): Promise<boolean> => {
+    const stamper = this.config.stamper as IframeStamper;
+    return await stamper.injectKeyExportBundle(
+      credentialBundle,
+      organizationId
+    );
+  };
+
+  injectImportBundle = async (
+    bundle: string,
+    organizationId: string,
+    userId: string
+  ): Promise<boolean> => {
+    const stamper = this.config.stamper as IframeStamper;
+    return await stamper.injectImportBundle(bundle, organizationId, userId);
+  };
+
+  extractWalletEncryptedBundle = async (): Promise<string> => {
+    const stamper = this.config.stamper as IframeStamper;
+    return await stamper.extractWalletEncryptedBundle();
   };
 }

--- a/packages/sdk-react/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react/src/contexts/TurnkeyContext.tsx
@@ -8,14 +8,14 @@ import {
 
 export interface TurnkeyClientType {
   turnkey: Turnkey | undefined;
-  iframeClient: TurnkeyIframeClient | undefined;
+  authIframeClient: TurnkeyIframeClient | undefined;
   passkeyClient: TurnkeyPasskeyClient | undefined;
 }
 
 export const TurnkeyContext = createContext<TurnkeyClientType>({
   turnkey: undefined,
   passkeyClient: undefined,
-  iframeClient: undefined,
+  authIframeClient: undefined,
 });
 
 interface TurnkeyProviderProps {
@@ -31,7 +31,7 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
   const [passkeyClient, setPasskeyClient] = useState<
     TurnkeyPasskeyClient | undefined
   >(undefined);
-  const [iframeClient, setIframeClient] = useState<
+  const [authIframeClient, setAuthIframeClient] = useState<
     TurnkeyIframeClient | undefined
   >(undefined);
   const iframeInit = useRef<boolean>(false);
@@ -45,10 +45,11 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
         const newTurnkey = new Turnkey(config);
         setTurnkey(newTurnkey);
         setPasskeyClient(newTurnkey.passkeyClient());
-        const newIframeClient = await newTurnkey.iframeClient(
-          document.getElementById(TurnkeyIframeContainerId)
-        );
-        setIframeClient(newIframeClient);
+        const newAuthIframeClient = await newTurnkey.iframeClient({
+          iframeContainer: document.getElementById(TurnkeyIframeContainerId),
+          iframeUrl: "https://auth.turnkey.com",
+        });
+        setAuthIframeClient(newAuthIframeClient);
       }
     })();
   }, []);
@@ -58,7 +59,7 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
       value={{
         turnkey,
         passkeyClient,
-        iframeClient,
+        authIframeClient,
       }}
     >
       {children}


### PR DESCRIPTION
This is to remove the iframeUrl config variable from the TurnkeyBrowser config, and have full customization over how the `iframeClient` is init