### PR TITLE
Update API endpoints

### DIFF
--- a/.changeset/smart-chefs-complain.md
+++ b/.changeset/smart-chefs-complain.md
@@ -1,7 +1,0 @@
----
-"@turnkey/sdk-browser": minor
-"@turnkey/sdk-server": minor
-"@turnkey/http": minor
----
-
-Update endpoints - surface GetWalletAccount

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/cosmjs
 
+## 0.6.11
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/sdk-browser@1.13.0
+  - @turnkey/sdk-server@2.1.0
+  - @turnkey/http@2.19.0
+
 ## 0.6.10
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @turnkey/eip-1193-provider
 
-## 4.0.0
+## 3.1.2
 
 ### Patch Changes
 

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/eip-1193-provider
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/sdk-browser@1.13.0
+  - @turnkey/http@2.19.0
+
 ## 3.1.1
 
 ### Patch Changes

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "4.0.0",
+  "version": "3.1.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/src/version.ts
+++ b/packages/eip-1193-provider/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/eip-1193-provider@3.1.1";
+export const VERSION = "@turnkey/eip-1193-provider@4.0.0";

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/ethers
 
+## 1.1.13
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/sdk-browser@1.13.0
+  - @turnkey/sdk-server@2.1.0
+  - @turnkey/http@2.19.0
+
 ## 1.1.12
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/http
 
+## 2.19.0
+
+### Minor Changes
+
+- 57f9cb0: Update endpoints - surface GetWalletAccount
+
 ## 2.18.0
 
 ### Minor Changes

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 57f9cb0: Update endpoints - surface GetWalletAccount
+- 57f9cb0: Update per mono release v2025.2.1 - surface GetWalletAccount
 
 ## 2.18.0
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@2.18.0";
+export const VERSION = "@turnkey/http@2.19.0";

--- a/packages/react-native-passkey-stamper/CHANGELOG.md
+++ b/packages/react-native-passkey-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/react-native-passkey-stamper
 
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/http@2.19.0
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/react-native-passkey-stamper/package.json
+++ b/packages/react-native-passkey-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-native-passkey-stamper",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/CHANGELOG.md
+++ b/packages/sdk-browser/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @turnkey/sdk-browser
 
+## 1.13.0
+
+### Minor Changes
+
+- 57f9cb0: Update endpoints - surface GetWalletAccount
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/http@2.19.0
+  - @turnkey/crypto@2.3.1
+  - @turnkey/wallet-stamper@1.0.3
+
 ## 1.12.1
 
 ### Patch Changes

--- a/packages/sdk-browser/CHANGELOG.md
+++ b/packages/sdk-browser/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 57f9cb0: Update endpoints - surface GetWalletAccount
+- 57f9cb0: Update per mono release v2025.2.1 - surface GetWalletAccount
 
 ### Patch Changes
 

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-browser",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/src/__generated__/version.ts
+++ b/packages/sdk-browser/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-browser@1.12.1";
+export const VERSION = "@turnkey/sdk-browser@1.13.0";

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/sdk-react
 
+## 3.0.3
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/sdk-browser@1.13.0
+  - @turnkey/sdk-server@2.1.0
+  - @turnkey/crypto@2.3.1
+  - @turnkey/wallet-stamper@1.0.3
+
 ## 3.0.2
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/CHANGELOG.md
+++ b/packages/sdk-server/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 57f9cb0: Update endpoints - surface GetWalletAccount
+- 57f9cb0: Update per mono release v2025.2.1 - surface GetWalletAccount
 
 ### Patch Changes
 

--- a/packages/sdk-server/CHANGELOG.md
+++ b/packages/sdk-server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/sdk-server
 
+## 2.1.0
+
+### Minor Changes
+
+- 57f9cb0: Update endpoints - surface GetWalletAccount
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/http@2.19.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-server",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/src/__generated__/version.ts
+++ b/packages/sdk-server/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-server@2.0.1";
+export const VERSION = "@turnkey/sdk-server@2.1.0";

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/solana
 
+## 1.0.12
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/sdk-browser@1.13.0
+  - @turnkey/sdk-server@2.1.0
+  - @turnkey/http@2.19.0
+
 ## 1.0.11
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/viem
 
+## 0.6.12
+
+### Patch Changes
+
+- Updated dependencies [57f9cb0]
+  - @turnkey/sdk-browser@1.13.0
+  - @turnkey/sdk-server@2.1.0
+  - @turnkey/http@2.19.0
+
 ## 0.6.11
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
Mono v2025.2.1 (latest release)

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
