### PR TITLE
add request ids to iframe stamper

### DIFF
--- a/.changeset/long-baboons-boil.md
+++ b/.changeset/long-baboons-boil.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/iframe-stamper": minor
+---
+
+Add request ID to iframe requests

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -180,9 +180,6 @@ export class IframeStamper {
   }
 
   onMessageHandler(event: MessageEvent): void {
-    console.log("full event data", event.data);
-    console.log("pending requests", this.pendingRequests);
-
     const { type, value, requestId } = event.data || {};
 
     // Handle messages without requestId (like PUBLIC_KEY_READY)
@@ -279,17 +276,14 @@ export class IframeStamper {
    * Generic function to abstract away request creation
    * @param type
    * @param payload
-   * @returns
+   * @returns expected shape <T>
    */
   private createRequest<T>(
     type: IframeEventType,
     payload: any = {}
   ): Promise<T> {
-    console.log("creating request");
     return new Promise((resolve, reject) => {
       const requestId = generateUUID();
-
-      console.log("new request id", requestId);
 
       this.pendingRequests.set(requestId, {
         resolve,
@@ -411,7 +405,6 @@ export class IframeStamper {
    * Function to sign a payload with the underlying iframe
    */
   async stamp(payload: string): Promise<TStamp> {
-    console.log("calling stamp");
     if (this.iframePublicKey === null) {
       throw new Error(
         "null iframe public key. Have you called/awaited .init()?"


### PR DESCRIPTION
## Summary & Motivation
$title

iframe counterpart: https://github.com/tkhq/frames/pull/59

This mainly serves the case where there are concurrent, or serial, requests. Request IDs are used to disambiguate between multiple requests.

Latency implications: roughly ~4 seconds for 100 parallel signing requests, compared to ~0.7 seconds if signing 100 payloads using an im-memory API key stamper. The difference comes in overhead cost of the iframe communications.

## How I Tested These Changes
- email auth example (https://github.com/tkhq/sdk/pull/468)
  - tested for backwards compatibility as well

## Did you add a changeset?
- yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
