### PR TITLE
add additional passkey configs

### DIFF
--- a/.changeset/twenty-flies-own.md
+++ b/.changeset/twenty-flies-own.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-browser": patch
+---
+
+Add authenticatorAttachment option

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -229,6 +229,7 @@ export class TurnkeyPasskeyClient extends TurnkeyBrowserClient {
     //
     // The pubkey type only supports one value, "public-key"
     // See https://www.w3.org/TR/webauthn-2/#enumdef-publickeycredentialtype for more details
+    // TODO: consider un-nesting these config params
     const webauthnConfig: CredentialCreationOptions = {
       publicKey: {
         rp: {
@@ -248,6 +249,9 @@ export class TurnkeyPasskeyClient extends TurnkeyBrowserClient {
           displayName: config.publicKey?.user?.displayName ?? "Default User",
         },
         authenticatorSelection: {
+          authenticatorAttachment:
+            config.publicKey?.authenticatorSelection?.authenticatorAttachment ??
+            undefined, // default to empty
           requireResidentKey:
             config.publicKey?.authenticatorSelection?.requireResidentKey ??
             true,


### PR DESCRIPTION
## Summary & Motivation
$title. We were missing the ability to override `authenticatorAttachment`. Corresponding context can be found here: https://docs.turnkey.com/passkeys/options#authenticatorattachment

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
