### PR TITLE
Fix SubOrgID issue with Passkey Examples

### DIFF
--- a/examples/with-eth-passkeys-galore/src/pages/index.tsx
+++ b/examples/with-eth-passkeys-galore/src/pages/index.tsx
@@ -132,6 +132,10 @@ export default function Home() {
 
     const response = res.data as TWalletDetails;
     setWallet(response);
+
+    if (passkeyClient && passkeyClient.config) {
+      passkeyClient.config.organizationId = response.subOrgId;
+    }
   };
 
   const login = async () => {

--- a/examples/with-solana-passkeys/src/pages/index.tsx
+++ b/examples/with-solana-passkeys/src/pages/index.tsx
@@ -171,6 +171,10 @@ export default function Home() {
 
     const response = res.data as TWalletDetails;
     setWallet(response);
+
+    if (passkeyClient && passkeyClient.config) {
+      passkeyClient.config.organizationId = response.subOrgId;
+    }
   };
 
   const login = async () => {


### PR DESCRIPTION
## Summary & Motivation

This PR fixes issues in examples `with-solana-passkeys` and `with-eth-passkeys-galore` where a passkey client makes sign requests with the orgID of the parent org and not the suborg

## How I Tested These Changes

ran examples locally

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
