### PR TITLE
chore: use named exports in Telegram package

### DIFF
--- a/.changeset/spicy-llamas-tease.md
+++ b/.changeset/spicy-llamas-tease.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/telegram-cloud-storage-stamper": patch
+---
+
+Remove default export and use named exports

--- a/.changeset/spicy-llamas-tease.md
+++ b/.changeset/spicy-llamas-tease.md
@@ -1,5 +1,0 @@
----
-"@turnkey/telegram-cloud-storage-stamper": patch
----
-
-Remove default export and use named exports

--- a/.changeset/stale-ducks-sneeze.md
+++ b/.changeset/stale-ducks-sneeze.md
@@ -1,0 +1,24 @@
+---
+"@turnkey/telegram-cloud-storage-stamper": major
+---
+
+Remove default export and used all named exportsfor consistency
+
+### Package imports for `@turnkey/telegram-cloud-storage-stamper`
+
+#### for versions < v2.0.0
+
+```typescript
+import TelegramCloudStorageStamper, {
+  CloudStorageAPIKey,
+} from "@turnkey/telegram-cloud-storage-stamper";
+```
+
+#### for versions >= v2.0.0
+
+```typescript
+import {
+  TelegramCloudStorageStamper,
+  CloudStorageAPIKey,
+} from "@turnkey/telegram-cloud-storage-stamper";
+```

--- a/.changeset/stale-ducks-sneeze.md
+++ b/.changeset/stale-ducks-sneeze.md
@@ -2,7 +2,7 @@
 "@turnkey/telegram-cloud-storage-stamper": major
 ---
 
-Remove default export and used all named exportsfor consistency
+Remove default export and used all named exports for consistency
 
 ### Package imports for `@turnkey/telegram-cloud-storage-stamper`
 

--- a/packages/telegram-cloud-storage-stamper/src/__tests__/stamp-test.ts
+++ b/packages/telegram-cloud-storage-stamper/src/__tests__/stamp-test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@jest/globals";
-import TelegramCloudStorageStamper, { CloudStorageAPIKey } from "../index";
+import { TelegramCloudStorageStamper, CloudStorageAPIKey } from "../index";
 import { readFixture } from "../__fixtures__/shared";
 import { assertValidSignature } from "./shared";
 import { fail } from "assert";
@@ -9,7 +9,7 @@ window.Telegram.WebApp.CloudStorage = {
   async setItem(
     key: string,
     value: string,
-    callback: (error: any, stored: boolean) => void,
+    callback: (error: any, stored: boolean) => void
   ) {
     localStorage.setItem(key, value);
     callback(null, true);
@@ -23,7 +23,7 @@ window.Telegram.WebApp.CloudStorage = {
   },
   async removeItem(
     key: string,
-    callback: (error: any, cleared: boolean) => void,
+    callback: (error: any, cleared: boolean) => void
   ) {
     localStorage.removeItem(key);
     callback(null, true);
@@ -50,7 +50,7 @@ test("uses provided signature to make stamp", async function () {
 
     // We expect the stamp to be base64url encoded
     const decodedStamp = JSON.parse(
-      Buffer.from(stamp.stampHeaderValue, "base64url").toString(),
+      Buffer.from(stamp.stampHeaderValue, "base64url").toString()
     );
     // ...with 3 keys.
     expect(Object.keys(decodedStamp)).toEqual([

--- a/packages/telegram-cloud-storage-stamper/src/__tests__/stamp-test.ts
+++ b/packages/telegram-cloud-storage-stamper/src/__tests__/stamp-test.ts
@@ -9,7 +9,7 @@ window.Telegram.WebApp.CloudStorage = {
   async setItem(
     key: string,
     value: string,
-    callback: (error: any, stored: boolean) => void
+    callback: (error: any, stored: boolean) => void,
   ) {
     localStorage.setItem(key, value);
     callback(null, true);
@@ -23,7 +23,7 @@ window.Telegram.WebApp.CloudStorage = {
   },
   async removeItem(
     key: string,
-    callback: (error: any, cleared: boolean) => void
+    callback: (error: any, cleared: boolean) => void,
   ) {
     localStorage.removeItem(key);
     callback(null, true);
@@ -50,7 +50,7 @@ test("uses provided signature to make stamp", async function () {
 
     // We expect the stamp to be base64url encoded
     const decodedStamp = JSON.parse(
-      Buffer.from(stamp.stampHeaderValue, "base64url").toString()
+      Buffer.from(stamp.stampHeaderValue, "base64url").toString(),
     );
     // ...with 3 keys.
     expect(Object.keys(decodedStamp)).toEqual([

--- a/packages/telegram-cloud-storage-stamper/src/index.ts
+++ b/packages/telegram-cloud-storage-stamper/src/index.ts
@@ -54,7 +54,7 @@ export class TelegramCloudStorageStamper {
     // check to see that the stamper was initialized
     if (!this.stamper) {
       throw new TelegramCloudStorageStamperError(
-        "Cannot stamp with uninitialized telegram stamper, try running .create() or .setSigningKey()"
+        "Cannot stamp with uninitialized telegram stamper, try running .create() or .setSigningKey()",
       );
     }
 
@@ -94,7 +94,7 @@ export class TelegramCloudStorageStamper {
       await this.insertAPIKey(
         config.cloudStorageAPIKey.apiPublicKey,
         config.cloudStorageAPIKey.apiPrivateKey,
-        DEFAULT_TURNKEY_CLOUD_STORAGE_KEY
+        DEFAULT_TURNKEY_CLOUD_STORAGE_KEY,
       );
 
       this.stamper = new ApiKeyStamper({
@@ -107,7 +107,7 @@ export class TelegramCloudStorageStamper {
       await this.insertAPIKey(
         config.cloudStorageAPIKey.apiPublicKey,
         config.cloudStorageAPIKey.apiPrivateKey,
-        config.cloudStorageKey
+        config.cloudStorageKey,
       );
 
       this.stamper = new ApiKeyStamper({
@@ -117,23 +117,23 @@ export class TelegramCloudStorageStamper {
       return;
     }
     throw new TelegramCloudStorageStamperError(
-      "Invalid configuration received for signing key"
+      "Invalid configuration received for signing key",
     );
   }
 
   async insertAPIKey(
     apiPublicKey: string,
     apiPrivateKey: string,
-    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY
+    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY,
   ) {
     return await this.setItem(
       key,
-      this.stringifyAPIKey(apiPublicKey, apiPrivateKey)
+      this.stringifyAPIKey(apiPublicKey, apiPrivateKey),
     );
   }
 
   async getAPIKey(
-    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY
+    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY,
   ): Promise<CloudStorageAPIKey | null> {
     try {
       const apiKey = await this.getItem(key);
@@ -151,7 +151,7 @@ export class TelegramCloudStorageStamper {
   checkTelegramContext() {
     if (window?.Telegram?.WebApp?.CloudStorage == null) {
       throw new TelegramCloudStorageStamperError(
-        "Cannot use telegram stamper in non telegram mini-app environment, window.Telegram.WebApp.CloudStorage is not defined"
+        "Cannot use telegram stamper in non telegram mini-app environment, window.Telegram.WebApp.CloudStorage is not defined",
       );
     }
   }
@@ -177,7 +177,7 @@ export class TelegramCloudStorageStamper {
       };
     } catch (err) {
       throw new TelegramCloudStorageStamperError(
-        "Failed parsing API key from Telegram Cloud Storage"
+        "Failed parsing API key from Telegram Cloud Storage",
       );
     }
   }
@@ -200,13 +200,13 @@ export class TelegramCloudStorageStamper {
               new TelegramCloudStorageStamperError(
                 `Failed getting value: ${key} from Telegram Cloud Storage${
                   err && `: ${err}`
-                }`
-              )
+                }`,
+              ),
             );
           }
 
           resolve(value);
-        }
+        },
       );
     });
   }
@@ -222,20 +222,20 @@ export class TelegramCloudStorageStamper {
               new TelegramCloudStorageStamperError(
                 `Failed inserting value: ${value} into Telegram Cloud Storage at key: ${key}${
                   err && `: ${err}`
-                }`
-              )
+                }`,
+              ),
             );
           }
           if (!stored) {
             reject(
               new TelegramSuccessButFalseError(
-                "Telegram indicated success for storing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage"
-              )
+                "Telegram indicated success for storing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage",
+              ),
             );
           }
 
           resolve();
-        }
+        },
       );
     });
   }
@@ -252,20 +252,20 @@ export class TelegramCloudStorageStamper {
           if (err) {
             reject(
               new TelegramCloudStorageStamperError(
-                `Failed removing key: ${key}${err && `: ${err}`}`
-              )
+                `Failed removing key: ${key}${err && `: ${err}`}`,
+              ),
             );
           }
           if (!removed) {
             reject(
               new TelegramSuccessButFalseError(
-                "Telegram indicated success for removing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage"
-              )
+                "Telegram indicated success for removing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage",
+              ),
             );
           }
 
           resolve();
-        }
+        },
       );
     });
   }

--- a/packages/telegram-cloud-storage-stamper/src/index.ts
+++ b/packages/telegram-cloud-storage-stamper/src/index.ts
@@ -23,7 +23,7 @@ export type CloudStorageAPIKey = {
 };
 
 // Constant for default key name
-export const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "TURNKEY_API_KEY";
+const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "TURNKEY_API_KEY";
 
 /**
  * Stamper to use within a `TurnkeyClient`
@@ -54,7 +54,7 @@ export default class TelegramCloudStorageStamper {
     // check to see that the stamper was initialized
     if (!this.stamper) {
       throw new TelegramCloudStorageStamperError(
-        "Cannot stamp with uninitialized telegram stamper, try running .create() or .setSigningKey()",
+        "Cannot stamp with uninitialized telegram stamper, try running .create() or .setSigningKey()"
       );
     }
 
@@ -94,7 +94,7 @@ export default class TelegramCloudStorageStamper {
       await this.insertAPIKey(
         config.cloudStorageAPIKey.apiPublicKey,
         config.cloudStorageAPIKey.apiPrivateKey,
-        DEFAULT_TURNKEY_CLOUD_STORAGE_KEY,
+        DEFAULT_TURNKEY_CLOUD_STORAGE_KEY
       );
 
       this.stamper = new ApiKeyStamper({
@@ -107,7 +107,7 @@ export default class TelegramCloudStorageStamper {
       await this.insertAPIKey(
         config.cloudStorageAPIKey.apiPublicKey,
         config.cloudStorageAPIKey.apiPrivateKey,
-        config.cloudStorageKey,
+        config.cloudStorageKey
       );
 
       this.stamper = new ApiKeyStamper({
@@ -117,23 +117,23 @@ export default class TelegramCloudStorageStamper {
       return;
     }
     throw new TelegramCloudStorageStamperError(
-      "Invalid configuration received for signing key",
+      "Invalid configuration received for signing key"
     );
   }
 
   async insertAPIKey(
     apiPublicKey: string,
     apiPrivateKey: string,
-    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY,
+    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY
   ) {
     return await this.setItem(
       key,
-      this.stringifyAPIKey(apiPublicKey, apiPrivateKey),
+      this.stringifyAPIKey(apiPublicKey, apiPrivateKey)
     );
   }
 
   async getAPIKey(
-    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY,
+    key: string = DEFAULT_TURNKEY_CLOUD_STORAGE_KEY
   ): Promise<CloudStorageAPIKey | null> {
     try {
       const apiKey = await this.getItem(key);
@@ -151,7 +151,7 @@ export default class TelegramCloudStorageStamper {
   checkTelegramContext() {
     if (window?.Telegram?.WebApp?.CloudStorage == null) {
       throw new TelegramCloudStorageStamperError(
-        "Cannot use telegram stamper in non telegram mini-app environment, window.Telegram.WebApp.CloudStorage is not defined",
+        "Cannot use telegram stamper in non telegram mini-app environment, window.Telegram.WebApp.CloudStorage is not defined"
       );
     }
   }
@@ -177,7 +177,7 @@ export default class TelegramCloudStorageStamper {
       };
     } catch (err) {
       throw new TelegramCloudStorageStamperError(
-        "Failed parsing API key from Telegram Cloud Storage",
+        "Failed parsing API key from Telegram Cloud Storage"
       );
     }
   }
@@ -200,13 +200,13 @@ export default class TelegramCloudStorageStamper {
               new TelegramCloudStorageStamperError(
                 `Failed getting value: ${key} from Telegram Cloud Storage${
                   err && `: ${err}`
-                }`,
-              ),
+                }`
+              )
             );
           }
 
           resolve(value);
-        },
+        }
       );
     });
   }
@@ -222,20 +222,20 @@ export default class TelegramCloudStorageStamper {
               new TelegramCloudStorageStamperError(
                 `Failed inserting value: ${value} into Telegram Cloud Storage at key: ${key}${
                   err && `: ${err}`
-                }`,
-              ),
+                }`
+              )
             );
           }
           if (!stored) {
             reject(
               new TelegramSuccessButFalseError(
-                "Telegram indicated success for storing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage",
-              ),
+                "Telegram indicated success for storing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage"
+              )
             );
           }
 
           resolve();
-        },
+        }
       );
     });
   }
@@ -252,20 +252,20 @@ export default class TelegramCloudStorageStamper {
           if (err) {
             reject(
               new TelegramCloudStorageStamperError(
-                `Failed removing key: ${key}${err && `: ${err}`}`,
-              ),
+                `Failed removing key: ${key}${err && `: ${err}`}`
+              )
             );
           }
           if (!removed) {
             reject(
               new TelegramSuccessButFalseError(
-                "Telegram indicated success for removing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage",
-              ),
+                "Telegram indicated success for removing key, but also returned false, see documention: https://core.telegram.org/bots/webapps#cloudstorage"
+              )
             );
           }
 
           resolve();
-        },
+        }
       );
     });
   }

--- a/packages/telegram-cloud-storage-stamper/src/index.ts
+++ b/packages/telegram-cloud-storage-stamper/src/index.ts
@@ -23,12 +23,12 @@ export type CloudStorageAPIKey = {
 };
 
 // Constant for default key name
-const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "TURNKEY_API_KEY";
+export const DEFAULT_TURNKEY_CLOUD_STORAGE_KEY = "TURNKEY_API_KEY";
 
 /**
  * Stamper to use within a `TurnkeyClient`
  */
-export default class TelegramCloudStorageStamper {
+export class TelegramCloudStorageStamper {
   // This stamper uses a typical @turnkey/api-key-stamper under the hood and abstracts away the storage of the actual API keys
   stamper?: ApiKeyStamper | undefined;
 


### PR DESCRIPTION
## Summary & Motivation

- remove export of `DEFAULT_TURNKEY_CLOUD_STORAGE_KEY`

### Build output before
```
packages/telegram-cloud-storage-stamper build$ rollup -c
[1 lines collapsed]
│ src/index.ts → dist...
│ created dist in 557ms
│
│ src/index.ts → dist...
│ (!) Mixing named and default exports
│ https://rollupjs.org/configuration-options/#output-exports
│ The following entry modules are using named and default export
│ src/index.ts
│ Consumers of your bundle will have to use chunk.default to acc
│ created dist in 607ms
└─ Done in 1.4s
```
### Build output after
```
packages/telegram-cloud-storage-stamper build$ rollup -c
│
│ src/index.ts → dist...
│ created dist in 600ms
│
│ src/index.ts → dist...
│ created dist in 500ms
└─ Done in 1.3s
```

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
