### PR TITLE
Adds postcss-import plugin + fixes import for react phone styles

### DIFF
--- a/.changeset/cuddly-starfishes-own.md
+++ b/.changeset/cuddly-starfishes-own.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react": patch
+---
+
+Fix build issues with React 19+ & NextJs 15+

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -66,10 +66,10 @@
     "usehooks-ts": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "@types/react": "^18.2.75"
   },
   "devDependencies": {
-    "@types/react": "^18.2.75",
     "postcss-import": "^16.1.0",
     "react": "^18.2.0"
   },

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -55,21 +55,22 @@
     "@mui/material": "^6.1.5",
     "@noble/hashes": "1.4.0",
     "@react-oauth/google": "^0.12.1",
-    "@turnkey/sdk-browser": "workspace:*",
-    "@turnkey/wallet-stamper": "workspace:*",
     "@turnkey/crypto": "workspace:*",
+    "@turnkey/sdk-browser": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
-    "usehooks-ts": "^3.1.0",
+    "@turnkey/wallet-stamper": "workspace:*",
     "libphonenumber-js": "^1.11.14",
     "next": "^15.0.2",
     "react-apple-login": "^1.1.6",
-    "react-international-phone": "^4.3.0"
+    "react-international-phone": "^4.3.0",
+    "usehooks-ts": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.75",
+    "postcss-import": "^16.1.0",
     "react": "^18.2.0"
   },
   "engines": {

--- a/packages/sdk-react/rollup.config.mjs
+++ b/packages/sdk-react/rollup.config.mjs
@@ -1,47 +1,54 @@
-import typescript from "@rollup/plugin-typescript";
-import nodeExternals from "rollup-plugin-node-externals";
-import path from "node:path";
-import postcss from "rollup-plugin-postcss";
-import preserveDirectives from "rollup-preserve-directives";
-import url from "@rollup/plugin-url";
-import alias from "@rollup/plugin-alias";
-import copy from "rollup-plugin-copy";
+import typescript from '@rollup/plugin-typescript';
+import nodeExternals from 'rollup-plugin-node-externals';
+import path from 'node:path';
+import postcss from 'rollup-plugin-postcss';
+import preserveDirectives from 'rollup-preserve-directives';
+import url from '@rollup/plugin-url';
+import alias from '@rollup/plugin-alias';
+import copy from 'rollup-plugin-copy';
+import postcssImport from 'postcss-import';
 
 const getFormatConfig = (format) => {
-  const pkgPath = path.join(process.cwd(), "package.json");
+  const pkgPath = path.join(process.cwd(), 'package.json');
   const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
   return {
     input: 'src/index.ts',
     output: {
       format,
-      dir: "dist",
+      dir: 'dist',
       entryFileNames: `[name].${format === 'esm' ? 'mjs' : 'js'}`,
       preserveModules: true,
       sourcemap: true,
     },
     plugins: [
-      alias({ // required for svg assets
+      alias({
+        // required for svg assets
         entries: [
-          { find: 'assets', replacement: path.resolve(__dirname, 'src/assets') }
-        ]
+          {
+            find: 'assets',
+            replacement: path.resolve(__dirname, 'src/assets'),
+          },
+        ],
       }),
-      postcss({ // required for css module bundling
+      postcss({
+        // required for css module bundling
         modules: true,
         extensions: ['.css', '.scss'],
         use: ['sass'],
         extract: `styles.${format}.css`,
         minimize: true,
         sourceMap: true,
+        plugins: [postcssImport()],
       }),
       typescript({
         outputToFilesystem: true,
         tsconfig: './tsconfig.json',
         compilerOptions: {
-          outDir: "dist",
+          outDir: 'dist',
           composite: false,
           declaration: format === 'esm',
-          declarationMap: format === "esm",
+          declarationMap: format === 'esm',
           sourceMap: true,
         },
       }),
@@ -50,29 +57,31 @@ const getFormatConfig = (format) => {
         packagePath: pkgPath,
         builtinsPrefix: 'ignore',
       }),
-      url({ // required for fonts and assets
+      url({
+        // required for fonts and assets
         include: [
-          '**/*.svg', 
-          '**/*.png', 
-          '**/*.jpg', 
+          '**/*.svg',
+          '**/*.png',
+          '**/*.jpg',
           '**/*.gif',
-          '**/*.woff', 
-          '**/*.woff2', 
-          '**/*.ttf', 
-          '**/*.eot'
+          '**/*.woff',
+          '**/*.woff2',
+          '**/*.ttf',
+          '**/*.eot',
         ],
         limit: 8192,
-        emitFiles: true, 
-        fileName: 'assets/fonts/[name].[hash][extname]', 
+        emitFiles: true,
+        fileName: 'assets/fonts/[name].[hash][extname]',
       }),
-      copy({ // required for fonts
+      copy({
+        // required for fonts
         targets: [
           {
-            src: path.resolve(__dirname, "src/assets/fonts/**/*"),
-            dest: path.resolve(__dirname, "dist/assets/fonts"),
+            src: path.resolve(__dirname, 'src/assets/fonts/**/*'),
+            dest: path.resolve(__dirname, 'dist/assets/fonts'),
           },
         ],
-        verbose: false, 
+        verbose: false,
       }),
     ],
   };

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import styles from "./Auth.module.css";
 import React, { useEffect, useState } from "react";
 import { initOtpAuth, getSuborgs, createSuborg, oauth } from "../../actions/";

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -1,24 +1,24 @@
-"use client";
+'use client';
 
-import styles from "./Auth.module.css";
-import React, { useEffect, useState } from "react";
-import { initOtpAuth, getSuborgs, createSuborg, oauth } from "../../actions/";
-import { MuiPhone } from "./PhoneInput";
-import GoogleAuthButton from "./Google";
-import AppleAuthButton from "./Apple";
-import FacebookAuthButton from "./Facebook";
-import { CircularProgress, TextField } from "@mui/material";
-import turnkeyIcon from "assets/turnkey.svg";
-import googleIcon from "assets/google.svg";
-import facebookIcon from "assets/facebook.svg";
-import appleIcon from "assets/apple.svg";
-import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
-import OtpVerification from "./OtpVerification";
-import { useTurnkey } from "../../hooks/use-turnkey";
-import { getVerifiedSuborgs } from "../../actions/getVerifiedSuborgs";
-import { FilterType, OtpType, authErrors } from "./constants";
+import styles from './Auth.module.css';
+import React, { useEffect, useState } from 'react';
+import { initOtpAuth, getSuborgs, createSuborg, oauth } from '../../actions/';
+import { MuiPhone } from './PhoneInput';
+import GoogleAuthButton from './Google';
+import AppleAuthButton from './Apple';
+import FacebookAuthButton from './Facebook';
+import { CircularProgress, TextField } from '@mui/material';
+import turnkeyIcon from 'assets/turnkey.svg';
+import googleIcon from 'assets/google.svg';
+import facebookIcon from 'assets/facebook.svg';
+import appleIcon from 'assets/apple.svg';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import OtpVerification from './OtpVerification';
+import { useTurnkey } from '../../hooks/use-turnkey';
+import { getVerifiedSuborgs } from '../../actions/getVerifiedSuborgs';
+import { FilterType, OtpType, authErrors } from './constants';
 
-type AuthSection = "email" | "passkey" | "phone" | "socials";
+type AuthSection = 'email' | 'passkey' | 'phone' | 'socials';
 
 const passkeyIcon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="43" height="48" fill="none">
@@ -64,7 +64,7 @@ interface AuthProps {
     facebookEnabled: boolean;
     googleEnabled: boolean;
   };
-  configOrder: string[];
+  configOrder: AuthSection[];
   customSmsMessage?: string;
 }
 
@@ -76,15 +76,15 @@ const Auth: React.FC<AuthProps> = ({
   customSmsMessage,
 }) => {
   const { passkeyClient, authIframeClient } = useTurnkey();
-  const [email, setEmail] = useState<string>("");
-  const [phone, setPhone] = useState<string>("");
+  const [email, setEmail] = useState<string>('');
+  const [phone, setPhone] = useState<string>('');
   const [otpId, setOtpId] = useState<string | null>(null);
-  const [step, setStep] = useState<string>("auth");
-  const [oauthLoading, setOauthLoading] = useState<string>("");
-  const [suborgId, setSuborgId] = useState<string>("");
+  const [step, setStep] = useState<string>('auth');
+  const [oauthLoading, setOauthLoading] = useState<string>('');
+  const [suborgId, setSuborgId] = useState<string>('');
   const [passkeySignupScreen, setPasskeySignupScreen] = useState(false);
   const [passkeyCreationScreen, setPasskeyCreationScreen] = useState(false);
-  const [passkeySignupError, setPasskeySignupError] = useState("");
+  const [passkeySignupError, setPasskeySignupError] = useState('');
   const [loading, setLoading] = useState(true);
   const [passkeyCreated, setPasskeyCreated] = useState(false);
 
@@ -172,16 +172,16 @@ const Auth: React.FC<AuthProps> = ({
   };
 
   const handleSignupWithPasskey = async () => {
-    setPasskeySignupError("");
+    setPasskeySignupError('');
     const siteInfo = `${
       new URL(window.location.href).hostname
     } - ${new Date().toLocaleString(undefined, {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
     })}`;
     setPasskeySignupScreen(false);
     setPasskeyCreationScreen(true);
@@ -196,7 +196,7 @@ const Auth: React.FC<AuthProps> = ({
           const response = await createSuborg({
             email,
             passkey: {
-              authenticatorName: "First Passkey",
+              authenticatorName: 'First Passkey',
               challenge: encodedChallenge,
               attestation,
             },
@@ -289,20 +289,20 @@ const Auth: React.FC<AuthProps> = ({
     <ChevronLeftIcon
       onClick={() => {
         setPasskeyCreationScreen(false);
-        setPasskeySignupError("");
+        setPasskeySignupError('');
         setPasskeySignupScreen(false);
         setOtpId(null);
       }}
       sx={{
-        color: "var(--text-secondary)",
-        position: "absolute",
+        color: 'var(--text-secondary)',
+        position: 'absolute',
         top: 16,
         left: 16,
         zIndex: 10,
-        cursor: "pointer",
-        borderRadius: "50%",
-        padding: "6px",
-        transition: "background-color 0.3s ease",
+        cursor: 'pointer',
+        borderRadius: '50%',
+        padding: '6px',
+        transition: 'background-color 0.3s ease',
       }}
     />
   );
@@ -311,13 +311,13 @@ const Auth: React.FC<AuthProps> = ({
     const { googleEnabled, appleEnabled, facebookEnabled } = authConfig;
     const layout =
       [googleEnabled, appleEnabled, facebookEnabled].filter(Boolean).length >= 2
-        ? "inline"
-        : "stacked";
+        ? 'inline'
+        : 'stacked';
 
     return (
       <div
         className={
-          layout === "inline"
+          layout === 'inline'
             ? styles.socialButtonContainerInline
             : styles.socialButtonContainerStacked
         }
@@ -328,7 +328,7 @@ const Auth: React.FC<AuthProps> = ({
             clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!}
             iframePublicKey={authIframeClient!.iframePublicKey!}
             onSuccess={(response: any) =>
-              handleOAuthLogin(response.idToken, "Google")
+              handleOAuthLogin(response.idToken, 'Google')
             }
           />
         )}
@@ -338,7 +338,7 @@ const Auth: React.FC<AuthProps> = ({
             clientId={process.env.NEXT_PUBLIC_APPLE_CLIENT_ID!}
             iframePublicKey={authIframeClient!.iframePublicKey!}
             onSuccess={(response: any) =>
-              handleOAuthLogin(response.idToken, "Apple")
+              handleOAuthLogin(response.idToken, 'Apple')
             }
           />
         )}
@@ -348,7 +348,7 @@ const Auth: React.FC<AuthProps> = ({
             clientId={process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID!}
             iframePublicKey={authIframeClient!.iframePublicKey!}
             onSuccess={(response: any) =>
-              handleOAuthLogin(response.id_token, "Facebook")
+              handleOAuthLogin(response.id_token, 'Facebook')
             }
           />
         )}
@@ -358,7 +358,7 @@ const Auth: React.FC<AuthProps> = ({
 
   const renderSection = (section: AuthSection) => {
     switch (section) {
-      case "email":
+      case 'email':
         return authConfig.emailEnabled && !otpId ? (
           <div>
             <div className={styles.inputGroup}>
@@ -371,23 +371,23 @@ const Auth: React.FC<AuthProps> = ({
                 onChange={(e) => setEmail(e.target.value)}
                 fullWidth
                 sx={{
-                  "& .MuiOutlinedInput-root": {
-                    color: "var(--input-text)",
-                    "& fieldset": {
-                      borderColor: "var(--input-border)",
+                  '& .MuiOutlinedInput-root': {
+                    color: 'var(--input-text)',
+                    '& fieldset': {
+                      borderColor: 'var(--input-border)',
                     },
-                    "&:hover fieldset": {
-                      borderColor: "var(--input-hover-border)",
+                    '&:hover fieldset': {
+                      borderColor: 'var(--input-hover-border)',
                     },
-                    "&.Mui-focused fieldset": {
-                      borderColor: "var(--input-focus-border)",
-                      border: "1px solid",
+                    '&.Mui-focused fieldset': {
+                      borderColor: 'var(--input-focus-border)',
+                      border: '1px solid',
                     },
                   },
-                  "& .MuiInputBase-input": {
-                    padding: "12px",
+                  '& .MuiInputBase-input': {
+                    padding: '12px',
                   },
-                  backgroundColor: "var(--input-bg)",
+                  backgroundColor: 'var(--input-bg)',
                 }}
                 variant="outlined"
               />
@@ -405,7 +405,7 @@ const Auth: React.FC<AuthProps> = ({
           </div>
         ) : null;
 
-      case "passkey":
+      case 'passkey':
         return authConfig.passkeyEnabled && !otpId ? (
           <div className={styles.passkeyContainer}>
             <button
@@ -424,7 +424,7 @@ const Auth: React.FC<AuthProps> = ({
           </div>
         ) : null;
 
-      case "phone":
+      case 'phone':
         return authConfig.phoneEnabled && !otpId ? (
           <div>
             <div className={styles.phoneInput}>
@@ -443,7 +443,7 @@ const Auth: React.FC<AuthProps> = ({
           </div>
         ) : null;
 
-      case "socials":
+      case 'socials':
         return authConfig.googleEnabled ||
           authConfig.appleEnabled ||
           authConfig.facebookEnabled
@@ -500,15 +500,15 @@ const Auth: React.FC<AuthProps> = ({
           <center>
             <h3 className={styles.primaryText}>
               {passkeySignupError
-                ? "Authentication error"
+                ? 'Authentication error'
                 : passkeyCreated
-                ? "Logging in with passkey..."
-                : "Creating passkey..."}
+                ? 'Logging in with passkey...'
+                : 'Creating passkey...'}
             </h3>
           </center>
           <div className={styles.rowsContainer}>
             <span className={styles.primaryText}>
-              <center>{passkeySignupError ? passkeySignupError : ""}</center>
+              <center>{passkeySignupError ? passkeySignupError : ''}</center>
             </span>
           </div>
           {passkeySignupError && (
@@ -523,7 +523,7 @@ const Auth: React.FC<AuthProps> = ({
         </div>
       ) : (
         <div>
-          {oauthLoading !== "" ? (
+          {oauthLoading !== '' ? (
             <div className={styles.authCardLoading}>
               <h3 className={styles.verifyingText}>
                 Verifying with {oauthLoading}
@@ -534,13 +534,13 @@ const Auth: React.FC<AuthProps> = ({
                   thickness={1}
                   className={styles.circularProgress!}
                 />
-                {oauthLoading === "Google" && (
+                {oauthLoading === 'Google' && (
                   <img src={googleIcon} className={styles.oauthIcon} />
                 )}
-                {oauthLoading === "Facebook" && (
+                {oauthLoading === 'Facebook' && (
                   <img src={facebookIcon} className={styles.oauthIcon} />
                 )}
-                {oauthLoading === "Apple" && (
+                {oauthLoading === 'Apple' && (
                   <img src={appleIcon} className={styles.oauthIcon} />
                 )}
               </div>
@@ -553,7 +553,7 @@ const Auth: React.FC<AuthProps> = ({
             <div className={styles.authCard}>
               {otpId && renderBackButton()}
               <h2 className={styles.primaryText}>
-                {!otpId && "Log in or sign up"}
+                {!otpId && 'Log in or sign up'}
               </h2>
               <div className={styles.authForm}>
                 {!otpId &&
@@ -584,7 +584,7 @@ const Auth: React.FC<AuthProps> = ({
                 {!otpId && (
                   <div className={styles.tos}>
                     <span>
-                      By continuing, you agree to our{" "}
+                      By continuing, you agree to our{' '}
                       <a
                         href="https://www.turnkey.com/legal/terms"
                         target="_blank"
@@ -592,8 +592,8 @@ const Auth: React.FC<AuthProps> = ({
                         className={styles.tosBold}
                       >
                         Terms of Service
-                      </a>{" "}
-                      &{" "}
+                      </a>{' '}
+                      &{' '}
                       <a
                         href="https://www.turnkey.com/legal/privacy"
                         target="_blank"
@@ -602,14 +602,14 @@ const Auth: React.FC<AuthProps> = ({
                       >
                         Privacy Policy
                       </a>
-                      {"."}
+                      {'.'}
                     </span>
                   </div>
                 )}
               </div>
               <div
                 onClick={() =>
-                  (window.location.href = "https://www.turnkey.com/")
+                  (window.location.href = 'https://www.turnkey.com/')
                 }
                 className={styles.poweredBy}
               >

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -18,8 +18,6 @@ import { useTurnkey } from "../../hooks/use-turnkey";
 import { getVerifiedSuborgs } from "../../actions/getVerifiedSuborgs";
 import { FilterType, OtpType, authErrors } from "./constants";
 
-type AuthSection = "email" | "passkey" | "phone" | "socials";
-
 const passkeyIcon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="43" height="48" fill="none">
     <path
@@ -64,7 +62,7 @@ interface AuthProps {
     facebookEnabled: boolean;
     googleEnabled: boolean;
   };
-  configOrder: AuthSection[];
+  configOrder: string[];
   customSmsMessage?: string;
 }
 
@@ -356,7 +354,7 @@ const Auth: React.FC<AuthProps> = ({
     );
   };
 
-  const renderSection = (section: AuthSection) => {
+  const renderSection = (section: string) => {
     switch (section) {
       case "email":
         return authConfig.emailEnabled && !otpId ? (

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -18,6 +18,8 @@ import { useTurnkey } from "../../hooks/use-turnkey";
 import { getVerifiedSuborgs } from "../../actions/getVerifiedSuborgs";
 import { FilterType, OtpType, authErrors } from "./constants";
 
+type AuthSection = "email" | "passkey" | "phone" | "socials";
+
 const passkeyIcon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="43" height="48" fill="none">
     <path
@@ -354,7 +356,7 @@ const Auth: React.FC<AuthProps> = ({
     );
   };
 
-  const renderSection = (section: string) => {
+  const renderSection = (section: AuthSection) => {
     switch (section) {
       case "email":
         return authConfig.emailEnabled && !otpId ? (

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -1,24 +1,24 @@
-'use client';
+"use client";
 
-import styles from './Auth.module.css';
-import React, { useEffect, useState } from 'react';
-import { initOtpAuth, getSuborgs, createSuborg, oauth } from '../../actions/';
-import { MuiPhone } from './PhoneInput';
-import GoogleAuthButton from './Google';
-import AppleAuthButton from './Apple';
-import FacebookAuthButton from './Facebook';
-import { CircularProgress, TextField } from '@mui/material';
-import turnkeyIcon from 'assets/turnkey.svg';
-import googleIcon from 'assets/google.svg';
-import facebookIcon from 'assets/facebook.svg';
-import appleIcon from 'assets/apple.svg';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import OtpVerification from './OtpVerification';
-import { useTurnkey } from '../../hooks/use-turnkey';
-import { getVerifiedSuborgs } from '../../actions/getVerifiedSuborgs';
-import { FilterType, OtpType, authErrors } from './constants';
+import styles from "./Auth.module.css";
+import React, { useEffect, useState } from "react";
+import { initOtpAuth, getSuborgs, createSuborg, oauth } from "../../actions/";
+import { MuiPhone } from "./PhoneInput";
+import GoogleAuthButton from "./Google";
+import AppleAuthButton from "./Apple";
+import FacebookAuthButton from "./Facebook";
+import { CircularProgress, TextField } from "@mui/material";
+import turnkeyIcon from "assets/turnkey.svg";
+import googleIcon from "assets/google.svg";
+import facebookIcon from "assets/facebook.svg";
+import appleIcon from "assets/apple.svg";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import OtpVerification from "./OtpVerification";
+import { useTurnkey } from "../../hooks/use-turnkey";
+import { getVerifiedSuborgs } from "../../actions/getVerifiedSuborgs";
+import { FilterType, OtpType, authErrors } from "./constants";
 
-type AuthSection = 'email' | 'passkey' | 'phone' | 'socials';
+type AuthSection = "email" | "passkey" | "phone" | "socials";
 
 const passkeyIcon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="43" height="48" fill="none">
@@ -76,15 +76,15 @@ const Auth: React.FC<AuthProps> = ({
   customSmsMessage,
 }) => {
   const { passkeyClient, authIframeClient } = useTurnkey();
-  const [email, setEmail] = useState<string>('');
-  const [phone, setPhone] = useState<string>('');
+  const [email, setEmail] = useState<string>("");
+  const [phone, setPhone] = useState<string>("");
   const [otpId, setOtpId] = useState<string | null>(null);
-  const [step, setStep] = useState<string>('auth');
-  const [oauthLoading, setOauthLoading] = useState<string>('');
-  const [suborgId, setSuborgId] = useState<string>('');
+  const [step, setStep] = useState<string>("auth");
+  const [oauthLoading, setOauthLoading] = useState<string>("");
+  const [suborgId, setSuborgId] = useState<string>("");
   const [passkeySignupScreen, setPasskeySignupScreen] = useState(false);
   const [passkeyCreationScreen, setPasskeyCreationScreen] = useState(false);
-  const [passkeySignupError, setPasskeySignupError] = useState('');
+  const [passkeySignupError, setPasskeySignupError] = useState("");
   const [loading, setLoading] = useState(true);
   const [passkeyCreated, setPasskeyCreated] = useState(false);
 
@@ -172,16 +172,16 @@ const Auth: React.FC<AuthProps> = ({
   };
 
   const handleSignupWithPasskey = async () => {
-    setPasskeySignupError('');
+    setPasskeySignupError("");
     const siteInfo = `${
       new URL(window.location.href).hostname
     } - ${new Date().toLocaleString(undefined, {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
     })}`;
     setPasskeySignupScreen(false);
     setPasskeyCreationScreen(true);
@@ -196,7 +196,7 @@ const Auth: React.FC<AuthProps> = ({
           const response = await createSuborg({
             email,
             passkey: {
-              authenticatorName: 'First Passkey',
+              authenticatorName: "First Passkey",
               challenge: encodedChallenge,
               attestation,
             },
@@ -289,20 +289,20 @@ const Auth: React.FC<AuthProps> = ({
     <ChevronLeftIcon
       onClick={() => {
         setPasskeyCreationScreen(false);
-        setPasskeySignupError('');
+        setPasskeySignupError("");
         setPasskeySignupScreen(false);
         setOtpId(null);
       }}
       sx={{
-        color: 'var(--text-secondary)',
-        position: 'absolute',
+        color: "var(--text-secondary)",
+        position: "absolute",
         top: 16,
         left: 16,
         zIndex: 10,
-        cursor: 'pointer',
-        borderRadius: '50%',
-        padding: '6px',
-        transition: 'background-color 0.3s ease',
+        cursor: "pointer",
+        borderRadius: "50%",
+        padding: "6px",
+        transition: "background-color 0.3s ease",
       }}
     />
   );
@@ -311,13 +311,13 @@ const Auth: React.FC<AuthProps> = ({
     const { googleEnabled, appleEnabled, facebookEnabled } = authConfig;
     const layout =
       [googleEnabled, appleEnabled, facebookEnabled].filter(Boolean).length >= 2
-        ? 'inline'
-        : 'stacked';
+        ? "inline"
+        : "stacked";
 
     return (
       <div
         className={
-          layout === 'inline'
+          layout === "inline"
             ? styles.socialButtonContainerInline
             : styles.socialButtonContainerStacked
         }
@@ -328,7 +328,7 @@ const Auth: React.FC<AuthProps> = ({
             clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!}
             iframePublicKey={authIframeClient!.iframePublicKey!}
             onSuccess={(response: any) =>
-              handleOAuthLogin(response.idToken, 'Google')
+              handleOAuthLogin(response.idToken, "Google")
             }
           />
         )}
@@ -338,7 +338,7 @@ const Auth: React.FC<AuthProps> = ({
             clientId={process.env.NEXT_PUBLIC_APPLE_CLIENT_ID!}
             iframePublicKey={authIframeClient!.iframePublicKey!}
             onSuccess={(response: any) =>
-              handleOAuthLogin(response.idToken, 'Apple')
+              handleOAuthLogin(response.idToken, "Apple")
             }
           />
         )}
@@ -348,7 +348,7 @@ const Auth: React.FC<AuthProps> = ({
             clientId={process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID!}
             iframePublicKey={authIframeClient!.iframePublicKey!}
             onSuccess={(response: any) =>
-              handleOAuthLogin(response.id_token, 'Facebook')
+              handleOAuthLogin(response.id_token, "Facebook")
             }
           />
         )}
@@ -358,7 +358,7 @@ const Auth: React.FC<AuthProps> = ({
 
   const renderSection = (section: AuthSection) => {
     switch (section) {
-      case 'email':
+      case "email":
         return authConfig.emailEnabled && !otpId ? (
           <div>
             <div className={styles.inputGroup}>
@@ -371,23 +371,23 @@ const Auth: React.FC<AuthProps> = ({
                 onChange={(e) => setEmail(e.target.value)}
                 fullWidth
                 sx={{
-                  '& .MuiOutlinedInput-root': {
-                    color: 'var(--input-text)',
-                    '& fieldset': {
-                      borderColor: 'var(--input-border)',
+                  "& .MuiOutlinedInput-root": {
+                    color: "var(--input-text)",
+                    "& fieldset": {
+                      borderColor: "var(--input-border)",
                     },
-                    '&:hover fieldset': {
-                      borderColor: 'var(--input-hover-border)',
+                    "&:hover fieldset": {
+                      borderColor: "var(--input-hover-border)",
                     },
-                    '&.Mui-focused fieldset': {
-                      borderColor: 'var(--input-focus-border)',
-                      border: '1px solid',
+                    "&.Mui-focused fieldset": {
+                      borderColor: "var(--input-focus-border)",
+                      border: "1px solid",
                     },
                   },
-                  '& .MuiInputBase-input': {
-                    padding: '12px',
+                  "& .MuiInputBase-input": {
+                    padding: "12px",
                   },
-                  backgroundColor: 'var(--input-bg)',
+                  backgroundColor: "var(--input-bg)",
                 }}
                 variant="outlined"
               />
@@ -405,7 +405,7 @@ const Auth: React.FC<AuthProps> = ({
           </div>
         ) : null;
 
-      case 'passkey':
+      case "passkey":
         return authConfig.passkeyEnabled && !otpId ? (
           <div className={styles.passkeyContainer}>
             <button
@@ -424,7 +424,7 @@ const Auth: React.FC<AuthProps> = ({
           </div>
         ) : null;
 
-      case 'phone':
+      case "phone":
         return authConfig.phoneEnabled && !otpId ? (
           <div>
             <div className={styles.phoneInput}>
@@ -443,7 +443,7 @@ const Auth: React.FC<AuthProps> = ({
           </div>
         ) : null;
 
-      case 'socials':
+      case "socials":
         return authConfig.googleEnabled ||
           authConfig.appleEnabled ||
           authConfig.facebookEnabled
@@ -500,15 +500,15 @@ const Auth: React.FC<AuthProps> = ({
           <center>
             <h3 className={styles.primaryText}>
               {passkeySignupError
-                ? 'Authentication error'
+                ? "Authentication error"
                 : passkeyCreated
-                ? 'Logging in with passkey...'
-                : 'Creating passkey...'}
+                ? "Logging in with passkey..."
+                : "Creating passkey..."}
             </h3>
           </center>
           <div className={styles.rowsContainer}>
             <span className={styles.primaryText}>
-              <center>{passkeySignupError ? passkeySignupError : ''}</center>
+              <center>{passkeySignupError ? passkeySignupError : ""}</center>
             </span>
           </div>
           {passkeySignupError && (
@@ -523,7 +523,7 @@ const Auth: React.FC<AuthProps> = ({
         </div>
       ) : (
         <div>
-          {oauthLoading !== '' ? (
+          {oauthLoading !== "" ? (
             <div className={styles.authCardLoading}>
               <h3 className={styles.verifyingText}>
                 Verifying with {oauthLoading}
@@ -534,13 +534,13 @@ const Auth: React.FC<AuthProps> = ({
                   thickness={1}
                   className={styles.circularProgress!}
                 />
-                {oauthLoading === 'Google' && (
+                {oauthLoading === "Google" && (
                   <img src={googleIcon} className={styles.oauthIcon} />
                 )}
-                {oauthLoading === 'Facebook' && (
+                {oauthLoading === "Facebook" && (
                   <img src={facebookIcon} className={styles.oauthIcon} />
                 )}
-                {oauthLoading === 'Apple' && (
+                {oauthLoading === "Apple" && (
                   <img src={appleIcon} className={styles.oauthIcon} />
                 )}
               </div>
@@ -553,7 +553,7 @@ const Auth: React.FC<AuthProps> = ({
             <div className={styles.authCard}>
               {otpId && renderBackButton()}
               <h2 className={styles.primaryText}>
-                {!otpId && 'Log in or sign up'}
+                {!otpId && "Log in or sign up"}
               </h2>
               <div className={styles.authForm}>
                 {!otpId &&
@@ -584,7 +584,7 @@ const Auth: React.FC<AuthProps> = ({
                 {!otpId && (
                   <div className={styles.tos}>
                     <span>
-                      By continuing, you agree to our{' '}
+                      By continuing, you agree to our{" "}
                       <a
                         href="https://www.turnkey.com/legal/terms"
                         target="_blank"
@@ -592,8 +592,8 @@ const Auth: React.FC<AuthProps> = ({
                         className={styles.tosBold}
                       >
                         Terms of Service
-                      </a>{' '}
-                      &{' '}
+                      </a>{" "}
+                      &{" "}
                       <a
                         href="https://www.turnkey.com/legal/privacy"
                         target="_blank"
@@ -602,14 +602,14 @@ const Auth: React.FC<AuthProps> = ({
                       >
                         Privacy Policy
                       </a>
-                      {'.'}
+                      {"."}
                     </span>
                   </div>
                 )}
               </div>
               <div
                 onClick={() =>
-                  (window.location.href = 'https://www.turnkey.com/')
+                  (window.location.href = "https://www.turnkey.com/")
                 }
                 className={styles.poweredBy}
               >

--- a/packages/sdk-react/src/components/auth/PhoneInput.css
+++ b/packages/sdk-react/src/components/auth/PhoneInput.css
@@ -1,1 +1,0 @@
-@import "react-international-phone/style.css";

--- a/packages/sdk-react/src/components/auth/PhoneInput.tsx
+++ b/packages/sdk-react/src/components/auth/PhoneInput.tsx
@@ -1,4 +1,3 @@
-import "./PhoneInput.css";
 import {
   BaseTextFieldProps,
   InputAdornment,
@@ -14,7 +13,7 @@ import {
   usePhoneInput,
 } from "react-international-phone";
 import { FlagImage as OriginalFlagImage } from "react-international-phone";
-
+import "react-international-phone/style.css";
 const FlagImage = OriginalFlagImage as React.ElementType;
 const allowedCountries = ["us", "ca"];
 

--- a/packages/sdk-react/src/index.ts
+++ b/packages/sdk-react/src/index.ts
@@ -1,6 +1,5 @@
 import "./components/auth/Auth.module.css";
 import "./components/auth/OtpVerification.module.css";
-import "./components/auth/PhoneInput.css";
 import "./components/export/Export.module.css";
 import "./components/import/Import.module.css";
 import "./components/theme.css";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1855,6 +1855,9 @@ importers:
       '@turnkey/wallet-stamper':
         specifier: workspace:*
         version: link:../wallet-stamper
+      '@types/react':
+        specifier: ^18.2.75
+        version: 18.2.75
       libphonenumber-js:
         specifier: ^1.11.14
         version: 1.11.14
@@ -1871,9 +1874,6 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(react@18.2.0)
     devDependencies:
-      '@types/react':
-        specifier: ^18.2.75
-        version: 18.2.75
       postcss-import:
         specifier: ^16.1.0
         version: 16.1.0(postcss@8.4.38)
@@ -7296,10 +7296,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.0
       '@emotion/cache': 11.13.1
-      '@emotion/react': 11.13.3(@types/react@18.2.75)(react@18.2.0)
+      '@emotion/react': 11.13.3(@types/react@18.2.14)(react@18.2.0)
       '@emotion/serialize': 1.3.2
       '@emotion/sheet': 1.4.0
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.75)(react@18.2.0)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.14)(react@18.2.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
@@ -13023,6 +13023,7 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.5
       csstype: 3.1.2
+    dev: false
 
   /@types/react@18.3.3:
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1874,6 +1874,9 @@ importers:
       '@types/react':
         specifier: ^18.2.75
         version: 18.2.75
+      postcss-import:
+        specifier: ^16.1.0
+        version: 16.1.0(postcss@8.4.38)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -7293,10 +7296,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.0
       '@emotion/cache': 11.13.1
-      '@emotion/react': 11.13.3(@types/react@18.2.14)(react@18.2.0)
+      '@emotion/react': 11.13.3(@types/react@18.2.75)(react@18.2.0)
       '@emotion/serialize': 1.3.2
       '@emotion/sheet': 1.4.0
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.14)(react@18.2.0)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.75)(react@18.2.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
@@ -21592,6 +21595,18 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
+
+  /postcss-import@16.1.0(postcss@8.4.38):
+    resolution: {integrity: sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.38
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+    dev: true
 
   /postcss-js@4.0.1(postcss@8.4.38):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}


### PR DESCRIPTION
## Summary & Motivation

### CSS Import Rules Error

After importing `import '@turnkey/sdk-react/styles';` in the `layout.tsx` file and running `npm run dev`, an error occurred. When bundling CSS with Rollup using `rollup-plugin-postcss`, `@import` rules are not being correctly placed at the top of the final CSS bundle. This violates CSS specifications, which require `@import` statements to precede all other rules (except `@charset` and `@layer`).

#### Solution

Add `postcss-import` plugin to the PostCSS configuration to the Rollup setup.

The `postcss-import` plugin processes `@import rules` and ensures they appear at the top of the CSS file. By including this in the PostCSS plugins array, all `@import` rules are handled correctly before other CSS rules are processed, preventing build errors.

```bash
@import rules must precede all rules aside from @charset and @layer statements at [project]/node_modules/@turnkey/sdk-react/dist/styles.esm.css:0:6309
```

#### Additional Build Error with postcss-import

When using `postcss-import`, I encountered a build error related to importing CSS from external packages:

```bash
postcss-import: Failed to find 'react-international-phone/style.css'
```

This occurs because `postcss-import` cannot resolve the CSS import from the `node_modules` directory when it's imported within a CSS file.

##### Solution

Instead of importing the styles in `PhoneInput.css`:

```css
@import "react-international-phone/style.css";
```

Move the import to the React component file (`PhoneInput.tsx`) directly:

```tsx
import "react-international-phone/style.css";
```

This approach allows the bundler to correctly resolve the CSS import from `node_modules`, fixing the build error.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
