### PR TITLE
Simple `@turnkey/sdk-server` example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,11 @@ typings/
 # dotenv environment variables file
 .env
 .env.*
+config.json
 !.env.local.example
 !.env.test.example
 !.env.example
+!config.json.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/examples/with-sdk-server/README.md
+++ b/examples/with-sdk-server/README.md
@@ -1,0 +1,49 @@
+# Example: `with-sdk-server`
+
+This example shows how to set up our server SDK ([`@turnkey/sdk-server`](https://www.npmjs.com/package/@turnkey/sdk-server)) and call our API endpoints.
+
+## Getting started
+
+### 1/ Cloning the example
+
+Make sure you have `node` installed locally; we recommend using Node v16+.
+
+```bash
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/with-sdk-server/
+```
+
+### 2/ Setting up Turnkey
+
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
+
+- A public/private API key pair for Turnkey
+- An organization ID
+
+Once you've gathered these values, add them to a new `config.json` file. Notice that your API private key should be securely managed and **_never_** be committed to git.
+
+```bash
+$ cp config.json.example config.json
+```
+
+Now open `config.json` and add the missing values: `apiPublicKey`, `apiPrivateKey`, and `organizationId`.
+
+### 3/ Run the example
+
+```bash
+$ pnpm run start
+```
+
+This will simply make a [`Whoami request`](https://docs.turnkey.com/api#tag/Sessions/operation/GetWhoami). If it's successful you should see something like the following:
+```
+Successfully called Turnkey. Whoami response:  {
+  organizationId: '4c9c6e70-d30b-405f-ae30-41e766279eb6',
+  organizationName: 'Test',
+  userId: '7fd1bc44-9a4f-47ec-aad2-8a4a2a5de82e',
+  username: 'Root user'
+}
+```

--- a/examples/with-sdk-server/README.md
+++ b/examples/with-sdk-server/README.md
@@ -6,7 +6,7 @@ This example shows how to set up our server SDK ([`@turnkey/sdk-server`](https:/
 
 ### 1/ Cloning the example
 
-Make sure you have `node` installed locally; we recommend using Node v16+.
+Make sure you have `node` installed locally; we recommend using Node v18+.
 
 ```bash
 $ git clone https://github.com/tkhq/sdk

--- a/examples/with-sdk-server/README.md
+++ b/examples/with-sdk-server/README.md
@@ -39,6 +39,7 @@ $ pnpm run start
 ```
 
 This will simply make a [`Whoami request`](https://docs.turnkey.com/api#tag/Sessions/operation/GetWhoami). If it's successful you should see something like the following:
+
 ```
 Successfully called Turnkey. Whoami response:  {
   organizationId: '4c9c6e70-d30b-405f-ae30-41e766279eb6',

--- a/examples/with-sdk-server/config.json.example
+++ b/examples/with-sdk-server/config.json.example
@@ -1,0 +1,6 @@
+{
+    "apiBaseUrl": "https://api.turnkey.com",
+    "apiPublicKey": "<Turnkey API Public Key (that starts with 02 or 03)>",
+    "apiPrivateKey": "<Turnkey API Private Key>",
+    "defaultOrganizationId": "<Turnkey Organization ID>"
+}

--- a/examples/with-sdk-server/package.json
+++ b/examples/with-sdk-server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@turnkey/example-with-sdk-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@turnkey/sdk-server": "workspace:*"
+  }
+}

--- a/examples/with-sdk-server/src/index.ts
+++ b/examples/with-sdk-server/src/index.ts
@@ -1,0 +1,12 @@
+import { Turnkey } from '@turnkey/sdk-server';
+import fs from 'fs';
+
+const turnkeyConfig = JSON.parse(fs.readFileSync("./config.json", "utf8"));
+const turnkeyServerClient = new Turnkey(turnkeyConfig);
+const client = turnkeyServerClient.apiClient();
+
+// Now you can call any method you like. Whoami is the simplest of all:
+const response = await client.getWhoami();
+
+// Log the response
+console.log("Successfully called Turnkey. Whoami response: ", response);

--- a/examples/with-sdk-server/src/index.ts
+++ b/examples/with-sdk-server/src/index.ts
@@ -1,5 +1,5 @@
-import { Turnkey } from '@turnkey/sdk-server';
-import fs from 'fs';
+import { Turnkey } from "@turnkey/sdk-server";
+import fs from "fs";
 
 const turnkeyConfig = JSON.parse(fs.readFileSync("./config.json", "utf8"));
 const turnkeyServerClient = new Turnkey(turnkeyConfig);

--- a/examples/with-sdk-server/tsconfig.json
+++ b/examples/with-sdk-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "lib": ["es2020"],
+    "module": "es2022",
+    "preserveConstEnums": true,
+    "moduleResolution": "node",
+    "strict": true,
+    "sourceMap": true,
+    "target": "es2022",
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sdk-server/README.md
+++ b/packages/sdk-server/README.md
@@ -16,7 +16,7 @@ $ npm install @turnkey/sdk-server
 const { Turnkey } = require("@turnkey/sdk-server");
 
 // This config contains parameters including base URLs, API credentials, and org ID
-const turnkeyConfig = JSON.parse(fs.readFileSync("./turnkey.json"), "utf8");
+const turnkeyConfig = JSON.parse(fs.readFileSync("./turnkey.json", "utf8"));
 
 // Use the config to instantiate a Turnkey Client
 const turnkeyServerClient = new Turnkey(turnkeyConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,6 +613,12 @@ importers:
         specifier: ^16.0.3
         version: 16.0.3
 
+  examples/with-sdk-server:
+    dependencies:
+      '@turnkey/sdk-server':
+        specifier: workspace:*
+        version: link:../../packages/sdk-server
+
   examples/with-solana:
     dependencies:
       '@inquirer/prompts':


### PR DESCRIPTION
## Summary & Motivation
Simple example to show how one can use `@turnkey/sdk-browser` to make API calls. Nothing fancy, but could be a good base for node scripts using the Turnkey API.

Bonus: spotted and fixed a mistake in the sdk-browser package README :)

## How I Tested These Changes
Ran the new example.
