### PR TITLE
use public key

### DIFF
--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -8,6 +8,7 @@ import {
   generateP256KeyPair,
   decryptBundle,
   extractPrivateKeyFromPKCS8Bytes,
+  compressRawPublicKey,
 } from "../crypto";
 
 // Mock data for testing
@@ -33,6 +34,15 @@ describe("Turnkey Crypto Primitives", () => {
     expect(keyPair.privateKey).toBeTruthy();
     expect(keyPair.publicKey).toBeTruthy();
     expect(keyPair.publicKeyUncompressed).toBeTruthy();
+    expect(keyPair.privateKey).not.toEqual(keyPair.publicKey);
+    expect(keyPair.publicKey).not.toEqual(keyPair.publicKeyUncompressed);
+  });
+
+  test("compressRawPublicKey - returns a valid value", () => {
+    const { publicKey, publicKeyUncompressed } = generateP256KeyPair();
+    expect(
+      compressRawPublicKey(uint8ArrayFromHexString(publicKeyUncompressed))
+    ).toEqual(uint8ArrayFromHexString(publicKey));
   });
 
   test("decryptBundle - successfully decrypts a credential bundle", () => {

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -144,7 +144,7 @@ export const generateP256KeyPair = (): KeyPair => {
   );
   return {
     privateKey: uint8ArrayToHexString(privateKey),
-    publicKey: uint8ArrayToHexString(privateKey),
+    publicKey: uint8ArrayToHexString(publicKey),
     publicKeyUncompressed,
   };
 };


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
