### PR TITLE
Remove version from constants

### DIFF
--- a/.changeset/lemon-trains-joke.md
+++ b/.changeset/lemon-trains-joke.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/eip-1193-provider": patch
+---
+
+Removes unused VERSION from constants. Fixes issue with using process in a browser environment.

--- a/packages/eip-1193-provider/src/constants.ts
+++ b/packages/eip-1193-provider/src/constants.ts
@@ -4,19 +4,19 @@ export const PROVIDER_ERROR_MESSAGE = {
   INVALID_CHAIN_ID_HEX:
     "Expected 0x-prefixed, unpadded, non-zero hexadecimal string 'chainId'. Received: ",
   INVALID_CHAIN_ID_VALUE:
-    'Expected numerical value greater than max safe value. Received: ',
+    "Expected numerical value greater than max safe value. Received: ",
   NATIVE_CURRENCY_SYMBOL_LENGTH:
     "Expected 2-6 character string 'nativeCurrency.symbol'. Received: ",
   NATIVE_CURRENCY_SYMBOL_MISMATCH:
-    'nativeCurrency.symbol does not match currency symbol for a network the user already has added with the same chainId. Received: ',
+    "nativeCurrency.symbol does not match currency symbol for a network the user already has added with the same chainId. Received: ",
   INVALID_RPC_URL:
-    'rpcUrls field is required and must contain at least one valid HTTP/HTTPS URL',
+    "rpcUrls field is required and must contain at least one valid HTTP/HTTPS URL",
   UNRECOGNIZED_CHAIN_ID:
-    'Unrecognized chain ID. Try adding the chain using wallet_addEthereumChain first. Received: ',
+    "Unrecognized chain ID. Try adding the chain using wallet_addEthereumChain first. Received: ",
   CHAIN_ID_RPC_MISMATCH:
-    'Chain ID does not match the RPC endpoint. Provider Chain ID: ',
-  PROVIDER_DISCONNECTED: 'Provider is disconnected from chain.',
-  RPC_URLS_REQUIRED: 'rpcUrls field is required and cannot be empty',
+    "Chain ID does not match the RPC endpoint. Provider Chain ID: ",
+  PROVIDER_DISCONNECTED: "Provider is disconnected from chain.",
+  RPC_URLS_REQUIRED: "rpcUrls field is required and cannot be empty",
 };
 
 export const PROVIDER_ERROR_CODE = {

--- a/packages/eip-1193-provider/src/constants.ts
+++ b/packages/eip-1193-provider/src/constants.ts
@@ -4,19 +4,19 @@ export const PROVIDER_ERROR_MESSAGE = {
   INVALID_CHAIN_ID_HEX:
     "Expected 0x-prefixed, unpadded, non-zero hexadecimal string 'chainId'. Received: ",
   INVALID_CHAIN_ID_VALUE:
-    "Expected numerical value greater than max safe value. Received: ",
+    'Expected numerical value greater than max safe value. Received: ',
   NATIVE_CURRENCY_SYMBOL_LENGTH:
     "Expected 2-6 character string 'nativeCurrency.symbol'. Received: ",
   NATIVE_CURRENCY_SYMBOL_MISMATCH:
-    "nativeCurrency.symbol does not match currency symbol for a network the user already has added with the same chainId. Received: ",
+    'nativeCurrency.symbol does not match currency symbol for a network the user already has added with the same chainId. Received: ',
   INVALID_RPC_URL:
-    "rpcUrls field is required and must contain at least one valid HTTP/HTTPS URL",
+    'rpcUrls field is required and must contain at least one valid HTTP/HTTPS URL',
   UNRECOGNIZED_CHAIN_ID:
-    "Unrecognized chain ID. Try adding the chain using wallet_addEthereumChain first. Received: ",
+    'Unrecognized chain ID. Try adding the chain using wallet_addEthereumChain first. Received: ',
   CHAIN_ID_RPC_MISMATCH:
-    "Chain ID does not match the RPC endpoint. Provider Chain ID: ",
-  PROVIDER_DISCONNECTED: "Provider is disconnected from chain.",
-  RPC_URLS_REQUIRED: "rpcUrls field is required and cannot be empty",
+    'Chain ID does not match the RPC endpoint. Provider Chain ID: ',
+  PROVIDER_DISCONNECTED: 'Provider is disconnected from chain.',
+  RPC_URLS_REQUIRED: 'rpcUrls field is required and cannot be empty',
 };
 
 export const PROVIDER_ERROR_CODE = {
@@ -27,5 +27,3 @@ export const TURNKEY_ERROR_CODE = {
   WALLET_NOT_FOUND: 5,
   ORG_NOT_FOUND: 3,
 };
-
-export const VERSION = process.env.VERSION ?? "[VI]{version}[/VI]";


### PR DESCRIPTION
## Summary & Motivation
Use discovered issue using the eip-1193-provider as it was using process in the `constant.ts` file. It looks like a relic from how I was getting the package version originally.

## How I Tested These Changes
- Running tests scripts

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
