### PR TITLE
fix: update session handling of `TurnkeyBrowserClient.login()` to align with other functions

### DIFF
--- a/.changeset/pretty-seahorses-cross.md
+++ b/.changeset/pretty-seahorses-cross.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-browser": patch
+---
+
+update `TurnkeyBrowserClient.login()` to align with other functions like `loginWithPasskey()` and `loginWithWallet()`

--- a/packages/sdk-browser/src/__clients__/browser-clients.ts
+++ b/packages/sdk-browser/src/__clients__/browser-clients.ts
@@ -113,9 +113,16 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
     const readOnlySessionResult = await this.createReadOnlySession(
       config || {},
     );
-    await saveSession(readOnlySessionResult, this.authClient);
+    const session: Session = {
+      sessionType: SessionType.READ_ONLY,
+      userId: readOnlySessionResult.userId,
+      organizationId: readOnlySessionResult.organizationId,
+      expiry: Number(readOnlySessionResult.sessionExpiry),
+      token: readOnlySessionResult.session,
+    };
+    await storeSession(session, this.authClient);
 
-    return readOnlySessionResult!;
+    return readOnlySessionResult;
   };
 
   /**

--- a/packages/sdk-browser/src/storage.ts
+++ b/packages/sdk-browser/src/storage.ts
@@ -81,9 +81,11 @@ export const removeStorageValue = async <K extends StorageKeys>(
  * @returns {Promise<void>} A promise that resolves when the session is saved.
  */
 
-export const storeSession = async (session: Session, client: AuthClient) => {
+export const storeSession = async (session: Session, client?: AuthClient) => {
   await setStorageValue(StorageKeys.Session, session);
-  await setStorageValue(StorageKeys.Client, client);
+  if (client) {
+    await setStorageValue(StorageKeys.Client, client);
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary & Motivation
I noticed that the original session key`@turnkey/session/v1` is deprecated and changed to `@turnkey/session/v2`, and functions like `TurnkeyBrowserClient.loginWithPasskey()`, `TurnkeyBrowserClient.loginWithWallet()`, `TurnkeyBrowserSDK.currentUserSession()` is already changed to use the new key name.

But currently the `TurnkeyBrowserClient.login()` function is still using the deprecated key, this will result in inconsistent read/write when combining the functions above.

## How I Tested These Changes

In browser, login with `passkeyClient` and then read session with `TurnkeyBrowserSDK`

```
const config = {
  apiBaseUrl: "https://api.turnkey.com",
  defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID,
  serverSignUrl: "https://your-server-sign-url.com",
};
const turnkeySDK = new Turnkey(config);
const passkeyClient = turnkeySDK.passkeyClient();

await passkeyClient.login()                            // save to @turnkey/session/v1
const session = await turnkeySDK.currentUserSession()  // read from @turnkey/session/v2, return undefined
```

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
