### PR TITLE
add utils and rearrange @turnkey/crypto

### DIFF
--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -3,7 +3,12 @@ import {
   uint8ArrayFromHexString,
   uint8ArrayToHexString,
 } from "@turnkey/encoding";
-import { getPublicKey, generateP256KeyPair, decryptBundle } from "../crypto";
+import {
+  getPublicKey,
+  generateP256KeyPair,
+  decryptBundle,
+  extractPrivateKeyFromPKCS8Bytes,
+} from "../crypto";
 
 // Mock data for testing
 const mockSenderPrivateKey =
@@ -34,5 +39,15 @@ describe("Turnkey Crypto Primitives", () => {
     const decryptedData = decryptBundle(mockCredentialBundle, mockPrivateKey);
     expect(decryptedData).toBeInstanceOf(Uint8Array);
     expect(uint8ArrayToHexString(decryptedData)).toBe(mockSenderPrivateKey);
+  });
+
+  test("extractPrivateKeyFromPKCS8Bytes", () => {
+    const pkcs8PrivateKeyHex =
+      "308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b020101042001d95d256f744b2a855fe2036ec1074c726445f1382f53580a17ce3296cc2deca1440342000440fa0a112351e0f5cdcc3edad914e7e3b911d3e83874d4ef55ff5639f4a3633e65087a8499c46a77f8e68c937203d85e6d38ade95d755a6cf88fa101091d5983";
+    const expectedRawPrivateKeyHex =
+      "01d95d256f744b2a855fe2036ec1074c726445f1382f53580a17ce3296cc2dec";
+    expect(extractPrivateKeyFromPKCS8Bytes(uint8ArrayFromHexString(pkcs8PrivateKeyHex))).toEqual(
+      uint8ArrayFromHexString(expectedRawPrivateKeyHex)
+    );
   });
 });

--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -46,8 +46,10 @@ describe("Turnkey Crypto Primitives", () => {
       "308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b020101042001d95d256f744b2a855fe2036ec1074c726445f1382f53580a17ce3296cc2deca1440342000440fa0a112351e0f5cdcc3edad914e7e3b911d3e83874d4ef55ff5639f4a3633e65087a8499c46a77f8e68c937203d85e6d38ade95d755a6cf88fa101091d5983";
     const expectedRawPrivateKeyHex =
       "01d95d256f744b2a855fe2036ec1074c726445f1382f53580a17ce3296cc2dec";
-    expect(extractPrivateKeyFromPKCS8Bytes(uint8ArrayFromHexString(pkcs8PrivateKeyHex))).toEqual(
-      uint8ArrayFromHexString(expectedRawPrivateKeyHex)
-    );
+    expect(
+      extractPrivateKeyFromPKCS8Bytes(
+        uint8ArrayFromHexString(pkcs8PrivateKeyHex)
+      )
+    ).toEqual(uint8ArrayFromHexString(expectedRawPrivateKeyHex));
   });
 });

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -150,7 +150,7 @@ export const generateP256KeyPair = (): KeyPair => {
 
 /**
  * Create additional associated data (AAD) for AES-GCM decryption.
- * 
+ *
  * @param {Uint8Array} senderPubBuf
  * @param {Uint8Array} receiverPubBuf
  * @return {Uint8Array} - The resulting concatenation of sender and receiver pubkeys.
@@ -167,7 +167,7 @@ export const buildAdditionalAssociatedData = (
 
 /**
  * Accepts a private key Uint8Array in the PKCS8 format, and returns the encapsulated private key.
- * 
+ *
  * @param {Uint8Array} privateKey - A PKCS#8 private key structured with the key data at a specific position. The actual key starts at byte 36 and is 32 bytes long.
  * @return {Uint8Array} - The private key.
  */
@@ -179,7 +179,7 @@ export const extractPrivateKeyFromPKCS8Bytes = (
 
 /**
  * Accepts a public key Uint8Array, and returns a Uint8Array with the compressed version of the public key.
- * 
+ *
  * @param {Uint8Array} rawPublicKey - The raw public key.
  * @return {Uint8Array} – The compressed public key.
  */

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -36,9 +36,9 @@ interface KeyPair {
  * Get PublicKey function
  * Derives public key from Uint8Array or hexstring private key
  *
- * @param {Uint8Array | string} privateKey - The Uint8Array or hexstring representation of a compressed private key
- * @param {boolean} isCompressed - true by default, specifies whether to return a compressed or uncompressed public key
- * @returns {<Uint8Array>} - The public key in Uin8Array representation.
+ * @param {Uint8Array | string} privateKey - The Uint8Array or hexstring representation of a compressed private key.
+ * @param {boolean} isCompressed - Specifies whether to return a compressed or uncompressed public key. Defaults to true.
+ * @returns {Uint8Array} - The public key in Uin8Array representation.
  */
 export const getPublicKey = (
   privateKey: Uint8Array | string,
@@ -133,7 +133,7 @@ export const decryptBundle = (
 /**
  * Generate a P-256 key pair. Contains the hexed privateKey, publicKey, and Uncompressed publicKey
  *
- * @returns {<KeyPair>} - The generated key pair.
+ * @returns {KeyPair} - The generated key pair.
  */
 export const generateP256KeyPair = (): KeyPair => {
   const privateKey = randomBytes(32);
@@ -150,6 +150,10 @@ export const generateP256KeyPair = (): KeyPair => {
 
 /**
  * Create additional associated data (AAD) for AES-GCM decryption.
+ * 
+ * @param {Uint8Array} senderPubBuf
+ * @param {Uint8Array} receiverPubBuf
+ * @return {Uint8Array} - The resulting concatenation of sender and receiver pubkeys.
  */
 export const buildAdditionalAssociatedData = (
   senderPubBuf: Uint8Array,
@@ -163,9 +167,9 @@ export const buildAdditionalAssociatedData = (
 
 /**
  * Accepts a private key Uint8Array in the PKCS8 format, and returns the encapsulated private key.
- * PKCS#8 private key is structured with the key data at a specific position.
- * The actual key starts at byte 36 and is 32 bytes long
- * @param {Uint8Array} privateKey
+ * 
+ * @param {Uint8Array} privateKey - A PKCS#8 private key structured with the key data at a specific position. The actual key starts at byte 36 and is 32 bytes long.
+ * @return {Uint8Array} - The private key.
  */
 export const extractPrivateKeyFromPKCS8Bytes = (
   privateKey: Uint8Array
@@ -174,8 +178,10 @@ export const extractPrivateKeyFromPKCS8Bytes = (
 };
 
 /**
- * Accepts a public key Uint8Array, and returns a Uint8Array with the compressed version of the public key
- * @param {Uint8Array} rawPublicKey
+ * Accepts a public key Uint8Array, and returns a Uint8Array with the compressed version of the public key.
+ * 
+ * @param {Uint8Array} rawPublicKey - The raw public key.
+ * @return {Uint8Array} – The compressed public key.
  */
 export const compressRawPublicKey = (rawPublicKey: Uint8Array): Uint8Array => {
   const len = rawPublicKey.byteLength;
@@ -194,8 +200,8 @@ export const compressRawPublicKey = (rawPublicKey: Uint8Array): Uint8Array => {
 
 /**
  * Accepts a public key array buffer, and returns a buffer with the uncompressed version of the public key
- * @param {Uint8Array} rawPublicKey
- * @return {Uint8Array} the uncompressed bytes
+ * @param {Uint8Array} rawPublicKey - The public key.
+ * @return {Uint8Array} - The uncompressed public key.
  */
 const uncompressRawPublicKey = (rawPublicKey: Uint8Array): Uint8Array => {
   // point[0] must be 2 (false) or 3 (true).

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { p256 } from "@noble/curves/p256";
 import * as hkdf from "@noble/hashes/hkdf";
 import { sha256 } from "@noble/hashes/sha256";
@@ -6,9 +7,9 @@ import {
   uint8ArrayToHexString,
   uint8ArrayFromHexString,
 } from "@turnkey/encoding";
-import * as bs58check from "bs58check";
+import bs58check from "bs58check";
 
-import { modSqrt, testBit, randomBytes } from "./math";
+import { modSqrt, testBit } from "./math";
 import {
   AES_KEY_INFO,
   HPKE_VERSION,
@@ -235,6 +236,14 @@ const uncompressRawPublicKey = (rawPublicKey: Uint8Array): Uint8Array => {
 
   var uncompressedHexString = "04" + bigIntToHex(x, 64) + bigIntToHex(y, 64);
   return uint8ArrayFromHexString(uncompressedHexString);
+};
+
+/**
+ * Generate a random Uint8Array of a specific length. Note that this ultimately depends on the crypto implementation.
+ */
+const randomBytes = (length: number): Uint8Array => {
+  const array = new Uint8Array(length);
+  return crypto.getRandomValues(array);
 };
 
 /**

--- a/packages/crypto/src/math.ts
+++ b/packages/crypto/src/math.ts
@@ -1,0 +1,57 @@
+/**
+ * Compute the modular square root using the Tonelli-Shanks algorithm.
+ */
+export const modSqrt = (x: bigint, p: bigint): bigint => {
+  if (p <= BigInt(0)) {
+    throw new Error("p must be positive");
+  }
+  const base = x % p;
+
+  // Check if p % 4 == 3 (applies to NIST curves P-256, P-384, and P-521)
+  if (testBit(p, 0) && testBit(p, 1)) {
+    const q = (p + BigInt(1)) >> BigInt(2);
+    const squareRoot = modPow(base, q, p);
+    if ((squareRoot * squareRoot) % p !== base) {
+      throw new Error("could not find a modular square root");
+    }
+    return squareRoot;
+  }
+
+  // Other elliptic curve types not supported
+  throw new Error("unsupported modulus value");
+};
+
+/**
+ * Test if a specific bit is set.
+ */
+export const testBit = (n: bigint, i: number): boolean => {
+  const m = BigInt(1) << BigInt(i);
+  return (n & m) !== BigInt(0);
+};
+
+/**
+ * Generate a random Uint8Array of a specific length.
+ */
+export const randomBytes = (length: number): Uint8Array => {
+  const array = new Uint8Array(length);
+  // @ts-ignore
+  return crypto.getRandomValues(array);
+};
+
+/**
+ * Compute the modular exponentiation.
+ */
+const modPow = (b: bigint, exp: bigint, p: bigint): bigint => {
+  if (exp === BigInt(0)) {
+    return BigInt(1);
+  }
+  let result = b;
+  const exponentBitString = exp.toString(2);
+  for (let i = 1; i < exponentBitString.length; ++i) {
+    result = (result * result) % p;
+    if (exponentBitString[i] === "1") {
+      result = (result * b) % p;
+    }
+  }
+  return result;
+};

--- a/packages/crypto/src/math.ts
+++ b/packages/crypto/src/math.ts
@@ -30,15 +30,6 @@ export const testBit = (n: bigint, i: number): boolean => {
 };
 
 /**
- * Generate a random Uint8Array of a specific length.
- */
-export const randomBytes = (length: number): Uint8Array => {
-  const array = new Uint8Array(length);
-  // @ts-ignore
-  return crypto.getRandomValues(array);
-};
-
-/**
  * Compute the modular exponentiation.
  */
 const modPow = (b: bigint, exp: bigint, p: bigint): bigint => {


### PR DESCRIPTION
## Summary & Motivation
- move math-related utils to `math.ts`
- rename + rearrange some functions
- add `extractPrivateKeyFromPKCS8Bytes`, specifically for use in https://github.com/tkhq/sdk/pull/282. This is required because exporting private keys using webcrypto is only supported by the `pkcs8` format; you can't export using `raw`. As a result, we have to do some manual manipulation to get the 32-byte "actual" private key out of the pkcs8 envelope

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
