### PR TITLE
Update default cloud storage key

### DIFF
--- a/packages/telegram-cloud-storage-stamper/CHANGELOG.md
+++ b/packages/telegram-cloud-storage-stamper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/telegram-cloud-storage-stamper
 
+## 1.0.1
+
+### Patch Changes
+
+- Update the default cloud storage key to conform to cloud storage key constraints
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/telegram-cloud-storage-stamper/README.md
+++ b/packages/telegram-cloud-storage-stamper/README.md
@@ -12,7 +12,7 @@ Telegram Bot API >= 6.9
 
 The Telegram Cloud Storage Stamper has a few different modes of operation, namely a classic [stamper](https://docs.turnkey.com/api-overview/stamps) for stamping requests made to Turnkey's API, and an interface for a Telegram Mini App built with Turnkey to interact with Telegram Cloud Storage. This provides the developer of the application utilities such as creating stamps on requests made by users, storing user API keys, storing temporary keys that are needed for decrypting credential bundles for activites like [email auth](https://docs.turnkey.com/features/email-auth) or [oauth](https://docs.turnkey.com/features/oauth), or storing arbitrary values that would be helpful to have saved for a user from session to session on device to device.
 
-The Telegram Cloud Storage Stamper will, by default, store the API key used for signing in Telegram Cloud Storage under the key `@turnkey/TURNKEY_API_KEY`. A Cloud Storage "key" is the index under which a value is stored in Telegram Cloud Storage. This can be changed when using the `.create()` or `.setSigningKey()` functions. An API key is stored within Cloud Storage as a JSON string of the following object:
+The Telegram Cloud Storage Stamper will, by default, store the API key used for signing in Telegram Cloud Storage under the key `TURNKEY_API_KEY`. A Cloud Storage "key" is the index under which a value is stored in Telegram Cloud Storage. This can be changed when using the `.create()` or `.setSigningKey()` functions. An API key is stored within Cloud Storage as a JSON string of the following object:
 
 ```
 {
@@ -25,7 +25,7 @@ The Telegram Cloud Storage Stamper will, by default, store the API key used for 
 
 The `.create()` and `.setSigningKey()` functions take one of the following 4 sets of arguments:
 
-- No arguments: Use an API key at the default location within Telegram Cloud Storage `@turnkey/TURNKEY_API_KEY` and set that as the signing key
+- No arguments: Use an API key at the default location within Telegram Cloud Storage `TURNKEY_API_KEY` and set that as the signing key
 - Just an API key: Store the passed in API key at the default Telegram Cloud Storage location and set that as the signing key
 - Just a Cloud Storage key: Use an API key stored at the specified Telegram Cloud Storage key location and set that as the signing key
 - Both an API key and a Cloud Storage key: Store the passed API key at the specified Telegram Cloud Storage key location and set that as the signing key
@@ -141,7 +141,7 @@ await stamper.insertAPIKey(
 );
 ```
 
-Set a new API key as the signing key for the stamper at a specified key. This will also insert the API key to that location within Telegram CloudStorage. Any subsequent requests for stamping will sign with this API key. The API key and CloudStorage key can also be omitted and the API key at the default location `@turnkey/TURNKEY_API_KEY` will be used. If an API key is omitted and a CloudStorage key is specified an API key at that location will be used. Refer to the [argument-usage](#argument-usage) section for a full explanation. A stamper that was originally used to just view Cloud Storage values can later be used for signing by using the `.setSigningKey()` function.
+Set a new API key as the signing key for the stamper at a specified key. This will also insert the API key to that location within Telegram CloudStorage. Any subsequent requests for stamping will sign with this API key. The API key and CloudStorage key can also be omitted and the API key at the default location `TURNKEY_API_KEY` will be used. If an API key is omitted and a CloudStorage key is specified an API key at that location will be used. Refer to the [argument-usage](#argument-usage) section for a full explanation. A stamper that was originally used to just view Cloud Storage values can later be used for signing by using the `.setSigningKey()` function.
 
 ```ts
 import TelegramCloudStorageStamper, {

--- a/packages/telegram-cloud-storage-stamper/package.json
+++ b/packages/telegram-cloud-storage-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/telegram-cloud-storage-stamper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/telegram-cloud-storage-stamper/src/index.ts
+++ b/packages/telegram-cloud-storage-stamper/src/index.ts
@@ -23,7 +23,7 @@ export type CloudStorageAPIKey = {
 };
 
 // Constant for default key name
-const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "@turnkey/TURNKEY_API_KEY";
+const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "TURNKEY_API_KEY";
 
 /**
  * Stamper to use within a `TurnkeyClient`


### PR DESCRIPTION
## Summary & Motivation
Telegram Cloud storage does not allow for the `@` or `/` signs in cloud storage keys, so change the default key to conform to those standards.
## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
