### PR TITLE
Patch release for sdk-react to fix EWK issues

### DIFF
--- a/.changeset/khaki-glasses-teach.md
+++ b/.changeset/khaki-glasses-teach.md
@@ -1,5 +1,0 @@
----
-"@turnkey/sdk-react": patch
----
-
-Patch EWK custom session lengths - previously not working as intended (defaulted to 15 minute sessions only) and fix the following useLocalStorage issue when compiling: [Error: useLocalStorage is a client-only hook]

--- a/.changeset/proud-moles-lie.md
+++ b/.changeset/proud-moles-lie.md
@@ -1,5 +1,0 @@
----
-"@turnkey/sdk-react": patch
----
-
-Fix issue with EWK where suborgs were being created on failed fetches

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/sdk-react
 
+## 3.0.2
+
+### Patch Changes
+
+- faa757c: Patch EWK custom session lengths - previously not working as intended (defaulted to 15 minute sessions only) and fix the following useLocalStorage issue when compiling: [Error: useLocalStorage is a client-only hook]
+- a8bd73b: Fix issue with EWK where suborgs were being created on failed fetches
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
