### PR TITLE
temporarily ignore CVE-2025-3194

### DIFF
--- a/examples/wallet-import-export/src/pages/index.module.css
+++ b/examples/wallet-import-export/src/pages/index.module.css
@@ -103,8 +103,9 @@
   display: flex;
   gap: 12px;
   justify-content: baseline;
-  font-family: "iA Writer Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
-    Consolas, "Liberation Mono", monospace;
+  font-family:
+    "iA Writer Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
 }
 
 .buttons {

--- a/examples/with-federated-passkeys/src/pages/index.module.css
+++ b/examples/with-federated-passkeys/src/pages/index.module.css
@@ -85,7 +85,8 @@
 
 .td {
   /* From https://qwtel.com/posts/software/the-monospaced-system-ui-css-font-stack/ */
-  font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  font-family:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
   padding: 10px;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
   "packageManager": "pnpm@8.4.0",
   "pnpm": {
     "auditConfig": {
-      "ignoreCves": []
+      "ignoreCves": [
+        "CVE-2025-3194"
+      ]
     },
     "overrides": {
       "@confio/ics23@0.6.8>protobufjs": ">=7.2.5",


### PR DESCRIPTION
## Summary & Motivation
$title

@solana/web3.js depends on `bigint-buffer`, which is currently unpatched, and unfortunately unmaintained. 

Mitigation: upgrade to using @solana/kit: 2.1.0, which no longer depends on that library.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
