### PR TITLE
Solana export support for decryptExportBundle fxn

### DIFF
--- a/.changeset/curly-eyes-cover.md
+++ b/.changeset/curly-eyes-cover.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": minor
+---
+
+Add keyformat to decryptExportBundle for displaying Solana private keys

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -18,11 +18,14 @@ import {
   uncompressRawPublicKey,
 } from "./crypto";
 
+import { ed25519 } from '@noble/curves/ed25519';
+
 interface DecryptExportBundleParams {
   exportBundle: string;
   organizationId: string;
   embeddedKey: string;
   dangerouslyOverrideSignerPublicKey?: string; // Optional override for signer key
+  keyFormat?: "SOLANA" | "HEXADECIMAL";
   returnMnemonic: boolean;
 }
 interface EncryptPrivateKeyToBundleParams {
@@ -99,6 +102,7 @@ export const decryptExportBundle = async ({
   embeddedKey,
   organizationId,
   dangerouslyOverrideSignerPublicKey,
+  keyFormat,
   returnMnemonic,
 }: DecryptExportBundleParams): Promise<string> => {
   try {
@@ -139,12 +143,31 @@ export const decryptExportBundle = async ({
       receiverPriv: embeddedKey,
     });
 
+    if (keyFormat === "SOLANA" && !returnMnemonic) {
+      if (decryptedData.length !== 32) {
+        throw new Error(
+          `invalid private key length. Expected 32 bytes. Got ${decryptedData.length}.`
+        );
+      }
+      const publicKeyBytes = ed25519.getPublicKey(decryptedData);
+      if (publicKeyBytes.length !== 32) {
+        throw new Error(
+          `invalid public key length. Expected 32 bytes. Got ${publicKeyBytes.length}.`
+        );
+      }
+      const concatenatedBytes = new Uint8Array(64);
+      concatenatedBytes.set(decryptedData, 0);
+      concatenatedBytes.set(publicKeyBytes, 32);
+      return bs58.encode(concatenatedBytes);
+    }
+
     const decryptedDataHex = uint8ArrayToHexString(decryptedData);
     return returnMnemonic ? hexToAscii(decryptedDataHex) : decryptedDataHex;
   } catch (error) {
-    throw new Error(`"Error decrypting bundle:", ${error}`);
+    throw new Error(`Error decrypting bundle: ${error}`);
   }
 };
+
 
 /**
  * Verifies a signature from a Turnkey stamp using ECDSA and SHA-256.

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -18,7 +18,7 @@ import {
   uncompressRawPublicKey,
 } from "./crypto";
 
-import { ed25519 } from '@noble/curves/ed25519';
+import { ed25519 } from "@noble/curves/ed25519";
 
 interface DecryptExportBundleParams {
   exportBundle: string;
@@ -167,7 +167,6 @@ export const decryptExportBundle = async ({
     throw new Error(`Error decrypting bundle: ${error}`);
   }
 };
-
 
 /**
  * Verifies a signature from a Turnkey stamp using ECDSA and SHA-256.


### PR DESCRIPTION
## Summary & Motivation
We have this functionality in our iframe stamper but not in our 'crypto' helper functions

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
