### PR TITLE
Patch: Fix improper result init otp auth

### DIFF
--- a/.changeset/thirty-buckets-camp.md
+++ b/.changeset/thirty-buckets-camp.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/sdk-browser": patch
+"@turnkey/sdk-server": patch
+---
+
+Fix initOtpAuth bug with improper version result (to be updated to V2 following release r2025.3.8)

--- a/packages/sdk-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-browser/src/__generated__/sdk-client-base.ts
@@ -2118,7 +2118,7 @@ export class TurnkeySDKClientBase {
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_INIT_OTP_AUTH",
       },
-      "initOtpAuthResultV2",
+      "initOtpAuthResult",
     );
   };
 

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -1961,7 +1961,7 @@ export class TurnkeySDKClientBase {
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_INIT_OTP_AUTH",
       },
-      "initOtpAuthResultV2",
+      "initOtpAuthResult",
     );
   };
 


### PR DESCRIPTION
## Summary & Motivation
Result was defaulting to an activity version we were not ready to release due to a faulty codegen script. This reverts that change.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
