### PR TITLE
Fix `personal_sign` parameters

### DIFF
--- a/.changeset/lemon-baboons-dress.md
+++ b/.changeset/lemon-baboons-dress.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/eip-1193-provider": patch
+---
+
+fix: personal_sign parameters

--- a/packages/eip-1193-provider/src/index.ts
+++ b/packages/eip-1193-provider/src/index.ts
@@ -135,7 +135,19 @@ export const createEIP1193Provider = async (
         case "eth_accounts":
           setConnected(true, { chainId: activeChain.chainId });
           return [...accounts];
-        case "personal_sign":
+        case "personal_sign": {
+          const [message, signWith] =
+            params as WalletRpcSchema[10]["Parameters"];
+
+          const signedMessage = await signMessage({
+            organizationId,
+            message,
+            signWith,
+            client: turnkeyClient,
+          });
+          setConnected(true, { chainId: activeChain.chainId });
+          return signedMessage;
+        }
         case "eth_sign": {
           const [signWith, message] =
             params as WalletRpcSchema[6]["Parameters"];


### PR DESCRIPTION
## Summary & Motivation
`personal_sign` function parameters are flipped incorrectly, the first parameter is the data to be signed and the second parameter is the address, this fixes that.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
