### PR TITLE
Encoding update to public package, added hexstring to array

### DIFF
--- a/packages/encoding/README.md
+++ b/packages/encoding/README.md
@@ -1,5 +1,3 @@
 # @turnkey/encoding
 
-This is an internal package, not meant for public consumption.
-
-Temporary workaround until we can bring this as a proper internal package. See https://github.com/lmc-eu/spirit-design-system/issues/1238 for a great outline of the problem and potential ways forward.
+This is a package containing decoding and encoding functions

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -13,7 +13,7 @@
   },
   "types": "./dist/index.d.ts",
   "license": "Apache-2.0",
-  "description": "Encoding utility functions (internal)",
+  "description": "Encoding utility functions",
   "author": {
     "name": "Turnkey",
     "url": "https://turnkey.com/"

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -18,6 +18,17 @@ export function uint8ArrayToHexString(input: Uint8Array): string {
   );
 }
 
+export const uint8ArrayFromHexString = (hexString: string): Uint8Array => {
+  const hexRegex = /^[0-9A-Fa-f]+$/;
+  if (!hexString || hexString.length % 2 != 0 || !hexRegex.test(hexString)) {
+    throw new Error(
+      `cannot create uint8array from invalid hex string: "${hexString}"`
+    );
+  }
+  return new Uint8Array(
+    hexString!.match(/../g)!.map((h: string) => parseInt(h, 16))
+  );
+};
 // Polyfill btoa with a pure JS implementation. This is adapted from the following:
 // https://github.com/jsdom/abab/blob/80874ae1fe1cde2e587bb6e51b6d7c9b42ca1d34/lib/btoa.js
 function btoa(s: string): string {


### PR DESCRIPTION
## Summary & Motivation
Removed internal related disclaimer, added uint8ArrayFromHexstring

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
