### PR TITLE
enable passkey sessions

### DIFF
--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -48,6 +48,7 @@
     "@turnkey/http": "workspace:*",
     "@turnkey/iframe-stamper": "workspace:*",
     "@turnkey/webauthn-stamper": "workspace:*",
+    "@turnkey/crypto": "workspace:*",
     "buffer": "^6.0.3",
     "elliptic": "^6.5.5",
     "cross-fetch": "^3.1.5"

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -45,13 +45,16 @@
   },
   "dependencies": {
     "@turnkey/api-key-stamper": "workspace:*",
+    "@turnkey/crypto": "workspace:*",
+    "@turnkey/encoding": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@turnkey/iframe-stamper": "workspace:*",
     "@turnkey/webauthn-stamper": "workspace:*",
-    "@turnkey/crypto": "workspace:*",
+    "bs58check": "^3.0.1",
     "buffer": "^6.0.3",
+    "cross-fetch": "^3.1.5",
     "elliptic": "^6.5.5",
-    "cross-fetch": "^3.1.5"
+    "hpke-js": "^1.2.7"
   },
   "devDependencies": {
     "@types/elliptic": "^6.4.18",

--- a/packages/sdk-browser/src/models.ts
+++ b/packages/sdk-browser/src/models.ts
@@ -14,3 +14,8 @@ export interface SubOrganization {
   organizationId: string;
   organizationName: string;
 }
+
+export type EmbeddedAPIKey = {
+  authBundle: string;
+  publicKey: string;
+};

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -1,14 +1,6 @@
 import { WebauthnStamper } from "@turnkey/webauthn-stamper";
 import { IframeStamper } from "@turnkey/iframe-stamper";
-import bs58check from "bs58check";
-import { AeadId, CipherSuite, KdfId, KemId } from "hpke-js";
-import { uint8ArrayFromHexString } from "@turnkey/encoding";
 import { getWebAuthnAttestation } from "@turnkey/http";
-import {
-  generateP256KeyPair,
-  buildAdditionalAssociatedData,
-  compressRawPublicKey,
-} from "@turnkey/crypto";
 
 import { VERSION } from "./__generated__/version";
 import WindowWrapper from "./__polyfills__/window";
@@ -25,14 +17,18 @@ import { TurnkeyRequestError } from "./__types__/base";
 import { TurnkeySDKClientBase } from "./__generated__/sdk-client-base";
 import type * as SdkApiTypes from "./__generated__/sdk_api_types";
 
-import type { User, SubOrganization, EmbeddedAPIKey } from "./models";
+import type { User, SubOrganization } from "./models";
 import {
   StorageKeys,
   getStorageValue,
   removeStorageValue,
   setStorageValue,
 } from "./storage";
-import { generateRandomBuffer, base64UrlEncode } from "./utils";
+import {
+  generateRandomBuffer,
+  base64UrlEncode,
+  createEmbeddedAPIKey,
+} from "./utils";
 
 export class TurnkeyBrowserSDK {
   config: TurnkeySDKBrowserConfig;
@@ -195,64 +191,6 @@ export class TurnkeyBrowserClient extends TurnkeySDKClientBase {
     await setStorageValue(StorageKeys.CurrentUser, currentUser);
     return readOnlySessionResult!;
   };
-
-  // createEmbeddedAPIKey creates an embedded API key encrypted to a target key (typically embedded within an iframe).
-  // This returns a bundle that can be decrypted by that target key, as well as the public key of the newly created API key.
-  createEmbeddedAPIKey = async (
-    targetPublicKey: string
-  ): Promise<EmbeddedAPIKey> => {
-    const TURNKEY_HPKE_INFO = new TextEncoder().encode("turnkey_hpke");
-
-    // 1: create new API key (to be encrypted to the targetPublicKey)
-    const p256key = generateP256KeyPair();
-
-    // 2: set up encryption
-    const suite = new CipherSuite({
-      kem: KemId.DhkemP256HkdfSha256,
-      kdf: KdfId.HkdfSha256,
-      aead: AeadId.Aes256Gcm,
-    });
-
-    // 3: import the targetPublicKey (i.e. passed in from the iframe)
-    const targetKeyBytes = uint8ArrayFromHexString(targetPublicKey);
-    const targetKey = await crypto.subtle.importKey(
-      "raw",
-      targetKeyBytes,
-      {
-        name: "ECDH",
-        namedCurve: "P-256",
-      },
-      true,
-      []
-    );
-
-    // 4: sender encrypts a message to the target key
-    const sender = await suite.createSenderContext({
-      recipientPublicKey: targetKey,
-      info: TURNKEY_HPKE_INFO,
-    });
-    const ciphertext = await sender.seal(
-      uint8ArrayFromHexString(p256key.privateKey),
-      buildAdditionalAssociatedData(new Uint8Array(sender.enc), targetKeyBytes)
-    );
-    const ciphertextUint8Array = new Uint8Array(ciphertext);
-
-    // 5: assemble bundle
-    const encappedKey = new Uint8Array(sender.enc);
-    const compressedEncappedKey = compressRawPublicKey(encappedKey);
-    const result = new Uint8Array(
-      compressedEncappedKey.length + ciphertextUint8Array.length
-    );
-    result.set(compressedEncappedKey);
-    result.set(ciphertextUint8Array, compressedEncappedKey.length);
-
-    const base58encodedBundle = bs58check.encode(result);
-
-    return {
-      authBundle: base58encodedBundle,
-      publicKey: p256key.publicKey,
-    };
-  };
 }
 
 export class TurnkeyPasskeyClient extends TurnkeyBrowserClient {
@@ -327,7 +265,7 @@ export class TurnkeyPasskeyClient extends TurnkeyBrowserClient {
     const localStorageUser = await getStorageValue(StorageKeys.CurrentUser);
     userId = userId ?? localStorageUser?.userId;
 
-    const { authBundle, publicKey } = await this.createEmbeddedAPIKey(
+    const { authBundle, publicKey } = await createEmbeddedAPIKey(
       targetEmbeddedKey
     );
 

--- a/packages/sdk-browser/src/storage.ts
+++ b/packages/sdk-browser/src/storage.ts
@@ -3,7 +3,7 @@ import WindowWrapper from "./__polyfills__/window";
 
 export enum StorageKeys {
   CurrentUser = "@turnkey/current_user",
-  AuthBundle = "@turnkey/auth_bundle"
+  AuthBundle = "@turnkey/auth_bundle",
 }
 
 interface StorageValue {

--- a/packages/sdk-browser/src/storage.ts
+++ b/packages/sdk-browser/src/storage.ts
@@ -3,10 +3,12 @@ import WindowWrapper from "./__polyfills__/window";
 
 export enum StorageKeys {
   CurrentUser = "@turnkey/current_user",
+  AuthBundle = "@turnkey/auth_bundle"
 }
 
 interface StorageValue {
   [StorageKeys.CurrentUser]: User;
+  [StorageKeys.AuthBundle]: string;
 }
 
 enum StorageLocation {
@@ -17,6 +19,7 @@ enum StorageLocation {
 
 const STORAGE_VALUE_LOCATIONS: Record<StorageKeys, StorageLocation> = {
   [StorageKeys.CurrentUser]: StorageLocation.Local,
+  [StorageKeys.AuthBundle]: StorageLocation.Local,
 };
 
 const STORAGE_LOCATIONS = {

--- a/packages/sdk-browser/src/utils.ts
+++ b/packages/sdk-browser/src/utils.ts
@@ -1,4 +1,73 @@
+import { uint8ArrayFromHexString } from "@turnkey/encoding";
+import {
+  generateP256KeyPair,
+  buildAdditionalAssociatedData,
+  compressRawPublicKey,
+} from "@turnkey/crypto";
+
 import { Buffer } from "buffer";
+import bs58check from "bs58check";
+import { AeadId, CipherSuite, KdfId, KemId } from "hpke-js";
+
+import type { EmbeddedAPIKey } from "./models";
+
+// createEmbeddedAPIKey creates an embedded API key encrypted to a target key (typically embedded within an iframe).
+// This returns a bundle that can be decrypted by that target key, as well as the public key of the newly created API key.
+export const createEmbeddedAPIKey = async (
+  targetPublicKey: string
+): Promise<EmbeddedAPIKey> => {
+  const TURNKEY_HPKE_INFO = new TextEncoder().encode("turnkey_hpke");
+
+  // 1: create new API key (to be encrypted to the targetPublicKey)
+  const p256key = generateP256KeyPair();
+
+  // 2: set up encryption
+  const suite = new CipherSuite({
+    kem: KemId.DhkemP256HkdfSha256,
+    kdf: KdfId.HkdfSha256,
+    aead: AeadId.Aes256Gcm,
+  });
+
+  // 3: import the targetPublicKey (i.e. passed in from the iframe)
+  const targetKeyBytes = uint8ArrayFromHexString(targetPublicKey);
+  const targetKey = await crypto.subtle.importKey(
+    "raw",
+    targetKeyBytes,
+    {
+      name: "ECDH",
+      namedCurve: "P-256",
+    },
+    true,
+    []
+  );
+
+  // 4: sender encrypts a message to the target key
+  const sender = await suite.createSenderContext({
+    recipientPublicKey: targetKey,
+    info: TURNKEY_HPKE_INFO,
+  });
+  const ciphertext = await sender.seal(
+    uint8ArrayFromHexString(p256key.privateKey),
+    buildAdditionalAssociatedData(new Uint8Array(sender.enc), targetKeyBytes)
+  );
+  const ciphertextUint8Array = new Uint8Array(ciphertext);
+
+  // 5: assemble bundle
+  const encappedKey = new Uint8Array(sender.enc);
+  const compressedEncappedKey = compressRawPublicKey(encappedKey);
+  const result = new Uint8Array(
+    compressedEncappedKey.length + ciphertextUint8Array.length
+  );
+  result.set(compressedEncappedKey);
+  result.set(ciphertextUint8Array, compressedEncappedKey.length);
+
+  const base58encodedBundle = bs58check.encode(result);
+
+  return {
+    authBundle: base58encodedBundle,
+    publicKey: p256key.publicKey,
+  };
+};
 
 export const generateRandomBuffer = (): ArrayBuffer => {
   const arr = new Uint8Array(32);

--- a/packages/sdk-react/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react/src/contexts/TurnkeyContext.tsx
@@ -36,7 +36,8 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
   >(undefined);
   const iframeInit = useRef<boolean>(false);
 
-  const TurnkeyIframeContainerId = "turnkey-default-iframe-container-id";
+  const TurnkeyAuthIframeContainerId = "turnkey-auth-iframe-container-id";
+  const TurnkeyAuthIframeElementId = "turnkey-auth-iframe-element-id";
 
   useEffect(() => {
     (async () => {
@@ -46,8 +47,11 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
         setTurnkey(newTurnkey);
         setPasskeyClient(newTurnkey.passkeyClient());
         const newAuthIframeClient = await newTurnkey.iframeClient({
-          iframeContainer: document.getElementById(TurnkeyIframeContainerId),
+          iframeContainer: document.getElementById(
+            TurnkeyAuthIframeContainerId
+          ),
           iframeUrl: "https://auth.turnkey.com",
+          iframeElementId: TurnkeyAuthIframeElementId,
         });
         setAuthIframeClient(newAuthIframeClient);
       }
@@ -65,7 +69,7 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
       {children}
       <div
         className=""
-        id={TurnkeyIframeContainerId}
+        id={TurnkeyAuthIframeContainerId}
         style={{ display: "none" }}
       />
     </TurnkeyContext.Provider>

--- a/packages/sdk-react/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react/src/contexts/TurnkeyContext.tsx
@@ -4,18 +4,23 @@ import {
   TurnkeyIframeClient,
   TurnkeyPasskeyClient,
   TurnkeySDKBrowserConfig,
+  TurnkeyBrowserClient,
 } from "@turnkey/sdk-browser";
 
 export interface TurnkeyClientType {
   turnkey: Turnkey | undefined;
   authIframeClient: TurnkeyIframeClient | undefined;
   passkeyClient: TurnkeyPasskeyClient | undefined;
+  getActiveClient: () => Promise<TurnkeyBrowserClient | undefined>;
 }
 
 export const TurnkeyContext = createContext<TurnkeyClientType>({
   turnkey: undefined,
   passkeyClient: undefined,
   authIframeClient: undefined,
+  getActiveClient: async () => {
+    return undefined;
+  },
 });
 
 interface TurnkeyProviderProps {
@@ -39,13 +44,44 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
   const TurnkeyAuthIframeContainerId = "turnkey-auth-iframe-container-id";
   const TurnkeyAuthIframeElementId = "turnkey-auth-iframe-element-id";
 
+  const getActiveClient = async () => {
+    let currentClient: TurnkeyBrowserClient | undefined = passkeyClient;
+
+    try {
+      const authBundle = await turnkey?.getAuthBundle();
+
+      if (authBundle) {
+        const injected = await authIframeClient?.injectCredentialBundle(
+          authBundle
+        );
+        if (injected) {
+          const currentUser = await turnkey?.getCurrentUser();
+          await authIframeClient?.getWhoami({
+            organizationId:
+              currentUser?.organization.organizationId ??
+              turnkey?.config.defaultOrganizationId!,
+          });
+
+          currentClient = authIframeClient;
+        }
+      }
+    } catch (err: any) {
+      console.error("Failed to use iframe client", err);
+      console.log("Defaulting to passkey client");
+    }
+
+    return currentClient;
+  };
+
   useEffect(() => {
     (async () => {
       if (!iframeInit.current) {
         iframeInit.current = true;
+
         const newTurnkey = new Turnkey(config);
         setTurnkey(newTurnkey);
         setPasskeyClient(newTurnkey.passkeyClient());
+
         const newAuthIframeClient = await newTurnkey.iframeClient({
           iframeContainer: document.getElementById(
             TurnkeyAuthIframeContainerId
@@ -64,6 +100,7 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
         turnkey,
         passkeyClient,
         authIframeClient,
+        getActiveClient,
       }}
     >
       {children}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,6 +886,9 @@ importers:
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../api-key-stamper
+      '@turnkey/crypto':
+        specifier: workspace:*
+        version: link:../crypto
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,6 +889,9 @@ importers:
       '@turnkey/crypto':
         specifier: workspace:*
         version: link:../crypto
+      '@turnkey/encoding':
+        specifier: workspace:*
+        version: link:../encoding
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http
@@ -898,6 +901,9 @@ importers:
       '@turnkey/webauthn-stamper':
         specifier: workspace:*
         version: link:../webauthn-stamper
+      bs58check:
+        specifier: ^3.0.1
+        version: 3.0.1
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -907,6 +913,9 @@ importers:
       elliptic:
         specifier: ^6.5.5
         version: 6.5.5
+      hpke-js:
+        specifier: ^1.2.7
+        version: 1.2.7
     devDependencies:
       '@types/elliptic':
         specifier: ^6.4.18
@@ -5466,6 +5475,10 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@noble/ciphers@0.4.1:
+    resolution: {integrity: sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==}
+    dev: false
 
   /@noble/ciphers@0.5.3:
     resolution: {integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==}
@@ -12175,6 +12188,15 @@ packages:
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
+
+  /hpke-js@1.2.7:
+    resolution: {integrity: sha512-g6gW2QZki8PktguvoXzAN4jKDWUPkApkBFHAVlhnr/tZUHlvuvMLZb7ZpdDMU8UvCh4iUDFMOJJrjN18OqEpIQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@noble/ciphers': 0.4.1
+      '@noble/curves': 1.3.0
+      '@noble/hashes': 1.3.3
+    dev: false
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}


### PR DESCRIPTION
## Summary & Motivation
See iteration cycles on https://replit.com/@andrew306/RepulsiveRundownObject#index.ts

This flavor of creating passkey sessions assumes that you've created the suborg already and know their suborg ID.

This does not encapsulate logic to, say, create a new suborg and have a fresh passkey session for them out of the gate. However, the abstraction is there: you could call `createEmbeddedAPIKey`, grab the resulting public key and include it as a user's API key within a `CreateSubOrganization` call.

Note that this depends on `hpke-js` which is not available in some environments (such as react native). We'll have to do some followup work there to get native support at a later time.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
