### PR TITLE
sdk-react release Dec 19: css bundling issue fix

### DIFF
--- a/.changeset/cuddly-starfishes-own.md
+++ b/.changeset/cuddly-starfishes-own.md
@@ -1,5 +1,0 @@
----
-"@turnkey/sdk-react": patch
----
-
-Fix build issues with React 19+ & NextJs 15+

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/sdk-react
 
+## 2.0.2
+
+### Patch Changes
+
+- eaf3e20: Fix css related build issues with React 19+ & NextJs 15+
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
