### PR TITLE
update iframe stamper to have methods to refresh an embedded key

### DIFF
--- a/.changeset/brave-keys-punch.md
+++ b/.changeset/brave-keys-punch.md
@@ -1,0 +1,8 @@
+---
+"@turnkey/iframe-stamper": minor
+"@turnkey/sdk-browser": minor
+---
+
+Add new utility functions
+- Add `resetEmbeddedKey()` async function, which resets the embedded key within an iframe by clearing the existing one
+- Add `initEmbeddedKey()` async function, which reinitializes the embedded key within an iframe

--- a/.changeset/brave-keys-punch.md
+++ b/.changeset/brave-keys-punch.md
@@ -4,5 +4,6 @@
 ---
 
 Add new utility functions
+
 - Add `resetEmbeddedKey()` async function, which resets the embedded key within an iframe by clearing the existing one
 - Add `initEmbeddedKey()` async function, which reinitializes the embedded key within an iframe

--- a/.changeset/brave-keys-punch.md
+++ b/.changeset/brave-keys-punch.md
@@ -5,5 +5,5 @@
 
 Add new utility functions
 
-- Add `resetEmbeddedKey()` async function, which resets the embedded key within an iframe by clearing the existing one
+- Add `clearEmbeddedKey()` async function, which clears the embedded key within an iframe
 - Add `initEmbeddedKey()` async function, which reinitializes the embedded key within an iframe

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -300,12 +300,13 @@ export class IframeStamper {
   /**
    * Resets the embedded key within an iframe by clearing the existing one.
    */
-  async resetEmbeddedKey(): Promise<string | null> {
-    return this.createRequest<string | null>(IframeEventType.ResetEmbeddedKey);
+  async resetEmbeddedKey(): Promise<null> {
+    return this.createRequest<null>(IframeEventType.ResetEmbeddedKey);
   }
 
   /**
    * Reinitializes the embedded key within an iframe.
+   * @return {string | null} the newly created embedded public key.
    */
   async initEmbeddedKey(): Promise<string | null> {
     return this.createRequest<string | null>(IframeEventType.InitEmbeddedKey);

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -292,24 +292,37 @@ export class IframeStamper {
    * This differs from the above in that it reaches out to the live iframe to see if an embedded key exists.
    */
   async getEmbeddedPublicKey(): Promise<string | null> {
-    return this.createRequest<string | null>(
+    const publicKey = await this.createRequest<string | null>(
       IframeEventType.GetEmbeddedPublicKey,
     );
+    this.iframePublicKey = publicKey;
+
+    return publicKey;
   }
 
   /**
    * Clears the embedded key within an iframe.
    */
   async clearEmbeddedKey(): Promise<null> {
-    return this.createRequest<null>(IframeEventType.ClearEmbeddedKey);
+    await this.createRequest<null>(IframeEventType.ClearEmbeddedKey);
+    this.iframePublicKey = "";
+
+    return null;
   }
 
   /**
-   * Reinitializes the embedded key within an iframe.
+   * Creates a new embedded key within an iframe. If an embedded key already exists, this will return it.
+   * This is primarily to be used in conjunction with `clearEmbeddedKey()`: after an embedded key is cleared,
+   * this can be used to create a new one.
    * @return {string | null} the newly created embedded public key.
    */
   async initEmbeddedKey(): Promise<string | null> {
-    return this.createRequest<string | null>(IframeEventType.InitEmbeddedKey);
+    const publicKey = await this.createRequest<string | null>(
+      IframeEventType.InitEmbeddedKey,
+    );
+    this.iframePublicKey = publicKey;
+
+    return publicKey;
   }
 
   /**

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -53,9 +53,9 @@ export enum IframeEventType {
   // Event sent by the parent to get the iframe target embedded key's public key.
   // Value: none
   GetEmbeddedPublicKey = "GET_EMBEDDED_PUBLIC_KEY",
-  // Event sent by the parent to reset the iframe's embedded key.
+  // Event sent by the parent to clear the iframe's embedded key.
   // Value: none
-  ResetEmbeddedKey = "RESET_EMBEDDED_KEY",
+  ClearEmbeddedKey = "RESET_EMBEDDED_KEY",
   // Event sent by the parent to initialize a new embedded key.
   // Value: none
   InitEmbeddedKey = "INIT_EMBEDDED_KEY",
@@ -298,10 +298,10 @@ export class IframeStamper {
   }
 
   /**
-   * Resets the embedded key within an iframe by clearing the existing one.
+   * Clears the embedded key within an iframe.
    */
-  async resetEmbeddedKey(): Promise<null> {
-    return this.createRequest<null>(IframeEventType.ResetEmbeddedKey);
+  async clearEmbeddedKey(): Promise<null> {
+    return this.createRequest<null>(IframeEventType.ClearEmbeddedKey);
   }
 
   /**

--- a/packages/iframe-stamper/src/index.ts
+++ b/packages/iframe-stamper/src/index.ts
@@ -50,9 +50,15 @@ export enum IframeEventType {
   // Event sent by the parent to establish secure communication via MessageChannel API.
   // Value: MessageChannel port
   TurnkeyInitMessageChannel = "TURNKEY_INIT_MESSAGE_CHANNEL",
-  // Event sent by the parent to get the target embedded key's public key.
-  // Value: public key
+  // Event sent by the parent to get the iframe target embedded key's public key.
+  // Value: none
   GetEmbeddedPublicKey = "GET_EMBEDDED_PUBLIC_KEY",
+  // Event sent by the parent to reset the iframe's embedded key.
+  // Value: none
+  ResetEmbeddedKey = "RESET_EMBEDDED_KEY",
+  // Event sent by the parent to initialize a new embedded key.
+  // Value: none
+  InitEmbeddedKey = "INIT_EMBEDDED_KEY",
   // Event sent by the iframe to communicate an error
   // Value: serialized error
   Error = "ERROR",
@@ -289,6 +295,20 @@ export class IframeStamper {
     return this.createRequest<string | null>(
       IframeEventType.GetEmbeddedPublicKey,
     );
+  }
+
+  /**
+   * Resets the embedded key within an iframe by clearing the existing one.
+   */
+  async resetEmbeddedKey(): Promise<string | null> {
+    return this.createRequest<string | null>(IframeEventType.ResetEmbeddedKey);
+  }
+
+  /**
+   * Reinitializes the embedded key within an iframe.
+   */
+  async initEmbeddedKey(): Promise<string | null> {
+    return this.createRequest<string | null>(IframeEventType.InitEmbeddedKey);
   }
 
   /**

--- a/packages/sdk-browser/src/__clients__/browser-clients.ts
+++ b/packages/sdk-browser/src/__clients__/browser-clients.ts
@@ -921,8 +921,8 @@ export class TurnkeyIframeClient extends TurnkeyBrowserClient {
     return await (this.stamper as IframeStamper).getEmbeddedPublicKey();
   };
 
-  resetEmbeddedKey = async (): Promise<null> => {
-    return await (this.stamper as IframeStamper).resetEmbeddedKey();
+  clearEmbeddedKey = async (): Promise<null> => {
+    return await (this.stamper as IframeStamper).clearEmbeddedKey();
   };
 
   initEmbeddedKey = async (): Promise<string | null> => {

--- a/packages/sdk-browser/src/__clients__/browser-clients.ts
+++ b/packages/sdk-browser/src/__clients__/browser-clients.ts
@@ -920,6 +920,14 @@ export class TurnkeyIframeClient extends TurnkeyBrowserClient {
   getEmbeddedPublicKey = async (): Promise<string | null> => {
     return await (this.stamper as IframeStamper).getEmbeddedPublicKey();
   };
+
+  resetEmbeddedKey = async (): Promise<null> => {
+    return await (this.stamper as IframeStamper).resetEmbeddedKey();
+  };
+
+  initEmbeddedKey = async (): Promise<string | null> => {
+    return await (this.stamper as IframeStamper).initEmbeddedKey();
+  };
 }
 
 export class TurnkeyWalletClient extends TurnkeyBrowserClient {


### PR DESCRIPTION
## Summary & Motivation
$title

Accompying `tkhq/frames` change (with demo vid): https://github.com/tkhq/frames/pull/67 

## How I Tested These Changes

https://github.com/user-attachments/assets/2672cea8-d58d-43f0-b0b7-ca3044504c33



## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
