### PR TITLE
feat: remove export for deprecated PublicApiService

### DIFF
--- a/.changeset/rude-colts-poke.md
+++ b/.changeset/rude-colts-poke.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/http": major
+---
+
+Remove deprecated TurnkeyApiService. TurnkeyApi should be used instead.

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -27,13 +27,6 @@ export { withAsyncPolling, createActivityPoller } from "./async";
 
 export { TurnkeyApi };
 
-/**
- * @deprecated use `TurnkeyApi` instead
- */
-const PublicApiService = TurnkeyApi;
-
-export { PublicApiService };
-
 export { sealAndStampRequestBody } from "./base";
 
 export { VERSION } from "./version";

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@3.0.0";
+export const VERSION = "@turnkey/http@2.22.0";

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@2.22.0";
+export const VERSION = "@turnkey/http@3.0.0";


### PR DESCRIPTION
## Summary & Motivation

- Remove PublicApiService export which has been deprecated
- Cleaning this up separately from the docs generation PR

## How I Tested These Changes

- locally

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
