### PR TITLE
Moe/add hpke encryption 

### DIFF
--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -5,3 +5,36 @@ This package consolidates some common cryptographic utilities used across our ap
 ```
 import 'react-native-get-random-values'
 ```
+
+Example usage (Hpke):
+
+```
+const senderKeyPair = generateP256KeyPair();
+const receiverKeyPair = generateP256KeyPair();
+
+
+const receiverPublicKeyUncompressed = uncompressRawPublicKey(
+      uint8ArrayFromHexString(receiverKeyPair.publicKey)
+);
+
+const plaintext = "Hello, this is a secure message!";
+const encryptedData = hpkeEncrypt({
+    plainText: plaintext,
+    encappedKeyBuf: receiverPublicKeyUncompressed, // Assuming the use of uncompressed format
+    senderPriv: senderKeyPair.privateKey,
+    });
+
+    // Extract the encapsulated key buffer and the ciphertext
+    const encappedKeyBuf = encryptedData.slice(0, 33);
+    const ciphertextBuf = encryptedData.slice(33);
+
+    const decryptedData = hpkeDecrypt({
+      ciphertextBuf,
+      encappedKeyBuf: uncompressRawPublicKey(encappedKeyBuf), // Directly pass the buffer without additional processing
+      receiverPriv: receiverKeyPair.privateKey,
+    });
+
+    // Convert decrypted data back to string
+    const decryptedText = new TextDecoder().decode(decryptedData);
+
+```

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,40 +1,38 @@
 # @turnkey/crypto
 
-This package consolidates some common cryptographic utilities used across our applications, particularly primitives related to keys, encryption, and decryption. For react-native you will need to polyfill our random byte generation by importing react-native-get-random-values: https://www.npmjs.com/package/react-native-get-random-values
+This package is runtime agnostic and consolidates some common cryptographic utilities used across our applications, particularly primitives related to keys, encryption, and decryption. For react-native you will need to polyfill our random byte generation by importing react-native-get-random-values: https://www.npmjs.com/package/react-native-get-random-values
 
 ```
 import 'react-native-get-random-values'
 ```
 
-Example usage (Hpke):
+Example usage (Hpke E2E):
 
 ```
 const senderKeyPair = generateP256KeyPair();
 const receiverKeyPair = generateP256KeyPair();
 
-
 const receiverPublicKeyUncompressed = uncompressRawPublicKey(
-      uint8ArrayFromHexString(receiverKeyPair.publicKey)
+  uint8ArrayFromHexString(receiverKeyPair.publicKey),
 );
 
 const plaintext = "Hello, this is a secure message!";
 const encryptedData = hpkeEncrypt({
-    plainText: plaintext,
-    encappedKeyBuf: receiverPublicKeyUncompressed, // Assuming the use of uncompressed format
-    senderPriv: senderKeyPair.privateKey,
-    });
+  plainText: plaintext,
+  encappedKeyBuf: receiverPublicKeyUncompressed,
+  senderPriv: senderKeyPair.privateKey,
+});
 
-    // Extract the encapsulated key buffer and the ciphertext
-    const encappedKeyBuf = encryptedData.slice(0, 33);
-    const ciphertextBuf = encryptedData.slice(33);
+// Extract the encapsulated key buffer and the ciphertext
+const encappedKeyBuf = encryptedData.slice(0, 33);
+const ciphertextBuf = encryptedData.slice(33);
 
-    const decryptedData = hpkeDecrypt({
-      ciphertextBuf,
-      encappedKeyBuf: uncompressRawPublicKey(encappedKeyBuf), // Directly pass the buffer without additional processing
-      receiverPriv: receiverKeyPair.privateKey,
-    });
+const decryptedData = hpkeDecrypt({
+  ciphertextBuf,
+  encappedKeyBuf: uncompressRawPublicKey(encappedKeyBuf),
+  receiverPriv: receiverKeyPair.privateKey,
+});
 
-    // Convert decrypted data back to string
-    const decryptedText = new TextDecoder().decode(decryptedData);
-
+// Convert decrypted data back to string
+const decryptedText = new TextDecoder().decode(decryptedData);
 ```

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,6 +1,6 @@
 # @turnkey/crypto
 
-This package is runtime agnostic and consolidates some common cryptographic utilities used across our applications, particularly primitives related to keys, encryption, and decryption. For react-native you will need to polyfill our random byte generation by importing react-native-get-random-values: https://www.npmjs.com/package/react-native-get-random-values
+This package consolidates some common cryptographic utilities used across our applications, particularly primitives related to keys, encryption, and decryption in a pure JS implementation. For react-native you will need to polyfill our random byte generation by importing react-native-get-random-values: https://www.npmjs.com/package/react-native-get-random-values
 
 ```
 import 'react-native-get-random-values'

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -16,9 +16,10 @@ const receiverPublicKeyUncompressed = uncompressRawPublicKey(
   uint8ArrayFromHexString(receiverKeyPair.publicKey),
 );
 
-const plaintext = "Hello, this is a secure message!";
+const plainText = "Hello, this is a secure message!";
+const plainTextBuf = textEncoder.encode(plainText);
 const encryptedData = hpkeEncrypt({
-  plainText: plaintext,
+  plainTextBuf: plainTextBuf,
   encappedKeyBuf: receiverPublicKeyUncompressed,
   senderPriv: senderKeyPair.privateKey,
 });

--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -30,13 +30,14 @@ describe("HPKE Encryption and Decryption", () => {
       uint8ArrayFromHexString(receiverKeyPair.publicKey)
     );
 
+    const textEncoder = new TextEncoder();
     // Mock plaintext
     const plaintext = "Hello, this is a secure message!";
-
+    const plainTextBuf = textEncoder.encode(plaintext);
     // Encrypt
     const encryptedData = hpkeEncrypt({
-      plainText: plaintext,
-      encappedKeyBuf: receiverPublicKeyUncompressed,
+      plainTextBuf: plainTextBuf,
+      targetKeyBuf: receiverPublicKeyUncompressed,
       senderPriv: senderKeyPair.privateKey,
     });
 

--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -32,8 +32,8 @@ describe("HPKE Encryption and Decryption", () => {
 
     const textEncoder = new TextEncoder();
     // Mock plaintext
-    const plaintext = "Hello, this is a secure message!";
-    const plainTextBuf = textEncoder.encode(plaintext);
+    const plainText = "Hello, this is a secure message!";
+    const plainTextBuf = textEncoder.encode(plainText);
     // Encrypt
     const encryptedData = hpkeEncrypt({
       plainTextBuf: plainTextBuf,
@@ -56,7 +56,7 @@ describe("HPKE Encryption and Decryption", () => {
     const decryptedText = new TextDecoder().decode(decryptedData);
 
     // Expect the decrypted text to equal the original plaintext
-    expect(decryptedText).toEqual(plaintext);
+    expect(decryptedText).toEqual(plainText);
   });
 });
 

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -55,8 +55,8 @@ export const getPublicKey = (
 };
 
 /**
- * HPKE Decrypt Function
- * Decrypts data using Hybrid Public Key Encryption (HPKE) standard https://datatracker.ietf.org/doc/rfc9180/.
+ * HPKE Encrypt Function
+ * Encrypts data using Hybrid Public Key Encryption (HPKE) standard https://datatracker.ietf.org/doc/rfc9180/.
  *
  * @param {HpkeEncryptParams} params - The encryption parameters including plain text, encapsulated key, and sender private key.
  * @returns {Uint8Array} - The encrypted data.

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -170,7 +170,7 @@ export const hpkeDecrypt = ({
 };
 
 /**
- * Decrypt an encrypted credential bundle.
+ * Decrypt an encrypted email auth/recovery credential bundle.
  *
  * @param {string} credentialBundle - The encrypted credential bundle.
  * @param {string} embeddedKey - The private key for decryption.

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -411,13 +411,13 @@ const deriveSS = (encappedKeyBuf: Uint8Array, priv: string): Uint8Array => {
  * Encrypt data using AES-GCM.
  */
 const aesGcmEncrypt = (
-  plaintextData: Uint8Array,
+  plainTextData: Uint8Array,
   key: Uint8Array,
   iv: Uint8Array,
   aad?: Uint8Array
 ): Uint8Array => {
   const aes = gcm(key, iv, aad);
-  const data = aes.encrypt(plaintextData);
+  const data = aes.encrypt(plainTextData);
   return data;
 };
 


### PR DESCRIPTION
## Summary & Motivation
We got decryption so we may as well have encryption! Afaik, nothing really out there that supports e2e hpke decryption and encryption that can be used with any runtime, so why not :)

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
