### PR TITLE
Update api endpoints for sdk

### DIFF
--- a/.changeset/smart-chefs-complain.md
+++ b/.changeset/smart-chefs-complain.md
@@ -1,0 +1,7 @@
+---
+"@turnkey/sdk-browser": minor
+"@turnkey/sdk-server": minor
+"@turnkey/http": minor
+---
+
+Update endpoints - surface GetWalletAccount

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -50,6 +50,10 @@ import type {
 import type { TGetUserBody, TGetUserResponse } from "./public_api.fetcher";
 import type { TGetWalletBody, TGetWalletResponse } from "./public_api.fetcher";
 import type {
+  TGetWalletAccountBody,
+  TGetWalletAccountResponse,
+} from "./public_api.fetcher";
+import type {
   TGetActivitiesBody,
   TGetActivitiesResponse,
 } from "./public_api.fetcher";
@@ -722,6 +726,37 @@ export class TurnkeyClient {
   };
 
   /**
+   * Get a single wallet account
+   *
+   * Sign the provided `TGetWalletAccountBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_wallet_account).
+   *
+   * See also {@link stampGetWalletAccount}.
+   */
+  getWalletAccount = async (
+    input: TGetWalletAccountBody,
+  ): Promise<TGetWalletAccountResponse> => {
+    return this.request("/public/v1/query/get_wallet_account", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetWalletAccountBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetWalletAccount}.
+   */
+  stampGetWalletAccount = async (
+    input: TGetWalletAccountBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/query/get_wallet_account";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * List all Activities within an Organization
    *
    * Sign the provided `TGetActivitiesBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/list_activities).
@@ -968,7 +1003,7 @@ export class TurnkeyClient {
   };
 
   /**
-   * List all Accounts wirhin a Wallet
+   * List all Accounts within a Wallet
    *
    * Sign the provided `TGetWalletAccountsBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/list_wallet_accounts).
    *

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -640,6 +640,58 @@ export const signGetWallet = (
   });
 
 /**
+ * `POST /public/v1/query/get_wallet_account`
+ */
+export type TGetWalletAccountResponse =
+  operations["PublicApiService_GetWalletAccount"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_wallet_account`
+ */
+export type TGetWalletAccountInput = { body: TGetWalletAccountBody };
+
+/**
+ * `POST /public/v1/query/get_wallet_account`
+ */
+export type TGetWalletAccountBody =
+  operations["PublicApiService_GetWalletAccount"]["parameters"]["body"]["body"];
+
+/**
+ * Get Wallet Account
+ *
+ * Get a single wallet account
+ *
+ * `POST /public/v1/query/get_wallet_account`
+ */
+export const getWalletAccount = (input: TGetWalletAccountInput) =>
+  request<
+    TGetWalletAccountResponse,
+    TGetWalletAccountBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/query/get_wallet_account",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetWalletAccount` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetWalletAccount}
+ */
+export const signGetWalletAccount = (
+  input: TGetWalletAccountInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetWalletAccountBody, never, never>({
+    uri: "/public/v1/query/get_wallet_account",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/query/list_activities`
  */
 export type TGetActivitiesResponse =
@@ -1039,7 +1091,7 @@ export type TGetWalletAccountsBody =
 /**
  * List Wallets Accounts
  *
- * List all Accounts wirhin a Wallet
+ * List all Accounts within a Wallet
  *
  * `POST /public/v1/query/list_wallet_accounts`
  */

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -484,6 +484,38 @@
         "tags": ["Wallets"]
       }
     },
+    "/public/v1/query/get_wallet_account": {
+      "post": {
+        "summary": "Get Wallet Account",
+        "description": "Get a single wallet account",
+        "operationId": "PublicApiService_GetWalletAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletAccountRequest"
+            }
+          }
+        ],
+        "tags": ["Wallets"]
+      }
+    },
     "/public/v1/query/list_activities": {
       "post": {
         "summary": "List Activities",
@@ -743,7 +775,7 @@
     "/public/v1/query/list_wallet_accounts": {
       "post": {
         "summary": "List Wallets Accounts",
-        "description": "List all Accounts wirhin a Wallet",
+        "description": "List all Accounts within a Wallet",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
           "200": {
@@ -6151,6 +6183,38 @@
       },
       "required": ["organizationIds"]
     },
+    "v1GetWalletAccountRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "walletId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address corresponding to a Wallet Account."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path corresponding to a Wallet Account."
+        }
+      },
+      "required": ["organizationId", "walletId"]
+    },
+    "v1GetWalletAccountResponse": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/v1WalletAccount",
+          "description": "The resulting Wallet Account."
+        }
+      },
+      "required": ["account"]
+    },
     "v1GetWalletAccountsRequest": {
       "type": "object",
       "properties": {
@@ -6178,7 +6242,7 @@
             "type": "object",
             "$ref": "#/definitions/v1WalletAccount"
           },
-          "description": "A list of Accounts generated from a Wallet that share a common seed"
+          "description": "A list of Accounts generated from a Wallet that share a common seed."
         }
       },
       "required": ["accounts"]

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -56,6 +56,10 @@ export type paths = {
     /** Get details about a Wallet */
     post: operations["PublicApiService_GetWallet"];
   };
+  "/public/v1/query/get_wallet_account": {
+    /** Get a single wallet account */
+    post: operations["PublicApiService_GetWalletAccount"];
+  };
   "/public/v1/query/list_activities": {
     /** List all Activities within an Organization */
     post: operations["PublicApiService_GetActivities"];
@@ -89,7 +93,7 @@ export type paths = {
     post: operations["PublicApiService_GetVerifiedSubOrgIds"];
   };
   "/public/v1/query/list_wallet_accounts": {
-    /** List all Accounts wirhin a Wallet */
+    /** List all Accounts within a Wallet */
     post: operations["PublicApiService_GetWalletAccounts"];
   };
   "/public/v1/query/list_wallets": {
@@ -1807,6 +1811,20 @@ export type definitions = {
     /** @description List of unique identifiers for the matching sub-organizations. */
     organizationIds: string[];
   };
+  v1GetWalletAccountRequest: {
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given Wallet. */
+    walletId: string;
+    /** @description Address corresponding to a Wallet Account. */
+    address?: string;
+    /** @description Path corresponding to a Wallet Account. */
+    path?: string;
+  };
+  v1GetWalletAccountResponse: {
+    /** @description The resulting Wallet Account. */
+    account: definitions["v1WalletAccount"];
+  };
   v1GetWalletAccountsRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -1816,7 +1834,7 @@ export type definitions = {
     paginationOptions?: definitions["v1Pagination"];
   };
   v1GetWalletAccountsResponse: {
-    /** @description A list of Accounts generated from a Wallet that share a common seed */
+    /** @description A list of Accounts generated from a Wallet that share a common seed. */
     accounts: definitions["v1WalletAccount"][];
   };
   v1GetWalletRequest: {
@@ -3122,6 +3140,24 @@ export type operations = {
       };
     };
   };
+  /** Get a single wallet account */
+  PublicApiService_GetWalletAccount: {
+    parameters: {
+      body: {
+        body: definitions["v1GetWalletAccountRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetWalletAccountResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** List all Activities within an Organization */
   PublicApiService_GetActivities: {
     parameters: {
@@ -3266,7 +3302,7 @@ export type operations = {
       };
     };
   };
-  /** List all Accounts wirhin a Wallet */
+  /** List all Accounts within a Wallet */
   PublicApiService_GetWalletAccounts: {
     parameters: {
       body: {

--- a/packages/sdk-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-browser/src/__generated__/sdk-client-base.ts
@@ -480,6 +480,32 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getWalletAccount = async (
+    input: SdkApiTypes.TGetWalletAccountBody,
+  ): Promise<SdkApiTypes.TGetWalletAccountResponse> => {
+    return this.request("/public/v1/query/get_wallet_account", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetWalletAccount = async (
+    input: SdkApiTypes.TGetWalletAccountBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_wallet_account";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getActivities = async (
     input: SdkApiTypes.TGetActivitiesBody = {},
   ): Promise<SdkApiTypes.TGetActivitiesResponse> => {

--- a/packages/sdk-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-browser/src/__generated__/sdk_api_types.ts
@@ -154,6 +154,17 @@ export type TGetWalletBody = Omit<
 > &
   queryOverrideParams;
 
+export type TGetWalletAccountResponse =
+  operations["PublicApiService_GetWalletAccount"]["responses"]["200"]["schema"];
+
+export type TGetWalletAccountInput = { body: TGetWalletAccountBody };
+
+export type TGetWalletAccountBody = Omit<
+  operations["PublicApiService_GetWalletAccount"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetActivitiesResponse =
   operations["PublicApiService_GetActivities"]["responses"]["200"]["schema"];
 

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -484,6 +484,38 @@
         "tags": ["Wallets"]
       }
     },
+    "/public/v1/query/get_wallet_account": {
+      "post": {
+        "summary": "Get Wallet Account",
+        "description": "Get a single wallet account",
+        "operationId": "PublicApiService_GetWalletAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletAccountRequest"
+            }
+          }
+        ],
+        "tags": ["Wallets"]
+      }
+    },
     "/public/v1/query/list_activities": {
       "post": {
         "summary": "List Activities",
@@ -743,7 +775,7 @@
     "/public/v1/query/list_wallet_accounts": {
       "post": {
         "summary": "List Wallets Accounts",
-        "description": "List all Accounts wirhin a Wallet",
+        "description": "List all Accounts within a Wallet",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
           "200": {
@@ -6151,6 +6183,38 @@
       },
       "required": ["organizationIds"]
     },
+    "v1GetWalletAccountRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "walletId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address corresponding to a Wallet Account."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path corresponding to a Wallet Account."
+        }
+      },
+      "required": ["organizationId", "walletId"]
+    },
+    "v1GetWalletAccountResponse": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/v1WalletAccount",
+          "description": "The resulting Wallet Account."
+        }
+      },
+      "required": ["account"]
+    },
     "v1GetWalletAccountsRequest": {
       "type": "object",
       "properties": {
@@ -6178,7 +6242,7 @@
             "type": "object",
             "$ref": "#/definitions/v1WalletAccount"
           },
-          "description": "A list of Accounts generated from a Wallet that share a common seed"
+          "description": "A list of Accounts generated from a Wallet that share a common seed."
         }
       },
       "required": ["accounts"]

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -56,6 +56,10 @@ export type paths = {
     /** Get details about a Wallet */
     post: operations["PublicApiService_GetWallet"];
   };
+  "/public/v1/query/get_wallet_account": {
+    /** Get a single wallet account */
+    post: operations["PublicApiService_GetWalletAccount"];
+  };
   "/public/v1/query/list_activities": {
     /** List all Activities within an Organization */
     post: operations["PublicApiService_GetActivities"];
@@ -89,7 +93,7 @@ export type paths = {
     post: operations["PublicApiService_GetVerifiedSubOrgIds"];
   };
   "/public/v1/query/list_wallet_accounts": {
-    /** List all Accounts wirhin a Wallet */
+    /** List all Accounts within a Wallet */
     post: operations["PublicApiService_GetWalletAccounts"];
   };
   "/public/v1/query/list_wallets": {
@@ -1807,6 +1811,20 @@ export type definitions = {
     /** @description List of unique identifiers for the matching sub-organizations. */
     organizationIds: string[];
   };
+  v1GetWalletAccountRequest: {
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given Wallet. */
+    walletId: string;
+    /** @description Address corresponding to a Wallet Account. */
+    address?: string;
+    /** @description Path corresponding to a Wallet Account. */
+    path?: string;
+  };
+  v1GetWalletAccountResponse: {
+    /** @description The resulting Wallet Account. */
+    account: definitions["v1WalletAccount"];
+  };
   v1GetWalletAccountsRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -1816,7 +1834,7 @@ export type definitions = {
     paginationOptions?: definitions["v1Pagination"];
   };
   v1GetWalletAccountsResponse: {
-    /** @description A list of Accounts generated from a Wallet that share a common seed */
+    /** @description A list of Accounts generated from a Wallet that share a common seed. */
     accounts: definitions["v1WalletAccount"][];
   };
   v1GetWalletRequest: {
@@ -3122,6 +3140,24 @@ export type operations = {
       };
     };
   };
+  /** Get a single wallet account */
+  PublicApiService_GetWalletAccount: {
+    parameters: {
+      body: {
+        body: definitions["v1GetWalletAccountRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetWalletAccountResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** List all Activities within an Organization */
   PublicApiService_GetActivities: {
     parameters: {
@@ -3266,7 +3302,7 @@ export type operations = {
       };
     };
   };
-  /** List all Accounts wirhin a Wallet */
+  /** List all Accounts within a Wallet */
   PublicApiService_GetWalletAccounts: {
     parameters: {
       body: {

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -469,6 +469,32 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getWalletAccount = async (
+    input: SdkApiTypes.TGetWalletAccountBody,
+  ): Promise<SdkApiTypes.TGetWalletAccountResponse> => {
+    return this.request("/public/v1/query/get_wallet_account", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetWalletAccount = async (
+    input: SdkApiTypes.TGetWalletAccountBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_wallet_account";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getActivities = async (
     input: SdkApiTypes.TGetActivitiesBody = {},
   ): Promise<SdkApiTypes.TGetActivitiesResponse> => {

--- a/packages/sdk-server/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-server/src/__generated__/sdk_api_types.ts
@@ -154,6 +154,17 @@ export type TGetWalletBody = Omit<
 > &
   queryOverrideParams;
 
+export type TGetWalletAccountResponse =
+  operations["PublicApiService_GetWalletAccount"]["responses"]["200"]["schema"];
+
+export type TGetWalletAccountInput = { body: TGetWalletAccountBody };
+
+export type TGetWalletAccountBody = Omit<
+  operations["PublicApiService_GetWalletAccount"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetActivitiesResponse =
   operations["PublicApiService_GetActivities"]["responses"]["200"]["schema"];
 

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -484,6 +484,38 @@
         "tags": ["Wallets"]
       }
     },
+    "/public/v1/query/get_wallet_account": {
+      "post": {
+        "summary": "Get Wallet Account",
+        "description": "Get a single wallet account",
+        "operationId": "PublicApiService_GetWalletAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletAccountRequest"
+            }
+          }
+        ],
+        "tags": ["Wallets"]
+      }
+    },
     "/public/v1/query/list_activities": {
       "post": {
         "summary": "List Activities",
@@ -743,7 +775,7 @@
     "/public/v1/query/list_wallet_accounts": {
       "post": {
         "summary": "List Wallets Accounts",
-        "description": "List all Accounts wirhin a Wallet",
+        "description": "List all Accounts within a Wallet",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
           "200": {
@@ -6151,6 +6183,38 @@
       },
       "required": ["organizationIds"]
     },
+    "v1GetWalletAccountRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "walletId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address corresponding to a Wallet Account."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path corresponding to a Wallet Account."
+        }
+      },
+      "required": ["organizationId", "walletId"]
+    },
+    "v1GetWalletAccountResponse": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/v1WalletAccount",
+          "description": "The resulting Wallet Account."
+        }
+      },
+      "required": ["account"]
+    },
     "v1GetWalletAccountsRequest": {
       "type": "object",
       "properties": {
@@ -6178,7 +6242,7 @@
             "type": "object",
             "$ref": "#/definitions/v1WalletAccount"
           },
-          "description": "A list of Accounts generated from a Wallet that share a common seed"
+          "description": "A list of Accounts generated from a Wallet that share a common seed."
         }
       },
       "required": ["accounts"]

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -56,6 +56,10 @@ export type paths = {
     /** Get details about a Wallet */
     post: operations["PublicApiService_GetWallet"];
   };
+  "/public/v1/query/get_wallet_account": {
+    /** Get a single wallet account */
+    post: operations["PublicApiService_GetWalletAccount"];
+  };
   "/public/v1/query/list_activities": {
     /** List all Activities within an Organization */
     post: operations["PublicApiService_GetActivities"];
@@ -89,7 +93,7 @@ export type paths = {
     post: operations["PublicApiService_GetVerifiedSubOrgIds"];
   };
   "/public/v1/query/list_wallet_accounts": {
-    /** List all Accounts wirhin a Wallet */
+    /** List all Accounts within a Wallet */
     post: operations["PublicApiService_GetWalletAccounts"];
   };
   "/public/v1/query/list_wallets": {
@@ -1807,6 +1811,20 @@ export type definitions = {
     /** @description List of unique identifiers for the matching sub-organizations. */
     organizationIds: string[];
   };
+  v1GetWalletAccountRequest: {
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given Wallet. */
+    walletId: string;
+    /** @description Address corresponding to a Wallet Account. */
+    address?: string;
+    /** @description Path corresponding to a Wallet Account. */
+    path?: string;
+  };
+  v1GetWalletAccountResponse: {
+    /** @description The resulting Wallet Account. */
+    account: definitions["v1WalletAccount"];
+  };
   v1GetWalletAccountsRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -1816,7 +1834,7 @@ export type definitions = {
     paginationOptions?: definitions["v1Pagination"];
   };
   v1GetWalletAccountsResponse: {
-    /** @description A list of Accounts generated from a Wallet that share a common seed */
+    /** @description A list of Accounts generated from a Wallet that share a common seed. */
     accounts: definitions["v1WalletAccount"][];
   };
   v1GetWalletRequest: {
@@ -3122,6 +3140,24 @@ export type operations = {
       };
     };
   };
+  /** Get a single wallet account */
+  PublicApiService_GetWalletAccount: {
+    parameters: {
+      body: {
+        body: definitions["v1GetWalletAccountRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetWalletAccountResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** List all Activities within an Organization */
   PublicApiService_GetActivities: {
     parameters: {
@@ -3266,7 +3302,7 @@ export type operations = {
       };
     };
   };
-  /** List all Accounts wirhin a Wallet */
+  /** List all Accounts within a Wallet */
   PublicApiService_GetWalletAccounts: {
     parameters: {
       body: {


### PR DESCRIPTION
## Summary & Motivation
Based on Mono release version v2025.2.1 (most recent)

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
