### PR TITLE
wait for transaction confirmation in unit tests

### DIFF
--- a/packages/viem/src/__tests__/index-test.ts
+++ b/packages/viem/src/__tests__/index-test.ts
@@ -365,6 +365,12 @@ describe("TurnkeyAccount", () => {
 
         expect(mintHash).toMatch(/^0x/);
 
+        const mintTx = await walletClient.waitForTransactionReceipt({
+          hash: mintHash,
+        });
+
+        expect(mintTx.blockHash).toMatch(/^0x/);
+
         // Approve
         // @ts-expect-error
         const approveHash = await contract.write.approve([
@@ -373,6 +379,12 @@ describe("TurnkeyAccount", () => {
         ]);
 
         expect(approveHash).toMatch(/^0x/);
+
+        const approveTx = await walletClient.waitForTransactionReceipt({
+          hash: approveHash,
+        });
+
+        expect(approveTx.blockHash).toMatch(/^0x/);
       });
     });
   });


### PR DESCRIPTION
## Summary & Motivation
$title

Hopefully, this resolves some test flakiness

## How I Tested These Changes
- locally, against a local anvil instance

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
