### PR TITLE
remove auth bundle on logout

### DIFF
--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -159,6 +159,7 @@ export class TurnkeyBrowserSDK {
 
   logoutUser = async (): Promise<boolean> => {
     await removeStorageValue(StorageKeys.CurrentUser);
+    await removeStorageValue(StorageKeys.AuthBundle);
 
     return true;
   };


### PR DESCRIPTION
removes the auth bundle from localstorage when "logoutUser" is called to prevent issues where a user is logged in with another user's signing auth bundle