### PR TITLE
chore: update GitHub Action SHAs

### DIFF
--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
     # https://github.com/actions/setup-node
     - name: Install Node.js
-      uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
       with:
         node-version-file: ".nvmrc"
 
@@ -28,7 +28,7 @@ runs:
 
     # https://github.com/actions/cache
     - name: Setup pnpm store cache
-      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ steps.pnpm-cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Install and cache JS toolchain and dependencies (node_modules)
       - name: Setup JS


### PR DESCRIPTION
## Summary & Motivation

As of Feb 1, 2025 specific versions of `actions/cache` will be deprecated. Their [docs](https://github.com/actions/cache/releases/tag/v4.2.0) recommend using either the v4.2.0 or v3.4.0 GitHub SHA if you are using pinned versions in your workflows.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
