### PR TITLE
chore: update manageSession logic

### DIFF
--- a/examples/react-components/src/app/dashboard/page.tsx
+++ b/examples/react-components/src/app/dashboard/page.tsx
@@ -303,8 +303,9 @@ export default function Dashboard() {
       try {
         if (turnkey && authIframeClient) {
           const session = await turnkey?.getSession();
-          if (!session || Date.now() > session.expiry) {
+          if (!session) {
             await handleLogout();
+            return;
           }
 
           await authIframeClient.injectCredentialBundle(session!.token);

--- a/examples/react-components/src/app/page.tsx
+++ b/examples/react-components/src/app/page.tsx
@@ -73,8 +73,8 @@ export default function AuthPage() {
   useEffect(() => {
     const manageSession = async () => {
       if (turnkey) {
-        const session = await turnkey?.getReadWriteSession();
-        if (session && Date.now() < session.expiry) {
+        const session = await turnkey?.getSession();
+        if (session) {
           await handleAuthSuccess();
         }
       }


### PR DESCRIPTION
## Summary & Motivation

- Handle uncaught exception during page reload when session is expired
  - `examples/react-components/src/app/page.tsx`
    - replaced deprecated `.getReadWriteSession()` with `.getSession()`
    - removed session expiry logic as that is handled within `.getSession()`
  - `examples/react-components/src/app/dashboard/page.tsx`
    - removed session expiry logic as that is handled within `.getSession()`

## How I Tested These Changes

### Locally
- authenticated via OTP and set `sessionExpiration` to 30 seconds
- refreshed page while session was still active and page rehydrated
- refreshed page after session expired, `handleLogout()` was called and the app navigated back to the auth screen

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
