### PR TITLE
Add key format to inject key export

### DIFF
--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -2414,6 +2414,99 @@
       },
       "required": ["productId"]
     },
+    "billingDeletePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The payment method that the customer wants to remove."
+        }
+      },
+      "required": ["paymentMethodId"]
+    },
+    "billingDeletePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The payment method that was removed."
+        }
+      },
+      "required": ["paymentMethodId"]
+    },
+    "billingSetPaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "number": {
+          "type": "string",
+          "description": "The account number of the customer's credit card."
+        },
+        "cvv": {
+          "type": "string",
+          "description": "The verification digits of the customer's credit card."
+        },
+        "expiryMonth": {
+          "type": "string",
+          "description": "The month that the credit card expires."
+        },
+        "expiryYear": {
+          "type": "string",
+          "description": "The year that the credit card expires."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the credit card."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the credit card."
+        }
+      },
+      "required": [
+        "number",
+        "cvv",
+        "expiryMonth",
+        "expiryYear",
+        "cardHolderEmail",
+        "cardHolderName"
+      ]
+    },
+    "billingSetPaymentMethodIntentV2": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The id of the payment method that was created clientside."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the credit card."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the credit card."
+        }
+      },
+      "required": ["paymentMethodId", "cardHolderEmail", "cardHolderName"]
+    },
+    "billingSetPaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "lastFour": {
+          "type": "string",
+          "description": "The last four digits of the credit card added."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the payment method."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -2764,7 +2857,29 @@
         "ADDRESS_FORMAT_ETHEREUM",
         "ADDRESS_FORMAT_SOLANA",
         "ADDRESS_FORMAT_COSMOS",
-        "ADDRESS_FORMAT_TRON"
+        "ADDRESS_FORMAT_TRON",
+        "ADDRESS_FORMAT_SUI",
+        "ADDRESS_FORMAT_APTOS",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR"
       ]
     },
     "v1ApiKey": {
@@ -4671,26 +4786,6 @@
       },
       "required": ["organizationId"]
     },
-    "v1DeletePaymentMethodIntent": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The payment method that the customer wants to remove."
-        }
-      },
-      "required": ["paymentMethodId"]
-    },
-    "v1DeletePaymentMethodResult": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The payment method that was removed."
-        }
-      },
-      "required": ["paymentMethodId"]
-    },
     "v1DeletePolicyIntent": {
       "type": "object",
       "properties": {
@@ -6207,13 +6302,13 @@
           "$ref": "#/definitions/v1CreatePolicyIntentV2"
         },
         "setPaymentMethodIntent": {
-          "$ref": "#/definitions/v1SetPaymentMethodIntent"
+          "$ref": "#/definitions/billingSetPaymentMethodIntent"
         },
         "activateBillingTierIntent": {
           "$ref": "#/definitions/billingActivateBillingTierIntent"
         },
         "deletePaymentMethodIntent": {
-          "$ref": "#/definitions/v1DeletePaymentMethodIntent"
+          "$ref": "#/definitions/billingDeletePaymentMethodIntent"
         },
         "createPolicyIntentV3": {
           "$ref": "#/definitions/v1CreatePolicyIntentV3"
@@ -6261,7 +6356,7 @@
           "$ref": "#/definitions/v1UpdatePolicyIntent"
         },
         "setPaymentMethodIntentV2": {
-          "$ref": "#/definitions/v1SetPaymentMethodIntentV2"
+          "$ref": "#/definitions/billingSetPaymentMethodIntentV2"
         },
         "createSubOrganizationIntentV3": {
           "$ref": "#/definitions/v1CreateSubOrganizationIntentV3"
@@ -7120,13 +7215,13 @@
           "$ref": "#/definitions/v1DeletePrivateKeyTagsResult"
         },
         "setPaymentMethodResult": {
-          "$ref": "#/definitions/v1SetPaymentMethodResult"
+          "$ref": "#/definitions/billingSetPaymentMethodResult"
         },
         "activateBillingTierResult": {
           "$ref": "#/definitions/billingActivateBillingTierResult"
         },
         "deletePaymentMethodResult": {
-          "$ref": "#/definitions/v1DeletePaymentMethodResult"
+          "$ref": "#/definitions/billingDeletePaymentMethodResult"
         },
         "createApiOnlyUsersResult": {
           "$ref": "#/definitions/v1CreateApiOnlyUsersResult"
@@ -7426,79 +7521,6 @@
         }
       },
       "required": ["features"]
-    },
-    "v1SetPaymentMethodIntent": {
-      "type": "object",
-      "properties": {
-        "number": {
-          "type": "string",
-          "description": "The account number of the customer's credit card."
-        },
-        "cvv": {
-          "type": "string",
-          "description": "The verification digits of the customer's credit card."
-        },
-        "expiryMonth": {
-          "type": "string",
-          "description": "The month that the credit card expires."
-        },
-        "expiryYear": {
-          "type": "string",
-          "description": "The year that the credit card expires."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email that will receive invoices for the credit card."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the credit card."
-        }
-      },
-      "required": [
-        "number",
-        "cvv",
-        "expiryMonth",
-        "expiryYear",
-        "cardHolderEmail",
-        "cardHolderName"
-      ]
-    },
-    "v1SetPaymentMethodIntentV2": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The id of the payment method that was created clientside."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email that will receive invoices for the credit card."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the credit card."
-        }
-      },
-      "required": ["paymentMethodId", "cardHolderEmail", "cardHolderName"]
-    },
-    "v1SetPaymentMethodResult": {
-      "type": "object",
-      "properties": {
-        "lastFour": {
-          "type": "string",
-          "description": "The last four digits of the credit card added."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the payment method."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email address associated with the payment method."
-        }
-      },
-      "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
     "v1SignRawPayloadIntent": {
       "type": "object",

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -306,6 +306,44 @@ export type definitions = {
     /** @description The id of the product being subscribed to. */
     productId: string;
   };
+  billingDeletePaymentMethodIntent: {
+    /** @description The payment method that the customer wants to remove. */
+    paymentMethodId: string;
+  };
+  billingDeletePaymentMethodResult: {
+    /** @description The payment method that was removed. */
+    paymentMethodId: string;
+  };
+  billingSetPaymentMethodIntent: {
+    /** @description The account number of the customer's credit card. */
+    number: string;
+    /** @description The verification digits of the customer's credit card. */
+    cvv: string;
+    /** @description The month that the credit card expires. */
+    expiryMonth: string;
+    /** @description The year that the credit card expires. */
+    expiryYear: string;
+    /** @description The email that will receive invoices for the credit card. */
+    cardHolderEmail: string;
+    /** @description The name associated with the credit card. */
+    cardHolderName: string;
+  };
+  billingSetPaymentMethodIntentV2: {
+    /** @description The id of the payment method that was created clientside. */
+    paymentMethodId: string;
+    /** @description The email that will receive invoices for the credit card. */
+    cardHolderEmail: string;
+    /** @description The name associated with the credit card. */
+    cardHolderName: string;
+  };
+  billingSetPaymentMethodResult: {
+    /** @description The last four digits of the credit card added. */
+    lastFour: string;
+    /** @description The name associated with the payment method. */
+    cardHolderName: string;
+    /** @description The email address associated with the payment method. */
+    cardHolderEmail: string;
+  };
   datav1Tag: {
     /** @description Unique identifier for a given Tag. */
     tagId: string;
@@ -494,7 +532,29 @@ export type definitions = {
     | "ADDRESS_FORMAT_ETHEREUM"
     | "ADDRESS_FORMAT_SOLANA"
     | "ADDRESS_FORMAT_COSMOS"
-    | "ADDRESS_FORMAT_TRON";
+    | "ADDRESS_FORMAT_TRON"
+    | "ADDRESS_FORMAT_SUI"
+    | "ADDRESS_FORMAT_APTOS"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR";
   v1ApiKey: {
     /** @description A User credential that can be used to authenticate to Turnkey. */
     credential: definitions["externaldatav1Credential"];
@@ -1233,14 +1293,6 @@ export type definitions = {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
   };
-  v1DeletePaymentMethodIntent: {
-    /** @description The payment method that the customer wants to remove. */
-    paymentMethodId: string;
-  };
-  v1DeletePaymentMethodResult: {
-    /** @description The payment method that was removed. */
-    paymentMethodId: string;
-  };
   v1DeletePolicyIntent: {
     /** @description Unique identifier for a given Policy. */
     policyId: string;
@@ -1843,9 +1895,9 @@ export type definitions = {
     createPrivateKeyTagIntent?: definitions["v1CreatePrivateKeyTagIntent"];
     deletePrivateKeyTagsIntent?: definitions["v1DeletePrivateKeyTagsIntent"];
     createPolicyIntentV2?: definitions["v1CreatePolicyIntentV2"];
-    setPaymentMethodIntent?: definitions["v1SetPaymentMethodIntent"];
+    setPaymentMethodIntent?: definitions["billingSetPaymentMethodIntent"];
     activateBillingTierIntent?: definitions["billingActivateBillingTierIntent"];
-    deletePaymentMethodIntent?: definitions["v1DeletePaymentMethodIntent"];
+    deletePaymentMethodIntent?: definitions["billingDeletePaymentMethodIntent"];
     createPolicyIntentV3?: definitions["v1CreatePolicyIntentV3"];
     createApiOnlyUsersIntent?: definitions["v1CreateApiOnlyUsersIntent"];
     updateRootQuorumIntent?: definitions["v1UpdateRootQuorumIntent"];
@@ -1861,7 +1913,7 @@ export type definitions = {
     createPrivateKeysIntentV2?: definitions["v1CreatePrivateKeysIntentV2"];
     updateUserIntent?: definitions["v1UpdateUserIntent"];
     updatePolicyIntent?: definitions["v1UpdatePolicyIntent"];
-    setPaymentMethodIntentV2?: definitions["v1SetPaymentMethodIntentV2"];
+    setPaymentMethodIntentV2?: definitions["billingSetPaymentMethodIntentV2"];
     createSubOrganizationIntentV3?: definitions["v1CreateSubOrganizationIntentV3"];
     createWalletIntent?: definitions["v1CreateWalletIntent"];
     createWalletAccountsIntent?: definitions["v1CreateWalletAccountsIntent"];
@@ -2177,9 +2229,9 @@ export type definitions = {
     createApiKeysResult?: definitions["v1CreateApiKeysResult"];
     createPrivateKeyTagResult?: definitions["v1CreatePrivateKeyTagResult"];
     deletePrivateKeyTagsResult?: definitions["v1DeletePrivateKeyTagsResult"];
-    setPaymentMethodResult?: definitions["v1SetPaymentMethodResult"];
+    setPaymentMethodResult?: definitions["billingSetPaymentMethodResult"];
     activateBillingTierResult?: definitions["billingActivateBillingTierResult"];
-    deletePaymentMethodResult?: definitions["v1DeletePaymentMethodResult"];
+    deletePaymentMethodResult?: definitions["billingDeletePaymentMethodResult"];
     createApiOnlyUsersResult?: definitions["v1CreateApiOnlyUsersResult"];
     updateRootQuorumResult?: definitions["v1UpdateRootQuorumResult"];
     updateUserTagResult?: definitions["v1UpdateUserTagResult"];
@@ -2280,36 +2332,6 @@ export type definitions = {
   v1SetOrganizationFeatureResult: {
     /** @description Resulting list of organization features. */
     features: definitions["v1Feature"][];
-  };
-  v1SetPaymentMethodIntent: {
-    /** @description The account number of the customer's credit card. */
-    number: string;
-    /** @description The verification digits of the customer's credit card. */
-    cvv: string;
-    /** @description The month that the credit card expires. */
-    expiryMonth: string;
-    /** @description The year that the credit card expires. */
-    expiryYear: string;
-    /** @description The email that will receive invoices for the credit card. */
-    cardHolderEmail: string;
-    /** @description The name associated with the credit card. */
-    cardHolderName: string;
-  };
-  v1SetPaymentMethodIntentV2: {
-    /** @description The id of the payment method that was created clientside. */
-    paymentMethodId: string;
-    /** @description The email that will receive invoices for the credit card. */
-    cardHolderEmail: string;
-    /** @description The name associated with the credit card. */
-    cardHolderName: string;
-  };
-  v1SetPaymentMethodResult: {
-    /** @description The last four digits of the credit card added. */
-    lastFour: string;
-    /** @description The name associated with the payment method. */
-    cardHolderName: string;
-    /** @description The email address associated with the payment method. */
-    cardHolderEmail: string;
   };
   v1SignRawPayloadIntent: {
     /** @description Unique identifier for a given Private Key. */

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -2414,6 +2414,99 @@
       },
       "required": ["productId"]
     },
+    "billingDeletePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The payment method that the customer wants to remove."
+        }
+      },
+      "required": ["paymentMethodId"]
+    },
+    "billingDeletePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The payment method that was removed."
+        }
+      },
+      "required": ["paymentMethodId"]
+    },
+    "billingSetPaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "number": {
+          "type": "string",
+          "description": "The account number of the customer's credit card."
+        },
+        "cvv": {
+          "type": "string",
+          "description": "The verification digits of the customer's credit card."
+        },
+        "expiryMonth": {
+          "type": "string",
+          "description": "The month that the credit card expires."
+        },
+        "expiryYear": {
+          "type": "string",
+          "description": "The year that the credit card expires."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the credit card."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the credit card."
+        }
+      },
+      "required": [
+        "number",
+        "cvv",
+        "expiryMonth",
+        "expiryYear",
+        "cardHolderEmail",
+        "cardHolderName"
+      ]
+    },
+    "billingSetPaymentMethodIntentV2": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The id of the payment method that was created clientside."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the credit card."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the credit card."
+        }
+      },
+      "required": ["paymentMethodId", "cardHolderEmail", "cardHolderName"]
+    },
+    "billingSetPaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "lastFour": {
+          "type": "string",
+          "description": "The last four digits of the credit card added."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the payment method."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -2764,7 +2857,29 @@
         "ADDRESS_FORMAT_ETHEREUM",
         "ADDRESS_FORMAT_SOLANA",
         "ADDRESS_FORMAT_COSMOS",
-        "ADDRESS_FORMAT_TRON"
+        "ADDRESS_FORMAT_TRON",
+        "ADDRESS_FORMAT_SUI",
+        "ADDRESS_FORMAT_APTOS",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR"
       ]
     },
     "v1ApiKey": {
@@ -4671,26 +4786,6 @@
       },
       "required": ["organizationId"]
     },
-    "v1DeletePaymentMethodIntent": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The payment method that the customer wants to remove."
-        }
-      },
-      "required": ["paymentMethodId"]
-    },
-    "v1DeletePaymentMethodResult": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The payment method that was removed."
-        }
-      },
-      "required": ["paymentMethodId"]
-    },
     "v1DeletePolicyIntent": {
       "type": "object",
       "properties": {
@@ -6207,13 +6302,13 @@
           "$ref": "#/definitions/v1CreatePolicyIntentV2"
         },
         "setPaymentMethodIntent": {
-          "$ref": "#/definitions/v1SetPaymentMethodIntent"
+          "$ref": "#/definitions/billingSetPaymentMethodIntent"
         },
         "activateBillingTierIntent": {
           "$ref": "#/definitions/billingActivateBillingTierIntent"
         },
         "deletePaymentMethodIntent": {
-          "$ref": "#/definitions/v1DeletePaymentMethodIntent"
+          "$ref": "#/definitions/billingDeletePaymentMethodIntent"
         },
         "createPolicyIntentV3": {
           "$ref": "#/definitions/v1CreatePolicyIntentV3"
@@ -6261,7 +6356,7 @@
           "$ref": "#/definitions/v1UpdatePolicyIntent"
         },
         "setPaymentMethodIntentV2": {
-          "$ref": "#/definitions/v1SetPaymentMethodIntentV2"
+          "$ref": "#/definitions/billingSetPaymentMethodIntentV2"
         },
         "createSubOrganizationIntentV3": {
           "$ref": "#/definitions/v1CreateSubOrganizationIntentV3"
@@ -7120,13 +7215,13 @@
           "$ref": "#/definitions/v1DeletePrivateKeyTagsResult"
         },
         "setPaymentMethodResult": {
-          "$ref": "#/definitions/v1SetPaymentMethodResult"
+          "$ref": "#/definitions/billingSetPaymentMethodResult"
         },
         "activateBillingTierResult": {
           "$ref": "#/definitions/billingActivateBillingTierResult"
         },
         "deletePaymentMethodResult": {
-          "$ref": "#/definitions/v1DeletePaymentMethodResult"
+          "$ref": "#/definitions/billingDeletePaymentMethodResult"
         },
         "createApiOnlyUsersResult": {
           "$ref": "#/definitions/v1CreateApiOnlyUsersResult"
@@ -7426,79 +7521,6 @@
         }
       },
       "required": ["features"]
-    },
-    "v1SetPaymentMethodIntent": {
-      "type": "object",
-      "properties": {
-        "number": {
-          "type": "string",
-          "description": "The account number of the customer's credit card."
-        },
-        "cvv": {
-          "type": "string",
-          "description": "The verification digits of the customer's credit card."
-        },
-        "expiryMonth": {
-          "type": "string",
-          "description": "The month that the credit card expires."
-        },
-        "expiryYear": {
-          "type": "string",
-          "description": "The year that the credit card expires."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email that will receive invoices for the credit card."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the credit card."
-        }
-      },
-      "required": [
-        "number",
-        "cvv",
-        "expiryMonth",
-        "expiryYear",
-        "cardHolderEmail",
-        "cardHolderName"
-      ]
-    },
-    "v1SetPaymentMethodIntentV2": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The id of the payment method that was created clientside."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email that will receive invoices for the credit card."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the credit card."
-        }
-      },
-      "required": ["paymentMethodId", "cardHolderEmail", "cardHolderName"]
-    },
-    "v1SetPaymentMethodResult": {
-      "type": "object",
-      "properties": {
-        "lastFour": {
-          "type": "string",
-          "description": "The last four digits of the credit card added."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the payment method."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email address associated with the payment method."
-        }
-      },
-      "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
     "v1SignRawPayloadIntent": {
       "type": "object",

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -306,6 +306,44 @@ export type definitions = {
     /** @description The id of the product being subscribed to. */
     productId: string;
   };
+  billingDeletePaymentMethodIntent: {
+    /** @description The payment method that the customer wants to remove. */
+    paymentMethodId: string;
+  };
+  billingDeletePaymentMethodResult: {
+    /** @description The payment method that was removed. */
+    paymentMethodId: string;
+  };
+  billingSetPaymentMethodIntent: {
+    /** @description The account number of the customer's credit card. */
+    number: string;
+    /** @description The verification digits of the customer's credit card. */
+    cvv: string;
+    /** @description The month that the credit card expires. */
+    expiryMonth: string;
+    /** @description The year that the credit card expires. */
+    expiryYear: string;
+    /** @description The email that will receive invoices for the credit card. */
+    cardHolderEmail: string;
+    /** @description The name associated with the credit card. */
+    cardHolderName: string;
+  };
+  billingSetPaymentMethodIntentV2: {
+    /** @description The id of the payment method that was created clientside. */
+    paymentMethodId: string;
+    /** @description The email that will receive invoices for the credit card. */
+    cardHolderEmail: string;
+    /** @description The name associated with the credit card. */
+    cardHolderName: string;
+  };
+  billingSetPaymentMethodResult: {
+    /** @description The last four digits of the credit card added. */
+    lastFour: string;
+    /** @description The name associated with the payment method. */
+    cardHolderName: string;
+    /** @description The email address associated with the payment method. */
+    cardHolderEmail: string;
+  };
   datav1Tag: {
     /** @description Unique identifier for a given Tag. */
     tagId: string;
@@ -494,7 +532,29 @@ export type definitions = {
     | "ADDRESS_FORMAT_ETHEREUM"
     | "ADDRESS_FORMAT_SOLANA"
     | "ADDRESS_FORMAT_COSMOS"
-    | "ADDRESS_FORMAT_TRON";
+    | "ADDRESS_FORMAT_TRON"
+    | "ADDRESS_FORMAT_SUI"
+    | "ADDRESS_FORMAT_APTOS"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR";
   v1ApiKey: {
     /** @description A User credential that can be used to authenticate to Turnkey. */
     credential: definitions["externaldatav1Credential"];
@@ -1233,14 +1293,6 @@ export type definitions = {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
   };
-  v1DeletePaymentMethodIntent: {
-    /** @description The payment method that the customer wants to remove. */
-    paymentMethodId: string;
-  };
-  v1DeletePaymentMethodResult: {
-    /** @description The payment method that was removed. */
-    paymentMethodId: string;
-  };
   v1DeletePolicyIntent: {
     /** @description Unique identifier for a given Policy. */
     policyId: string;
@@ -1843,9 +1895,9 @@ export type definitions = {
     createPrivateKeyTagIntent?: definitions["v1CreatePrivateKeyTagIntent"];
     deletePrivateKeyTagsIntent?: definitions["v1DeletePrivateKeyTagsIntent"];
     createPolicyIntentV2?: definitions["v1CreatePolicyIntentV2"];
-    setPaymentMethodIntent?: definitions["v1SetPaymentMethodIntent"];
+    setPaymentMethodIntent?: definitions["billingSetPaymentMethodIntent"];
     activateBillingTierIntent?: definitions["billingActivateBillingTierIntent"];
-    deletePaymentMethodIntent?: definitions["v1DeletePaymentMethodIntent"];
+    deletePaymentMethodIntent?: definitions["billingDeletePaymentMethodIntent"];
     createPolicyIntentV3?: definitions["v1CreatePolicyIntentV3"];
     createApiOnlyUsersIntent?: definitions["v1CreateApiOnlyUsersIntent"];
     updateRootQuorumIntent?: definitions["v1UpdateRootQuorumIntent"];
@@ -1861,7 +1913,7 @@ export type definitions = {
     createPrivateKeysIntentV2?: definitions["v1CreatePrivateKeysIntentV2"];
     updateUserIntent?: definitions["v1UpdateUserIntent"];
     updatePolicyIntent?: definitions["v1UpdatePolicyIntent"];
-    setPaymentMethodIntentV2?: definitions["v1SetPaymentMethodIntentV2"];
+    setPaymentMethodIntentV2?: definitions["billingSetPaymentMethodIntentV2"];
     createSubOrganizationIntentV3?: definitions["v1CreateSubOrganizationIntentV3"];
     createWalletIntent?: definitions["v1CreateWalletIntent"];
     createWalletAccountsIntent?: definitions["v1CreateWalletAccountsIntent"];
@@ -2177,9 +2229,9 @@ export type definitions = {
     createApiKeysResult?: definitions["v1CreateApiKeysResult"];
     createPrivateKeyTagResult?: definitions["v1CreatePrivateKeyTagResult"];
     deletePrivateKeyTagsResult?: definitions["v1DeletePrivateKeyTagsResult"];
-    setPaymentMethodResult?: definitions["v1SetPaymentMethodResult"];
+    setPaymentMethodResult?: definitions["billingSetPaymentMethodResult"];
     activateBillingTierResult?: definitions["billingActivateBillingTierResult"];
-    deletePaymentMethodResult?: definitions["v1DeletePaymentMethodResult"];
+    deletePaymentMethodResult?: definitions["billingDeletePaymentMethodResult"];
     createApiOnlyUsersResult?: definitions["v1CreateApiOnlyUsersResult"];
     updateRootQuorumResult?: definitions["v1UpdateRootQuorumResult"];
     updateUserTagResult?: definitions["v1UpdateUserTagResult"];
@@ -2280,36 +2332,6 @@ export type definitions = {
   v1SetOrganizationFeatureResult: {
     /** @description Resulting list of organization features. */
     features: definitions["v1Feature"][];
-  };
-  v1SetPaymentMethodIntent: {
-    /** @description The account number of the customer's credit card. */
-    number: string;
-    /** @description The verification digits of the customer's credit card. */
-    cvv: string;
-    /** @description The month that the credit card expires. */
-    expiryMonth: string;
-    /** @description The year that the credit card expires. */
-    expiryYear: string;
-    /** @description The email that will receive invoices for the credit card. */
-    cardHolderEmail: string;
-    /** @description The name associated with the credit card. */
-    cardHolderName: string;
-  };
-  v1SetPaymentMethodIntentV2: {
-    /** @description The id of the payment method that was created clientside. */
-    paymentMethodId: string;
-    /** @description The email that will receive invoices for the credit card. */
-    cardHolderEmail: string;
-    /** @description The name associated with the credit card. */
-    cardHolderName: string;
-  };
-  v1SetPaymentMethodResult: {
-    /** @description The last four digits of the credit card added. */
-    lastFour: string;
-    /** @description The name associated with the payment method. */
-    cardHolderName: string;
-    /** @description The email address associated with the payment method. */
-    cardHolderEmail: string;
   };
   v1SignRawPayloadIntent: {
     /** @description Unique identifier for a given Private Key. */

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -1,5 +1,5 @@
 import { WebauthnStamper } from "@turnkey/webauthn-stamper";
-import { IframeStamper } from "@turnkey/iframe-stamper";
+import { IframeStamper, KeyFormat } from "@turnkey/iframe-stamper";
 import { getWebAuthnAttestation } from "@turnkey/http";
 
 import { VERSION } from "./__generated__/version";
@@ -342,12 +342,14 @@ export class TurnkeyIframeClient extends TurnkeyBrowserClient {
 
   injectKeyExportBundle = async (
     credentialBundle: string,
-    organizationId: string
+    organizationId: string,
+    keyFormat?: KeyFormat | undefined
   ): Promise<boolean> => {
     const stamper = this.config.stamper as IframeStamper;
     return await stamper.injectKeyExportBundle(
       credentialBundle,
-      organizationId
+      organizationId,
+      keyFormat
     );
   };
 

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -2414,6 +2414,99 @@
       },
       "required": ["productId"]
     },
+    "billingDeletePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The payment method that the customer wants to remove."
+        }
+      },
+      "required": ["paymentMethodId"]
+    },
+    "billingDeletePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The payment method that was removed."
+        }
+      },
+      "required": ["paymentMethodId"]
+    },
+    "billingSetPaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "number": {
+          "type": "string",
+          "description": "The account number of the customer's credit card."
+        },
+        "cvv": {
+          "type": "string",
+          "description": "The verification digits of the customer's credit card."
+        },
+        "expiryMonth": {
+          "type": "string",
+          "description": "The month that the credit card expires."
+        },
+        "expiryYear": {
+          "type": "string",
+          "description": "The year that the credit card expires."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the credit card."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the credit card."
+        }
+      },
+      "required": [
+        "number",
+        "cvv",
+        "expiryMonth",
+        "expiryYear",
+        "cardHolderEmail",
+        "cardHolderName"
+      ]
+    },
+    "billingSetPaymentMethodIntentV2": {
+      "type": "object",
+      "properties": {
+        "paymentMethodId": {
+          "type": "string",
+          "description": "The id of the payment method that was created clientside."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the credit card."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the credit card."
+        }
+      },
+      "required": ["paymentMethodId", "cardHolderEmail", "cardHolderName"]
+    },
+    "billingSetPaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "lastFour": {
+          "type": "string",
+          "description": "The last four digits of the credit card added."
+        },
+        "cardHolderName": {
+          "type": "string",
+          "description": "The name associated with the payment method."
+        },
+        "cardHolderEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -2764,7 +2857,29 @@
         "ADDRESS_FORMAT_ETHEREUM",
         "ADDRESS_FORMAT_SOLANA",
         "ADDRESS_FORMAT_COSMOS",
-        "ADDRESS_FORMAT_TRON"
+        "ADDRESS_FORMAT_TRON",
+        "ADDRESS_FORMAT_SUI",
+        "ADDRESS_FORMAT_APTOS",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_TESTNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_SIGNET_P2TR",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2PKH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2SH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WPKH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WSH",
+        "ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR"
       ]
     },
     "v1ApiKey": {
@@ -4671,26 +4786,6 @@
       },
       "required": ["organizationId"]
     },
-    "v1DeletePaymentMethodIntent": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The payment method that the customer wants to remove."
-        }
-      },
-      "required": ["paymentMethodId"]
-    },
-    "v1DeletePaymentMethodResult": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The payment method that was removed."
-        }
-      },
-      "required": ["paymentMethodId"]
-    },
     "v1DeletePolicyIntent": {
       "type": "object",
       "properties": {
@@ -6207,13 +6302,13 @@
           "$ref": "#/definitions/v1CreatePolicyIntentV2"
         },
         "setPaymentMethodIntent": {
-          "$ref": "#/definitions/v1SetPaymentMethodIntent"
+          "$ref": "#/definitions/billingSetPaymentMethodIntent"
         },
         "activateBillingTierIntent": {
           "$ref": "#/definitions/billingActivateBillingTierIntent"
         },
         "deletePaymentMethodIntent": {
-          "$ref": "#/definitions/v1DeletePaymentMethodIntent"
+          "$ref": "#/definitions/billingDeletePaymentMethodIntent"
         },
         "createPolicyIntentV3": {
           "$ref": "#/definitions/v1CreatePolicyIntentV3"
@@ -6261,7 +6356,7 @@
           "$ref": "#/definitions/v1UpdatePolicyIntent"
         },
         "setPaymentMethodIntentV2": {
-          "$ref": "#/definitions/v1SetPaymentMethodIntentV2"
+          "$ref": "#/definitions/billingSetPaymentMethodIntentV2"
         },
         "createSubOrganizationIntentV3": {
           "$ref": "#/definitions/v1CreateSubOrganizationIntentV3"
@@ -7120,13 +7215,13 @@
           "$ref": "#/definitions/v1DeletePrivateKeyTagsResult"
         },
         "setPaymentMethodResult": {
-          "$ref": "#/definitions/v1SetPaymentMethodResult"
+          "$ref": "#/definitions/billingSetPaymentMethodResult"
         },
         "activateBillingTierResult": {
           "$ref": "#/definitions/billingActivateBillingTierResult"
         },
         "deletePaymentMethodResult": {
-          "$ref": "#/definitions/v1DeletePaymentMethodResult"
+          "$ref": "#/definitions/billingDeletePaymentMethodResult"
         },
         "createApiOnlyUsersResult": {
           "$ref": "#/definitions/v1CreateApiOnlyUsersResult"
@@ -7426,79 +7521,6 @@
         }
       },
       "required": ["features"]
-    },
-    "v1SetPaymentMethodIntent": {
-      "type": "object",
-      "properties": {
-        "number": {
-          "type": "string",
-          "description": "The account number of the customer's credit card."
-        },
-        "cvv": {
-          "type": "string",
-          "description": "The verification digits of the customer's credit card."
-        },
-        "expiryMonth": {
-          "type": "string",
-          "description": "The month that the credit card expires."
-        },
-        "expiryYear": {
-          "type": "string",
-          "description": "The year that the credit card expires."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email that will receive invoices for the credit card."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the credit card."
-        }
-      },
-      "required": [
-        "number",
-        "cvv",
-        "expiryMonth",
-        "expiryYear",
-        "cardHolderEmail",
-        "cardHolderName"
-      ]
-    },
-    "v1SetPaymentMethodIntentV2": {
-      "type": "object",
-      "properties": {
-        "paymentMethodId": {
-          "type": "string",
-          "description": "The id of the payment method that was created clientside."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email that will receive invoices for the credit card."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the credit card."
-        }
-      },
-      "required": ["paymentMethodId", "cardHolderEmail", "cardHolderName"]
-    },
-    "v1SetPaymentMethodResult": {
-      "type": "object",
-      "properties": {
-        "lastFour": {
-          "type": "string",
-          "description": "The last four digits of the credit card added."
-        },
-        "cardHolderName": {
-          "type": "string",
-          "description": "The name associated with the payment method."
-        },
-        "cardHolderEmail": {
-          "type": "string",
-          "description": "The email address associated with the payment method."
-        }
-      },
-      "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
     "v1SignRawPayloadIntent": {
       "type": "object",

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -306,6 +306,44 @@ export type definitions = {
     /** @description The id of the product being subscribed to. */
     productId: string;
   };
+  billingDeletePaymentMethodIntent: {
+    /** @description The payment method that the customer wants to remove. */
+    paymentMethodId: string;
+  };
+  billingDeletePaymentMethodResult: {
+    /** @description The payment method that was removed. */
+    paymentMethodId: string;
+  };
+  billingSetPaymentMethodIntent: {
+    /** @description The account number of the customer's credit card. */
+    number: string;
+    /** @description The verification digits of the customer's credit card. */
+    cvv: string;
+    /** @description The month that the credit card expires. */
+    expiryMonth: string;
+    /** @description The year that the credit card expires. */
+    expiryYear: string;
+    /** @description The email that will receive invoices for the credit card. */
+    cardHolderEmail: string;
+    /** @description The name associated with the credit card. */
+    cardHolderName: string;
+  };
+  billingSetPaymentMethodIntentV2: {
+    /** @description The id of the payment method that was created clientside. */
+    paymentMethodId: string;
+    /** @description The email that will receive invoices for the credit card. */
+    cardHolderEmail: string;
+    /** @description The name associated with the credit card. */
+    cardHolderName: string;
+  };
+  billingSetPaymentMethodResult: {
+    /** @description The last four digits of the credit card added. */
+    lastFour: string;
+    /** @description The name associated with the payment method. */
+    cardHolderName: string;
+    /** @description The email address associated with the payment method. */
+    cardHolderEmail: string;
+  };
   datav1Tag: {
     /** @description Unique identifier for a given Tag. */
     tagId: string;
@@ -494,7 +532,29 @@ export type definitions = {
     | "ADDRESS_FORMAT_ETHEREUM"
     | "ADDRESS_FORMAT_SOLANA"
     | "ADDRESS_FORMAT_COSMOS"
-    | "ADDRESS_FORMAT_TRON";
+    | "ADDRESS_FORMAT_TRON"
+    | "ADDRESS_FORMAT_SUI"
+    | "ADDRESS_FORMAT_APTOS"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_TESTNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_SIGNET_P2TR"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2PKH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2SH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WPKH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2WSH"
+    | "ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR";
   v1ApiKey: {
     /** @description A User credential that can be used to authenticate to Turnkey. */
     credential: definitions["externaldatav1Credential"];
@@ -1233,14 +1293,6 @@ export type definitions = {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
   };
-  v1DeletePaymentMethodIntent: {
-    /** @description The payment method that the customer wants to remove. */
-    paymentMethodId: string;
-  };
-  v1DeletePaymentMethodResult: {
-    /** @description The payment method that was removed. */
-    paymentMethodId: string;
-  };
   v1DeletePolicyIntent: {
     /** @description Unique identifier for a given Policy. */
     policyId: string;
@@ -1843,9 +1895,9 @@ export type definitions = {
     createPrivateKeyTagIntent?: definitions["v1CreatePrivateKeyTagIntent"];
     deletePrivateKeyTagsIntent?: definitions["v1DeletePrivateKeyTagsIntent"];
     createPolicyIntentV2?: definitions["v1CreatePolicyIntentV2"];
-    setPaymentMethodIntent?: definitions["v1SetPaymentMethodIntent"];
+    setPaymentMethodIntent?: definitions["billingSetPaymentMethodIntent"];
     activateBillingTierIntent?: definitions["billingActivateBillingTierIntent"];
-    deletePaymentMethodIntent?: definitions["v1DeletePaymentMethodIntent"];
+    deletePaymentMethodIntent?: definitions["billingDeletePaymentMethodIntent"];
     createPolicyIntentV3?: definitions["v1CreatePolicyIntentV3"];
     createApiOnlyUsersIntent?: definitions["v1CreateApiOnlyUsersIntent"];
     updateRootQuorumIntent?: definitions["v1UpdateRootQuorumIntent"];
@@ -1861,7 +1913,7 @@ export type definitions = {
     createPrivateKeysIntentV2?: definitions["v1CreatePrivateKeysIntentV2"];
     updateUserIntent?: definitions["v1UpdateUserIntent"];
     updatePolicyIntent?: definitions["v1UpdatePolicyIntent"];
-    setPaymentMethodIntentV2?: definitions["v1SetPaymentMethodIntentV2"];
+    setPaymentMethodIntentV2?: definitions["billingSetPaymentMethodIntentV2"];
     createSubOrganizationIntentV3?: definitions["v1CreateSubOrganizationIntentV3"];
     createWalletIntent?: definitions["v1CreateWalletIntent"];
     createWalletAccountsIntent?: definitions["v1CreateWalletAccountsIntent"];
@@ -2177,9 +2229,9 @@ export type definitions = {
     createApiKeysResult?: definitions["v1CreateApiKeysResult"];
     createPrivateKeyTagResult?: definitions["v1CreatePrivateKeyTagResult"];
     deletePrivateKeyTagsResult?: definitions["v1DeletePrivateKeyTagsResult"];
-    setPaymentMethodResult?: definitions["v1SetPaymentMethodResult"];
+    setPaymentMethodResult?: definitions["billingSetPaymentMethodResult"];
     activateBillingTierResult?: definitions["billingActivateBillingTierResult"];
-    deletePaymentMethodResult?: definitions["v1DeletePaymentMethodResult"];
+    deletePaymentMethodResult?: definitions["billingDeletePaymentMethodResult"];
     createApiOnlyUsersResult?: definitions["v1CreateApiOnlyUsersResult"];
     updateRootQuorumResult?: definitions["v1UpdateRootQuorumResult"];
     updateUserTagResult?: definitions["v1UpdateUserTagResult"];
@@ -2280,36 +2332,6 @@ export type definitions = {
   v1SetOrganizationFeatureResult: {
     /** @description Resulting list of organization features. */
     features: definitions["v1Feature"][];
-  };
-  v1SetPaymentMethodIntent: {
-    /** @description The account number of the customer's credit card. */
-    number: string;
-    /** @description The verification digits of the customer's credit card. */
-    cvv: string;
-    /** @description The month that the credit card expires. */
-    expiryMonth: string;
-    /** @description The year that the credit card expires. */
-    expiryYear: string;
-    /** @description The email that will receive invoices for the credit card. */
-    cardHolderEmail: string;
-    /** @description The name associated with the credit card. */
-    cardHolderName: string;
-  };
-  v1SetPaymentMethodIntentV2: {
-    /** @description The id of the payment method that was created clientside. */
-    paymentMethodId: string;
-    /** @description The email that will receive invoices for the credit card. */
-    cardHolderEmail: string;
-    /** @description The name associated with the credit card. */
-    cardHolderName: string;
-  };
-  v1SetPaymentMethodResult: {
-    /** @description The last four digits of the credit card added. */
-    lastFour: string;
-    /** @description The name associated with the payment method. */
-    cardHolderName: string;
-    /** @description The email address associated with the payment method. */
-    cardHolderEmail: string;
   };
   v1SignRawPayloadIntent: {
     /** @description Unique identifier for a given Private Key. */


### PR DESCRIPTION
## Summary & Motivation
Add keyFormat option to injectKeyExport bundle so users can export PKs in Solana Format

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
