### PR TITLE
add live getter for iframe targetEmbeddedKey

### DIFF
--- a/.changeset/silver-chicken-boil.md
+++ b/.changeset/silver-chicken-boil.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/iframe-stamper": minor
+---
+
+Add `getLivePublicKey()` async function to get the public key of the live embedded key within the iframe

--- a/.changeset/silver-chicken-boil.md
+++ b/.changeset/silver-chicken-boil.md
@@ -2,4 +2,4 @@
 "@turnkey/iframe-stamper": minor
 ---
 
-Add `getLivePublicKey()` async function to get the public key of the live embedded key within the iframe
+Add `getEmbeddedPublicKey()` async function to get the public key of the live embedded key within the iframe

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -286,7 +286,9 @@ export class IframeStamper {
    * This differs from the above in that it reaches out to the live iframe to see if an embedded key exists.
    */
   async getEmbeddedPublicKey(): Promise<string | null> {
-    return this.createRequest<string | null>(IframeEventType.GetEmbeddedPublicKey);
+    return this.createRequest<string | null>(
+      IframeEventType.GetEmbeddedPublicKey,
+    );
   }
 
   /**

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -50,6 +50,9 @@ export enum IframeEventType {
   // Event sent by the parent to establish secure communication via MessageChannel API.
   // Value: MessageChannel port
   TurnkeyInitMessageChannel = "TURNKEY_INIT_MESSAGE_CHANNEL",
+  // Event sent by the parent to get the target embedded key's public key.
+  // Value: public key
+  EmbeddedKey = "EMBEDDED_KEY",
   // Event sent by the iframe to communicate an error
   // Value: serialized error
   Error = "ERROR",
@@ -276,6 +279,14 @@ export class IframeStamper {
    */
   publicKey(): string | null {
     return this.iframePublicKey;
+  }
+
+  /**
+   * Returns the public key, or `null` if the underlying iframe isn't properly initialized.
+   * This differs from the above in that it reaches out to the iframe to see if an embedded key exists.
+   */
+  async getLivePublicKey(): Promise<string | null> {
+    return this.createRequest<string | null>(IframeEventType.EmbeddedKey);
   }
 
   /**

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -52,7 +52,7 @@ export enum IframeEventType {
   TurnkeyInitMessageChannel = "TURNKEY_INIT_MESSAGE_CHANNEL",
   // Event sent by the parent to get the target embedded key's public key.
   // Value: public key
-  EmbeddedKey = "EMBEDDED_KEY",
+  EmbeddedPublicKey = "EMBEDDED_PUBLIC_KEY",
   // Event sent by the iframe to communicate an error
   // Value: serialized error
   Error = "ERROR",
@@ -283,10 +283,10 @@ export class IframeStamper {
 
   /**
    * Returns the public key, or `null` if the underlying iframe isn't properly initialized.
-   * This differs from the above in that it reaches out to the iframe to see if an embedded key exists.
+   * This differs from the above in that it reaches out to the live iframe to see if an embedded key exists.
    */
-  async getLivePublicKey(): Promise<string | null> {
-    return this.createRequest<string | null>(IframeEventType.EmbeddedKey);
+  async getEmbeddedPublicKey(): Promise<string | null> {
+    return this.createRequest<string | null>(IframeEventType.EmbeddedPublicKey);
   }
 
   /**

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -52,7 +52,7 @@ export enum IframeEventType {
   TurnkeyInitMessageChannel = "TURNKEY_INIT_MESSAGE_CHANNEL",
   // Event sent by the parent to get the target embedded key's public key.
   // Value: public key
-  EmbeddedPublicKey = "EMBEDDED_PUBLIC_KEY",
+  GetEmbeddedPublicKey = "GET_EMBEDDED_PUBLIC_KEY",
   // Event sent by the iframe to communicate an error
   // Value: serialized error
   Error = "ERROR",
@@ -286,7 +286,7 @@ export class IframeStamper {
    * This differs from the above in that it reaches out to the live iframe to see if an embedded key exists.
    */
   async getEmbeddedPublicKey(): Promise<string | null> {
-    return this.createRequest<string | null>(IframeEventType.EmbeddedPublicKey);
+    return this.createRequest<string | null>(IframeEventType.GetEmbeddedPublicKey);
   }
 
   /**


### PR DESCRIPTION
## Summary & Motivation
$title

Frames counterpart: https://github.com/tkhq/frames/pull/64

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
