### PR TITLE
Add @turnkey/sdk-types package

### DIFF
--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@turnkey/sdk-types",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "pnpm run build",
+    "clean": "rimraf ./dist ./.cache",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
+  },
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "license": "Apache-2.0",
+  "description": "Turnkey SDK Types",
+  "keywords": [
+    "Turnkey"
+  ],
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com"
+  },
+  "homepage": "https://github.com/tkhq/sdk/packages/sdk-types#readme",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tkhq/sdk.git",
+    "directory": "packages/sdk-types"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "private": true,
+  "devDependencies": {
+    "typescript": "^5.4.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/sdk-types/rollup.config.mjs
+++ b/packages/sdk-types/rollup.config.mjs
@@ -1,0 +1,3 @@
+import rollup from "../../rollup.config.base.mjs";
+
+export default (options) => rollup();

--- a/packages/sdk-types/src/index.ts
+++ b/packages/sdk-types/src/index.ts
@@ -1,0 +1,12 @@
+export enum SessionType {
+  READ_ONLY = "SESSION_TYPE_READ_ONLY",
+  READ_WRITE = "SESSION_TYPE_READ_WRITE",
+}
+
+export type Session = {
+  sessionType: SessionType;
+  userId: string;
+  organizationId: string;
+  expiry: number;
+  token: string;
+};

--- a/packages/sdk-types/tsconfig.json
+++ b/packages/sdk-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sdk-types/tsconfig.typecheck.json
+++ b/packages/sdk-types/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.typecheck.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/sdk-types/turbo.json
+++ b/packages/sdk-types/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/packages/sdk-types/typedoc.json
+++ b/packages/sdk-types/typedoc.json
@@ -1,0 +1,16 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "excludeInternal": true,
+  "includeVersion": true,
+  "fileExtension": ".mdx",
+  "plugin": ["typedoc-plugin-markdown"],
+  "projectDocuments": ["documents/*.md"],
+  "outputs": [
+    {
+      // requires typedoc-plugin-markdown
+      "name": "markdown",
+      "path": "./docs/markdown",
+      "fileExtension": ".mdx"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,7 +741,7 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       viem:
-        specifier: 2.23.13
+        specifier: ^2.23.13
         version: 2.23.13(typescript@5.4.3)
     devDependencies:
       '@types/prompts':
@@ -2001,6 +2001,12 @@ importers:
       glob:
         specifier: ^8.0.3
         version: 8.1.0
+
+  packages/sdk-types:
+    devDependencies:
+      typescript:
+        specifier: ^5.4.3
+        version: 5.4.3
 
   packages/solana:
     dependencies:
@@ -14192,6 +14198,20 @@ packages:
       zod: 3.23.8
     dev: false
 
+  /abitype@1.0.6(typescript@5.1.3):
+    resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
+    dev: false
+
   /abitype@1.0.6(typescript@5.4.3):
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
     peerDependencies:
@@ -25269,6 +25289,29 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
+
+  /viem@2.23.13(typescript@5.4.3):
+    resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.4.3)
+      isows: 1.0.6(ws@8.17.1)
+      ox: 0.6.9(typescript@5.4.3)
+      typescript: 5.4.3
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
 
   /viem@2.23.13(typescript@5.4.3):
     resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,7 +741,7 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       viem:
-        specifier: ^2.23.13
+        specifier: 2.23.13
         version: 2.23.13(typescript@5.4.3)
     devDependencies:
       '@types/prompts':
@@ -13190,7 +13190,7 @@ packages:
   /@types/prompts@2.4.2:
     resolution: {integrity: sha512-TwNx7qsjvRIUv/BCx583tqF5IINEVjCNqg9ofKHRlSoUHE62WBHrem4B1HGXcIrG511v29d1kJ9a/t2Esz7MIg==}
     dependencies:
-      '@types/node': 22.7.7
+      '@types/node': 20.3.1
       kleur: 3.0.3
     dev: true
 
@@ -14196,20 +14196,6 @@ packages:
     dependencies:
       typescript: 5.1.5
       zod: 3.23.8
-    dev: false
-
-  /abitype@1.0.6(typescript@5.1.3):
-    resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      typescript: 5.1.3
     dev: false
 
   /abitype@1.0.6(typescript@5.4.3):
@@ -25289,29 +25275,6 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
-
-  /viem@2.23.13(typescript@5.4.3):
-    resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.4.3)
-      isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.4.3)
-      typescript: 5.4.3
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
 
   /viem@2.23.13(typescript@5.4.3):
     resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}


### PR DESCRIPTION
## Summary & Motivation

- scaffold `@turnkey/sdk-types` for re-usable typings

## How I Tested These Changes

- added `@turnkey/sdk-types` as a dependency to `@turnkey/sdk-react`
```
{
  "name": "@turnkey/sdk-react",
  "version": "4.2.1",
  ...
  "dependencies": {
    ...
    "@turnkey/crypto": "workspace:*",
    "@turnkey/sdk-browser": "workspace:*",
    "@turnkey/sdk-server": "workspace:*",
    "@turnkey/wallet-stamper": "workspace:*",
    "@turnkey/sdk-types": "workspace:*",
    ...
  },
}

```
- `pnpm install -r`
- `pnpm run build-all`
- removed `SessionType` enum declaration in `packages/sdk-react/src/components/auth/Auth.tsx`
- `import { SessionType } from "@turnkey/sdk-types";`
- tested `examples/react-components` locally

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
