### PR TITLE
Quick fix for aptos and sui examples

### DIFF
--- a/examples/with-aptos/src/index.ts
+++ b/examples/with-aptos/src/index.ts
@@ -53,16 +53,12 @@ async function main() {
   );
 
   // Prepare the transaction payload
-  const token = new TxnBuilderTypes.TypeTagStruct(
-    TxnBuilderTypes.StructTag.fromString("0x1::aptos_coin::AptosCoin")
-  );
-
   const entryFunctionPayload =
     new TxnBuilderTypes.TransactionPayloadEntryFunction(
       TxnBuilderTypes.EntryFunction.natural(
-        "0x1::coin",
+        "0x1::aptos_account",
         "transfer",
-        [token],
+        [],
         [
           BCS.bcsToBytes(
             TxnBuilderTypes.AccountAddress.fromHex(recipientAddress)

--- a/examples/with-sui/src/index.ts
+++ b/examples/with-sui/src/index.ts
@@ -93,7 +93,7 @@ async function main() {
 
   const referenceGasPrice = await provider.getReferenceGasPrice();
   tx.setGasPrice(referenceGasPrice);
-  tx.setGasBudget(1000000n);
+  tx.setGasBudget(5000000n);
 
   // Set gas payment
   tx.setGasPayment([


### PR DESCRIPTION
## Summary & Motivation
- Increase gas budget for SUI
- Sender creates onchain account for APTOS if it doesn't already exist

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
