### PR TITLE
add biconomy aa support to eth passkeys example

### DIFF
--- a/examples/with-eth-passkeys-galore/.env.local.example
+++ b/examples/with-eth-passkeys-galore/.env.local.example
@@ -4,3 +4,8 @@ NEXT_PUBLIC_ORGANIZATION_ID="<Turnkey organization ID>"
 NEXT_PUBLIC_BASE_URL=https://api.turnkey.com
 NEXT_PUBLIC_RPID=localhost # replace with domain in production
 NEXT_PUBLIC_SERVER_SIGN_URL=http://localhost:3000/api # replace with backend URL in production
+NEXT_PUBLIC_INFURA_KEY=""
+
+# Optional account abstraction-related parameters
+NEXT_PUBLIC_BICONOMY_BUNDLER_URL=""
+NEXT_PUBLIC_BICONOMY_PAYMASTER_API_KEY=""

--- a/examples/with-eth-passkeys-galore/CHANGELOG.md
+++ b/examples/with-eth-passkeys-galore/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/with-eth-passkey-signers
 
+## 0.2.0
+
+### Features
+
+- Add transaction signing both signers (Viem and Ethers)
+- Add Biconomy paymaster support
+  - If paymaster details are not set, the example will default to using the Turnkey wallet account as opposed to the corresponding smart wallet account
+
 ## 0.1.1
 
 ### Patch Changes
@@ -11,3 +19,7 @@
   - @turnkey/ethers@1.1.3
   - @turnkey/sdk-react@1.0.13
   - @turnkey/viem@0.6.2
+
+## 0.1.0
+
+- Initial release

--- a/examples/with-eth-passkeys-galore/README.md
+++ b/examples/with-eth-passkeys-galore/README.md
@@ -37,10 +37,12 @@ The first step is to set up your Turnkey organization and account. By following 
 
 ### 2b/ Setting up Biconomy (optional)
 
-The next step is to navigate to Biconomy to create a paymaster. Visit the [Biconomy Dashboard](https://dashboard.biconomy.io/) to create a your paymaster and find the following:
+If you would like to use [account abstraction](https://docs.turnkey.com/reference/aa-wallets) to power experiences where end-users have their transactions paid for, the next step is to navigate to Biconomy to create a paymaster. Visit the [Biconomy Dashboard](https://dashboard.biconomy.io/) to create a your paymaster and find the following:
 
 - Bundler URL
 - Paymaster API Key
+
+If these parameters are _not_ provided, the application will default to using the Turnkey-provided EOA as the sender address.
 
 Once you've gathered these values, add them to a new `.env.local` file. Notice that your API private key should be securely managed and **_never_** be committed to git.
 

--- a/examples/with-eth-passkeys-galore/README.md
+++ b/examples/with-eth-passkeys-galore/README.md
@@ -28,12 +28,19 @@ $ pnpm install # Install dependencies
 $ pnpm run build  # Compile source code
 ```
 
-### 2/ Setting up Turnkey
+### 2a/ Setting up Turnkey
 
 The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
 
 - A public/private API key pair for Turnkey
 - An organization ID
+
+### 2b/ Setting up Biconomy (optional)
+
+The next step is to navigate to Biconomy to create a paymaster. Visit the [Biconomy Dashboard](https://dashboard.biconomy.io/) to create a your paymaster and find the following:
+
+- Bundler URL
+- Paymaster API Key
 
 Once you've gathered these values, add them to a new `.env.local` file. Notice that your API private key should be securely managed and **_never_** be committed to git.
 
@@ -48,6 +55,9 @@ Now open `.env.local` and add the missing environment variables:
 - `NEXT_PUBLIC_BASE_URL`
 - `NEXT_PUBLIC_ORGANIZATION_ID`
 - `NEXT_PUBLIC_RPID`
+- `NEXT_PUBLIC_INFURA_KEY` -- if this is not set, it will default to using the Community Infura key
+- `NEXT_PUBLIC_BICONOMY_BUNDLER_URL`
+- `NEXT_PUBLIC_BICONOMY_PAYMASTER_API_KEY`
 
 ### 3/ Running the app
 

--- a/examples/with-eth-passkeys-galore/package.json
+++ b/examples/with-eth-passkeys-galore/package.json
@@ -13,12 +13,13 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@biconomy/account": "^4.5.6",
     "@turnkey/api-key-stamper": "workspace:*",
+    "@turnkey/ethers": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@turnkey/sdk-browser": "workspace:*",
     "@turnkey/sdk-react": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
-    "@turnkey/ethers": "workspace:*",
     "@turnkey/viem": "workspace:*",
     "@turnkey/webauthn-stamper": "workspace:*",
     "@types/node": "20.3.1",
@@ -36,6 +37,6 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
     "typescript": "5.1.3",
-    "viem": "^1.10.0"
+    "viem": "^2.21.9"
   }
 }

--- a/examples/with-eth-passkeys-galore/package.json
+++ b/examples/with-eth-passkeys-galore/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "18.2.6",
     "axios": "^1.4.0",
     "encoding": "^0.1.13",
+    "ethers": "^6.10.0",
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.7",
     "esm": "^3.2.25",

--- a/examples/with-eth-passkeys-galore/package.json
+++ b/examples/with-eth-passkeys-galore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/with-eth-passkey-signers",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/with-eth-passkeys-galore/src/pages/index.tsx
+++ b/examples/with-eth-passkeys-galore/src/pages/index.tsx
@@ -2,8 +2,14 @@ import Image from "next/image";
 import { useForm } from "react-hook-form";
 import axios from "axios";
 import { useState, useEffect } from "react";
-import { Account, createWalletClient, http } from "viem";
+import { Account, createWalletClient, http, type WalletClient } from "viem";
 import { sepolia } from "viem/chains";
+import {
+  createSmartAccountClient,
+  BiconomySmartAccountV2,
+  PaymasterMode,
+  LightSigner,
+} from "@biconomy/account";
 
 import { TurnkeySigner } from "@turnkey/ethers";
 import { createAccount } from "@turnkey/viem";
@@ -16,8 +22,13 @@ type subOrgFormData = {
   subOrgName: string;
 };
 
-type signingFormData = {
+type signMessageFormData = {
   messageToSign: string;
+};
+
+type signTransactionFormData = {
+  destinationAddress: string;
+  amount: string;
 };
 
 type TWalletState = TWalletDetails | null;
@@ -36,14 +47,28 @@ export default function Home() {
 
   // Wallet is used as a proxy for logged-in state
   const [wallet, setWallet] = useState<TWalletState>(null);
+  const [smartAccountAddress, setSmartAccountAddress] = useState<string>("");
   const [signedMessage, setSignedMessage] = useState<TSignedMessage>(null);
+  const [signedTransaction, setSignedTransaction] = useState<string | null>(
+    null
+  );
   const [useViem, setUseViem] = useState(true);
+  const [viemClient, setViemClient] = useState<WalletClient | null>(null);
+  const [ethersClient, setEthersClient] = useState<TurnkeySigner | null>(null);
 
   const { handleSubmit: subOrgFormSubmit } = useForm<subOrgFormData>();
   const { register: signingFormRegister, handleSubmit: signingFormSubmit } =
-    useForm<signingFormData>();
+    useForm<signMessageFormData>();
   const { register: _loginFormRegister, handleSubmit: loginFormSubmit } =
     useForm();
+  const {
+    register: signTransactionFormRegister,
+    handleSubmit: signTransactionFormSubmit,
+  } = useForm<signTransactionFormData>({
+    defaultValues: {
+      destinationAddress: "0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7",
+    },
+  });
 
   // First, logout user if there is no current wallet set
   useEffect(() => {
@@ -54,7 +79,89 @@ export default function Home() {
     })();
   });
 
-  const signMessage = async (data: signingFormData) => {
+  useEffect(() => {
+    const initializeClients = async () => {
+      if (!wallet || !passkeyClient) return;
+
+      let smartAccount;
+      if (useViem) {
+        const viemAccount = await createAccount({
+          client: passkeyClient,
+          organizationId: wallet.subOrgId,
+          signWith: wallet.address,
+          ethereumAddress: wallet.address,
+        });
+
+        const viemClient = createWalletClient({
+          account: viemAccount as Account,
+          chain: sepolia,
+          transport: http(),
+        });
+        setViemClient(viemClient);
+
+        smartAccount = await connectViemClient(viemClient);
+      } else {
+        const ethersClient = new TurnkeySigner({
+          organizationId: wallet.subOrgId,
+          client: passkeyClient,
+          signWith: wallet.address,
+        });
+        setEthersClient(ethersClient);
+
+        smartAccount = await connectEthersClient(ethersClient);
+      }
+
+      const smartAccountAddress = await smartAccount.getAccountAddress();
+      setSmartAccountAddress(smartAccountAddress);
+    };
+
+    initializeClients();
+  }, [wallet, passkeyClient, useViem]);
+
+  // Connect a TurnkeySigner to a Biconomy Smart Account Client, defaulting to Sepolia
+  // Ensure this method is hoisted
+  const connectEthersClient = async (
+    turnkeyClient: TurnkeySigner
+  ): Promise<BiconomySmartAccountV2> => {
+    try {
+      const smartAccount = await createSmartAccountClient({
+        signer: turnkeyClient as LightSigner,
+        bundlerUrl: process.env.NEXT_PUBLIC_BICONOMY_BUNDLER_URL!, // <-- Read about this at https://docs.biconomy.io/dashboard#bundler-url
+        biconomyPaymasterApiKey:
+          process.env.NEXT_PUBLIC_BICONOMY_PAYMASTER_API_KEY!, // <-- Read about at https://docs.biconomy.io/dashboard/paymaster
+        rpcUrl: `https://sepolia.infura.io/v3/${process.env
+          .NEXT_PUBLIC_INFURA_KEY!}`, // <-- read about this at https://docs.biconomy.io/account/methods#createsmartaccountclient
+        chainId: Number(sepolia.id),
+      });
+
+      return smartAccount;
+    } catch (error: any) {
+      throw new Error(error);
+    }
+  };
+  // Connect a TurnkeySigner to a Biconomy Smart Account Client, defaulting to Sepolia
+  // Ensure this method is hoisted
+  const connectViemClient = async (
+    turnkeyClient: WalletClient
+  ): Promise<BiconomySmartAccountV2> => {
+    try {
+      const smartAccount = await createSmartAccountClient({
+        signer: turnkeyClient,
+        bundlerUrl: process.env.NEXT_PUBLIC_BICONOMY_BUNDLER_URL!, // <-- Read about this at https://docs.biconomy.io/dashboard#bundler-url
+        biconomyPaymasterApiKey:
+          process.env.NEXT_PUBLIC_BICONOMY_PAYMASTER_API_KEY!, // <-- Read about at https://docs.biconomy.io/dashboard/paymaster
+        rpcUrl: `https://sepolia.infura.io/v3/${process.env
+          .NEXT_PUBLIC_INFURA_KEY!}`, // <-- read about this at https://docs.biconomy.io/account/methods#createsmartaccountclient
+        chainId: Number(sepolia.id),
+      });
+
+      return smartAccount;
+    } catch (error: any) {
+      throw new Error(error);
+    }
+  };
+
+  const signMessage = async (data: signMessageFormData) => {
     if (!wallet) {
       throw new Error("wallet not found");
     }
@@ -66,7 +173,7 @@ export default function Home() {
     }
   };
 
-  const signMessageViem = async (data: signingFormData) => {
+  const signMessageViem = async (data: signMessageFormData) => {
     const viemAccount = await createAccount({
       client: passkeyClient!,
       organizationId: wallet!.subOrgId,
@@ -90,7 +197,7 @@ export default function Home() {
     });
   };
 
-  const signMessageEthers = async (data: signingFormData) => {
+  const signMessageEthers = async (data: signMessageFormData) => {
     const ethersSigner = new TurnkeySigner({
       client: passkeyClient!,
       organizationId: wallet!.subOrgId,
@@ -103,6 +210,38 @@ export default function Home() {
       message: data.messageToSign,
       signature: signedMessage,
     });
+  };
+
+  const setClient = async () => {
+    let client: WalletClient | TurnkeySigner;
+    if (useViem) {
+      const viemAccount = await createAccount({
+        client: passkeyClient!,
+        organizationId: wallet!.subOrgId,
+        signWith: wallet!.address,
+        ethereumAddress: wallet!.address,
+      });
+
+      const viemClient = createWalletClient({
+        account: viemAccount as Account,
+        chain: sepolia,
+        transport: http(),
+      });
+      setViemClient(viemClient);
+
+      client = viemClient;
+    } else {
+      const ethersClient = new TurnkeySigner({
+        organizationId: wallet!.subOrgId,
+        client: passkeyClient!,
+        signWith: wallet!.address,
+      });
+      setEthersClient(ethersClient);
+
+      client = ethersClient;
+    }
+
+    return client;
   };
 
   const createSubOrgAndWallet = async () => {
@@ -131,6 +270,7 @@ export default function Home() {
     });
 
     const response = res.data as TWalletDetails;
+
     setWallet(response);
 
     if (passkeyClient && passkeyClient.config) {
@@ -178,6 +318,69 @@ export default function Home() {
     }
   };
 
+  const signTransactionEthers = async (data: signTransactionFormData) => {
+    const { destinationAddress, amount } = data;
+
+    const smartAccount = await connectEthersClient(ethersClient!);
+    const transactionRequest = {
+      to: destinationAddress,
+      value: amount,
+      type: 2,
+    };
+
+    // Make a simple send tx (which calls `signTransaction` under the hood)
+    const userOpResponse = await smartAccount?.sendTransaction(
+      transactionRequest,
+      {
+        nonceOptions: { nonceKey: Number(0) },
+        paymasterServiceData: { mode: PaymasterMode.SPONSORED },
+      }
+    );
+
+    const { transactionHash } = await userOpResponse.waitForTxHash();
+
+    setSignedTransaction(
+      `https://jiffyscan.xyz/bundle/${transactionHash}?network=sepolia&pageNo=0&pageSize=10`
+    );
+  };
+
+  const signTransactionViem = async (data: signTransactionFormData) => {
+    const { destinationAddress, amount } = data;
+
+    const smartAccount = await connectViemClient(viemClient!);
+    const transactionRequest = {
+      to: destinationAddress,
+      value: amount,
+      type: 2,
+    };
+
+    // Make a simple send tx (which calls `signTransaction` under the hood)
+    const userOpResponse = await smartAccount?.sendTransaction(
+      transactionRequest,
+      {
+        paymasterServiceData: { mode: PaymasterMode.SPONSORED },
+      }
+    );
+
+    const { transactionHash } = await userOpResponse.waitForTxHash();
+
+    setSignedTransaction(
+      `https://jiffyscan.xyz/bundle/${transactionHash}?network=sepolia&pageNo=0&pageSize=10`
+    );
+  };
+
+  const signTransaction = async (data: signTransactionFormData) => {
+    if (!wallet) {
+      throw new Error("wallet not found");
+    }
+
+    if (useViem) {
+      await signTransactionViem(data);
+    } else {
+      await signTransactionEthers(data);
+    }
+  };
+
   return (
     <main className={styles.main}>
       <a href="https://turnkey.com" target="_blank" rel="noopener noreferrer">
@@ -191,7 +394,7 @@ export default function Home() {
         />
       </a>
       <div>
-        {wallet !== null && (
+        {wallet && (
           <div className={styles.info}>
             Your sub-org ID: <br />
             <span className={styles.code}>{wallet.subOrgId}</span>
@@ -199,8 +402,14 @@ export default function Home() {
         )}
         {wallet && (
           <div className={styles.info}>
-            ETH address: <br />
+            ETH signer address: <br />
             <span className={styles.code}>{wallet.address}</span>
+          </div>
+        )}
+        {smartAccountAddress && (
+          <div className={styles.info}>
+            Smart account address: <br />
+            <span className={styles.code}>{smartAccountAddress}</span>
           </div>
         )}
         {signedMessage && (
@@ -364,6 +573,46 @@ export default function Home() {
               value="Sign Message"
             />
           </form>
+        </div>
+      )}
+      {wallet && (
+        <div>
+          <h2>... and now let&apos;s sign a transaction!</h2>
+          <form
+            className={styles.form}
+            onSubmit={signTransactionFormSubmit(signTransaction)}
+          >
+            <input
+              className={styles.input}
+              {...signTransactionFormRegister("amount")}
+              placeholder="Amount (wei)"
+            />
+            <input
+              className={styles.input}
+              {...signTransactionFormRegister("destinationAddress")}
+            />
+            <input
+              className={styles.button}
+              type="submit"
+              value="Sign and Broadcast Transaction"
+            />
+          </form>
+          {signedTransaction && (
+            <div className={styles.info}>
+              <p>
+                🚀 Transaction broadcasted and confirmed!
+                <br />
+                <br />
+                <a
+                  href={signedTransaction}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {signedTransaction}
+                </a>
+              </p>
+            </div>
+          )}
         </div>
       )}
     </main>

--- a/examples/with-solana-passkeys/src/pages/index.tsx
+++ b/examples/with-solana-passkeys/src/pages/index.tsx
@@ -12,15 +12,15 @@ import { useTurnkey } from "@turnkey/sdk-react";
 import { TurnkeySigner } from "@turnkey/solana";
 import { broadcast, connect } from "@/utils";
 
-type subOrgFormData = {
+type TSubOrgFormData = {
   subOrgName: string;
 };
 
-type signMessageFormData = {
+type TSignMessageFormData = {
   messageToSign: string;
 };
 
-type signTransactionFormData = {
+type TSignTransactionFormData = {
   destinationAddress: string;
   amount: string;
 };
@@ -51,15 +51,15 @@ export default function Home() {
     null
   );
 
-  const { handleSubmit: subOrgFormSubmit } = useForm<subOrgFormData>();
+  const { handleSubmit: subOrgFormSubmit } = useForm<TSubOrgFormData>();
   const {
     register: signMessageFormRegister,
     handleSubmit: signMessageFormSubmit,
-  } = useForm<signMessageFormData>();
+  } = useForm<TSignMessageFormData>();
   const {
     register: signTransactionFormRegister,
     handleSubmit: signTransactionFormSubmit,
-  } = useForm<signTransactionFormData>({
+  } = useForm<TSignTransactionFormData>({
     defaultValues: {
       destinationAddress: "tkhqC9QX2gkqJtUFk2QKhBmQfFyyqZXSpr73VFRi35C",
     },
@@ -76,7 +76,7 @@ export default function Home() {
     })();
   });
 
-  const signMessage = async (data: signMessageFormData) => {
+  const signMessage = async (data: TSignMessageFormData) => {
     if (!wallet) {
       throw new Error("wallet not found");
     }
@@ -105,7 +105,7 @@ export default function Home() {
     });
   };
 
-  const signTransaction = async (data: signTransactionFormData) => {
+  const signTransaction = async (data: TSignTransactionFormData) => {
     if (!wallet) {
       throw new Error("wallet not found");
     }
@@ -278,7 +278,7 @@ export default function Home() {
         <div>
           <h2>Create a new wallet</h2>
           <p className={styles.explainer}>
-            We&apos;ll prompt your browser to create a new passkey. The details
+            {"We'll"} prompt your browser to create a new passkey. The details
             (credential ID, authenticator data, client data, attestation) will
             be used to create a new{" "}
             <a
@@ -338,9 +338,9 @@ export default function Home() {
       )}
       {wallet && (
         <div>
-          <h2>Now let&apos;s sign a message!</h2>
+          <h2>Now {"let's"} sign a message!</h2>
           <p className={styles.explainer}>
-            We&apos;ll use a{" "}
+            {"We'll"} use a{" "}
             <a
               href="https://solana.com/docs/clients/javascript"
               target="_blank"
@@ -377,7 +377,7 @@ export default function Home() {
       )}
       {wallet && (
         <div>
-          <h2>... and now let&apos;s sign a transaction!</h2>
+          <h2>... and now {"let's"} sign a transaction!</h2>
           <form
             className={styles.form}
             onSubmit={signTransactionFormSubmit(signTransaction)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -819,6 +819,9 @@ importers:
 
   examples/with-eth-passkeys-galore:
     dependencies:
+      '@biconomy/account':
+        specifier: ^4.5.6
+        version: 4.5.6(typescript@5.1.3)(viem@2.21.29)
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../../packages/api-key-stamper
@@ -889,8 +892,8 @@ importers:
         specifier: 5.1.3
         version: 5.1.3
       viem:
-        specifier: ^1.10.0
-        version: 1.16.6(typescript@5.1.3)
+        specifier: ^2.21.9
+        version: 2.21.29(typescript@5.1.3)
 
   examples/with-ethers:
     dependencies:
@@ -4711,6 +4714,22 @@ packages:
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
+
+  /@biconomy/account@4.5.6(typescript@5.1.3)(viem@2.21.29):
+    resolution: {integrity: sha512-Mq0X9HF4fsPTkf87eXklJJE/Hl3GQwQHN/2/D1fCA4Q4o4AM9HV7Tzpb+hBsh8cUJ+s2j0Q9wORXA1c0onAImQ==}
+    peerDependencies:
+      typescript: ^5
+      viem: ^2
+    dependencies:
+      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.1.3)
+      merkletreejs: 0.4.0
+      typescript: 5.1.3
+      viem: 2.21.29(typescript@5.1.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
 
   /@biconomy/account@4.5.6(typescript@5.1.5)(viem@2.21.29):
     resolution: {integrity: sha512-Mq0X9HF4fsPTkf87eXklJJE/Hl3GQwQHN/2/D1fCA4Q4o4AM9HV7Tzpb+hBsh8cUJ+s2j0Q9wORXA1c0onAImQ==}
@@ -9743,7 +9762,7 @@ packages:
     dependencies:
       '@noble/curves': 1.6.0
       '@noble/hashes': 1.5.0
-      '@scure/base': 1.1.7
+      '@scure/base': 1.1.9
     dev: false
 
   /@scure/bip39@1.1.1:
@@ -9855,10 +9874,22 @@ packages:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: false
 
+  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.1.3):
+    resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
+    dependencies:
+      '@noble/curves': 1.6.0
+      viem: 2.21.29(typescript@5.1.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
   /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.1.5):
     resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
     dependencies:
-      '@noble/curves': 1.4.2
+      '@noble/curves': 1.6.0
       viem: 2.21.29(typescript@5.1.5)
     transitivePeerDependencies:
       - bufferutil
@@ -12736,6 +12767,20 @@ packages:
     dependencies:
       typescript: 5.1.5
       zod: 3.23.8
+
+  /abitype@1.0.6(typescript@5.1.3):
+    resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
+    dev: false
 
   /abitype@1.0.6(typescript@5.1.5):
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
@@ -22426,6 +22471,30 @@ packages:
       - utf-8-validate
       - zod
     dev: true
+
+  /viem@2.21.29(typescript@5.1.3):
+    resolution: {integrity: sha512-n9LoCJjmI1XsE33nl+M4p3Wy5hczv7YC682RpX4Qk9cw8s9HJU+hUi5eDcNDPBcAwIHGCPKsf8yFBEYnE2XYVg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/bip32': 1.5.0
+      '@scure/bip39': 1.4.0
+      abitype: 1.0.6(typescript@5.1.3)
+      isows: 1.0.6(ws@8.17.1)
+      typescript: 5.1.3
+      webauthn-p256: 0.0.10
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
 
   /viem@2.21.29(typescript@5.1.5):
     resolution: {integrity: sha512-n9LoCJjmI1XsE33nl+M4p3Wy5hczv7YC682RpX4Qk9cw8s9HJU+hUi5eDcNDPBcAwIHGCPKsf8yFBEYnE2XYVg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,9 @@ importers:
       esm:
         specifier: ^3.2.25
         version: 3.2.25
+      ethers:
+        specifier: ^6.10.0
+        version: 6.10.0
       install:
         specifier: ^0.13.0
         version: 0.13.0


### PR DESCRIPTION
## Summary & Motivation
$title

see changelog

## How I Tested These Changes
- Local

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
