### PR TITLE
Exposes the storage APIs for the sdk-browser

### DIFF
--- a/.changeset/popular-rats-dance.md
+++ b/.changeset/popular-rats-dance.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-browser": patch
+---
+
+Exposes storage APIs used by the sdk for managing users & sessions

--- a/packages/sdk-browser/src/index.ts
+++ b/packages/sdk-browser/src/index.ts
@@ -33,6 +33,8 @@ import {
   TurnkeyPasskeyClient,
 } from "./sdk-client";
 
+export { getStorageValue, setStorageValue, StorageKeys } from "./storage";
+
 import {
   defaultEthereumAccountAtIndex,
   DEFAULT_ETHEREUM_ACCOUNTS,


### PR DESCRIPTION
## Summary & Motivation
There are times where a developers may want to manage the local storage of the users, sessions and auth bundles themselves. When implementing the demo-embeded-wallet I found that I needed to store the current session after creating a new sub organization. Without this, you need to call one of the `login` functions such as `passkeyClient.login()` in order to save the session to local storage. However, this would require an additional passkey tap.

This would allow for creating a session for a new sub org using the parent org and then saving the session in local storage.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
