### PR TITLE
Support RS256 by default in `createUserPasskey`

### DIFF
--- a/.changeset/odd-chefs-whisper.md
+++ b/.changeset/odd-chefs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-browser": minor
+---
+
+Support RS256 by default when invoking createUserPasskey

--- a/packages/sdk-browser/src/sdk-client.ts
+++ b/packages/sdk-browser/src/sdk-client.ts
@@ -324,6 +324,10 @@ export class TurnkeyPasskeyClient extends TurnkeyBrowserClient {
             type: "public-key",
             alg: -7,
           },
+          {
+            type: "public-key",
+            alg: -257,
+          },
         ],
         user: {
           id: config.publicKey?.user?.id ?? authenticatorUserId,


### PR DESCRIPTION
## Summary & Motivation
Turnkey has long been supporting both ES256 and RS256. This is a spot that was missed. Of course users can override `pubKeyCredParams` if they so desire, but by default we should support RS256. RSA is used for e.g. Windows Hello passkeys.


## Did you add a changeset?
✅ 
