### PR TITLE
fix: undefined client on first render

### DIFF
--- a/.changeset/smart-camels-tickle.md
+++ b/.changeset/smart-camels-tickle.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react": minor
+---
+
+Fix `undefined` client on first render

--- a/packages/sdk-react/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react/src/contexts/TurnkeyContext.tsx
@@ -151,7 +151,7 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
       }[session?.authClient];
       setClient(client);
     }
-  }, [session]);
+  }, [session, authIframeClient, passkeyClient, walletClient])
 
   return (
     <TurnkeyContext.Provider


### PR DESCRIPTION
## Summary & Motivation
 in every place where uses `const { client } = useTurnkey()` , `client` is `undefined` (if you reload page)

## How I Tested These Changes
Auth by email and reload page

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
