### PR TITLE
Export the default tg cloud storage api key location

### DIFF
--- a/.changeset/wicked-frogs-prove.md
+++ b/.changeset/wicked-frogs-prove.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/telegram-cloud-storage-stamper": patch
+---
+
+Export the default cloud storage api key location

--- a/.changeset/wicked-frogs-prove.md
+++ b/.changeset/wicked-frogs-prove.md
@@ -1,5 +1,0 @@
----
-"@turnkey/telegram-cloud-storage-stamper": patch
----
-
-Export the default cloud storage api key location

--- a/packages/telegram-cloud-storage-stamper/CHANGELOG.md
+++ b/packages/telegram-cloud-storage-stamper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/telegram-cloud-storage-stamper
 
+## 1.0.2
+
+### Patch Changes
+
+- Export the default cloud storage api key location
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/telegram-cloud-storage-stamper/package.json
+++ b/packages/telegram-cloud-storage-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/telegram-cloud-storage-stamper",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/telegram-cloud-storage-stamper/src/index.ts
+++ b/packages/telegram-cloud-storage-stamper/src/index.ts
@@ -23,7 +23,7 @@ export type CloudStorageAPIKey = {
 };
 
 // Constant for default key name
-const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "TURNKEY_API_KEY";
+export const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "TURNKEY_API_KEY";
 
 /**
  * Stamper to use within a `TurnkeyClient`


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
