### PR TITLE
Release/v2024.8.12

### DIFF
--- a/.changeset/kind-jeans-check.md
+++ b/.changeset/kind-jeans-check.md
@@ -1,5 +1,0 @@
----
-"@turnkey/wallet-stamper": patch
----
-
-Initial release! 🎉

--- a/examples/with-wallet-stamper/CHANGELOG.md
+++ b/examples/with-wallet-stamper/CHANGELOG.md
@@ -1,0 +1,8 @@
+# with-wallet-stamper
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [68a14dd]
+  - @turnkey/wallet-stamper@0.0.2

--- a/examples/with-wallet-stamper/package.json
+++ b/examples/with-wallet-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-wallet-stamper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/wallet-stamper/CHANGELOG.md
+++ b/packages/wallet-stamper/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @turnkey/wallet-stamper
+
+## 0.0.2
+
+### Patch Changes
+
+- 68a14dd: Initial release! 🎉

--- a/packages/wallet-stamper/package.json
+++ b/packages/wallet-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/wallet-stamper",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
- Adds new `@turnkey/wallet-stamper` package
- Adds example `with-wallet-stamper` show casing how to stamp request using `@turnkey/wallet-stamper` with a solana wallet
