### PR TITLE
padding fixes

### DIFF
--- a/.changeset/nice-taxis-smash.md
+++ b/.changeset/nice-taxis-smash.md
@@ -1,0 +1,11 @@
+---
+"@turnkey/api-key-stamper": patch
+"@turnkey/encoding": patch
+"@turnkey/http": patch
+---
+
+Updates to various libraries:
+
+- `@turnkey/api-key-stamper`: resolve a bug where byte arrays might not be sufficiently padded (32 bytes are expected for x, y, and d elements of a JWK)
+- `@turnkey/encoding`: include additional utility functions
+- `@turnkey/http`: fix a (currently unused) return value

--- a/packages/api-key-stamper/src/tink/elliptic_curves.ts
+++ b/packages/api-key-stamper/src/tink/elliptic_curves.ts
@@ -1,6 +1,6 @@
 /**
  * Code modified from https://github.com/google/tink/blob/6f74b99a2bfe6677e3670799116a57268fd067fa/javascript/subtle/elliptic_curves.ts
- * - The implementation of integerToByteArray has been modified to optionally augment the resulting byte array to a certain length.
+ * - The implementation of integerToByteArray has been modified to augment the resulting byte array to a certain length.
  *
  * @license
  * Copyright 2020 Google LLC

--- a/packages/api-key-stamper/src/tink/elliptic_curves.ts
+++ b/packages/api-key-stamper/src/tink/elliptic_curves.ts
@@ -1,5 +1,6 @@
 /**
  * Code modified from https://github.com/google/tink/blob/6f74b99a2bfe6677e3670799116a57268fd067fa/javascript/subtle/elliptic_curves.ts
+ * - The implementation of integerToByteArray has been modified to optionally augment the resulting byte array to a certain length.
  *
  * @license
  * Copyright 2020 Google LLC
@@ -7,10 +8,6 @@
  */
 
 import * as Bytes from "./bytes";
-import {
-  DEFAULT_JWK_MEMBER_BYTE_LENGTH,
-  uint8ArrayFromHexString,
-} from "@turnkey/encoding";
 
 /**
  * P-256 only
@@ -38,20 +35,19 @@ function byteArrayToInteger(bytes: Uint8Array): bigint {
   return BigInt("0x" + Bytes.toHex(bytes));
 }
 
-/** Converts bigint to byte array. This implementation has been modified to optionally augment the resulting byte array to a certain length. */
-function integerToByteArray(i: bigint, length?: number): Uint8Array {
-  let input = i.toString(16);
-  // If necessary, prepend leading zero to ensure that input length is even.
-  input = input.length % 2 === 0 ? input : "0" + input;
-  if (!length) {
-    return Bytes.fromHex(input);
-  }
-  if (input.length / 2 > length) {
+/** Converts bigint to byte array. */
+function integerToByteArray(i: bigint, length: number): Uint8Array {
+  const input = i.toString(16);
+  const numHexChars = length * 2;
+  let padding = "";
+  if (numHexChars < input.length) {
     throw new Error(
-      "hex value cannot fit in a buffer of " + length + " byte(s)"
+      `cannot pack integer with ${input.length} hex chars into ${length} bytes`
     );
+  } else {
+    padding = "0".repeat(numHexChars - input.length);
   }
-  return uint8ArrayFromHexString(input, length);
+  return Bytes.fromHex(padding + input);
 }
 
 /** Returns true iff the ith bit (in lsb order) of n is set. */
@@ -141,6 +137,7 @@ function getY(x: bigint, lsb: boolean): bigint {
 
 /**
  * Decodes a public key in _compressed_ format.
+ * Augmented to ensure that the x and y components are padded to fit 32 bytes.
  *
  * P-256 only
  */
@@ -163,14 +160,8 @@ export function pointDecode(point: Uint8Array): JsonWebKey {
   const result: JsonWebKey = {
     kty: "EC",
     crv: "P-256",
-    x: Bytes.toBase64(
-      integerToByteArray(x, DEFAULT_JWK_MEMBER_BYTE_LENGTH),
-      /* websafe */ true
-    ),
-    y: Bytes.toBase64(
-      integerToByteArray(y, DEFAULT_JWK_MEMBER_BYTE_LENGTH),
-      /* websafe */ true
-    ),
+    x: Bytes.toBase64(integerToByteArray(x, 32), /* websafe */ true),
+    y: Bytes.toBase64(integerToByteArray(y, 32), /* websafe */ true),
     ext: true,
   };
   return result;

--- a/packages/api-key-stamper/src/utils.ts
+++ b/packages/api-key-stamper/src/utils.ts
@@ -1,11 +1,9 @@
 import { pointDecode } from "./tink/elliptic_curves";
 import {
-  stringToBase64urlString,
-  base64urlToBuffer,
-  uint8ArrayToHexString,
+  hexStringToBase64url,
+  uint8ArrayFromHexString,
+  DEFAULT_JWK_MEMBER_BYTE_LENGTH,
 } from "@turnkey/encoding";
-
-const DEFAULT_JWK_MEMBER_BYTE_LENGTH = 32;
 
 export function convertTurnkeyApiKeyToJwk(input: {
   uncompressedPrivateKeyHex: string;
@@ -13,74 +11,13 @@ export function convertTurnkeyApiKeyToJwk(input: {
 }): JsonWebKey {
   const { uncompressedPrivateKeyHex, compressedPublicKeyHex } = input;
 
-  const jwk = pointDecode(hexStringToUint8Array(compressedPublicKeyHex));
+  const jwk = pointDecode(uint8ArrayFromHexString(compressedPublicKeyHex));
 
-  // First make a copy to manipulate
-  const jwkCopy = { ...jwk };
-
-  // Ensure that each of the constituent parts are sufficiently padded
-  const paddedD = hexStringToBase64urlString(
+  // Ensure that d is sufficiently padded
+  jwk.d = hexStringToBase64url(
     uncompressedPrivateKeyHex,
     DEFAULT_JWK_MEMBER_BYTE_LENGTH
   );
 
-  // Manipulate x and y
-  const decodedX = base64urlToBuffer(jwkCopy.x!);
-  const paddedX = hexStringToBase64urlString(
-    uint8ArrayToHexString(new Uint8Array(decodedX)),
-    DEFAULT_JWK_MEMBER_BYTE_LENGTH
-  );
-
-  const decodedY = base64urlToBuffer(jwkCopy.y!);
-  const paddedY = hexStringToBase64urlString(
-    uint8ArrayToHexString(new Uint8Array(decodedY)),
-    DEFAULT_JWK_MEMBER_BYTE_LENGTH
-  );
-
-  jwkCopy.d = paddedD;
-  jwkCopy.x = paddedX;
-  jwkCopy.y = paddedY;
-
-  return jwkCopy;
-}
-
-/*
- * Note: the following helpers will soon be moved to @tkhq/encoding
- */
-function hexStringToUint8Array(input: string, length?: number): Uint8Array {
-  if (
-    input.length === 0 ||
-    input.length % 2 !== 0 ||
-    /[^a-fA-F0-9]/u.test(input)
-  ) {
-    throw new Error(`Invalid hex string: ${JSON.stringify(input)}`);
-  }
-
-  const buffer = Uint8Array.from(
-    input
-      .match(
-        /.{2}/g // Split string by every two characters
-      )!
-      .map((byte) => parseInt(byte, 16))
-  );
-
-  if (!length) {
-    return buffer;
-  }
-
-  // If a length is specified, ensure we sufficiently pad
-  let paddedBuffer = new Uint8Array(length);
-  paddedBuffer.set(buffer, length - buffer.length);
-  return paddedBuffer;
-}
-
-function hexStringToBase64urlString(input: string, length?: number): string {
-  // Add an extra 0 to the start of the string to get a valid hex string (even length)
-  // (e.g. 0x0123 instead of 0x123)
-  const hexString = input.padStart(Math.ceil(input.length / 2) * 2, "0");
-  const buffer = hexStringToUint8Array(hexString, length);
-
-  return stringToBase64urlString(
-    buffer.reduce((result, x) => result + String.fromCharCode(x), "")
-  );
+  return jwk;
 }

--- a/packages/api-key-stamper/src/utils.ts
+++ b/packages/api-key-stamper/src/utils.ts
@@ -1,5 +1,11 @@
 import { pointDecode } from "./tink/elliptic_curves";
-import { stringToBase64urlString, base64urlToBuffer, uint8ArrayToHexString } from "@turnkey/encoding";
+import {
+  stringToBase64urlString,
+  base64urlToBuffer,
+  uint8ArrayToHexString,
+} from "@turnkey/encoding";
+
+const DEFAULT_JWK_MEMBER_BYTE_LENGTH = 32;
 
 export function convertTurnkeyApiKeyToJwk(input: {
   uncompressedPrivateKeyHex: string;
@@ -17,10 +23,16 @@ export function convertTurnkeyApiKeyToJwk(input: {
 
   // Manipulate x and y
   const decodedX = base64urlToBuffer(jwkCopy.x!);
-  const paddedX = hexStringToBase64urlString(uint8ArrayToHexString(new Uint8Array(decodedX)));
-  
+  const paddedX = hexStringToBase64urlString(
+    uint8ArrayToHexString(new Uint8Array(decodedX)),
+    DEFAULT_JWK_MEMBER_BYTE_LENGTH
+  );
+
   const decodedY = base64urlToBuffer(jwkCopy.y!);
-  const paddedY = hexStringToBase64urlString(uint8ArrayToHexString(new Uint8Array(decodedY)));
+  const paddedY = hexStringToBase64urlString(
+    uint8ArrayToHexString(new Uint8Array(decodedY)),
+    DEFAULT_JWK_MEMBER_BYTE_LENGTH
+  );
 
   jwkCopy.x = paddedX;
   jwkCopy.y = paddedY;

--- a/packages/api-key-stamper/src/utils.ts
+++ b/packages/api-key-stamper/src/utils.ts
@@ -19,7 +19,10 @@ export function convertTurnkeyApiKeyToJwk(input: {
   const jwkCopy = { ...jwk };
 
   // Ensure that each of the constituent parts are sufficiently padded
-  jwkCopy.d = hexStringToBase64urlString(uncompressedPrivateKeyHex);
+  const paddedD = hexStringToBase64urlString(
+    uncompressedPrivateKeyHex,
+    DEFAULT_JWK_MEMBER_BYTE_LENGTH
+  );
 
   // Manipulate x and y
   const decodedX = base64urlToBuffer(jwkCopy.x!);
@@ -34,6 +37,7 @@ export function convertTurnkeyApiKeyToJwk(input: {
     DEFAULT_JWK_MEMBER_BYTE_LENGTH
   );
 
+  jwkCopy.d = paddedD;
   jwkCopy.x = paddedX;
   jwkCopy.y = paddedY;
 

--- a/packages/api-key-stamper/src/utils.ts
+++ b/packages/api-key-stamper/src/utils.ts
@@ -1,5 +1,5 @@
 import { pointDecode } from "./tink/elliptic_curves";
-import { stringToBase64urlString } from "@turnkey/encoding";
+import { stringToBase64urlString, base64urlToBuffer, uint8ArrayToHexString } from "@turnkey/encoding";
 
 export function convertTurnkeyApiKeyToJwk(input: {
   uncompressedPrivateKeyHex: string;
@@ -9,12 +9,29 @@ export function convertTurnkeyApiKeyToJwk(input: {
 
   const jwk = pointDecode(hexStringToUint8Array(compressedPublicKeyHex));
 
-  jwk.d = hexStringToBase64urlString(uncompressedPrivateKeyHex);
+  // First make a copy to manipulate
+  const jwkCopy = { ...jwk };
 
-  return jwk;
+  // Ensure that each of the constituent parts are sufficiently padded
+  jwkCopy.d = hexStringToBase64urlString(uncompressedPrivateKeyHex);
+
+  // Manipulate x and y
+  const decodedX = base64urlToBuffer(jwkCopy.x!);
+  const paddedX = hexStringToBase64urlString(uint8ArrayToHexString(new Uint8Array(decodedX)));
+  
+  const decodedY = base64urlToBuffer(jwkCopy.y!);
+  const paddedY = hexStringToBase64urlString(uint8ArrayToHexString(new Uint8Array(decodedY)));
+
+  jwkCopy.x = paddedX;
+  jwkCopy.y = paddedY;
+
+  return jwkCopy;
 }
 
-function hexStringToUint8Array(input: string): Uint8Array {
+/*
+ * Note: the following helpers will soon be moved to @tkhq/encoding
+ */
+function hexStringToUint8Array(input: string, length?: number): Uint8Array {
   if (
     input.length === 0 ||
     input.length % 2 !== 0 ||
@@ -23,17 +40,29 @@ function hexStringToUint8Array(input: string): Uint8Array {
     throw new Error(`Invalid hex string: ${JSON.stringify(input)}`);
   }
 
-  return Uint8Array.from(
+  const buffer = Uint8Array.from(
     input
       .match(
         /.{2}/g // Split string by every two characters
       )!
       .map((byte) => parseInt(byte, 16))
   );
+
+  if (!length) {
+    return buffer;
+  }
+
+  // If a length is specified, ensure we sufficiently pad
+  let paddedBuffer = new Uint8Array(length);
+  paddedBuffer.set(buffer, length - buffer.length);
+  return paddedBuffer;
 }
 
-function hexStringToBase64urlString(input: string): string {
-  const buffer = hexStringToUint8Array(input);
+function hexStringToBase64urlString(input: string, length?: number): string {
+  // Add an extra 0 to the start of the string to get a valid hex string (even length)
+  // (e.g. 0x0123 instead of 0x123)
+  const hexString = input.padStart(Math.ceil(input.length / 2) * 2, "0");
+  const buffer = hexStringToUint8Array(hexString, length);
 
   return stringToBase64urlString(
     buffer.reduce((result, x) => result + String.fromCharCode(x), "")

--- a/packages/encoding/src/__tests__/index-test.ts
+++ b/packages/encoding/src/__tests__/index-test.ts
@@ -4,6 +4,8 @@ import {
   uint8ArrayFromHexString,
   uint8ArrayToHexString,
   base64StringToBase64UrlEncodedString,
+  base64urlToBuffer,
+  bufferToBase64url,
 } from "..";
 
 // Test for stringToBase64urlString
@@ -32,6 +34,34 @@ test("stringToBase64urlString", async function () {
   ).toBe(
     "eyJwdWJsaWNLZXkiOiIwMmY3MzlmOGM3N2IzMmY0ZDVmMTMyNjU4NjFmZWJkNzZlN2E5YzYxYTExNDBkMjk2YjhjMTYzMDI1MDg4NzAzMTYiLCJzaWduYXR1cmUiOiIzMDQ0MDIyMDJhOTJjMjRlNGI0ZGUzY2RiNWMwNWEyYjFmNDIyNjRiYTgxMzljZjY2YjJkMWVjZjBhMDk5ODdhYjlhMmZlY2IwMjIwM2JmZDkxZDhjNWU4N2Y3OGRhOGI1Y2Y1ZGRiMjdjOTZjYjAwYjg0ODc5N2QwZmM3M2JmMzcxODkyYzQyM2Y4MSIsInNjaGVtZSI6IlNJR05BVFVSRV9TQ0hFTUVfVEtfQVBJX1AyNTYifQ" // Base64url encoded
   );
+});
+
+test("base64urlToBuffer", async function () {
+  // Trivial test string
+  expect(base64urlToBuffer("aGVsbG8")).toEqual(
+    new Uint8Array([104, 101, 108, 108, 111])
+  ); // "hello"
+
+  // Hello, World!
+  expect(base64urlToBuffer("SGVsbG8sIFdvcmxkIQ")).toEqual(
+    new Uint8Array([72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33])
+  );
+});
+
+test("bufferToBase64url", async function () {
+  // Trivial test string
+  expect(bufferToBase64url(new Uint8Array([104, 101, 108, 108, 111]))).toEqual(
+    "aGVsbG8"
+  ); // "hello"
+
+  // Hello, World!
+  expect(
+    bufferToBase64url(
+      new Uint8Array([
+        72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33,
+      ])
+    )
+  ).toEqual("SGVsbG8sIFdvcmxkIQ");
 });
 
 // Test for base64StringToBase64UrlEncodedString

--- a/packages/encoding/src/__tests__/index-test.ts
+++ b/packages/encoding/src/__tests__/index-test.ts
@@ -4,8 +4,6 @@ import {
   uint8ArrayFromHexString,
   uint8ArrayToHexString,
   base64StringToBase64UrlEncodedString,
-  base64urlToBuffer,
-  bufferToBase64url,
   hexStringToBase64url,
 } from "..";
 
@@ -35,34 +33,6 @@ test("stringToBase64urlString", async function () {
   ).toBe(
     "eyJwdWJsaWNLZXkiOiIwMmY3MzlmOGM3N2IzMmY0ZDVmMTMyNjU4NjFmZWJkNzZlN2E5YzYxYTExNDBkMjk2YjhjMTYzMDI1MDg4NzAzMTYiLCJzaWduYXR1cmUiOiIzMDQ0MDIyMDJhOTJjMjRlNGI0ZGUzY2RiNWMwNWEyYjFmNDIyNjRiYTgxMzljZjY2YjJkMWVjZjBhMDk5ODdhYjlhMmZlY2IwMjIwM2JmZDkxZDhjNWU4N2Y3OGRhOGI1Y2Y1ZGRiMjdjOTZjYjAwYjg0ODc5N2QwZmM3M2JmMzcxODkyYzQyM2Y4MSIsInNjaGVtZSI6IlNJR05BVFVSRV9TQ0hFTUVfVEtfQVBJX1AyNTYifQ" // Base64url encoded
   );
-});
-
-test("base64urlToBuffer", async function () {
-  // Trivial test string
-  expect(base64urlToBuffer("aGVsbG8")).toEqual(
-    new Uint8Array([104, 101, 108, 108, 111])
-  ); // "hello"
-
-  // Hello, World!
-  expect(base64urlToBuffer("SGVsbG8sIFdvcmxkIQ")).toEqual(
-    new Uint8Array([72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33])
-  );
-});
-
-test("bufferToBase64url", async function () {
-  // Trivial test string
-  expect(bufferToBase64url(new Uint8Array([104, 101, 108, 108, 111]))).toEqual(
-    "aGVsbG8"
-  ); // "hello"
-
-  // Hello, World!
-  expect(
-    bufferToBase64url(
-      new Uint8Array([
-        72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33,
-      ])
-    )
-  ).toEqual("SGVsbG8sIFdvcmxkIQ");
 });
 
 // Test for base64StringToBase64UrlEncodedString

--- a/packages/encoding/src/__tests__/index-test.ts
+++ b/packages/encoding/src/__tests__/index-test.ts
@@ -6,6 +6,7 @@ import {
   base64StringToBase64UrlEncodedString,
   base64urlToBuffer,
   bufferToBase64url,
+  hexStringToBase64url,
 } from "..";
 
 // Test for stringToBase64urlString
@@ -98,4 +99,44 @@ test("uint8ArrayFromHexString", async function () {
     133, 190, 199, 136, 134, 232, 226, 1, 175, 204, 177, 102, 252, 84, 193,
   ]);
   expect(uint8ArrayFromHexString(hexString)).toEqual(expectedUint8Array); // Hex string => Uint8Array
+
+  expect(uint8ArrayFromHexString("627566666572").toString()).toEqual(
+    "98,117,102,102,101,114"
+  );
+
+  // Error case: empty string
+  expect(() => {
+    uint8ArrayFromHexString("");
+  }).toThrow("cannot create uint8array from invalid hex string");
+  // Error case: odd number of characters
+  expect(() => {
+    uint8ArrayFromHexString("123");
+  }).toThrow("cannot create uint8array from invalid hex string");
+  // Error case: bad characters outside of hex range
+  expect(() => {
+    uint8ArrayFromHexString("oops");
+  }).toThrow("cannot create uint8array from invalid hex string");
+  // Happy path: if length parameter is included, pad the resulting buffer
+  expect(uint8ArrayFromHexString("01", 2).toString()).toEqual("0,1");
+  // Happy path: if length parameter is omitted, do not pad the resulting buffer
+  expect(uint8ArrayFromHexString("01").toString()).toEqual("1");
+  // Error case: hex value cannot fit in desired length
+  expect(() => {
+    uint8ArrayFromHexString("0100", 1).toString(); // the number 256 cannot fit into 1 byte
+  }).toThrow("hex value cannot fit in a buffer of 1 byte(s)");
+});
+
+// Test for hexStringToBase64url
+test("hexStringToBase64url", async function () {
+  expect(hexStringToBase64url("01")).toEqual("AQ");
+  expect(hexStringToBase64url("01", 2)).toEqual("AAE");
+
+  // extrapolate to larger numbers
+  expect(hexStringToBase64url("ff")).toEqual("_w"); // max 1 byte
+  expect(hexStringToBase64url("ff", 2)).toEqual("AP8"); // max 1 byte expressed in 2 bytes
+
+  // error case
+  expect(() => {
+    hexStringToBase64url("0100", 1);
+  }).toThrow("hex value cannot fit in a buffer of 1 byte(s)");
 });

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -7,9 +7,7 @@ export function stringToBase64urlString(input: string): string {
   return base64StringToBase64UrlEncodedString(base64String);
 }
 
-export function base64urlToBuffer(
-  baseurl64String: string
-): ArrayBuffer {
+export function base64urlToBuffer(baseurl64String: string): ArrayBuffer {
   // Base64url to Base64
   const padding = "==".slice(0, (4 - (baseurl64String.length % 4)) % 4);
   const base64String =
@@ -24,7 +22,7 @@ export function base64urlToBuffer(
   for (let i = 0; i < str.length; i++) {
     byteView[i] = str.charCodeAt(i);
   }
-  return buffer;
+  return byteView;
 }
 
 export function bufferToBase64url(buffer: ArrayBuffer): string {
@@ -46,7 +44,6 @@ export function bufferToBase64url(buffer: ArrayBuffer): string {
     .replace(/=/g, "");
   return base64urlString;
 }
-
 
 export function base64StringToBase64UrlEncodedString(input: string): string {
   return input.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -1,6 +1,8 @@
 /**
  * Code modified from https://github.com/github/webauthn-json/blob/e932b3585fa70b0bd5b5a4012ba7dbad7b0a0d0f/src/webauthn-json/base64url.ts#L23
  */
+export const DEFAULT_JWK_MEMBER_BYTE_LENGTH = 32;
+
 export function stringToBase64urlString(input: string): string {
   // string to base64 -- we do not rely on the browser's btoa since it's not present in React Native environments
   const base64String = btoa(input);
@@ -45,6 +47,17 @@ export function bufferToBase64url(buffer: ArrayBuffer): string {
   return base64urlString;
 }
 
+export function hexStringToBase64url(input: string, length?: number): string {
+  // Add an extra 0 to the start of the string to get a valid hex string (even length)
+  // (e.g. 0x0123 instead of 0x123)
+  const hexString = input.padStart(Math.ceil(input.length / 2) * 2, "0");
+  const buffer = uint8ArrayFromHexString(hexString, length);
+
+  return stringToBase64urlString(
+    buffer.reduce((result, x) => result + String.fromCharCode(x), "")
+  );
+}
+
 export function base64StringToBase64UrlEncodedString(input: string): string {
   return input.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
@@ -56,16 +69,34 @@ export function uint8ArrayToHexString(input: Uint8Array): string {
   );
 }
 
-export const uint8ArrayFromHexString = (hexString: string): Uint8Array => {
+export const uint8ArrayFromHexString = (
+  hexString: string,
+  length?: number
+): Uint8Array => {
   const hexRegex = /^[0-9A-Fa-f]+$/;
   if (!hexString || hexString.length % 2 != 0 || !hexRegex.test(hexString)) {
     throw new Error(
       `cannot create uint8array from invalid hex string: "${hexString}"`
     );
   }
-  return new Uint8Array(
+
+  const buffer = new Uint8Array(
     hexString!.match(/../g)!.map((h: string) => parseInt(h, 16))
   );
+
+  if (!length) {
+    return buffer;
+  }
+  if (hexString.length / 2 > length) {
+    throw new Error(
+      "hex value cannot fit in a buffer of " + length + " byte(s)"
+    );
+  }
+
+  // If a length is specified, ensure we sufficiently pad
+  let paddedBuffer = new Uint8Array(length);
+  paddedBuffer.set(buffer, length - buffer.length);
+  return paddedBuffer;
 };
 
 // Pure JS implementation of btoa. This is adapted from the following:

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -7,6 +7,47 @@ export function stringToBase64urlString(input: string): string {
   return base64StringToBase64UrlEncodedString(base64String);
 }
 
+export function base64urlToBuffer(
+  baseurl64String: string
+): ArrayBuffer {
+  // Base64url to Base64
+  const padding = "==".slice(0, (4 - (baseurl64String.length % 4)) % 4);
+  const base64String =
+    baseurl64String.replace(/-/g, "+").replace(/_/g, "/") + padding;
+
+  // Base64 to binary string
+  const str = atob(base64String);
+
+  // Binary string to buffer
+  const buffer = new ArrayBuffer(str.length);
+  const byteView = new Uint8Array(buffer);
+  for (let i = 0; i < str.length; i++) {
+    byteView[i] = str.charCodeAt(i);
+  }
+  return buffer;
+}
+
+export function bufferToBase64url(buffer: ArrayBuffer): string {
+  // Buffer to binary string
+  const byteView = new Uint8Array(buffer);
+  let str = "";
+  for (const charCode of byteView) {
+    str += String.fromCharCode(charCode);
+  }
+
+  // Binary string to base64
+  const base64String = btoa(str);
+
+  // Base64 to base64url
+  // We assume that the base64url string is well-formed.
+  const base64urlString = base64String
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+  return base64urlString;
+}
+
+
 export function base64StringToBase64UrlEncodedString(input: string): string {
   return input.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -9,44 +9,6 @@ export function stringToBase64urlString(input: string): string {
   return base64StringToBase64UrlEncodedString(base64String);
 }
 
-export function base64urlToBuffer(baseurl64String: string): ArrayBuffer {
-  // Base64url to Base64
-  const padding = "==".slice(0, (4 - (baseurl64String.length % 4)) % 4);
-  const base64String =
-    baseurl64String.replace(/-/g, "+").replace(/_/g, "/") + padding;
-
-  // Base64 to binary string
-  const str = atob(base64String);
-
-  // Binary string to buffer
-  const buffer = new ArrayBuffer(str.length);
-  const byteView = new Uint8Array(buffer);
-  for (let i = 0; i < str.length; i++) {
-    byteView[i] = str.charCodeAt(i);
-  }
-  return byteView;
-}
-
-export function bufferToBase64url(buffer: ArrayBuffer): string {
-  // Buffer to binary string
-  const byteView = new Uint8Array(buffer);
-  let str = "";
-  for (const charCode of byteView) {
-    str += String.fromCharCode(charCode);
-  }
-
-  // Binary string to base64
-  const base64String = btoa(str);
-
-  // Base64 to base64url
-  // We assume that the base64url string is well-formed.
-  const base64urlString = base64String
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=/g, "");
-  return base64urlString;
-}
-
 export function hexStringToBase64url(input: string, length?: number): string {
   // Add an extra 0 to the start of the string to get a valid hex string (even length)
   // (e.g. 0x0123 instead of 0x123)

--- a/packages/http/src/webauthn-json/base64url.ts
+++ b/packages/http/src/webauthn-json/base64url.ts
@@ -17,7 +17,7 @@ export function base64urlToBuffer(
   for (let i = 0; i < str.length; i++) {
     byteView[i] = str.charCodeAt(i);
   }
-  return buffer;
+  return byteView;
 }
 
 export function bufferToBase64url(buffer: ArrayBuffer): Base64urlString {


### PR DESCRIPTION
## Summary & Motivation
$title

There are cases where we want to manually pad buffers to get to a certain length, primarily when we're dealing with jwks. 

The nature of this change is similar in spirit to another change we recently rolled out for our iframes: https://github.com/tkhq/frames/pull/44

## How I Tested These Changes
Unit, smoke via https://github.com/tkhq/sdk/pull/322

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
