### PR TITLE
Font inheritance fix allowing for customization

### DIFF
--- a/.changeset/beige-swans-build.md
+++ b/.changeset/beige-swans-build.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react": patch
+---
+
+Fixed MUI components not inheriting fonts.

--- a/examples/react-components/src/app/dashboard/dashboard.css
+++ b/examples/react-components/src/app/dashboard/dashboard.css
@@ -1,27 +1,4 @@
-@font-face {
-  font-family: "Inter";
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url("../../../public/fonts/inter/Inter-Regular.woff2?v=3.19")
-    format("woff2");
-}
-
-@font-face {
-  font-family: "Inter";
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: url("../../../public/fonts/inter/Inter-SemiBold.woff2?v=3.19")
-    format("woff2");
-}
-
-.MuiTypography-root {
-  font-family: "Inter", Arial, sans-serif !important;
-}
-
 body {
-  font-family: "Inter";
   margin: 0;
   padding: 0;
   width: 100vw;
@@ -30,7 +7,6 @@ body {
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
-  font-family: Inter, sans-serif;
 }
 
 .loaderOverlay {
@@ -50,7 +26,6 @@ body {
   color: #4c48ff;
 }
 .main {
-  font-family: Inter;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -75,7 +50,6 @@ body {
   width: 542px;
   height: 584px;
   border: 1px solid var(--Greyscale-100, #ebedf2);
-  font-family: Arial, sans-serif;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
@@ -83,7 +57,6 @@ body {
 }
 
 .socialsTitle {
-  font-family: "Inter";
   font-size: 1rem;
   font-weight: 700;
   line-height: 26px;
@@ -93,7 +66,6 @@ body {
 }
 
 .configTitle {
-  font-family: "Inter";
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 36px;
@@ -472,7 +444,6 @@ button:hover {
   transition: opacity 0.3s ease;
 }
 .passkeyContainer {
-  font-family: "Inter";
   font-style: normal;
   font-weight: 400;
 }
@@ -485,7 +456,6 @@ button:hover {
 }
 
 .sonner-toaster {
-  font-family: "Inter";
   font-size: 14px;
   z-index: 9999;
   pointer-events: none;

--- a/examples/react-components/src/app/index.css
+++ b/examples/react-components/src/app/index.css
@@ -1,28 +1,4 @@
-@font-face {
-  font-family: "Inter";
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url("../../public/fonts/inter/Inter-Regular.woff2?v=3.19")
-    format("woff2");
-}
-
-@font-face {
-  font-family: "Inter";
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: url("../../public/fonts/inter/Inter-SemiBold.woff2?v=3.19")
-    format("woff2");
-}
-.MuiTypography-root {
-  font-family: "Inter", Arial, sans-serif !important;
-}
-:root {
-  font-family: "Inter";
-}
 body {
-  font-family: "Inter";
   margin: 0;
   padding: 0;
   width: 100vw;
@@ -34,7 +10,6 @@ body {
 }
 
 .main {
-  font-family: "Inter";
   display: flex;
   justify-content: center;
   align-items: center;
@@ -59,7 +34,6 @@ body {
   width: 542px;
   height: 584px;
   border: 1px solid var(--Greyscale-100, #ebedf2);
-  font-family: Arial, sans-serif;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
@@ -67,7 +41,6 @@ body {
 }
 
 .configTitle {
-  font-family: "Inter";
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 36px;

--- a/packages/sdk-react/src/components/auth/Auth.module.css
+++ b/packages/sdk-react/src/components/auth/Auth.module.css
@@ -87,7 +87,6 @@
 }
 
 .authButton {
-  font-family: "Inter";
   padding: 10px 16px;
   gap: 8px;
   color: var(--button-text);

--- a/packages/sdk-react/src/components/auth/Socials.module.css
+++ b/packages/sdk-react/src/components/auth/Socials.module.css
@@ -1,6 +1,5 @@
 .socialButton {
   letter-spacing: -0.01em;
-  font-family: "Inter";
   padding: 10px 16px;
   gap: 8px;
   color: var(--button-text);

--- a/packages/sdk-react/src/components/auth/TurnkeyThemeProvider.tsx
+++ b/packages/sdk-react/src/components/auth/TurnkeyThemeProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { createContext, useContext, useEffect } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { createTheme, ThemeProvider } from "@mui/material";
 
 const ThemeContext = createContext<Record<string, string> | null>(null);
 
@@ -31,6 +32,8 @@ export const TurnkeyThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
   theme,
 }) => {
+  const [muiTheme, setMuiTheme] = useState(createTheme({}));
+
   useEffect(() => {
     if (theme) {
       const root = document.documentElement.style;
@@ -38,11 +41,18 @@ export const TurnkeyThemeProvider: React.FC<ThemeProviderProps> = ({
         root.setProperty(key, value);
       });
     }
+    setMuiTheme(
+      createTheme({
+        typography: {
+          fontFamily: "inherit", // We want MUI components to use the same font as the rest of the app
+        },
+      })
+    );
   }, [theme]);
 
   return (
     <ThemeContext.Provider value={theme || null}>
-      {children}
+      <ThemeProvider theme={muiTheme}>{children}</ThemeProvider>
     </ThemeContext.Provider>
   );
 };

--- a/packages/sdk-react/src/components/export/Export.module.css
+++ b/packages/sdk-react/src/components/export/Export.module.css
@@ -8,7 +8,6 @@
 }
 
 .exportCard {
-  font-family: Inter;
   position: relative;
   width: 100%;
   max-width: 450px;
@@ -65,7 +64,6 @@
 }
 
 .rowsContainer {
-  font-family: Inter;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -87,7 +85,6 @@
 }
 
 .poweredBy {
-  font-family: Inter;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/sdk-react/src/components/import/Import.module.css
+++ b/packages/sdk-react/src/components/import/Import.module.css
@@ -8,7 +8,6 @@
 }
 
 .importCard {
-  font-family: Inter;
   position: relative;
   width: 100%;
   max-width: 450px;
@@ -61,7 +60,6 @@
 }
 
 .poweredBy {
-  font-family: Inter;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/sdk-react/src/components/theme.css
+++ b/packages/sdk-react/src/components/theme.css
@@ -71,3 +71,7 @@
   --icon-color: var(--Greyscale-900, #2b2f33);
   --error-color: #ff4c4c;
 }
+
+button {
+  font-family: inherit;
+}


### PR DESCRIPTION
## Summary & Motivation

- Fonts now apply to all components, including MUI
- All components inherit font applied to the 'body' of the page
- Removed unnecessary font applications

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
