### PR TITLE
chore: use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Get pnpm store directory (for caching)
       id: pnpm-cache-dir
       run: |
-        echo "::set-output name=dir::$(pnpm store path)"
+        echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
       shell: bash
 
     # https://github.com/actions/cache


### PR DESCRIPTION
## Summary & Motivation
 - `set-output` GitHub workflow command is deprecated
 
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

## How I Tested These Changes
 - via CI
 
<img width="1135" alt="Screenshot 2025-02-03 at 23 28 43" src="https://github.com/user-attachments/assets/4c62b8d9-e233-463f-8cf8-abfd9eaa5163" />

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
