### PR TITLE
make modPow more efficient

### DIFF
--- a/packages/crypto/src/math.ts
+++ b/packages/crypto/src/math.ts
@@ -36,7 +36,7 @@ const modPow = (b: bigint, exp: bigint, p: bigint): bigint => {
   if (exp === BigInt(0)) {
     return BigInt(1);
   }
-  let result = b;
+  let result = b % p;
   const exponentBitString = exp.toString(2);
   for (let i = 1; i < exponentBitString.length; ++i) {
     result = (result * result) % p;

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -352,7 +352,7 @@ export const encryptPrivateKeyToBundle = async ({
     throw new Error('missing "targetPublic" in bundle signed data');
   }
 
-  // Load target public key generated from enclave and set in local storage
+  // Load target public key generated from enclave
   const targetKeyBuf = uint8ArrayFromHexString(signedData.targetPublic);
   const privateKeyBundle = hpkeEncrypt({ plainTextBuf, targetKeyBuf });
   return formatHpkeBuf(privateKeyBundle);
@@ -407,7 +407,7 @@ export const encryptWalletToBundle = async ({
     throw new Error('missing "targetPublic" in bundle signed data');
   }
 
-  // Load target public key generated from enclave and set in local storage
+  // Load target public key generated from enclave
   const targetKeyBuf = uint8ArrayFromHexString(signedData.targetPublic);
   const privateKeyBundle = hpkeEncrypt({ plainTextBuf, targetKeyBuf });
   return formatHpkeBuf(privateKeyBundle);


### PR DESCRIPTION
## Summary & Motivation

- Improved efficiency by adding `% p` in modPow to ensure calculations remain within a smaller range. This reduces unnecessary large number computations

- Small comment fix that didn't make sense to me

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
