### PR TITLE
Fix css bundling issue with sdk-react

### DIFF
--- a/.changeset/old-schools-lick.md
+++ b/.changeset/old-schools-lick.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react": patch
+---
+
+fix css bundling bug

--- a/packages/sdk-react/rollup.config.mjs
+++ b/packages/sdk-react/rollup.config.mjs
@@ -6,7 +6,6 @@ import preserveDirectives from "rollup-preserve-directives";
 import url from "@rollup/plugin-url";
 import alias from "@rollup/plugin-alias";
 import copy from "rollup-plugin-copy";
-import postcssImport from "postcss-import";
 
 const getFormatConfig = (format) => {
   const pkgPath = path.join(process.cwd(), "package.json");
@@ -39,7 +38,6 @@ const getFormatConfig = (format) => {
         extract: `styles.${format}.css`,
         minimize: true,
         sourceMap: true,
-        plugins: [postcssImport()],
       }),
       typescript({
         outputToFilesystem: true,

--- a/packages/sdk-react/src/components/auth/PhoneInput.module.css
+++ b/packages/sdk-react/src/components/auth/PhoneInput.module.css
@@ -1,0 +1,1 @@
+@import "react-international-phone/style.css";

--- a/packages/sdk-react/src/components/auth/PhoneInput.tsx
+++ b/packages/sdk-react/src/components/auth/PhoneInput.tsx
@@ -1,3 +1,4 @@
+import "./PhoneInput.module.css";
 import {
   BaseTextFieldProps,
   InputAdornment,
@@ -13,7 +14,6 @@ import {
   usePhoneInput,
 } from "react-international-phone";
 import { FlagImage as OriginalFlagImage } from "react-international-phone";
-import "react-international-phone/style.css";
 const FlagImage = OriginalFlagImage as React.ElementType;
 const allowedCountries = ["us", "ca"];
 

--- a/packages/sdk-react/src/index.ts
+++ b/packages/sdk-react/src/index.ts
@@ -1,3 +1,4 @@
+import "./components/auth/PhoneInput.module.css";
 import "./components/auth/Auth.module.css";
 import "./components/auth/OtpVerification.module.css";
 import "./components/export/Export.module.css";


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
