### PR TITLE
Release: mar26 patch fix initOtp bug for sdk-server/sdk-browser + associated dependency updates

### DIFF
--- a/.changeset/thirty-buckets-camp.md
+++ b/.changeset/thirty-buckets-camp.md
@@ -1,6 +1,0 @@
----
-"@turnkey/sdk-browser": patch
-"@turnkey/sdk-server": patch
----
-
-Fix initOtpAuth bug with improper version result (to be updated to V2 following release r2025.3.8)

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/cosmjs
 
+## 0.7.2
+
+### Patch Changes
+
+- Updated dependencies [5ec5187]
+  - @turnkey/sdk-browser@3.0.1
+  - @turnkey/sdk-server@2.6.1
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/eip-1193-provider
 
+## 3.3.2
+
+### Patch Changes
+
+- Updated dependencies [5ec5187]
+  - @turnkey/sdk-browser@3.0.1
+
 ## 3.3.1
 
 ### Patch Changes

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/src/version.ts
+++ b/packages/eip-1193-provider/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/eip-1193-provider@3.3.1";
+export const VERSION = "@turnkey/eip-1193-provider@3.3.2";

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/ethers
 
+## 1.1.19
+
+### Patch Changes
+
+- Updated dependencies [5ec5187]
+  - @turnkey/sdk-browser@3.0.1
+  - @turnkey/sdk-server@2.6.1
+
 ## 1.1.18
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/CHANGELOG.md
+++ b/packages/sdk-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/sdk-browser
 
+## 3.0.1
+
+### Patch Changes
+
+- 5ec5187: Fix initOtpAuth bug with improper version result (to be updated to V2 following release r2025.3.8)
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-browser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/src/__generated__/version.ts
+++ b/packages/sdk-browser/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-browser@3.0.0";
+export const VERSION = "@turnkey/sdk-browser@3.0.1";

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/sdk-react
 
+## 4.1.2
+
+### Patch Changes
+
+- Updated dependencies [5ec5187]
+  - @turnkey/sdk-browser@3.0.1
+  - @turnkey/sdk-server@2.6.1
+
 ## 4.1.1
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/CHANGELOG.md
+++ b/packages/sdk-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/sdk-server
 
+## 2.6.1
+
+### Patch Changes
+
+- 5ec5187: Fix initOtpAuth bug with improper version result (to be updated to V2 following release r2025.3.8)
+
 ## 2.6.0
 
 ### Minor Changes

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-server",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/src/__generated__/version.ts
+++ b/packages/sdk-server/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-server@2.6.0";
+export const VERSION = "@turnkey/sdk-server@2.6.1";

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/solana
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies [5ec5187]
+  - @turnkey/sdk-browser@3.0.1
+  - @turnkey/sdk-server@2.6.1
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/viem
 
+## 0.6.18
+
+### Patch Changes
+
+- Updated dependencies [5ec5187]
+  - @turnkey/sdk-browser@3.0.1
+  - @turnkey/sdk-server@2.6.1
+
 ## 0.6.17
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
