### PR TITLE
remove use of "crypto" library

### DIFF
--- a/.changeset/brave-steaks-drop.md
+++ b/.changeset/brave-steaks-drop.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": minor
+---
+
+Migrated from WebCrypto (crypto.subtle.verify) to Noble for ECDSA signature verification to ensure compatibility with React Native and other environments where WebCrypto is not fully supported

--- a/.changeset/brave-steaks-drop.md
+++ b/.changeset/brave-steaks-drop.md
@@ -2,4 +2,4 @@
 "@turnkey/crypto": minor
 ---
 
-Migrated from WebCrypto (crypto.subtle.verify) to Noble for ECDSA signature verification to ensure compatibility with React Native and other environments where WebCrypto is not fully supported
+Migrated from WebCrypto (crypto.subtle.verify) to Noble

--- a/.changeset/brave-steaks-drop.md
+++ b/.changeset/brave-steaks-drop.md
@@ -1,5 +1,0 @@
----
-"@turnkey/crypto": minor
----
-
-Migrated from WebCrypto (crypto.subtle.verify) to Noble

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,10 +1,6 @@
 # @turnkey/crypto
 
-This package consolidates some common cryptographic utilities used across our applications, particularly primitives related to keys, encryption, and decryption in a pure JS implementation. For react-native you will need to polyfill our random byte generation by importing react-native-get-random-values: https://www.npmjs.com/package/react-native-get-random-values
-
-```
-import 'react-native-get-random-values'
-```
+This package consolidates some common cryptographic utilities used across our applications, particularly primitives related to keys, encryption, and decryption in a pure JS implementation.
 
 Example usage (Hpke E2E):
 

--- a/packages/crypto/jest.config.js
+++ b/packages/crypto/jest.config.js
@@ -9,7 +9,6 @@ const config = {
     "<rootDir>/src/__tests__/shared.ts",
   ],
   testTimeout: 30 * 1000, // For Github CI machines. Locally tests are quite fast.
-  setupFiles: ["./setup.js"],
 };
 
 module.exports = config;

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -49,7 +49,6 @@
     "bs58": "^5.0.0"
   },
   "devDependencies": {
-    "crypto": "1.0.1",
     "jest": "29.7.0",
     "@turnkey/encoding": "workspace:*",
     "@turnkey/http": "workspace:*",

--- a/packages/crypto/setup.js
+++ b/packages/crypto/setup.js
@@ -1,4 +1,0 @@
-// setup.js
-if (typeof crypto === "undefined") {
-  global.crypto = require("crypto");
-}

--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -30,7 +30,7 @@ describe("HPKE Encryption and Decryption", () => {
     const senderKeyPair = generateP256KeyPair();
     const receiverKeyPair = generateP256KeyPair();
     const receiverPublicKeyUncompressed = uncompressRawPublicKey(
-      uint8ArrayFromHexString(receiverKeyPair.publicKey)
+      uint8ArrayFromHexString(receiverKeyPair.publicKey),
     );
 
     const textEncoder = new TextEncoder();
@@ -66,7 +66,7 @@ describe("HPKE Standard Encryption and Decryption", () => {
     // Generate a receiver key pair
     const receiverKeyPair = generateP256KeyPair();
     const receiverPublicKeyUncompressed = uncompressRawPublicKey(
-      uint8ArrayFromHexString(receiverKeyPair.publicKey)
+      uint8ArrayFromHexString(receiverKeyPair.publicKey),
     );
 
     // Prepare the plaintext
@@ -153,7 +153,7 @@ describe("Turnkey Crypto Primitives", () => {
     const keyPair = generateP256KeyPair();
     const publicKey = getPublicKey(
       uint8ArrayFromHexString(keyPair.privateKey),
-      true
+      true,
     );
     expect(publicKey).toHaveLength(33);
   });
@@ -170,14 +170,14 @@ describe("Turnkey Crypto Primitives", () => {
   test("compressRawPublicKey - returns a valid value", () => {
     const { publicKey, publicKeyUncompressed } = generateP256KeyPair();
     expect(
-      compressRawPublicKey(uint8ArrayFromHexString(publicKeyUncompressed))
+      compressRawPublicKey(uint8ArrayFromHexString(publicKeyUncompressed)),
     ).toEqual(uint8ArrayFromHexString(publicKey));
   });
 
   test("decryptCredentialBundle - successfully decrypts a credential bundle", () => {
     const decryptedData = decryptCredentialBundle(
       mockCredentialBundle,
-      mockPrivateKey
+      mockPrivateKey,
     );
     expect(decryptedData).toBe(mockSenderPrivateKey);
   });
@@ -189,8 +189,8 @@ describe("Turnkey Crypto Primitives", () => {
       "01d95d256f744b2a855fe2036ec1074c726445f1382f53580a17ce3296cc2dec";
     expect(
       extractPrivateKeyFromPKCS8Bytes(
-        uint8ArrayFromHexString(pkcs8PrivateKeyHex)
-      )
+        uint8ArrayFromHexString(pkcs8PrivateKeyHex),
+      ),
     ).toEqual(uint8ArrayFromHexString(expectedRawPrivateKeyHex));
   });
 
@@ -207,7 +207,7 @@ describe("Turnkey Crypto Primitives", () => {
       {
         baseUrl: "https://api.turnkey.com",
       },
-      stamper
+      stamper,
     );
 
     const stampedRequest = await turnkeyClient.stampGetWhoami({
@@ -222,7 +222,7 @@ describe("Turnkey Crypto Primitives", () => {
     const verified = await verifyStampSignature(
       publicKey,
       signature,
-      stampedRequest.body
+      stampedRequest.body,
     );
 
     expect(verified).toEqual(true);

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -3,7 +3,7 @@ import { p256 } from "@noble/curves/p256";
 import * as hkdf from "@noble/hashes/hkdf";
 import { sha256 } from "@noble/hashes/sha256";
 import { gcm } from "@noble/ciphers/aes";
-import { randomBytes } from '@noble/hashes/utils';
+import { randomBytes } from "@noble/hashes/utils";
 
 import {
   uint8ArrayToHexString,

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -520,7 +520,7 @@ const bigIntToHex = (num: bigint, length: number): string => {
 };
 
 /**
- * Converts an ASN.1 DER-encoded ECDSA signature to the raw format that WebCrypto uses.
+ * Converts an ASN.1 DER-encoded ECDSA signature to the raw format used for verification.
  *
  * @param {string} derSignature - The DER-encoded signature.
  * @returns {Uint8Array} - The raw signature.

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -3,6 +3,7 @@ import { p256 } from "@noble/curves/p256";
 import * as hkdf from "@noble/hashes/hkdf";
 import { sha256 } from "@noble/hashes/sha256";
 import { gcm } from "@noble/ciphers/aes";
+import { randomBytes } from '@noble/hashes/utils';
 
 import {
   uint8ArrayToHexString,
@@ -375,14 +376,6 @@ export const uncompressRawPublicKey = (
 };
 
 /**
- * Generate a random Uint8Array of a specific length. Note that this ultimately depends on the crypto implementation.
- */
-const randomBytes = (length: number): Uint8Array => {
-  const array = new Uint8Array(length);
-  return crypto.getRandomValues(array);
-};
-
-/**
  * Build labeled Initial Key Material (IKM).
  *
  * @param {Uint8Array} label - The label to use.
@@ -532,7 +525,7 @@ const bigIntToHex = (num: bigint, length: number): string => {
  * @param {string} derSignature - The DER-encoded signature.
  * @returns {Uint8Array} - The raw signature.
  */
-export const fromDerSignature = (derSignature: string) => {
+export const fromDerSignature = (derSignature: string): Uint8Array => {
   const derSignatureBuf = uint8ArrayFromHexString(derSignature);
 
   // Check and skip the sequence tag (0x30)

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -20,7 +20,7 @@ import {
 
 import { p256 } from "@noble/curves/p256";
 import { ed25519 } from "@noble/curves/ed25519";
-import { ProjPointType } from "@noble/curves/abstract/weierstrass";
+import type { ProjPointType } from "@noble/curves/abstract/weierstrass";
 import { sha256 } from "@noble/hashes/sha256";
 
 interface DecryptExportBundleParams {

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -201,7 +201,7 @@ export const verifyStampSignature = async (
     throw new Error("failed to load public key");
   }
 
-  // The ECDSA signature is ASN.1 DER encoded but WebCrypto uses raw format
+  // Convert the ASN.1 DER-encoded signature for verification
   const publicSignatureBuf = fromDerSignature(signature);
   const signedDataBuf = Buffer.from(signedData);
   const hashedData = sha256(signedDataBuf);
@@ -242,7 +242,7 @@ const verifyEnclaveSignature = async (
     throw new Error("failed to load quorum key");
   }
 
-  // The ECDSA signature is ASN.1 DER encoded but WebCrypto uses raw format
+  // Convert the ASN.1 DER-encoded signature for verification
   const publicSignatureBuf = fromDerSignature(publicSignature);
   const signedDataBuf = uint8ArrayFromHexString(signedData);
   const hashedData = sha256(signedDataBuf);

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -205,7 +205,7 @@ export const verifyStampSignature = async (
   const publicSignatureBuf = fromDerSignature(signature);
   const signedDataBuf = Buffer.from(signedData);
   const hashedData = sha256(signedDataBuf);
-  
+
   return p256.verify(publicSignatureBuf, hashedData, loadedPublicKey.toHex());
 };
 
@@ -258,7 +258,7 @@ const verifyEnclaveSignature = async (
  * @throws {Error} - If the public key is invalid.
  */
 const loadPublicKey = (publicKey: Uint8Array): ProjPointType<bigint> => {
-    return p256.ProjectivePoint.fromHex(Buffer.from(publicKey).toString("hex"));
+  return p256.ProjectivePoint.fromHex(Buffer.from(publicKey).toString("hex"));
 };
 
 /**

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -203,7 +203,7 @@ export const verifyStampSignature = async (
 
   // Convert the ASN.1 DER-encoded signature for verification
   const publicSignatureBuf = fromDerSignature(signature);
-  const signedDataBuf = Buffer.from(signedData);
+  const signedDataBuf = new TextEncoder().encode(signedData);
   const hashedData = sha256(signedDataBuf);
 
   return p256.verify(publicSignatureBuf, hashedData, loadedPublicKey.toHex());
@@ -258,7 +258,7 @@ const verifyEnclaveSignature = async (
  * @throws {Error} - If the public key is invalid.
  */
 const loadPublicKey = (publicKey: Uint8Array): ProjPointType<bigint> => {
-  return p256.ProjectivePoint.fromHex(Buffer.from(publicKey).toString("hex"));
+  return p256.ProjectivePoint.fromHex(uint8ArrayToHexString(publicKey));
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1690,9 +1690,6 @@ importers:
       '@turnkey/sdk-server':
         specifier: workspace:*
         version: link:../sdk-server
-      crypto:
-        specifier: 1.0.1
-        version: 1.0.1
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@18.18.2)
@@ -15830,11 +15827,6 @@ packages:
   /crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
     dev: false
-
-  /crypto@1.0.1:
-    resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
-    deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
-    dev: true
 
   /css-box-model@1.2.1:
     resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}


### PR DESCRIPTION
## Summary & Motivation

Crypto doesn't work for React Native, and the polyfill didn't include crypto.subtle.verify (for verifyEnclaveSignature), so I had to migrate away from it and use Noble instead.

## How I Tested These Changes

I reran the tests and added decryptExportBundle tests.

## Did you add a changeset?

yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
