### PR TITLE
@turnkey/cosmjs TurnkeyDirectWallet produces incorrect signatures when using @turnkey/http TurnkeyClient

### DIFF
--- a/packages/cosmjs/src/index.ts
+++ b/packages/cosmjs/src/index.ts
@@ -174,7 +174,7 @@ export class TurnkeyDirectWallet implements OfflineDirectSigner {
           signWith: this.signWith,
           payload: messageHex,
           encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
-          hashFunction: "HASH_FUNCTION_SHA256",
+          hashFunction: "HASH_FUNCTION_NO_OP",
         },
       });
 


### PR DESCRIPTION
The cosmos example uses the TurnkeyApiClient and so did our code until more recently.

Once switching to @turnkey/http our cosmos transactions were getting rejected until making this change to @turnkey/cosmjs
