### PR TITLE
Release packages (2024-11-27)

### DIFF
--- a/.changeset/clever-mayflies-itch.md
+++ b/.changeset/clever-mayflies-itch.md
@@ -1,5 +1,0 @@
----
-"@turnkey/react-native-passkey-stamper": major
----
-
-Upgrade react-native-passkey to 3.0.0

--- a/.changeset/itchy-jeans-try.md
+++ b/.changeset/itchy-jeans-try.md
@@ -1,5 +1,0 @@
----
-"@turnkey/solana": patch
----
-
-Add optional org id for all signing methods

--- a/examples/with-solana-passkeys/package.json
+++ b/examples/with-solana-passkeys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/with-solana-passkeys",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/with-wallet-stamper/package.json
+++ b/examples/with-wallet-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-wallet-stamper",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/react-native-passkey-stamper/CHANGELOG.md
+++ b/packages/react-native-passkey-stamper/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/react-native-passkey-stamper
 
+## 1.0.0
+
+### Major Changes
+
+Upgrade react-native-passkey to 3.0.0 (see [release notes](https://github.com/f-23/react-native-passkey/releases/tag/v3.0.0)). Among other things you can now specify `withSecurityKey` and `withPlatformKey` (new optional arguments to `createPasskey`) to target platform passkeys or security keys on iOS. The same options can be passed as configuration to `PasskeyStamper` to target these features at authentication time.
+
+This is a major change because the `transports` property, previously a string array (`Array<string>`) is now an array of enums (`Array<AuthenticatorTransport>`).
+
 ## 0.2.16
 
 ### Patch Changes

--- a/packages/react-native-passkey-stamper/package.json
+++ b/packages/react-native-passkey-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-native-passkey-stamper",
-  "version": "0.2.16",
+  "version": "1.0.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/solana
 
+## 1.0.4
+
+### Patch Changes
+
+- 9eaf38a: Add optional org id for all signing methods
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
This release contains 2 packages:
* `@turnkey/react-native-passkey-stamper`: major change (#426)
* `@turnkey/solana`: minor change to add the ability to override user IDs (#431)
