### PR TITLE
fix: unexpected error when using read-only session type

### DIFF
--- a/.changeset/tiny-pianos-rest.md
+++ b/.changeset/tiny-pianos-rest.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-browser": patch
+---
+
+fix unexpected error when using read-only session type when calling loginWithPasskey & loginWithWallet

--- a/packages/sdk-browser/src/__clients__/browser-clients.ts
+++ b/packages/sdk-browser/src/__clients__/browser-clients.ts
@@ -152,8 +152,7 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
         };
 
         await storeSession(session, AuthClient.Passkey);
-      }
-      if (sessionType === SessionType.READ_WRITE) {
+      } else if (sessionType === SessionType.READ_WRITE) {
         if (!targetPublicKey) {
           throw new Error(
             "You must provide a targetPublicKey to refresh a read-write session.",
@@ -180,6 +179,8 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
           );
         }
         await storeSession(session, AuthClient.Iframe);
+      } else {
+        throw new Error(`Invalid session type passed: ${sessionType}`);
       }
     } catch (error) {
       throw new Error(`Unable to refresh session: ${error}`);
@@ -271,10 +272,8 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
           token: readOnlySessionResult.session,
         };
         await storeSession(session, AuthClient.Passkey);
-      }
-
-      // Create a read-write session
-      if (sessionType === SessionType.READ_WRITE) {
+        // Create a read-write session
+      } else if (sessionType === SessionType.READ_WRITE) {
         if (!targetPublicKey) {
           throw new Error(
             "You must provide a targetPublicKey to create a read-write session.",
@@ -340,10 +339,8 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
           token: readOnlySessionResult.session,
         };
         await storeSession(session, AuthClient.Wallet);
-      }
-
-      // Create a read-write session
-      if (sessionType === SessionType.READ_WRITE) {
+        // Create a read-write session
+      } else if (sessionType === SessionType.READ_WRITE) {
         if (!targetPublicKey) {
           throw new Error(
             "You must provide a targetPublicKey to create a read-write session.",


### PR DESCRIPTION
## Summary & Motivation

In the current code, calling `loginWithPasskey` or `loginWithWallet` with `SessionType.READ_ONLY` throws an error, even if the login is successful.

## How I Tested These Changes

call `loginWithPasskey` with `SessionType.READ_ONLY` and correct parameters, error will be thrown from: https://github.com/tkhq/sdk/blob/95be4b9b131a61c76bec1d5e6dc4ecc4b11951e1/packages/sdk-browser/src/__clients__/browser-clients.ts#L306

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
