### PR TITLE
Change Inquirer/prompts dependency to prompts

### DIFF
--- a/examples/export-in-node/package.json
+++ b/examples/export-in-node/package.json
@@ -8,14 +8,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@inquirer/prompts": "^2.1.0",
     "@peculiar/webcrypto": "^1.5.0",
     "@turnkey/crypto": "workspace:*",
     "@turnkey/encoding": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
     "async-retry": "^1.3.3",
     "cross-fetch": "^4.0.0",
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "prompts": "^2.4.2"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.8"

--- a/examples/export-in-node/package.json
+++ b/examples/export-in-node/package.json
@@ -18,6 +18,7 @@
     "prompts": "^2.4.2"
   },
   "devDependencies": {
-    "@types/async-retry": "^1.4.8"
+    "@types/async-retry": "^1.4.8",
+    "@types/prompts": "^2.4.2"
   }
 }

--- a/examples/export-in-node/src/index.ts
+++ b/examples/export-in-node/src/index.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
-import { input } from "@inquirer/prompts";
+import prompts from "prompts";
 import { Turnkey } from "@turnkey/sdk-server";
 import { Crypto } from "@peculiar/webcrypto";
 import { generateP256KeyPair, decryptExportBundle } from "@turnkey/crypto";
@@ -19,31 +19,47 @@ async function main() {
     apiPrivateKey: process.env.API_PRIVATE_KEY!,
     defaultOrganizationId: organizationId,
   });
-  const exportType = await input({
-    message: `Enter Export Type, either "wallet" or "key" or "account"`,
-  });
+  const { exportType } = await prompts([
+    {
+      type: "text",
+      name: "exportType",
+      message: `Enter Export Type, either "wallet" or "key" or "account"`,
+    },
+  ]);
 
   let exportResult;
   if (exportType == "wallet") {
-    const walletId = await input({
-      message: `Enter wallet id to export`,
-    });
+    const { walletId } = await prompts([
+      {
+        type: "text",
+        name: "walletId",
+        message: `Enter wallet id to export`,
+      },
+    ]);
     exportResult = await turnkeyClient.apiClient().exportWallet({
       walletId,
       targetPublicKey: publicKey,
     });
   } else if (exportType == "key") {
-    const privateKeyId = await input({
-      message: `Enter private key id to export`,
-    });
+    const privateKeyId = await prompts([
+      {
+        type: "text",
+        name: "privateKeyId",
+        message: `Enter private key id to export`,
+      },
+    ]);
     exportResult = await turnkeyClient.apiClient().exportPrivateKey({
       privateKeyId,
       targetPublicKey: publicKey,
     });
   } else if (exportType == "account") {
-    const address = await input({
-      message: `Enter address to export`,
-    });
+    const address = await prompts([
+      {
+        type: "text",
+        name: "address",
+        message: `Enter address to export`,
+      },
+    ]);
     exportResult = await turnkeyClient.apiClient().exportWalletAccount({
       address,
       targetPublicKey: publicKey,

--- a/examples/export-in-node/src/index.ts
+++ b/examples/export-in-node/src/index.ts
@@ -5,9 +5,8 @@ import { Turnkey } from "@turnkey/sdk-server";
 import { Crypto } from "@peculiar/webcrypto";
 import { generateP256KeyPair, decryptExportBundle } from "@turnkey/crypto";
 if (typeof crypto === "undefined") {
-  global.crypto = new Crypto()
+  global.crypto = new Crypto();
 }
-
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 

--- a/examples/export-in-node/src/index.ts
+++ b/examples/export-in-node/src/index.ts
@@ -43,7 +43,7 @@ async function main() {
       targetPublicKey: publicKey,
     });
   } else if (exportType == "key") {
-    const privateKeyId = await prompts([
+    const { privateKeyId } = await prompts([
       {
         type: "text",
         name: "privateKeyId",
@@ -55,7 +55,7 @@ async function main() {
       targetPublicKey: publicKey,
     });
   } else if (exportType == "account") {
-    const address = await prompts([
+    const { address } = await prompts([
       {
         type: "text",
         name: "address",

--- a/examples/export-in-node/src/index.ts
+++ b/examples/export-in-node/src/index.ts
@@ -4,7 +4,10 @@ import prompts from "prompts";
 import { Turnkey } from "@turnkey/sdk-server";
 import { Crypto } from "@peculiar/webcrypto";
 import { generateP256KeyPair, decryptExportBundle } from "@turnkey/crypto";
-global.crypto = new Crypto();
+if (typeof crypto === "undefined") {
+  global.crypto = new Crypto()
+}
+
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 

--- a/examples/import-in-node/package.json
+++ b/examples/import-in-node/package.json
@@ -8,14 +8,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@inquirer/prompts": "^2.1.0",
     "@peculiar/webcrypto": "^1.5.0",
     "@turnkey/crypto": "workspace:*",
     "@turnkey/encoding": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
     "async-retry": "^1.3.3",
     "cross-fetch": "^4.0.0",
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "prompts": "^2.4.2"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.8"

--- a/examples/import-in-node/package.json
+++ b/examples/import-in-node/package.json
@@ -18,6 +18,7 @@
     "prompts": "^2.4.2"
   },
   "devDependencies": {
-    "@types/async-retry": "^1.4.8"
+    "@types/async-retry": "^1.4.8",
+    "@types/prompts": "^2.4.2"
   }
 }

--- a/examples/import-in-node/src/index.ts
+++ b/examples/import-in-node/src/index.ts
@@ -8,9 +8,8 @@ import {
   encryptWalletToBundle,
 } from "@turnkey/crypto";
 if (typeof crypto === "undefined") {
-  global.crypto = new Crypto()
+  global.crypto = new Crypto();
 }
-
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 

--- a/examples/import-in-node/src/index.ts
+++ b/examples/import-in-node/src/index.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
-import { input } from "@inquirer/prompts";
+import prompts from "prompts";
 import { Turnkey } from "@turnkey/sdk-server";
 import { Crypto } from "@peculiar/webcrypto";
 import {
@@ -20,9 +20,13 @@ async function main() {
     apiPrivateKey: process.env.API_PRIVATE_KEY!,
     defaultOrganizationId: organizationId,
   });
-  const importType = await input({
-    message: `Enter Import Type, either "wallet" or "key"`,
-  });
+  const { importType } = await prompts([
+    {
+      type: "text",
+      name: "importType",
+      message: `Enter Import Type, either "wallet" or "key"`,
+    },
+  ]);
   let initResult;
   if (importType == "wallet") {
     initResult = await turnkeyClient.apiClient().initImportWallet({
@@ -37,9 +41,13 @@ async function main() {
   }
 
   if (importType == "wallet") {
-    const mnemonic = await input({
-      message: "Enter mnemonic seed phrase for wallet to import",
-    });
+    const { mnemonic } = await prompts([
+      {
+        type: "text",
+        name: "mnemonic",
+        message: "Enter mnemonic seed phrase for wallet to import",
+      },
+    ]);
     const walletBundle = await encryptWalletToBundle({
       mnemonic,
       importBundle: initResult.importBundle,
@@ -57,12 +65,20 @@ async function main() {
     );
   }
   if (importType == "key") {
-    const privateKey = await input({
-      message: "Enter Private Key to import",
-    });
-    const keyFormat = await input({
-      message: "Enter Key Format, either HEXADECIMAL or SOLANA",
-    });
+    const { privateKey } = await prompts([
+      {
+        type: "text",
+        name: "privateKey",
+        message: "Enter Private Key to import",
+      },
+    ]);
+    const { keyFormat } = await prompts([
+      {
+        type: "text",
+        name: "keyFormat",
+        message: "Enter Key Format, either HEXADECIMAL or SOLANA",
+      },
+    ]);
     const privateKeyBundle = await encryptPrivateKeyToBundle({
       privateKey,
       keyFormat,

--- a/examples/import-in-node/src/index.ts
+++ b/examples/import-in-node/src/index.ts
@@ -7,7 +7,10 @@ import {
   encryptPrivateKeyToBundle,
   encryptWalletToBundle,
 } from "@turnkey/crypto";
-global.crypto = new Crypto();
+if (typeof crypto === "undefined") {
+  global.crypto = new Crypto()
+}
+
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 

--- a/examples/with-aptos/package.json
+++ b/examples/with-aptos/package.json
@@ -8,14 +8,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@inquirer/prompts": "^2.1.0",
     "@noble/hashes": "1.4.0",
     "@turnkey/http": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
     "aptos": "^1.21.0",
     "async-retry": "^1.3.3",
     "cross-fetch": "^4.0.0",
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "prompts": "^2.4.2"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.8",

--- a/examples/with-aptos/package.json
+++ b/examples/with-aptos/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.8",
+    "@types/prompts": "^2.4.2",
     "tsx": "^3.12.7",
     "typescript": "^5.0.4"
   }

--- a/examples/with-aptos/src/index.ts
+++ b/examples/with-aptos/src/index.ts
@@ -1,7 +1,7 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
 import { AptosClient, TxnBuilderTypes, BCS, TransactionBuilder } from "aptos";
-import { input } from "@inquirer/prompts";
+import prompts from "prompts";
 import { Turnkey } from "@turnkey/sdk-server";
 import { bytesToHex } from "@noble/hashes/utils";
 
@@ -39,10 +39,14 @@ async function main() {
   }
 
   // Create and sign a transaction
-  const recipientAddress = await input({
-    message: "Recipient address:",
-    default: "<recipient_aptos_address>",
-  });
+  const { recipientAddress } = await prompts([
+    {
+      type: "text",
+      name: "recipientAddress",
+      message: "Recipient address:",
+      default: "<recipient_aptos_address>",
+    },
+  ]);
 
   const amount = 100n; // 100 Octas (minimum practical amount)
 

--- a/examples/with-aptos/src/index.ts
+++ b/examples/with-aptos/src/index.ts
@@ -44,7 +44,7 @@ async function main() {
       type: "text",
       name: "recipientAddress",
       message: "Recipient address:",
-      default: "<recipient_aptos_address>",
+      initial: "<recipient_aptos_address>",
     },
   ]);
 

--- a/examples/with-offline/package.json
+++ b/examples/with-offline/package.json
@@ -8,9 +8,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*",
+    "@turnkey/http": "workspace:*",
     "dotenv": "^16.0.3",
     "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "@types/prompts": "^2.4.2"
   }
 }

--- a/examples/with-offline/package.json
+++ b/examples/with-offline/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@inquirer/prompts": "^1.2.3",
     "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*",
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "prompts": "^2.4.2"
   }
 }

--- a/examples/with-offline/src/index.ts
+++ b/examples/with-offline/src/index.ts
@@ -3,7 +3,7 @@ import * as dotenv from "dotenv";
 
 import { TurnkeyClient } from "@turnkey/http";
 import { ApiKeyStamper } from "@turnkey/api-key-stamper";
-import { input } from "@inquirer/prompts";
+import prompts from "prompts";
 
 // Load environment variables from `.env.local`
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
@@ -50,7 +50,13 @@ async function main() {
     `Creating a new Private Key for organization ${organizationId} using the configured Turnkey API key...`
   );
 
-  const privateKeyName = await input({ message: "New Private Key Name:" });
+  const { privateKeyName } = await prompts([
+    {
+      type: "text",
+      name: "privateKeyName",
+      message: "New Private Key Name:",
+    },
+  ]);
 
   const signedRequest = await turnkeyClient.stampCreatePrivateKeys({
     timestampMs: String(Date.now()), // millisecond timestamp

--- a/examples/with-solana/package.json
+++ b/examples/with-solana/package.json
@@ -14,7 +14,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@inquirer/prompts": "^2.1.0",
     "@project-serum/anchor": "^0.26.0",
     "@solana/spl-token": "^0.4.8",
     "@solana/web3.js": "^1.88.1",
@@ -26,9 +25,13 @@
     "bs58": "^5.0.0",
     "cross-fetch": "^4.0.0",
     "dotenv": "^16.0.3",
+    "prompts": "^2.4.2",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@types/async-retry": "^1.4.8"
+    "@types/async-retry": "^1.4.8",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3"
   }
 }

--- a/examples/with-solana/package.json
+++ b/examples/with-solana/package.json
@@ -29,6 +29,7 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@types/async-retry": "^1.4.8"
+    "@types/async-retry": "^1.4.8",
+    "@types/prompts": "^2.4.2"
   }
 }

--- a/examples/with-solana/package.json
+++ b/examples/with-solana/package.json
@@ -29,9 +29,6 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@types/async-retry": "^1.4.8",
-    "ts-node": "^10.9.2",
-    "tsx": "^4.19.1",
-    "typescript": "^5.6.3"
+    "@types/async-retry": "^1.4.8"
   }
 }

--- a/examples/with-solana/src/addSignature.ts
+++ b/examples/with-solana/src/addSignature.ts
@@ -75,9 +75,9 @@ async function main() {
   const { destination } = await prompts([
     {
       type: "text",
-      name: "destionation",
+      name: "destination",
       message: `Destination address:`,
-      default: TURNKEY_WAR_CHEST,
+      initial: TURNKEY_WAR_CHEST,
     },
   ]);
 
@@ -88,7 +88,7 @@ async function main() {
       name: "amount",
       type: "text",
       message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-      default: "100",
+      initial: "100",
       validate: function (str) {
         var n = Math.floor(Number(str));
         if (n !== Infinity && String(n) === str && n > 0) {

--- a/examples/with-solana/src/addSignature.ts
+++ b/examples/with-solana/src/addSignature.ts
@@ -57,18 +57,14 @@ async function main() {
       ].join("\n")
     );
     // Await user confirmation to continue
-    const { ready } = await prompts({
-      type: 'confirm',
-      name: 'ready',
-      message: 'Ready to Continue?',
-    });
+    await prompts([
+      {
+        type: "confirm",
+        name: "ready",
+        message: "Ready to Continue?",
+      },
+    ]);
 
-    // Check if the user is ready to continue
-    if (!ready) {
-      console.log('Waiting for your confirmation...');
-      continue;
-    }
-    
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -78,19 +74,19 @@ async function main() {
   // 1. Create, sign, and verify a transfer transaction using `addSignature` as opposed to `signTransaction`
   const { destination } = await prompts([
     {
-      type: 'text',
-      name: 'destionation',
+      type: "text",
+      name: "destionation",
       message: `Destination address:`,
       default: TURNKEY_WAR_CHEST,
-    }
-    ]);
+    },
+  ]);
 
   // Amount defaults to 100.
   // Any other amount is possible.
   const { amount } = await prompts([
     {
-      name: 'amount',
-      type: 'text',
+      name: "amount",
+      type: "text",
       message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
       default: "100",
       validate: function (str) {

--- a/examples/with-solana/src/addSignature.ts
+++ b/examples/with-solana/src/addSignature.ts
@@ -87,7 +87,7 @@ async function main() {
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await prompts([
+  const { amount } = await prompts([
     {
       name: 'amount',
       type: 'text',

--- a/examples/with-solana/src/addSignature.ts
+++ b/examples/with-solana/src/addSignature.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
-import { input, confirm } from "@inquirer/prompts";
+import prompts from "prompts";
 import { PublicKey, type Transaction } from "@solana/web3.js";
 
 // Load environment variables from `.env.local`
@@ -56,7 +56,7 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await confirm({ message: "Ready to Continue?" });
+    await prompts({ message: "Ready to Continue?" });
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -64,14 +64,14 @@ async function main() {
   print("SOL balance:", `${balance} Lamports`);
 
   // 1. Create, sign, and verify a transfer transaction using `addSignature` as opposed to `signTransaction`
-  const destination = await input({
+  const destination = await prompts({
     message: `Destination address:`,
     default: TURNKEY_WAR_CHEST,
   });
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await input({
+  const amount = await prompts({
     message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
     default: "100",
     validate: function (str) {

--- a/examples/with-solana/src/addSignature.ts
+++ b/examples/with-solana/src/addSignature.ts
@@ -56,7 +56,19 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await prompts({ message: "Ready to Continue?" });
+    // Await user confirmation to continue
+    const { ready } = await prompts({
+      type: 'confirm',
+      name: 'ready',
+      message: 'Ready to Continue?',
+    });
+
+    // Check if the user is ready to continue
+    if (!ready) {
+      console.log('Waiting for your confirmation...');
+      continue;
+    }
+    
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -64,31 +76,39 @@ async function main() {
   print("SOL balance:", `${balance} Lamports`);
 
   // 1. Create, sign, and verify a transfer transaction using `addSignature` as opposed to `signTransaction`
-  const destination = await prompts({
-    message: `Destination address:`,
-    default: TURNKEY_WAR_CHEST,
-  });
+  const { destination } = await prompts([
+    {
+      type: 'text',
+      name: 'destionation',
+      message: `Destination address:`,
+      default: TURNKEY_WAR_CHEST,
+    }
+    ]);
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await prompts({
-    message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-    default: "100",
-    validate: function (str) {
-      var n = Math.floor(Number(str));
-      if (n !== Infinity && String(n) === str && n > 0) {
-        // valid int was passed in
-        if (n + 5000 > balance) {
-          return `insufficient balance: current balance (${balance}) is less than ${
-            n + 5000
-          } (amount + 5000 for fee)`;
+  const amount = await prompts([
+    {
+      name: 'amount',
+      type: 'text',
+      message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
+      default: "100",
+      validate: function (str) {
+        var n = Math.floor(Number(str));
+        if (n !== Infinity && String(n) === str && n > 0) {
+          // valid int was passed in
+          if (n + 5000 > balance) {
+            return `insufficient balance: current balance (${balance}) is less than ${
+              n + 5000
+            } (amount + 5000 for fee)`;
+          }
+          return true;
+        } else {
+          return "amount must be a strictly positive integer";
         }
-        return true;
-      } else {
-        return "amount must be a strictly positive integer";
-      }
+      },
     },
-  });
+  ]);
 
   const transaction = await createTransfer({
     fromAddress: solAddress,

--- a/examples/with-solana/src/advanced.ts
+++ b/examples/with-solana/src/advanced.ts
@@ -59,51 +59,48 @@ async function main() {
       ].join("\n")
     );
     // Await user confirmation to continue
-    const { ready } = await prompts({
-      type: 'confirm',
-      name: 'ready',
-      message: 'Ready to Continue?',
-    });
-
-    // Check if the user is ready to continue
-    if (!ready) {
-      console.log('Waiting for your confirmation...');
-      continue;
-    }
+    await prompts([
+      {
+        type: "confirm",
+        name: "ready",
+        message: "Ready to Continue?",
+      },
+    ]);
 
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
 
-  const { numTxs } = parseInt(
-    await prompts([
-      {
-        type: 'text',
-        name: 'numTxs',
-        message: `Number of transactions:`,
-        default: "1",
-      }
-    ])
-  );
+  const { numTxsStr } = await prompts([
+    {
+      type: "text",
+      name: "numTxsStr",
+      message: `Number of transactions:`,
+      default: "1",
+    },
+  ]);
+  console.log(numTxsStr);
+
+  const numTxs = parseInt(numTxsStr);
 
   const unsignedTxs = new Array<VersionedTransaction>();
 
   for (let i = 0; i < numTxs; i++) {
     const destination = await prompts([
       {
-        type: 'text',
-        name: 'destination',
+        type: "text",
+        name: "destination",
         message: `${i + 1}. Destination address:`,
         default: TURNKEY_WAR_CHEST,
-      }
+      },
     ]);
 
     // Amount defaults to 100.
     // Any other amount is possible, so long as a sufficient balance remains for fees.
     const amount = await prompts([
       {
-        type: 'text',
-        name: 'amount',
+        type: "text",
+        name: "amount",
         message: `${
           i + 1
         }. Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
@@ -122,7 +119,7 @@ async function main() {
             return "amount must be a strictly positive integer";
           }
         },
-      }
+      },
     ]);
 
     const fromKey = new PublicKey(solAddress);

--- a/examples/with-solana/src/advanced.ts
+++ b/examples/with-solana/src/advanced.ts
@@ -75,7 +75,7 @@ async function main() {
     balance = await solanaNetwork.balance(connection, solAddress);
   }
 
-  const numTxs = parseInt(
+  const { numTxs } = parseInt(
     await prompts([
       {
         type: 'text',

--- a/examples/with-solana/src/advanced.ts
+++ b/examples/with-solana/src/advanced.ts
@@ -58,48 +58,72 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await prompts({ message: "Ready to Continue?" });
+    // Await user confirmation to continue
+    const { ready } = await prompts({
+      type: 'confirm',
+      name: 'ready',
+      message: 'Ready to Continue?',
+    });
+
+    // Check if the user is ready to continue
+    if (!ready) {
+      console.log('Waiting for your confirmation...');
+      continue;
+    }
+
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
 
   const numTxs = parseInt(
-    await prompts({
-      message: `Number of transactions:`,
-      default: "1",
-    })
+    await prompts([
+      {
+        type: 'text',
+        name: 'numTxs',
+        message: `Number of transactions:`,
+        default: "1",
+      }
+    ])
   );
 
   const unsignedTxs = new Array<VersionedTransaction>();
 
   for (let i = 0; i < numTxs; i++) {
-    const destination = await prompts({
-      message: `${i + 1}. Destination address:`,
-      default: TURNKEY_WAR_CHEST,
-    });
+    const destination = await prompts([
+      {
+        type: 'text',
+        name: 'destination',
+        message: `${i + 1}. Destination address:`,
+        default: TURNKEY_WAR_CHEST,
+      }
+    ]);
 
     // Amount defaults to 100.
     // Any other amount is possible, so long as a sufficient balance remains for fees.
-    const amount = await prompts({
-      message: `${
-        i + 1
-      }. Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-      default: "100",
-      validate: function (str) {
-        var n = Math.floor(Number(str));
-        if (n !== Infinity && String(n) === str && n > 0) {
-          // valid int was passed in
-          if (n + 5000 > balance) {
-            return `insufficient balance: current balance (${balance}) is less than ${
-              n + 5000 * numTxs
-            } (amount + 5000 lamports per tx for fee)`;
+    const amount = await prompts([
+      {
+        type: 'text',
+        name: 'amount',
+        message: `${
+          i + 1
+        }. Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
+        default: "100",
+        validate: function (str) {
+          var n = Math.floor(Number(str));
+          if (n !== Infinity && String(n) === str && n > 0) {
+            // valid int was passed in
+            if (n + 5000 > balance) {
+              return `insufficient balance: current balance (${balance}) is less than ${
+                n + 5000 * numTxs
+              } (amount + 5000 lamports per tx for fee)`;
+            }
+            return true;
+          } else {
+            return "amount must be a strictly positive integer";
           }
-          return true;
-        } else {
-          return "amount must be a strictly positive integer";
-        }
-      },
-    });
+        },
+      }
+    ]);
 
     const fromKey = new PublicKey(solAddress);
     const toKey = new PublicKey(destination);

--- a/examples/with-solana/src/advanced.ts
+++ b/examples/with-solana/src/advanced.ts
@@ -2,7 +2,7 @@ import * as dotenv from "dotenv";
 import * as path from "path";
 import nacl from "tweetnacl";
 import bs58 from "bs58";
-import { input, confirm } from "@inquirer/prompts";
+import prompts from "prompts";
 
 // Load environment variables from `.env.local`
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
@@ -58,13 +58,13 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await confirm({ message: "Ready to Continue?" });
+    await prompts({ message: "Ready to Continue?" });
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
 
   const numTxs = parseInt(
-    await input({
+    await prompts({
       message: `Number of transactions:`,
       default: "1",
     })
@@ -73,14 +73,14 @@ async function main() {
   const unsignedTxs = new Array<VersionedTransaction>();
 
   for (let i = 0; i < numTxs; i++) {
-    const destination = await input({
+    const destination = await prompts({
       message: `${i + 1}. Destination address:`,
       default: TURNKEY_WAR_CHEST,
     });
 
     // Amount defaults to 100.
     // Any other amount is possible, so long as a sufficient balance remains for fees.
-    const amount = await input({
+    const amount = await prompts({
       message: `${
         i + 1
       }. Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,

--- a/examples/with-solana/src/advanced.ts
+++ b/examples/with-solana/src/advanced.ts
@@ -76,7 +76,7 @@ async function main() {
       type: "text",
       name: "numTxsStr",
       message: `Number of transactions:`,
-      default: "1",
+      initial: "1",
     },
   ]);
   console.log(numTxsStr);
@@ -91,20 +91,20 @@ async function main() {
         type: "text",
         name: "destination",
         message: `${i + 1}. Destination address:`,
-        default: TURNKEY_WAR_CHEST,
+        initial: TURNKEY_WAR_CHEST,
       },
     ]);
 
     // Amount defaults to 100.
     // Any other amount is possible, so long as a sufficient balance remains for fees.
-    const amount = await prompts([
+    const { amount } = await prompts([
       {
         type: "text",
         name: "amount",
         message: `${
           i + 1
         }. Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-        default: "100",
+        initial: "100",
         validate: function (str) {
           var n = Math.floor(Number(str));
           if (n !== Infinity && String(n) === str && n > 0) {

--- a/examples/with-solana/src/advanced.ts
+++ b/examples/with-solana/src/advanced.ts
@@ -79,7 +79,6 @@ async function main() {
       initial: "1",
     },
   ]);
-  console.log(numTxsStr);
 
   const numTxs = parseInt(numTxsStr);
 

--- a/examples/with-solana/src/faucet.ts
+++ b/examples/with-solana/src/faucet.ts
@@ -2,9 +2,13 @@ import * as solanaNetwork from "./utils/solanaNetwork";
 import prompts from "prompts";
 
 async function main() {
-  const solAddress = await prompts({
+  const solAddress = await prompts([
+  {
+    type: 'text',
+    name: 'message',
     message: "Address to drop devnet tokens into:",
-  });
+  }
+]);
   const connection = solanaNetwork.connect();
   await solanaNetwork.dropTokens(connection, solAddress);
   process.exit(0);

--- a/examples/with-solana/src/faucet.ts
+++ b/examples/with-solana/src/faucet.ts
@@ -1,8 +1,8 @@
 import * as solanaNetwork from "./utils/solanaNetwork";
-import { input } from "@inquirer/prompts";
+import prompts from "prompts";
 
 async function main() {
-  const solAddress = await input({
+  const solAddress = await prompts({
     message: "Address to drop devnet tokens into:",
   });
   const connection = solanaNetwork.connect();

--- a/examples/with-solana/src/faucet.ts
+++ b/examples/with-solana/src/faucet.ts
@@ -3,12 +3,12 @@ import prompts from "prompts";
 
 async function main() {
   const { solAddress } = await prompts([
-  {
-    type: 'text',
-    name: 'solAddress',
-    message: "Address to drop devnet tokens into:",
-  }
-]);
+    {
+      type: "text",
+      name: "solAddress",
+      message: "Address to drop devnet tokens into:",
+    },
+  ]);
   const connection = solanaNetwork.connect();
   await solanaNetwork.dropTokens(connection, solAddress);
   process.exit(0);

--- a/examples/with-solana/src/faucet.ts
+++ b/examples/with-solana/src/faucet.ts
@@ -2,10 +2,10 @@ import * as solanaNetwork from "./utils/solanaNetwork";
 import prompts from "prompts";
 
 async function main() {
-  const solAddress = await prompts([
+  const { solAddress } = await prompts([
   {
     type: 'text',
-    name: 'message',
+    name: 'solAddress',
     message: "Address to drop devnet tokens into:",
   }
 ]);

--- a/examples/with-solana/src/index.ts
+++ b/examples/with-solana/src/index.ts
@@ -1,6 +1,7 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
 import nacl from "tweetnacl";
+import bs58 from "bs58";
 import prompts from "prompts";
 import { Transaction } from "@solana/web3.js";
 
@@ -72,7 +73,19 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await prompts({ message: "Ready to Continue?" });
+    // Await user confirmation to continue
+    const { ready } = await prompts({
+      type: 'confirm',
+      name: 'ready',
+      message: 'Ready to Continue?',
+    });
+
+    // Check if the user is ready to continue
+    if (!ready) {
+      console.log('Waiting for your confirmation...');
+      continue;
+    }
+
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -80,10 +93,14 @@ async function main() {
   print("SOL balance:", `${balance} Lamports`);
 
   // 1. Sign and verify a message
-  const message = await prompts({
-    message: "Message to sign",
-    default: "Hello Turnkey",
-  });
+  const { message } = await prompts([
+    {
+      type: 'text',
+      name: 'message',
+      message: 'Message to sign',
+      initial: 'Hello Turnkey',
+    },
+  ]);
   const messageAsUint8Array = Buffer.from(message);
 
   let signature;
@@ -119,31 +136,39 @@ async function main() {
   print("Turnkey-powered signature:", `${bs58.encode(signature)}`);
 
   // 2. Create, sign, and verify a transfer transaction
-  const destination = await prompts({
-    message: `Destination address:`,
-    default: TURNKEY_WAR_CHEST,
-  });
+  const { destination } = await prompts([
+    {
+      name: 'destination',
+      type: 'text',
+      message: `Destination address:`,
+      initial: TURNKEY_WAR_CHEST,
+    },
+  ]);
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await prompts({
-    message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-    default: "100",
-    validate: function (str) {
-      var n = Math.floor(Number(str));
-      if (n !== Infinity && String(n) === str && n > 0) {
-        // valid int was passed in
-        if (n + 5000 > balance) {
-          return `insufficient balance: current balance (${balance}) is less than ${
-            n + 5000
-          } (amount + 5000 for fee)`;
+  const { amount } = await prompts([
+    {
+      name: 'amount',
+      type: 'text',
+      message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
+      initial: '100',
+      validate: function (str) {
+        var n = Math.floor(Number(str));
+        if (n !== Infinity && String(n) === str && n > 0) {
+          // valid int was passed in
+          if (n + 5000 > balance) {
+            return `insufficient balance: current balance (${balance}) is less than ${
+              n + 5000
+            } (amount + 5000 for fee)`;
+          }
+          return true;
+        } else {
+          return 'amount must be a strictly positive integer';
         }
-        return true;
-      } else {
-        return "amount must be a strictly positive integer";
-      }
+      },
     },
-  });
+  ]);
 
   const transaction = await createTransfer({
     fromAddress: solAddress,

--- a/examples/with-solana/src/index.ts
+++ b/examples/with-solana/src/index.ts
@@ -74,17 +74,13 @@ async function main() {
       ].join("\n")
     );
     // Await user confirmation to continue
-    const { ready } = await prompts({
-      type: 'confirm',
-      name: 'ready',
-      message: 'Ready to Continue?',
-    });
-
-    // Check if the user is ready to continue
-    if (!ready) {
-      console.log('Waiting for your confirmation...');
-      continue;
-    }
+    await prompts([
+      {
+        type: "confirm",
+        name: "ready",
+        message: "Ready to Continue?",
+      },
+    ]);
 
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
@@ -95,10 +91,10 @@ async function main() {
   // 1. Sign and verify a message
   const { message } = await prompts([
     {
-      type: 'text',
-      name: 'message',
-      message: 'Message to sign',
-      initial: 'Hello Turnkey',
+      type: "text",
+      name: "message",
+      message: "Message to sign",
+      initial: "Hello Turnkey",
     },
   ]);
   const messageAsUint8Array = Buffer.from(message);
@@ -138,8 +134,8 @@ async function main() {
   // 2. Create, sign, and verify a transfer transaction
   const { destination } = await prompts([
     {
-      name: 'destination',
-      type: 'text',
+      name: "destination",
+      type: "text",
       message: `Destination address:`,
       initial: TURNKEY_WAR_CHEST,
     },
@@ -149,10 +145,10 @@ async function main() {
   // Any other amount is possible.
   const { amount } = await prompts([
     {
-      name: 'amount',
-      type: 'text',
+      name: "amount",
+      type: "text",
       message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-      initial: '100',
+      initial: "100",
       validate: function (str) {
         var n = Math.floor(Number(str));
         if (n !== Infinity && String(n) === str && n > 0) {
@@ -164,7 +160,7 @@ async function main() {
           }
           return true;
         } else {
-          return 'amount must be a strictly positive integer';
+          return "amount must be a strictly positive integer";
         }
       },
     },

--- a/examples/with-solana/src/index.ts
+++ b/examples/with-solana/src/index.ts
@@ -1,8 +1,7 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
 import nacl from "tweetnacl";
-import bs58 from "bs58";
-import { input, confirm } from "@inquirer/prompts";
+import prompts from "prompts";
 import { Transaction } from "@solana/web3.js";
 
 // Load environment variables from `.env.local`
@@ -73,7 +72,7 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await confirm({ message: "Ready to Continue?" });
+    await prompts({ message: "Ready to Continue?" });
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -81,7 +80,7 @@ async function main() {
   print("SOL balance:", `${balance} Lamports`);
 
   // 1. Sign and verify a message
-  const message = await input({
+  const message = await prompts({
     message: "Message to sign",
     default: "Hello Turnkey",
   });
@@ -120,14 +119,14 @@ async function main() {
   print("Turnkey-powered signature:", `${bs58.encode(signature)}`);
 
   // 2. Create, sign, and verify a transfer transaction
-  const destination = await input({
+  const destination = await prompts({
     message: `Destination address:`,
     default: TURNKEY_WAR_CHEST,
   });
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await input({
+  const amount = await prompts({
     message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
     default: "100",
     validate: function (str) {

--- a/examples/with-solana/src/tokenTransfer.ts
+++ b/examples/with-solana/src/tokenTransfer.ts
@@ -60,7 +60,18 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await prompts({ message: "Ready to Continue?" });
+    // Await user confirmation to continue
+    const { ready } = await prompts({
+      type: 'confirm',
+      name: 'ready',
+      message: 'Ready to Continue?',
+    });
+
+    // Check if the user is ready to continue
+    if (!ready) {
+      console.log('Waiting for your confirmation...');
+      continue;
+    }
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }

--- a/examples/with-solana/src/tokenTransfer.ts
+++ b/examples/with-solana/src/tokenTransfer.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 // Load environment variables from `.env.local`
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
-import { confirm } from "@inquirer/prompts";
+import prompts from "prompts";
 import { PublicKey } from "@solana/web3.js";
 import { getAccount, getAssociatedTokenAddress } from "@solana/spl-token";
 
@@ -60,7 +60,7 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await confirm({ message: "Ready to Continue?" });
+    await prompts({ message: "Ready to Continue?" });
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }

--- a/examples/with-solana/src/tokenTransfer.ts
+++ b/examples/with-solana/src/tokenTransfer.ts
@@ -61,17 +61,14 @@ async function main() {
       ].join("\n")
     );
     // Await user confirmation to continue
-    const { ready } = await prompts({
-      type: 'confirm',
-      name: 'ready',
-      message: 'Ready to Continue?',
-    });
+    await prompts([
+      {
+        type: "confirm",
+        name: "ready",
+        message: "Ready to Continue?",
+      },
+    ]);
 
-    // Check if the user is ready to continue
-    if (!ready) {
-      console.log('Waiting for your confirmation...');
-      continue;
-    }
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }

--- a/examples/with-solana/src/utils/handleActivityError.ts
+++ b/examples/with-solana/src/utils/handleActivityError.ts
@@ -15,10 +15,14 @@ export async function handleActivityError(turnkeyClient: Turnkey, error: any) {
     while (!TERMINAL_ACTIVITY_STATUSES.includes(activityStatus)) {
       console.log("\nWaiting for consensus...\n");
 
-      const retry = await prompts({
-        message: "Consensus reached? y/n",
-        default: "y",
-      });
+      const { retry } = await prompts([
+        {
+          type: "text",
+          name: "retry",
+          message: "Consensus reached? y/n",
+          initial: "y",
+        },
+      ]);
 
       if (retry === "n") {
         continue;

--- a/examples/with-solana/src/utils/handleActivityError.ts
+++ b/examples/with-solana/src/utils/handleActivityError.ts
@@ -1,4 +1,4 @@
-import { input } from "@inquirer/prompts";
+import prompts from "prompts";
 import {
   TurnkeyActivityConsensusNeededError,
   TERMINAL_ACTIVITY_STATUSES,
@@ -15,7 +15,7 @@ export async function handleActivityError(turnkeyClient: Turnkey, error: any) {
     while (!TERMINAL_ACTIVITY_STATUSES.includes(activityStatus)) {
       console.log("\nWaiting for consensus...\n");
 
-      const retry = await input({
+      const retry = await prompts({
         message: "Consensus reached? y/n",
         default: "y",
       });

--- a/examples/with-solana/src/withFeePayer.ts
+++ b/examples/with-solana/src/withFeePayer.ts
@@ -90,7 +90,7 @@ async function main() {
   print("SOL balance:", `${balance} Lamports`);
 
   // 1. Create, sign, and verify a transfer transaction
-  const destination = await prompts([
+  const { destination } = await prompts([
     {
       type: 'text',
       name: 'destination',
@@ -101,7 +101,7 @@ async function main() {
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await prompts([
+  const { amount } = await prompts([
     {
       type: 'text',
       name: 'amount',

--- a/examples/with-solana/src/withFeePayer.ts
+++ b/examples/with-solana/src/withFeePayer.ts
@@ -69,7 +69,20 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await prompts({ message: "Ready to Continue?" });
+    // Await user confirmation to continue
+    const { ready } = await prompts([
+      {
+        type: 'confirm',
+        name: 'ready',
+        message: 'Ready to Continue?',
+      }
+    ]);
+
+    // Check if the user is ready to continue
+    if (!ready) {
+      console.log('Waiting for your confirmation...');
+      continue;
+    }
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -77,31 +90,39 @@ async function main() {
   print("SOL balance:", `${balance} Lamports`);
 
   // 1. Create, sign, and verify a transfer transaction
-  const destination = await prompts({
-    message: `Destination address:`,
-    default: TURNKEY_WAR_CHEST,
-  });
+  const destination = await prompts([
+    {
+      type: 'text',
+      name: 'destination',
+      message: `Destination address:`,
+      default: TURNKEY_WAR_CHEST,
+    }]
+  );
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await prompts({
-    message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-    default: "100",
-    validate: function (str) {
-      var n = Math.floor(Number(str));
-      if (n !== Infinity && String(n) === str && n > 0) {
-        // valid int was passed in
-        if (n + 5000 > balance) {
-          return `insufficient balance: current balance (${balance}) is less than ${
-            n + 5000
-          } (amount + 5000 for fee)`;
+  const amount = await prompts([
+    {
+      type: 'text',
+      name: 'amount',
+      message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
+      default: "100",
+      validate: function (str) {
+        var n = Math.floor(Number(str));
+        if (n !== Infinity && String(n) === str && n > 0) {
+          // valid int was passed in
+          if (n + 5000 > balance) {
+            return `insufficient balance: current balance (${balance}) is less than ${
+              n + 5000
+            } (amount + 5000 for fee)`;
+          }
+          return true;
+        } else {
+          return "amount must be a strictly positive integer";
         }
-        return true;
-      } else {
-        return "amount must be a strictly positive integer";
-      }
-    },
-  });
+      },
+    }]
+  );
 
   const transaction = await createTransfer({
     fromAddress: solAddress,

--- a/examples/with-solana/src/withFeePayer.ts
+++ b/examples/with-solana/src/withFeePayer.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
-import { input, confirm } from "@inquirer/prompts";
+import prompts from "prompts";
 import { VersionedTransaction } from "@solana/web3.js";
 
 // Load environment variables from `.env.local`
@@ -69,7 +69,7 @@ async function main() {
         `\n--------`,
       ].join("\n")
     );
-    await confirm({ message: "Ready to Continue?" });
+    await prompts({ message: "Ready to Continue?" });
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -77,14 +77,14 @@ async function main() {
   print("SOL balance:", `${balance} Lamports`);
 
   // 1. Create, sign, and verify a transfer transaction
-  const destination = await input({
+  const destination = await prompts({
     message: `Destination address:`,
     default: TURNKEY_WAR_CHEST,
   });
 
   // Amount defaults to 100.
   // Any other amount is possible.
-  const amount = await input({
+  const amount = await prompts({
     message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
     default: "100",
     validate: function (str) {

--- a/examples/with-solana/src/withFeePayer.ts
+++ b/examples/with-solana/src/withFeePayer.ts
@@ -70,19 +70,14 @@ async function main() {
       ].join("\n")
     );
     // Await user confirmation to continue
-    const { ready } = await prompts([
+    await prompts([
       {
-        type: 'confirm',
-        name: 'ready',
-        message: 'Ready to Continue?',
-      }
+        type: "confirm",
+        name: "ready",
+        message: "Ready to Continue?",
+      },
     ]);
 
-    // Check if the user is ready to continue
-    if (!ready) {
-      console.log('Waiting for your confirmation...');
-      continue;
-    }
     // refresh balance...
     balance = await solanaNetwork.balance(connection, solAddress);
   }
@@ -92,19 +87,19 @@ async function main() {
   // 1. Create, sign, and verify a transfer transaction
   const { destination } = await prompts([
     {
-      type: 'text',
-      name: 'destination',
+      type: "text",
+      name: "destination",
       message: `Destination address:`,
       default: TURNKEY_WAR_CHEST,
-    }]
-  );
+    },
+  ]);
 
   // Amount defaults to 100.
   // Any other amount is possible.
   const { amount } = await prompts([
     {
-      type: 'text',
-      name: 'amount',
+      type: "text",
+      name: "amount",
       message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
       default: "100",
       validate: function (str) {
@@ -121,8 +116,8 @@ async function main() {
           return "amount must be a strictly positive integer";
         }
       },
-    }]
-  );
+    },
+  ]);
 
   const transaction = await createTransfer({
     fromAddress: solAddress,

--- a/examples/with-solana/src/withFeePayer.ts
+++ b/examples/with-solana/src/withFeePayer.ts
@@ -90,7 +90,7 @@ async function main() {
       type: "text",
       name: "destination",
       message: `Destination address:`,
-      default: TURNKEY_WAR_CHEST,
+      initial: TURNKEY_WAR_CHEST,
     },
   ]);
 
@@ -101,7 +101,7 @@ async function main() {
       type: "text",
       name: "amount",
       message: `Amount (in Lamports) to send to ${TURNKEY_WAR_CHEST}:`,
-      default: "100",
+      initial: "100",
       validate: function (str) {
         var n = Math.floor(Number(str));
         if (n !== Infinity && String(n) === str && n > 0) {

--- a/examples/with-sui/package.json
+++ b/examples/with-sui/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.8",
+    "@types/prompts": "^2.4.2",
     "tsx": "^3.12.7",
     "typescript": "^5.0.4"
   }

--- a/examples/with-sui/package.json
+++ b/examples/with-sui/package.json
@@ -8,14 +8,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@inquirer/prompts": "^2.1.0",
     "@mysten/sui.js": "^0.37.1",
     "@noble/hashes": "1.4.0",
     "@turnkey/http": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
     "async-retry": "^1.3.3",
     "cross-fetch": "^4.0.0",
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "prompts": "^2.4.2"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.8",

--- a/examples/with-sui/src/index.ts
+++ b/examples/with-sui/src/index.ts
@@ -79,7 +79,7 @@ async function main() {
       type: "text",
       name: "recipientAddress",
       message: "Recipient address:",
-      default: "<recipient_sui_address>",
+      initial: "<recipient_sui_address>",
     },
   ]);
 

--- a/examples/with-sui/src/index.ts
+++ b/examples/with-sui/src/index.ts
@@ -9,7 +9,7 @@ import {
   IntentScope,
   toSerializedSignature,
 } from "@mysten/sui.js";
-import { input } from "@inquirer/prompts";
+import prompts from "prompts";
 import { Turnkey } from "@turnkey/sdk-server";
 import { blake2b } from "@noble/hashes/blake2b";
 import { bytesToHex } from "@noble/hashes/utils";
@@ -74,10 +74,14 @@ async function main() {
   }
 
   // Create and sign a transaction
-  const recipientAddress = await input({
-    message: "Recipient address:",
-    default: "<recipient_sui_address>",
-  });
+  const { recipientAddress } = await prompts([
+    {
+      type: "text",
+      name: "recipientAddress",
+      message: "Recipient address:",
+      default: "<recipient_sui_address>",
+    },
+  ]);
 
   const amount = 1000n; // 1,000 MIST (minimum practical amount)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,7 +949,7 @@ importers:
     dependencies:
       '@safe-global/protocol-kit':
         specifier: ^3.0.1
-        version: 3.0.1(typescript@5.1.5)
+        version: 3.0.1(typescript@5.6.3)
       '@safe-global/safe-core-sdk-types':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1007,15 +1007,12 @@ importers:
 
   examples/with-solana:
     dependencies:
-      '@inquirer/prompts':
-        specifier: ^2.1.0
-        version: 2.1.0
       '@project-serum/anchor':
         specifier: ^0.26.0
         version: 0.26.0
       '@solana/spl-token':
         specifier: ^0.4.8
-        version: 0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
+        version: 0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/web3.js':
         specifier: ^1.88.1
         version: 1.95.1(encoding@0.1.13)
@@ -1043,6 +1040,9 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
@@ -1050,6 +1050,15 @@ importers:
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.3.1)(typescript@5.6.3)
+      tsx:
+        specifier: ^4.19.1
+        version: 4.19.1
+      typescript:
+        specifier: ^5.6.3
+        version: 5.6.3
 
   examples/with-solana-passkeys:
     dependencies:
@@ -1515,7 +1524,7 @@ importers:
         version: 4.9.0
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.1.5)
+        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.6.3)
       '@typechain/hardhat':
         specifier: ^9.1.0
         version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2)
@@ -1524,10 +1533,10 @@ importers:
         version: 6.10.0
       hardhat:
         specifier: ^2.19.4
-        version: 2.19.4(typescript@5.1.5)
+        version: 2.19.4(typescript@5.6.3)
       typechain:
         specifier: ^8.3.2
-        version: 8.3.2(typescript@5.1.5)
+        version: 8.3.2(typescript@5.6.3)
 
   packages/http:
     dependencies:
@@ -5016,6 +5025,13 @@ packages:
     resolution: {integrity: sha512-nNcycZWUYLNJlrIXgpcgVRqdl6BXjF4YlXdxobQWpW9Tikk61bEGeAFhDYtC0PwHlokCNw0KxWiHGJL4nL7Q5A==}
     dev: false
 
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
   /@emurgo/cardano-serialization-lib-browser@11.5.0:
     resolution: {integrity: sha512-qchOJ9NYDUz10tzs5r5QhP9hK0p+ZOlRiBwPdTAxqAYLw/8emYBkQQLaS8T1DF6EkeudyrgS00ym5Trw1fo4iA==}
     dev: false
@@ -5028,7 +5044,7 @@ packages:
     resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
     dependencies:
       '@esbuild-kit/core-utils': 3.1.0
-      get-tsconfig: 4.5.0
+      get-tsconfig: 4.8.1
     dev: true
 
   /@esbuild-kit/core-utils@3.1.0:
@@ -5042,12 +5058,30 @@ packages:
     resolution: {integrity: sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==}
     dependencies:
       '@esbuild-kit/core-utils': 3.1.0
-      get-tsconfig: 4.5.0
+      get-tsconfig: 4.8.1
     dev: true
+
+  /@esbuild/aix-ppc64@0.23.1:
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@esbuild/android-arm64@0.17.18:
     resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.23.1:
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -5063,9 +5097,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.23.1:
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.17.18:
     resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.23.1:
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
@@ -5081,9 +5133,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.23.1:
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.17.18:
     resolution: {integrity: sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.23.1:
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -5099,9 +5169,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.23.1:
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.17.18:
     resolution: {integrity: sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.23.1:
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -5117,9 +5205,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.23.1:
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.17.18:
     resolution: {integrity: sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.23.1:
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -5135,9 +5241,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.23.1:
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.17.18:
     resolution: {integrity: sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.23.1:
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
@@ -5153,9 +5277,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.23.1:
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.17.18:
     resolution: {integrity: sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.23.1:
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -5171,9 +5313,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.23.1:
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.17.18:
     resolution: {integrity: sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.23.1:
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -5189,6 +5349,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.23.1:
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.17.18:
     resolution: {integrity: sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==}
     engines: {node: '>=12'}
@@ -5198,9 +5367,36 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.23.1:
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.17.18:
     resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
@@ -5216,9 +5412,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.23.1:
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.17.18:
     resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.23.1:
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -5234,9 +5448,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.23.1:
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.17.18:
     resolution: {integrity: sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.23.1:
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -6407,6 +6639,13 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /@keystonehq/alias-sampling@0.1.2:
     resolution: {integrity: sha512-5ukLB3bcgltgaFfQfYKYwHDUbwHicekYo53fSEa7xhVkAEqsA74kxdIwoBIURmGUtXe3EVIRm4SYlgcrt2Ri0w==}
     dev: false
@@ -7185,7 +7424,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 6.10.0
-      hardhat: 2.19.4(typescript@5.1.5)
+      hardhat: 2.19.4(typescript@5.6.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -7197,7 +7436,7 @@ packages:
       hardhat: ^2.9.5
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.19.4(typescript@5.1.5)
+      hardhat: 2.19.4(typescript@5.6.3)
     dev: true
 
   /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0:
@@ -9770,7 +10009,7 @@ packages:
   /@rushstack/eslint-patch@1.9.0:
     resolution: {integrity: sha512-AAWymnpvHbGty1BmgbdfbqQDboXs6xN6h2yAacO4yKVyyUUBnpYkp+P9jjPrV9zrAGw7JVVriRtGOHPInnfjZQ==}
 
-  /@safe-global/protocol-kit@3.0.1(typescript@5.1.5):
+  /@safe-global/protocol-kit@3.0.1(typescript@5.6.3):
     resolution: {integrity: sha512-7S2QCvIDw3NsErF0f8tIfiTBz32btCAkw7IYuQFPc+G7clLrvDNhDaZYSoDsa8F0EoEhn+605VA7XP//iL6AIg==}
     dependencies:
       '@noble/hashes': 1.4.0
@@ -9778,7 +10017,7 @@ packages:
       ethereumjs-util: 7.1.5
       ethers: 6.10.0
       semver: 7.5.4
-      web3: 4.7.0(typescript@5.1.5)
+      web3: 4.7.0(typescript@5.6.3)
       web3-core: 4.3.2
       web3-utils: 4.2.1
     transitivePeerDependencies:
@@ -10086,13 +10325,13 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-core@2.0.0-preview.4(typescript@5.1.5):
+  /@solana/codecs-core@2.0.0-preview.4(typescript@5.6.3):
     resolution: {integrity: sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
-      typescript: 5.1.5
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
+      typescript: 5.6.3
     dev: false
 
   /@solana/codecs-data-structures@2.0.0-preview.2:
@@ -10103,15 +10342,15 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.1.5):
+  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.6.3):
     resolution: {integrity: sha512-nt2k2eTeyzlI/ccutPcG36M/J8NAYfxBPI9h/nQjgJ+M+IgOKi31JV8StDDlG/1XvY0zyqugV3I0r3KAbZRJpA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
-      typescript: 5.1.5
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
+      typescript: 5.6.3
     dev: false
 
   /@solana/codecs-numbers@2.0.0-preview.2:
@@ -10121,14 +10360,14 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.1.5):
+  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.6.3):
     resolution: {integrity: sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
-      typescript: 5.1.5
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
+      typescript: 5.6.3
     dev: false
 
   /@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -10142,17 +10381,17 @@ packages:
       fastestsmallesttextencoderdecoder: 1.0.22
     dev: false
 
-  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
+  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
     resolution: {integrity: sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.1.5
+      typescript: 5.6.3
     dev: false
 
   /@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -10167,17 +10406,17 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
+  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
     resolution: {integrity: sha512-gLMupqI4i+G4uPi2SGF/Tc1aXcviZF2ybC81x7Q/fARamNSgNOCUUoSCg9nWu1Gid6+UhA7LH80sWI8XjKaRog==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
-      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
-      typescript: 5.1.5
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
@@ -10190,7 +10429,7 @@ packages:
       commander: 12.1.0
     dev: false
 
-  /@solana/errors@2.0.0-preview.4(typescript@5.1.5):
+  /@solana/errors@2.0.0-preview.4(typescript@5.6.3):
     resolution: {integrity: sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==}
     hasBin: true
     peerDependencies:
@@ -10198,7 +10437,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
-      typescript: 5.1.5
+      typescript: 5.6.3
     dev: false
 
   /@solana/options@2.0.0-preview.2:
@@ -10208,28 +10447,28 @@ packages:
       '@solana/codecs-numbers': 2.0.0-preview.2
     dev: false
 
-  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
+  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
     resolution: {integrity: sha512-tv2O/Frxql/wSe3jbzi5nVicIWIus/BftH+5ZR+r9r3FO0/htEllZS5Q9XdbmSboHu+St87584JXeDx3xm4jaA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
-      typescript: 5.1.5
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
+  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
     resolution: {integrity: sha512-CLJnWEcdoUBpQJfx9WEbX3h6nTdNiUzswfFdkABUik7HVwSNA98u5AYvBVK2H93d9PGMOHAak2lHW9xr+zAJGQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.94.0
     dependencies:
-      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
+      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/spl-type-length-value': 0.1.0
       '@solana/web3.js': 1.95.1(encoding@0.1.13)
     transitivePeerDependencies:
@@ -10250,7 +10489,7 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
+  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
     resolution: {integrity: sha512-RO0JD9vPRi4LsAbMUdNbDJ5/cv2z11MGhtAvFeRzT4+hAGE/FUzRi0tkkWtuCfSIU3twC6CtmAihRp/+XXjWsA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -10258,7 +10497,7 @@ packages:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0
-      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
+      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/web3.js': 1.95.1(encoding@0.1.13)
       buffer: 6.0.3
@@ -11628,11 +11867,27 @@ packages:
       wif: 4.0.0
     dev: false
 
+  /@tsconfig/node10@1.0.11:
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
   /@tsconfig/node16-strictest@1.0.4:
     resolution: {integrity: sha512-kp6/DuAoKzHVv5U+p0uOesYbjrEvrYVNdQMl163a+yXXUv9twabvkCGEn3pmVxKXB45JU5MPGolDDWnONZL5ZQ==}
     dev: true
 
-  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.1.5):
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
+  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.6.3):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
@@ -11641,9 +11896,9 @@ packages:
     dependencies:
       ethers: 6.10.0
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.1.5)
-      typechain: 8.3.2(typescript@5.1.5)
-      typescript: 5.1.5
+      ts-essentials: 7.0.3(typescript@5.6.3)
+      typechain: 8.3.2(typescript@5.6.3)
+      typescript: 5.6.3
     dev: true
 
   /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2):
@@ -11654,11 +11909,11 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.1.5)
+      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.6.3)
       ethers: 6.10.0
       fs-extra: 9.1.0
-      hardhat: 2.19.4(typescript@5.1.5)
-      typechain: 8.3.2(typescript@5.1.5)
+      hardhat: 2.19.4(typescript@5.6.3)
+      typechain: 8.3.2(typescript@5.6.3)
     dev: true
 
   /@types/async-eventemitter@0.2.1:
@@ -12796,7 +13051,7 @@ packages:
       typescript: 5.1.5
     dev: true
 
-  /abitype@0.7.1(typescript@5.1.5):
+  /abitype@0.7.1(typescript@5.6.3):
     resolution: {integrity: sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -12805,7 +13060,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.1.5
+      typescript: 5.6.3
     dev: false
 
   /abitype@0.9.8(typescript@5.1.3):
@@ -12882,6 +13137,13 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.12.1
+
+  /acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.12.1
+    dev: true
 
   /acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
@@ -13018,6 +13280,10 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: false
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -14487,6 +14753,10 @@ packages:
       - ts-node
     dev: true
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
@@ -14834,6 +15104,11 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /diff@5.0.0:
@@ -15194,6 +15469,38 @@ packages:
       '@esbuild/win32-arm64': 0.17.18
       '@esbuild/win32-ia32': 0.17.18
       '@esbuild/win32-x64': 0.17.18
+    dev: true
+
+  /esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
     dev: true
 
   /escalade@3.1.1:
@@ -16232,6 +16539,12 @@ packages:
   /get-tsconfig@4.5.0:
     resolution: {integrity: sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==}
 
+  /get-tsconfig@4.8.1:
+    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -16492,7 +16805,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /hardhat@2.19.4(typescript@5.1.5):
+  /hardhat@2.19.4(typescript@5.6.3):
     resolution: {integrity: sha512-fTQJpqSt3Xo9Mn/WrdblNGAfcANM6XC3tAEi6YogB4s02DmTf93A8QsGb8uR0KR8TFcpcS8lgiW4ugAIYpnbrQ==}
     hasBin: true
     peerDependencies:
@@ -16549,7 +16862,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 5.1.5
+      typescript: 5.6.3
       undici: 5.24.0
       uuid: 8.3.2
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -18370,6 +18683,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       semver: 7.5.4
+    dev: true
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
   /makeerror@1.0.12:
@@ -20564,6 +20881,10 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /resolve.exports@2.0.0:
     resolution: {integrity: sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==}
     engines: {node: '>=10'}
@@ -21853,12 +22174,12 @@ packages:
       string-format: 2.0.0
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.1.5):
+  /ts-essentials@7.0.3(typescript@5.6.3):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.1.5
+      typescript: 5.6.3
     dev: true
 
   /ts-interface-checker@0.1.13:
@@ -21867,6 +22188,37 @@ packages:
   /ts-mixer@6.0.4:
     resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
     dev: false
+
+  /ts-node@10.9.2(@types/node@20.3.1)(typescript@5.6.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.3.1
+      acorn: 8.12.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
 
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -21913,6 +22265,17 @@ packages:
       '@esbuild-kit/cjs-loader': 2.4.2
       '@esbuild-kit/core-utils': 3.1.0
       '@esbuild-kit/esm-loader': 2.5.5
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /tsx@4.19.1:
+    resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.8.1
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -21974,7 +22337,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typechain@8.3.2(typescript@5.1.5):
+  /typechain@8.3.2(typescript@5.6.3):
     resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
     hasBin: true
     peerDependencies:
@@ -21989,8 +22352,8 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.1.5)
-      typescript: 5.1.5
+      ts-essentials: 7.0.3(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22052,6 +22415,11 @@ packages:
 
   /typescript@5.1.5:
     resolution: {integrity: sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  /typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -22373,6 +22741,10 @@ packages:
       uuid: 8.3.2
     dev: false
 
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
   /v8-to-istanbul@9.1.0:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
     engines: {node: '>=10.12.0'}
@@ -22587,11 +22959,11 @@ packages:
       web3-types: 1.5.0
     dev: false
 
-  /web3-eth-abi@4.2.0(typescript@5.1.5):
+  /web3-eth-abi@4.2.0(typescript@5.6.3):
     resolution: {integrity: sha512-x7dUCmk6th+5N63s5kUusoNtsDJKUUQgl9+jECvGTBOTiyHe/V6aOY0120FUjaAGaapOnR7BImQdhqHv6yT2YQ==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
-      abitype: 0.7.1(typescript@5.1.5)
+      abitype: 0.7.1(typescript@5.6.3)
       web3-errors: 1.1.4
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -22614,14 +22986,14 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-contract@4.3.0(typescript@5.1.5):
+  /web3-eth-contract@4.3.0(typescript@5.6.3):
     resolution: {integrity: sha512-4fzSklA65zUn6SthU3T3tbVJacfP8/wkJmCuvmPaf2ZTFdnhsF96G5IQtCRf0+wASb4yk0A6IBvXZfk1B4R4HA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.1.5)
-      web3-eth-abi: 4.2.0(typescript@5.1.5)
+      web3-eth: 4.5.0(typescript@5.6.3)
+      web3-eth-abi: 4.2.0(typescript@5.6.3)
       web3-types: 1.5.0
       web3-utils: 4.2.1
       web3-validator: 2.0.5
@@ -22633,15 +23005,15 @@ packages:
       - zod
     dev: false
 
-  /web3-eth-ens@4.2.0(typescript@5.1.5):
+  /web3-eth-ens@4.2.0(typescript@5.6.3):
     resolution: {integrity: sha512-qYj34te2UctoObt8rlEIY/t2MuTMiMiiHhO2JAHRGqSLCQ7b8DM3RpvkiiSB0N0ZyEn+CetZqJCTYb8DNKBS/g==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.1.5)
-      web3-eth-contract: 4.3.0(typescript@5.1.5)
+      web3-eth: 4.5.0(typescript@5.6.3)
+      web3-eth-contract: 4.3.0(typescript@5.6.3)
       web3-net: 4.0.7
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -22664,12 +23036,12 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-personal@4.0.8(typescript@5.1.5):
+  /web3-eth-personal@4.0.8(typescript@5.6.3):
     resolution: {integrity: sha512-sXeyLKJ7ddQdMxz1BZkAwImjqh7OmKxhXoBNF3isDmD4QDpMIwv/t237S3q4Z0sZQamPa/pHebJRWVuvP8jZdw==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
-      web3-eth: 4.5.0(typescript@5.1.5)
+      web3-eth: 4.5.0(typescript@5.6.3)
       web3-rpc-methods: 1.2.0
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -22682,14 +23054,14 @@ packages:
       - zod
     dev: false
 
-  /web3-eth@4.5.0(typescript@5.1.5):
+  /web3-eth@4.5.0(typescript@5.6.3):
     resolution: {integrity: sha512-crisE46o/SHMVm+XHAXEaR8k76NCImq+hi0QQEJ+VaLZbDobI/Gvog1HwTukDUDRgnYSAFGqD0cTRyAwDurwpA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       setimmediate: 1.0.5
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth-abi: 4.2.0(typescript@5.1.5)
+      web3-eth-abi: 4.2.0(typescript@5.6.3)
       web3-eth-accounts: 4.1.1
       web3-net: 4.0.7
       web3-providers-ws: 4.0.7
@@ -22808,19 +23180,19 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /web3@4.7.0(typescript@5.1.5):
+  /web3@4.7.0(typescript@5.6.3):
     resolution: {integrity: sha512-3g+1e7B/IW0Nw9WP1dotrZKWD9o5IBfl27dxEnE1LxBZBax6ZkviiAwf18utIhlNBD07RgI+PPfKDXxfDBlHWA==}
     engines: {node: '>=14.0.0', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.1.5)
-      web3-eth-abi: 4.2.0(typescript@5.1.5)
+      web3-eth: 4.5.0(typescript@5.6.3)
+      web3-eth-abi: 4.2.0(typescript@5.6.3)
       web3-eth-accounts: 4.1.1
-      web3-eth-contract: 4.3.0(typescript@5.1.5)
-      web3-eth-ens: 4.2.0(typescript@5.1.5)
+      web3-eth-contract: 4.3.0(typescript@5.6.3)
+      web3-eth-ens: 4.2.0(typescript@5.6.3)
       web3-eth-iban: 4.0.7
-      web3-eth-personal: 4.0.8(typescript@5.1.5)
+      web3-eth-personal: 4.0.8(typescript@5.6.3)
       web3-net: 4.0.7
       web3-providers-http: 4.1.0
       web3-providers-ws: 4.0.7
@@ -23165,6 +23537,11 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,9 +255,6 @@ importers:
 
   examples/export-in-node:
     dependencies:
-      '@inquirer/prompts':
-        specifier: ^2.1.0
-        version: 2.1.0
       '@peculiar/webcrypto':
         specifier: ^1.5.0
         version: 1.5.0
@@ -279,6 +276,9 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
     devDependencies:
       '@types/async-retry':
         specifier: ^1.4.8
@@ -286,9 +286,6 @@ importers:
 
   examples/import-in-node:
     dependencies:
-      '@inquirer/prompts':
-        specifier: ^2.1.0
-        version: 2.1.0
       '@peculiar/webcrypto':
         specifier: ^1.5.0
         version: 1.5.0
@@ -310,6 +307,9 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
     devDependencies:
       '@types/async-retry':
         specifier: ^1.4.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8
+      '@types/prompts':
+        specifier: ^2.4.2
+        version: 2.4.2
 
   examples/import-in-node:
     dependencies:
@@ -314,6 +317,9 @@ importers:
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8
+      '@types/prompts':
+        specifier: ^2.4.2
+        version: 2.4.2
 
   examples/kitchen-sink:
     dependencies:
@@ -998,6 +1004,10 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+    devDependencies:
+      '@types/prompts':
+        specifier: ^2.4.2
+        version: 2.4.2
 
   examples/with-sdk-server:
     dependencies:
@@ -1012,7 +1022,7 @@ importers:
         version: 0.26.0
       '@solana/spl-token':
         specifier: ^0.4.8
-        version: 0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        version: 0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
       '@solana/web3.js':
         specifier: ^1.88.1
         version: 1.95.1(encoding@0.1.13)
@@ -1050,6 +1060,9 @@ importers:
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8
+      '@types/prompts':
+        specifier: ^2.4.2
+        version: 2.4.2
 
   examples/with-solana-passkeys:
     dependencies:
@@ -9859,13 +9872,13 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-core@2.0.0-preview.4(typescript@5.6.3):
+  /@solana/codecs-core@2.0.0-preview.4(typescript@5.1.5):
     resolution: {integrity: sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
-      typescript: 5.6.3
+      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
+      typescript: 5.1.5
     dev: false
 
   /@solana/codecs-data-structures@2.0.0-preview.2:
@@ -9876,15 +9889,15 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.6.3):
+  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.1.5):
     resolution: {integrity: sha512-nt2k2eTeyzlI/ccutPcG36M/J8NAYfxBPI9h/nQjgJ+M+IgOKi31JV8StDDlG/1XvY0zyqugV3I0r3KAbZRJpA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
-      typescript: 5.6.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
+      typescript: 5.1.5
     dev: false
 
   /@solana/codecs-numbers@2.0.0-preview.2:
@@ -9894,14 +9907,14 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.6.3):
+  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.1.5):
     resolution: {integrity: sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
-      typescript: 5.6.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
+      typescript: 5.1.5
     dev: false
 
   /@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -9915,17 +9928,17 @@ packages:
       fastestsmallesttextencoderdecoder: 1.0.22
     dev: false
 
-  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
     resolution: {integrity: sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.6.3
+      typescript: 5.1.5
     dev: false
 
   /@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -9940,17 +9953,17 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
     resolution: {integrity: sha512-gLMupqI4i+G4uPi2SGF/Tc1aXcviZF2ybC81x7Q/fARamNSgNOCUUoSCg9nWu1Gid6+UhA7LH80sWI8XjKaRog==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      typescript: 5.6.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
+      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
+      typescript: 5.1.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
@@ -9963,7 +9976,7 @@ packages:
       commander: 12.1.0
     dev: false
 
-  /@solana/errors@2.0.0-preview.4(typescript@5.6.3):
+  /@solana/errors@2.0.0-preview.4(typescript@5.1.5):
     resolution: {integrity: sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==}
     hasBin: true
     peerDependencies:
@@ -9971,7 +9984,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
-      typescript: 5.6.3
+      typescript: 5.1.5
     dev: false
 
   /@solana/options@2.0.0-preview.2:
@@ -9981,28 +9994,28 @@ packages:
       '@solana/codecs-numbers': 2.0.0-preview.2
     dev: false
 
-  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
     resolution: {integrity: sha512-tv2O/Frxql/wSe3jbzi5nVicIWIus/BftH+5ZR+r9r3FO0/htEllZS5Q9XdbmSboHu+St87584JXeDx3xm4jaA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.6.3)
-      typescript: 5.6.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.1.5)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.1.5)
+      typescript: 5.1.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
     resolution: {integrity: sha512-CLJnWEcdoUBpQJfx9WEbX3h6nTdNiUzswfFdkABUik7HVwSNA98u5AYvBVK2H93d9PGMOHAak2lHW9xr+zAJGQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.94.0
     dependencies:
-      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
       '@solana/spl-type-length-value': 0.1.0
       '@solana/web3.js': 1.95.1(encoding@0.1.13)
     transitivePeerDependencies:
@@ -10023,7 +10036,7 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5):
     resolution: {integrity: sha512-RO0JD9vPRi4LsAbMUdNbDJ5/cv2z11MGhtAvFeRzT4+hAGE/FUzRi0tkkWtuCfSIU3twC6CtmAihRp/+XXjWsA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -10031,7 +10044,7 @@ packages:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0
-      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.1.5)
       '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.95.1)(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/web3.js': 1.95.1(encoding@0.1.13)
       buffer: 6.0.3
@@ -21817,12 +21830,6 @@ packages:
     resolution: {integrity: sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  /typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: false
 
   /typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1170,6 +1170,9 @@ importers:
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8
+      '@types/prompts':
+        specifier: ^2.4.2
+        version: 2.4.2
       tsx:
         specifier: ^3.12.7
         version: 3.12.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,7 +949,7 @@ importers:
     dependencies:
       '@safe-global/protocol-kit':
         specifier: ^3.0.1
-        version: 3.0.1(typescript@5.6.3)
+        version: 3.0.1(typescript@5.1.5)
       '@safe-global/safe-core-sdk-types':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1050,15 +1050,6 @@ importers:
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.3.1)(typescript@5.6.3)
-      tsx:
-        specifier: ^4.19.1
-        version: 4.19.1
-      typescript:
-        specifier: ^5.6.3
-        version: 5.6.3
 
   examples/with-solana-passkeys:
     dependencies:
@@ -1524,7 +1515,7 @@ importers:
         version: 4.9.0
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.6.3)
+        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.1.5)
       '@typechain/hardhat':
         specifier: ^9.1.0
         version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2)
@@ -1533,10 +1524,10 @@ importers:
         version: 6.10.0
       hardhat:
         specifier: ^2.19.4
-        version: 2.19.4(typescript@5.6.3)
+        version: 2.19.4(typescript@5.1.5)
       typechain:
         specifier: ^8.3.2
-        version: 8.3.2(typescript@5.6.3)
+        version: 8.3.2(typescript@5.1.5)
 
   packages/http:
     dependencies:
@@ -5025,13 +5016,6 @@ packages:
     resolution: {integrity: sha512-nNcycZWUYLNJlrIXgpcgVRqdl6BXjF4YlXdxobQWpW9Tikk61bEGeAFhDYtC0PwHlokCNw0KxWiHGJL4nL7Q5A==}
     dev: false
 
-  /@cspotcode/source-map-support@0.8.1:
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
-    dev: true
-
   /@emurgo/cardano-serialization-lib-browser@11.5.0:
     resolution: {integrity: sha512-qchOJ9NYDUz10tzs5r5QhP9hK0p+ZOlRiBwPdTAxqAYLw/8emYBkQQLaS8T1DF6EkeudyrgS00ym5Trw1fo4iA==}
     dev: false
@@ -5061,27 +5045,9 @@ packages:
       get-tsconfig: 4.8.1
     dev: true
 
-  /@esbuild/aix-ppc64@0.23.1:
-    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm64@0.17.18:
     resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm64@0.23.1:
-    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
-    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -5097,27 +5063,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.23.1:
-    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-x64@0.17.18:
     resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.23.1:
-    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
@@ -5133,27 +5081,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.23.1:
-    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/darwin-x64@0.17.18:
     resolution: {integrity: sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.23.1:
-    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -5169,27 +5099,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.23.1:
-    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/freebsd-x64@0.17.18:
     resolution: {integrity: sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.23.1:
-    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -5205,27 +5117,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.23.1:
-    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-arm@0.17.18:
     resolution: {integrity: sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==}
     engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.23.1:
-    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
-    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -5241,27 +5135,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.23.1:
-    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-loong64@0.17.18:
     resolution: {integrity: sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==}
     engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.23.1:
-    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
-    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
@@ -5277,27 +5153,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.23.1:
-    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-ppc64@0.17.18:
     resolution: {integrity: sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==}
     engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.23.1:
-    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
-    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -5313,27 +5171,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.23.1:
-    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-s390x@0.17.18:
     resolution: {integrity: sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==}
     engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.23.1:
-    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
-    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -5349,15 +5189,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.23.1:
-    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/netbsd-x64@0.17.18:
     resolution: {integrity: sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==}
     engines: {node: '>=12'}
@@ -5367,36 +5198,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.23.1:
-    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-arm64@0.23.1:
-    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/openbsd-x64@0.17.18:
     resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.23.1:
-    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
@@ -5412,27 +5216,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.23.1:
-    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-arm64@0.17.18:
     resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.23.1:
-    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
-    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -5448,27 +5234,9 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.23.1:
-    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-x64@0.17.18:
     resolution: {integrity: sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.23.1:
-    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -6412,13 +6180,6 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@jridgewell/trace-mapping@0.3.9:
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
-
   /@keystonehq/alias-sampling@0.1.2:
     resolution: {integrity: sha512-5ukLB3bcgltgaFfQfYKYwHDUbwHicekYo53fSEa7xhVkAEqsA74kxdIwoBIURmGUtXe3EVIRm4SYlgcrt2Ri0w==}
     dev: false
@@ -7197,7 +6958,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 6.10.0
-      hardhat: 2.19.4(typescript@5.6.3)
+      hardhat: 2.19.4(typescript@5.1.5)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -7209,7 +6970,7 @@ packages:
       hardhat: ^2.9.5
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.19.4(typescript@5.6.3)
+      hardhat: 2.19.4(typescript@5.1.5)
     dev: true
 
   /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0:
@@ -9782,7 +9543,7 @@ packages:
   /@rushstack/eslint-patch@1.9.0:
     resolution: {integrity: sha512-AAWymnpvHbGty1BmgbdfbqQDboXs6xN6h2yAacO4yKVyyUUBnpYkp+P9jjPrV9zrAGw7JVVriRtGOHPInnfjZQ==}
 
-  /@safe-global/protocol-kit@3.0.1(typescript@5.6.3):
+  /@safe-global/protocol-kit@3.0.1(typescript@5.1.5):
     resolution: {integrity: sha512-7S2QCvIDw3NsErF0f8tIfiTBz32btCAkw7IYuQFPc+G7clLrvDNhDaZYSoDsa8F0EoEhn+605VA7XP//iL6AIg==}
     dependencies:
       '@noble/hashes': 1.4.0
@@ -9790,7 +9551,7 @@ packages:
       ethereumjs-util: 7.1.5
       ethers: 6.10.0
       semver: 7.5.4
-      web3: 4.7.0(typescript@5.6.3)
+      web3: 4.7.0(typescript@5.1.5)
       web3-core: 4.3.2
       web3-utils: 4.2.1
     transitivePeerDependencies:
@@ -11640,27 +11401,11 @@ packages:
       wif: 4.0.0
     dev: false
 
-  /@tsconfig/node10@1.0.11:
-    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
-    dev: true
-
-  /@tsconfig/node12@1.0.11:
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-    dev: true
-
-  /@tsconfig/node14@1.0.3:
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-    dev: true
-
   /@tsconfig/node16-strictest@1.0.4:
     resolution: {integrity: sha512-kp6/DuAoKzHVv5U+p0uOesYbjrEvrYVNdQMl163a+yXXUv9twabvkCGEn3pmVxKXB45JU5MPGolDDWnONZL5ZQ==}
     dev: true
 
-  /@tsconfig/node16@1.0.4:
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-    dev: true
-
-  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.6.3):
+  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.1.5):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
@@ -11669,9 +11414,9 @@ packages:
     dependencies:
       ethers: 6.10.0
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.6.3)
-      typechain: 8.3.2(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-essentials: 7.0.3(typescript@5.1.5)
+      typechain: 8.3.2(typescript@5.1.5)
+      typescript: 5.1.5
     dev: true
 
   /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2):
@@ -11682,11 +11427,11 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.6.3)
+      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.1.5)
       ethers: 6.10.0
       fs-extra: 9.1.0
-      hardhat: 2.19.4(typescript@5.6.3)
-      typechain: 8.3.2(typescript@5.6.3)
+      hardhat: 2.19.4(typescript@5.1.5)
+      typechain: 8.3.2(typescript@5.1.5)
     dev: true
 
   /@types/async-eventemitter@0.2.1:
@@ -12824,7 +12569,7 @@ packages:
       typescript: 5.1.5
     dev: true
 
-  /abitype@0.7.1(typescript@5.6.3):
+  /abitype@0.7.1(typescript@5.1.5):
     resolution: {integrity: sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -12833,7 +12578,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.1.5
     dev: false
 
   /abitype@0.9.8(typescript@5.1.3):
@@ -12910,13 +12655,6 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.12.1
-
-  /acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
-    engines: {node: '>=0.4.0'}
-    dependencies:
-      acorn: 8.12.1
-    dev: true
 
   /acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
@@ -13053,10 +12791,6 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: false
-
-  /arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
-    dev: true
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -14522,10 +14256,6 @@ packages:
       - ts-node
     dev: true
 
-  /create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-    dev: true
-
   /cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
@@ -14873,11 +14603,6 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
-
-  /diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
     dev: true
 
   /diff@5.0.0:
@@ -15238,38 +14963,6 @@ packages:
       '@esbuild/win32-arm64': 0.17.18
       '@esbuild/win32-ia32': 0.17.18
       '@esbuild/win32-x64': 0.17.18
-    dev: true
-
-  /esbuild@0.23.1:
-    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
-    engines: {node: '>=18'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.23.1
-      '@esbuild/android-arm': 0.23.1
-      '@esbuild/android-arm64': 0.23.1
-      '@esbuild/android-x64': 0.23.1
-      '@esbuild/darwin-arm64': 0.23.1
-      '@esbuild/darwin-x64': 0.23.1
-      '@esbuild/freebsd-arm64': 0.23.1
-      '@esbuild/freebsd-x64': 0.23.1
-      '@esbuild/linux-arm': 0.23.1
-      '@esbuild/linux-arm64': 0.23.1
-      '@esbuild/linux-ia32': 0.23.1
-      '@esbuild/linux-loong64': 0.23.1
-      '@esbuild/linux-mips64el': 0.23.1
-      '@esbuild/linux-ppc64': 0.23.1
-      '@esbuild/linux-riscv64': 0.23.1
-      '@esbuild/linux-s390x': 0.23.1
-      '@esbuild/linux-x64': 0.23.1
-      '@esbuild/netbsd-x64': 0.23.1
-      '@esbuild/openbsd-arm64': 0.23.1
-      '@esbuild/openbsd-x64': 0.23.1
-      '@esbuild/sunos-x64': 0.23.1
-      '@esbuild/win32-arm64': 0.23.1
-      '@esbuild/win32-ia32': 0.23.1
-      '@esbuild/win32-x64': 0.23.1
     dev: true
 
   /escalade@3.1.1:
@@ -16568,7 +16261,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /hardhat@2.19.4(typescript@5.6.3):
+  /hardhat@2.19.4(typescript@5.1.5):
     resolution: {integrity: sha512-fTQJpqSt3Xo9Mn/WrdblNGAfcANM6XC3tAEi6YogB4s02DmTf93A8QsGb8uR0KR8TFcpcS8lgiW4ugAIYpnbrQ==}
     hasBin: true
     peerDependencies:
@@ -16625,7 +16318,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 5.6.3
+      typescript: 5.1.5
       undici: 5.24.0
       uuid: 8.3.2
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -18446,10 +18139,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       semver: 7.5.4
-    dev: true
-
-  /make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
   /makeerror@1.0.12:
@@ -21927,12 +21616,12 @@ packages:
       string-format: 2.0.0
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.6.3):
+  /ts-essentials@7.0.3(typescript@5.1.5):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.1.5
     dev: true
 
   /ts-interface-checker@0.1.13:
@@ -21941,37 +21630,6 @@ packages:
   /ts-mixer@6.0.4:
     resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
     dev: false
-
-  /ts-node@10.9.2(@types/node@20.3.1)(typescript@5.6.3):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.3.1
-      acorn: 8.12.1
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.6.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
 
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -22018,17 +21676,6 @@ packages:
       '@esbuild-kit/cjs-loader': 2.4.2
       '@esbuild-kit/core-utils': 3.1.0
       '@esbuild-kit/esm-loader': 2.5.5
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /tsx@4.19.1:
-    resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    dependencies:
-      esbuild: 0.23.1
-      get-tsconfig: 4.8.1
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -22090,7 +21737,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typechain@8.3.2(typescript@5.6.3):
+  /typechain@8.3.2(typescript@5.1.5):
     resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
     hasBin: true
     peerDependencies:
@@ -22105,8 +21752,8 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-essentials: 7.0.3(typescript@5.1.5)
+      typescript: 5.1.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22175,6 +21822,7 @@ packages:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: false
 
   /typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
@@ -22494,10 +22142,6 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-    dev: true
-
   /v8-to-istanbul@9.1.0:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
     engines: {node: '>=10.12.0'}
@@ -22712,11 +22356,11 @@ packages:
       web3-types: 1.5.0
     dev: false
 
-  /web3-eth-abi@4.2.0(typescript@5.6.3):
+  /web3-eth-abi@4.2.0(typescript@5.1.5):
     resolution: {integrity: sha512-x7dUCmk6th+5N63s5kUusoNtsDJKUUQgl9+jECvGTBOTiyHe/V6aOY0120FUjaAGaapOnR7BImQdhqHv6yT2YQ==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
-      abitype: 0.7.1(typescript@5.6.3)
+      abitype: 0.7.1(typescript@5.1.5)
       web3-errors: 1.1.4
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -22739,14 +22383,14 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-contract@4.3.0(typescript@5.6.3):
+  /web3-eth-contract@4.3.0(typescript@5.1.5):
     resolution: {integrity: sha512-4fzSklA65zUn6SthU3T3tbVJacfP8/wkJmCuvmPaf2ZTFdnhsF96G5IQtCRf0+wASb4yk0A6IBvXZfk1B4R4HA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.6.3)
-      web3-eth-abi: 4.2.0(typescript@5.6.3)
+      web3-eth: 4.5.0(typescript@5.1.5)
+      web3-eth-abi: 4.2.0(typescript@5.1.5)
       web3-types: 1.5.0
       web3-utils: 4.2.1
       web3-validator: 2.0.5
@@ -22758,15 +22402,15 @@ packages:
       - zod
     dev: false
 
-  /web3-eth-ens@4.2.0(typescript@5.6.3):
+  /web3-eth-ens@4.2.0(typescript@5.1.5):
     resolution: {integrity: sha512-qYj34te2UctoObt8rlEIY/t2MuTMiMiiHhO2JAHRGqSLCQ7b8DM3RpvkiiSB0N0ZyEn+CetZqJCTYb8DNKBS/g==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.6.3)
-      web3-eth-contract: 4.3.0(typescript@5.6.3)
+      web3-eth: 4.5.0(typescript@5.1.5)
+      web3-eth-contract: 4.3.0(typescript@5.1.5)
       web3-net: 4.0.7
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -22789,12 +22433,12 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-personal@4.0.8(typescript@5.6.3):
+  /web3-eth-personal@4.0.8(typescript@5.1.5):
     resolution: {integrity: sha512-sXeyLKJ7ddQdMxz1BZkAwImjqh7OmKxhXoBNF3isDmD4QDpMIwv/t237S3q4Z0sZQamPa/pHebJRWVuvP8jZdw==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
-      web3-eth: 4.5.0(typescript@5.6.3)
+      web3-eth: 4.5.0(typescript@5.1.5)
       web3-rpc-methods: 1.2.0
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -22807,14 +22451,14 @@ packages:
       - zod
     dev: false
 
-  /web3-eth@4.5.0(typescript@5.6.3):
+  /web3-eth@4.5.0(typescript@5.1.5):
     resolution: {integrity: sha512-crisE46o/SHMVm+XHAXEaR8k76NCImq+hi0QQEJ+VaLZbDobI/Gvog1HwTukDUDRgnYSAFGqD0cTRyAwDurwpA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       setimmediate: 1.0.5
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth-abi: 4.2.0(typescript@5.6.3)
+      web3-eth-abi: 4.2.0(typescript@5.1.5)
       web3-eth-accounts: 4.1.1
       web3-net: 4.0.7
       web3-providers-ws: 4.0.7
@@ -22933,19 +22577,19 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /web3@4.7.0(typescript@5.6.3):
+  /web3@4.7.0(typescript@5.1.5):
     resolution: {integrity: sha512-3g+1e7B/IW0Nw9WP1dotrZKWD9o5IBfl27dxEnE1LxBZBax6ZkviiAwf18utIhlNBD07RgI+PPfKDXxfDBlHWA==}
     engines: {node: '>=14.0.0', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.6.3)
-      web3-eth-abi: 4.2.0(typescript@5.6.3)
+      web3-eth: 4.5.0(typescript@5.1.5)
+      web3-eth-abi: 4.2.0(typescript@5.1.5)
       web3-eth-accounts: 4.1.1
-      web3-eth-contract: 4.3.0(typescript@5.6.3)
-      web3-eth-ens: 4.2.0(typescript@5.6.3)
+      web3-eth-contract: 4.3.0(typescript@5.1.5)
+      web3-eth-ens: 4.2.0(typescript@5.1.5)
       web3-eth-iban: 4.0.7
-      web3-eth-personal: 4.0.8(typescript@5.6.3)
+      web3-eth-personal: 4.0.8(typescript@5.1.5)
       web3-net: 4.0.7
       web3-providers-http: 4.1.0
       web3-providers-ws: 4.0.7
@@ -23290,11 +22934,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  /yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,9 @@ importers:
       '@types/async-retry':
         specifier: ^1.4.8
         version: 1.4.8
+      '@types/prompts':
+        specifier: ^2.4.2
+        version: 2.4.2
       tsx:
         specifier: ^3.12.7
         version: 3.12.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,9 +589,6 @@ importers:
 
   examples/with-aptos:
     dependencies:
-      '@inquirer/prompts':
-        specifier: ^2.1.0
-        version: 2.1.0
       '@noble/hashes':
         specifier: 1.4.0
         version: 1.4.0
@@ -613,6 +610,9 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
     devDependencies:
       '@types/async-retry':
         specifier: ^1.4.8
@@ -986,9 +986,6 @@ importers:
 
   examples/with-offline:
     dependencies:
-      '@inquirer/prompts':
-        specifier: ^1.2.3
-        version: 1.2.3
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../../packages/api-key-stamper
@@ -998,6 +995,9 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
 
   examples/with-sdk-server:
     dependencies:
@@ -1138,9 +1138,6 @@ importers:
 
   examples/with-sui:
     dependencies:
-      '@inquirer/prompts':
-        specifier: ^2.1.0
-        version: 2.1.0
       '@mysten/sui.js':
         specifier: ^0.37.1
         version: 0.37.1
@@ -1162,6 +1159,9 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
     devDependencies:
       '@types/async-retry':
         specifier: ^1.4.8
@@ -5957,233 +5957,6 @@ packages:
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     deprecated: Use @eslint/object-schema instead
-
-  /@inquirer/checkbox@1.2.8:
-    resolution: {integrity: sha512-yTnAsimBDy2Ft5Ky/0nNqJLkLYTX9/teuvkAHKm+aeOMVSaUfp8bPchkj6VThR5AHwzUhSnUswuYVUzTzWMzsw==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 1.3.0
-      '@inquirer/type': 1.5.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      figures: 3.2.0
-    dev: false
-
-  /@inquirer/checkbox@1.3.1:
-    resolution: {integrity: sha512-3l3aC6gYOPGaVOa9cNe4dZ8t96e3CFifC3Hee1MD+F7qaRxGAuXnhCQiUr4ngj2P7xd9U3DCDbLXNsLKQoHYCg==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 2.1.0
-      '@inquirer/type': 1.5.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      figures: 3.2.0
-    dev: false
-
-  /@inquirer/confirm@1.0.11:
-    resolution: {integrity: sha512-UWYJ+0dN9rWw0czTPqqKRGLqHsLML9rrQlScn5oOVUtiL2WDTxs95JehP2axKsNkSBMxmFAdA7TdctJkZFJcxA==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 1.3.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/confirm@2.0.2:
-    resolution: {integrity: sha512-2/Ogb3fkVyCp/V9aowa3Ge/aNiZCwH58BPYLeaMxRGDRtGV70aw50194/WSfceNfliHOFGQF6Db39c7Q85Dpkg==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 2.1.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/core@1.3.0:
-    resolution: {integrity: sha512-W7EA48gIMahFLiGW/zF+rgoineqTDK5IQizsOmwvbFfYgiQ8Asetut94THBmB3KnW0nrZL5UPHUK6QzcjEzaCw==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/type': 1.5.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      cli-spinners: 2.9.2
-      cli-width: 4.0.0
-      figures: 3.2.0
-      mute-stream: 1.0.0
-      run-async: 3.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-    dev: false
-
-  /@inquirer/core@2.1.0:
-    resolution: {integrity: sha512-Hq9hZ5G/VUaeWkSs283HZwwMbe79lcOI5HWwW1GIM1ohouy2/x489Qf/A1BJYvMUj+QG4LSB5LtVMjn9P3Ge6Q==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/type': 1.5.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      cli-spinners: 2.9.2
-      cli-width: 4.0.0
-      figures: 3.2.0
-      mute-stream: 1.0.0
-      run-async: 3.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-    dev: false
-
-  /@inquirer/editor@1.0.11:
-    resolution: {integrity: sha512-fAvkEKVRelMe5NzB1GM2zmAqbV0OWwAhXd6r34VgCKBAEfwI622A3M06g0ObL9qkcs0U+YW0G943X0ZqcUmKnQ==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 1.3.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-      external-editor: 3.1.0
-    dev: false
-
-  /@inquirer/editor@1.2.0:
-    resolution: {integrity: sha512-NMXLLNadvqIR6TD6mNZRa/PKHTvdaa4ndGGeXl+DwybQ4K7cVSJNRrztixpM1KDEoG8Ape5ightNwq25cyugTg==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 2.1.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-      external-editor: 3.1.0
-    dev: false
-
-  /@inquirer/expand@1.0.11:
-    resolution: {integrity: sha512-7JBEHJGyNx2KdRbrVrkD7aNz9P8FI54ug3WORwaJ3q/z19jy8+ItkswEkSn0cy1QHhB30fx3QlJdjFX14i59wA==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 1.3.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-      figures: 3.2.0
-    dev: false
-
-  /@inquirer/expand@1.1.1:
-    resolution: {integrity: sha512-fXk5NG2FOAiluDWPYfXHuof3sklL/HhZh3NnXfnBZ2IhTCRzXvlXRcQcPlev2sGcZknHn0g6JdKlxjSa+7H2nQ==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 2.1.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-      figures: 3.2.0
-    dev: false
-
-  /@inquirer/input@1.1.2:
-    resolution: {integrity: sha512-7/fS1EE9gvQJ7/NVKpsoyJeZAqbEoOiQBg6D8+YaCwnbEldXhKSyS53VlWoYrDWryw8XNutMpJI3o9vLxDw8KQ==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 1.3.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/input@1.2.1:
-    resolution: {integrity: sha512-OYwG3dEo1+lMAE6rYB8b1HTg8eSP++jk0pHSjKZu00gTlN5IHW/dliB82nsWe9Bn//93E9LJ1KrhjFMqOzkCFw==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 2.1.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/password@1.0.11:
-    resolution: {integrity: sha512-2GtNIBN906V5PzLFe0GIrXKInZM47T7QZdET0ML0sdGn4HFI7WEN+Gw0W2yC+0xhiTtm1kdrhFxRNIq8AZFnLA==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/input': 1.2.1
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/password@1.1.1:
-    resolution: {integrity: sha512-3M03aA04hOA4lRjLviB9uGoNmmd1YDNo4CYSFM9Uh4qlXdgvhke3xPU07k3kVstRIo0Te1hF14RL7vEgHJQ8tA==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/input': 1.2.1
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/prompts@1.2.3:
-    resolution: {integrity: sha512-vcPUWXA/boMJc5IDVx/9+ihf1FupsBK1RThnEXnLTpF6hR1iJCoaBoSpREZRdDp/XcPHe/b+QovehBYJoWsUhg==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/checkbox': 1.2.8
-      '@inquirer/confirm': 1.0.11
-      '@inquirer/core': 1.3.0
-      '@inquirer/editor': 1.0.11
-      '@inquirer/expand': 1.0.11
-      '@inquirer/input': 1.1.2
-      '@inquirer/password': 1.0.11
-      '@inquirer/rawlist': 1.1.3
-      '@inquirer/select': 1.1.7
-    dev: false
-
-  /@inquirer/prompts@2.1.0:
-    resolution: {integrity: sha512-YpfNrTjItyB9CYJUdIBp+9hRUu0e5JR//qC55gRrKjpGZP7CwrMvFJiS1LMZNG5vzd61CDxpOvNmkHcmMe6QmA==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/checkbox': 1.3.1
-      '@inquirer/confirm': 2.0.2
-      '@inquirer/core': 2.1.0
-      '@inquirer/editor': 1.2.0
-      '@inquirer/expand': 1.1.1
-      '@inquirer/input': 1.2.1
-      '@inquirer/password': 1.1.1
-      '@inquirer/rawlist': 1.2.1
-      '@inquirer/select': 1.2.1
-    dev: false
-
-  /@inquirer/rawlist@1.1.3:
-    resolution: {integrity: sha512-aBlXdQeADYbk9pFG4Z8HvRnjM7i/RYKJmf311infV2ivkD+d1QIdWdo0RnCuqk0m/6tdYsRgkhWGVhEkeh0nQg==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 1.3.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/rawlist@1.2.1:
-    resolution: {integrity: sha512-t8lMbE3Gqook4PvQYQl9eVJrl/mBy5kCgolwY9El8HLyGZ7Wc3SGIqHnQUlha4qms8HPOdUIBzyPfcAXl5+3SQ==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 2.1.0
-      '@inquirer/type': 1.5.2
-      chalk: 4.1.2
-    dev: false
-
-  /@inquirer/select@1.1.7:
-    resolution: {integrity: sha512-3Ym0WOoVduu/AG5GwIxa+fNz8Eop7S1zADbUmMsllrubdYu7qMe9HaTHCb5JOjaVNSoFJuYPH6TizFzGVFVrCQ==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 1.3.0
-      '@inquirer/type': 1.5.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      figures: 3.2.0
-    dev: false
-
-  /@inquirer/select@1.2.1:
-    resolution: {integrity: sha512-13JDLtlwFoqQUYRdMzz5wP3a4DWccJfNA/8M8MDUhhZ8HeKZ3MPaTMlpxwY+Q0Jgbmt56nf7xUuck0XXPce8Xw==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      '@inquirer/core': 2.1.0
-      '@inquirer/type': 1.5.2
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      figures: 3.2.0
-    dev: false
-
-  /@inquirer/type@1.5.2:
-    resolution: {integrity: sha512-w9qFkumYDCNyDZmNQjf/n6qQuvQ4dMC3BJesY4oF+yr0CxR5vxujflAVeIcS6U336uzi9GM0kAfZlLrZ9UTkpA==}
-    engines: {node: '>=18'}
-    dependencies:
-      mute-stream: 1.0.0
-    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -14323,6 +14096,7 @@ packages:
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+    dev: true
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -14428,11 +14202,6 @@ packages:
   /cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
-    dev: false
-
-  /cli-width@4.0.0:
-    resolution: {integrity: sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==}
-    engines: {node: '>= 12'}
     dev: false
 
   /client-only@0.0.1:
@@ -16182,6 +15951,7 @@ packages:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+    dev: true
 
   /eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
@@ -16257,13 +16027,6 @@ packages:
     dependencies:
       biskviit: 1.0.1
       encoding: 0.1.12
-    dev: false
-
-  /figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
-    dependencies:
-      escape-string-regexp: 1.0.5
     dev: false
 
   /file-entry-cache@6.0.1:
@@ -19170,11 +18933,6 @@ packages:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
     dev: false
 
-  /mute-stream@1.0.0:
-    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dev: false
-
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
     dependencies:
@@ -21109,11 +20867,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       execa: 5.1.1
-
-  /run-async@3.0.0:
-    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
-    engines: {node: '>=0.12.0'}
-    dev: false
 
   /run-parallel-limit@1.1.0:
     resolution: {integrity: sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==}


### PR DESCRIPTION
## Summary & Motivation

This PR changes it so that we use the `prompts` library instead of `inquirer/prompts` for consistency with our stackblitz examples -- since it seems friendlier to be used with `pnpm` or `npm`

## How I Tested These Changes

Tested the edited examples locally

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
