### PR TITLE
add @changesets/changelog-github for better changelogs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,10 +1,11 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "tkhq/sdk" }],
   "commit": false,
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": [
     "@turnkey/jest-config",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "tkhq/sdk" }],
+  "changelog": ["./changelog-custom.js", { "repo": "tkhq/sdk" }],
   "commit": false,
   "linked": [],
   "access": "public",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": ["./changelog-custom.js", { "repo": "tkhq/sdk" }],
+  "changelog": ["./custom-changelog.js", { "repo": "tkhq/sdk" }],
   "commit": false,
   "linked": [],
   "access": "public",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": ["@changesets/changelog-github", { "repo": "tkhq/sdk" }],
   "commit": false,
   "linked": [],
   "access": "public",

--- a/.changeset/custom-changelog.js
+++ b/.changeset/custom-changelog.js
@@ -6,7 +6,7 @@ module.exports = {
     const releaseLine = await githubChangelog.getReleaseLine(
       changeset,
       type,
-      options
+      options,
     );
 
     // replace "Thanks [username]!" with "Author [username]"
@@ -19,7 +19,7 @@ module.exports = {
     return githubChangelog.getDependencyReleaseLine(
       changesets,
       dependenciesUpdated,
-      options
+      options,
     );
   },
 };

--- a/.changeset/custom-changelog.js
+++ b/.changeset/custom-changelog.js
@@ -6,15 +6,14 @@ module.exports = {
     const releaseLine = await githubChangelog.getReleaseLine(
       changeset,
       type,
-      options,
+      options
     );
 
     // replace "Thanks [username]!" with "Author [username]"
     console.log("Original release line:", releaseLine);
-    const updatedReleaseLine = releaseLine.replace(
-      /Thanks (\[@.*\])!/,
-      "Author $1",
-    );
+    const regex = /Thanks (\[@\w+\]\(https:\/\/github\.com\/\w+\))!/;
+    const updatedReleaseLine = releaseLine.replace(regex, "Author $1");
+
     console.log("Updated release line:", updatedReleaseLine);
     return updatedReleaseLine;
   },
@@ -23,7 +22,7 @@ module.exports = {
     return githubChangelog.getDependencyReleaseLine(
       changesets,
       dependenciesUpdated,
-      options,
+      options
     );
   },
 };

--- a/.changeset/custom-changelog.js
+++ b/.changeset/custom-changelog.js
@@ -10,7 +10,13 @@ module.exports = {
     );
 
     // replace "Thanks [username]!" with "Author [username]"
-    return releaseLine.replace(/Thanks (\[@.*\])!/, "Author $1");
+    console.log("Original release line:", releaseLine);
+    const updatedReleaseLine = releaseLine.replace(
+      /Thanks (\[@.*\])!/,
+      "Author $1",
+    );
+    console.log("Updated release line:", updatedReleaseLine);
+    return updatedReleaseLine;
   },
   async getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
     // reuse the original dependency release line logic

--- a/.changeset/custom-changelog.js
+++ b/.changeset/custom-changelog.js
@@ -6,23 +6,20 @@ module.exports = {
     const releaseLine = await githubChangelog.getReleaseLine(
       changeset,
       type,
-      options,
+      options
     );
 
     // replace "Thanks [username]!" with "Author [username]"
-    console.log("Original release line:", releaseLine);
     const regex = /Thanks (\[@\w+\]\(https:\/\/github\.com\/\w+\))!/;
-    const updatedReleaseLine = releaseLine.replace(regex, "Author $1");
 
-    console.log("Updated release line:", updatedReleaseLine);
-    return updatedReleaseLine;
+    return releaseLine.replace(regex, "Author $1");
   },
   async getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
     // reuse the original dependency release line logic
     return githubChangelog.getDependencyReleaseLine(
       changesets,
       dependenciesUpdated,
-      options,
+      options
     );
   },
 };

--- a/.changeset/custom-changelog.js
+++ b/.changeset/custom-changelog.js
@@ -6,7 +6,7 @@ module.exports = {
     const releaseLine = await githubChangelog.getReleaseLine(
       changeset,
       type,
-      options
+      options,
     );
 
     // replace "Thanks [username]!" with "Author [username]"
@@ -22,7 +22,7 @@ module.exports = {
     return githubChangelog.getDependencyReleaseLine(
       changesets,
       dependenciesUpdated,
-      options
+      options,
     );
   },
 };

--- a/.changeset/custom-changelog.js
+++ b/.changeset/custom-changelog.js
@@ -1,0 +1,23 @@
+const { default: githubChangelog } = require("@changesets/changelog-github");
+
+module.exports = {
+  async getReleaseLine(changeset, type, options) {
+    // call the original getReleaseLine from @changesets/changelog-github
+    const releaseLine = await githubChangelog.getReleaseLine(
+      changeset,
+      type,
+      options
+    );
+
+    // replace "Thanks [username]!" with "Author [username]"
+    return releaseLine.replace(/Thanks (\[@.*\])!/, "Author $1");
+  },
+  async getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
+    // reuse the original dependency release line logic
+    return githubChangelog.getDependencyReleaseLine(
+      changesets,
+      dependenciesUpdated,
+      options
+    );
+  },
+};

--- a/.changeset/custom-changelog.js
+++ b/.changeset/custom-changelog.js
@@ -6,7 +6,7 @@ module.exports = {
     const releaseLine = await githubChangelog.getReleaseLine(
       changeset,
       type,
-      options
+      options,
     );
 
     // replace "Thanks [username]!" with "Author [username]"
@@ -17,7 +17,7 @@ module.exports = {
     return githubChangelog.getDependencyReleaseLine(
       changesets,
       dependenciesUpdated,
-      options
+      options,
     );
   },
 };

--- a/.changeset/kind-hats-sleep.md
+++ b/.changeset/kind-hats-sleep.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-types": patch
+---
+
+Publish @turnkey/sdk-types package

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -49,3 +49,7 @@ runs:
       uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
       with:
         version: stable
+        cache: true
+        cache-key: ${{ runner.os }}-foundry-stable-${{ hashFiles('**/pnpm-lock.yaml') }}
+        cache-restore-keys: |
+          ${{ runner.os }}-foundry-stable-

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -45,18 +45,32 @@ runs:
       run: pnpm install -r --frozen-lockfile
       shell: bash
 
-    - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
+    - name: Cache Foundry binary
+      id: cache-foundry
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
-        version: stable
-        cache: true
-        cache-key: ${{ runner.os }}-foundry-stable
-        cache-restore-keys: |
-          linux-foundry-chain-fork-${{ runner.os }}-foundry-stable
-          linux-foundry-chain-fork-${{ runner.os }}-foundry-stable-
-          linux-foundry-chain-fork-
+        path: ~/.foundry/bin
+        key: ${{ runner.os }}-foundry-stable
+        restore-keys: |
+          ${{ runner.os }}-foundry-stable-
       env:
         ACTIONS_CACHE_DEBUG: true
+
+    - name: Install Foundry
+      if: steps.cache-foundry.outputs.cache-hit != 'true'
+      run: |
+        # Download and extract Foundry to a temporary directory
+        curl -L https://github.com/foundry-rs/foundry/releases/download/stable/foundry_stable_linux_amd64.tar.gz -o foundry.tar.gz
+        mkdir -p /tmp/foundry
+        tar xz -C /tmp/foundry -f foundry.tar.gz
+        # Create ~/.foundry/bin and move binaries there
+        mkdir -p ~/.foundry/bin
+        mv /tmp/foundry/* ~/.foundry/bin/
+        # Add ~/.foundry/bin to PATH
+        echo "$HOME/.foundry/bin" >> $GITHUB_PATH
+        # Clean up
+        rm -rf /tmp/foundry foundry.tar.gz
+      shell: bash
 
     - name: Debug Foundry cache
       run: |

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -50,6 +50,6 @@ runs:
       with:
         version: stable
         cache: true
-        cache-key: ${{ runner.os }}-foundry-stable-${{ hashFiles('.github/workflows/release.yml') }}
+        cache-key: ${{ runner.os }}-foundry-stable
         cache-restore-keys: |
           ${{ runner.os }}-foundry-stable-

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -50,6 +50,7 @@ runs:
       with:
         version: stable
         cache: true
-        cache-key: ${{ runner.os }}-foundry-stable
+        cache-key: linux-foundry-chain-fork-${{ runner.os }}-foundry-stable
         cache-restore-keys: |
-          ${{ runner.os }}-foundry-stable-
+          linux-foundry-chain-fork-${{ runner.os }}-foundry-stable-
+          linux-foundry-chain-fork-

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -46,12 +46,21 @@ runs:
       shell: bash
 
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
+      uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
       with:
         version: stable
         cache: true
         cache-key: ${{ runner.os }}-foundry-stable
         cache-restore-keys: |
-          ${{ runner.os }}-foundry-stable-
           linux-foundry-chain-fork-${{ runner.os }}-foundry-stable-
+          linux-foundry-chain-fork-${{ runner.os }}-foundry-stable
           linux-foundry-chain-fork-
+      env:
+        ACTIONS_CACHE_DEBUG: true # enable cache debug logging
+
+    - name: Debug Foundry cache
+      run: |
+        echo "Foundry binary location:"
+        ls -la ~/.foundry/bin || echo "No Foundry binary found"
+        anvil --version || echo "anvil not installed"
+      shell: bash

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -52,15 +52,23 @@ runs:
         cache: true
         cache-key: ${{ runner.os }}-foundry-stable
         cache-restore-keys: |
-          linux-foundry-chain-fork-${{ runner.os }}-foundry-stable-
           linux-foundry-chain-fork-${{ runner.os }}-foundry-stable
+          linux-foundry-chain-fork-${{ runner.os }}-foundry-stable-
           linux-foundry-chain-fork-
       env:
-        ACTIONS_CACHE_DEBUG: true # enable cache debug logging
+        ACTIONS_CACHE_DEBUG: true
 
     - name: Debug Foundry cache
       run: |
         echo "Foundry binary location:"
-        ls -la ~/.foundry/bin || echo "No Foundry binary found"
+        ls -la ~/.foundry/bin || echo "No Foundry binary found in ~/.foundry/bin"
+        echo "Checking PATH for Foundry binaries:"
+        which anvil || echo "anvil not found"
+        which forge || echo "forge not found"
+        which cast || echo "cast not found"
+        echo "PATH contents:"
+        echo $PATH
+        echo "All binaries in PATH:"
+        find $(echo $PATH | tr ':' ' ') -maxdepth 1 -type f -executable 2>/dev/null || echo "Error searching PATH"
         anvil --version || echo "anvil not installed"
       shell: bash

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -50,6 +50,6 @@ runs:
       with:
         version: stable
         cache: true
-        cache-key: ${{ runner.os }}-foundry-stable-${{ hashFiles('**/pnpm-lock.yaml') }}
+        cache-key: ${{ runner.os }}-foundry-stable-${{ hashFiles('.github/workflows/release.yml') }}
         cache-restore-keys: |
           ${{ runner.os }}-foundry-stable-

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -50,7 +50,8 @@ runs:
       with:
         version: stable
         cache: true
-        cache-key: linux-foundry-chain-fork-${{ runner.os }}-foundry-stable
+        cache-key: ${{ runner.os }}-foundry-stable
         cache-restore-keys: |
+          ${{ runner.os }}-foundry-stable-
           linux-foundry-chain-fork-${{ runner.os }}-foundry-stable-
           linux-foundry-chain-fork-

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -53,8 +53,6 @@ runs:
         key: ${{ runner.os }}-foundry-stable
         restore-keys: |
           ${{ runner.os }}-foundry-stable-
-      env:
-        ACTIONS_CACHE_DEBUG: true
 
     - name: Install Foundry
       if: steps.cache-foundry.outputs.cache-hit != 'true'

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -45,83 +45,13 @@ runs:
       run: pnpm install -r --frozen-lockfile
       shell: bash
 
-    - name: Debug cache environment
-      run: |
-        echo "Runner OS: ${{ runner.os }}"
-        echo "Cache key: ${{ runner.os }}-foundry-stable"
-        echo "Restore keys:"
-        echo "${{ runner.os }}-foundry-stable-"
-        echo "Linux-foundry-stable-"
-        echo "Cache storage info:"
-        du -sh ~/.foundry/bin || echo "No cache directory"
-        echo "Current PATH:"
-        echo $PATH
-      shell: bash
-      env:
-        ACTIONS_CACHE_DEBUG: true
-
-    - name: Cache Foundry binary
-      id: cache-foundry
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      with:
-        path: ~/.foundry/bin
-        key: ${{ runner.os }}-foundry-stable
-        restore-keys: |
-          ${{ runner.os }}-foundry-stable-
-          Linux-foundry-stable-
-      env:
-        ACTIONS_CACHE_DEBUG: true
-
     - name: Install Foundry
-      if: steps.cache-foundry.outputs.cache-hit != 'true'
-      run: |
-        set -euxo pipefail
-        echo "Cache miss, installing Foundry"
-        curl -L https://github.com/foundry-rs/foundry/releases/download/stable/foundry_stable_linux_amd64.tar.gz -o foundry.tar.gz
-        ls -la foundry.tar.gz
-        echo "Inspecting archive contents:"
-        tar -tzf foundry.tar.gz
-        mkdir -p /tmp/foundry
-        tar xz -C /tmp/foundry -f foundry.tar.gz
-        echo "Temporary directory contents:"
-        find /tmp/foundry -ls
-        mkdir -p ~/.foundry/bin
-        # Move binaries, accounting for possible nested structure
-        find /tmp/foundry -type f -executable -exec mv {} ~/.foundry/bin/ \;
-        echo "Foundry bin directory contents:"
-        ls -la ~/.foundry/bin
-        chmod +x ~/.foundry/bin/*
-        echo "$HOME/.foundry/bin" >> $GITHUB_PATH
-        echo "Updated PATH:"
-        cat $GITHUB_PATH
-        echo $PATH
-        rm -rf /tmp/foundry foundry.tar.gz
-        echo "Verifying anvil installation:"
-        ~/.foundry/bin/anvil --version
-      shell: bash
-
-    - name: Verify Foundry cache save
-      if: steps.cache-foundry.outputs.cache-hit != 'true'
-      run: |
-        echo "Verifying cache contents before save"
-        ls -la ~/.foundry/bin || echo "No Foundry binaries found"
-        du -sh ~/.foundry/bin || echo "No cache directory"
-      shell: bash
-
-    - name: Debug Foundry cache
-      run: |
-        echo "Cache hit: ${{ steps.cache-foundry.outputs.cache-hit }}"
-        echo "Foundry binary location:"
-        ls -la ~/.foundry/bin || echo "No Foundry binary found in ~/.foundry/bin"
-        echo "Checking PATH for Foundry binaries:"
-        which anvil || echo "anvil not found"
-        which forge || echo "forge not found"
-        which cast || echo "cast not found"
-        echo "PATH contents:"
-        echo $PATH
-        echo "GITHUB_PATH contents:"
-        cat $GITHUB_PATH || echo "No GITHUB_PATH file"
-        echo "All binaries in PATH:"
-        find $(echo $PATH | tr ':' ' ') -maxdepth 1 -type f -executable 2>/dev/null || echo "Error searching PATH"
-        anvil --version || echo "anvil not installed"
-      shell: bash
+      uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
+      with:
+        cache: true
+        version: "stable"
+        cache-key: ${{ github.job }}-${{ github.sha }}
+        cache-restore-keys: |
+          ${{ github.job }}-${{ github.sha }}
+          ${{ github.job }}-
+          ${{ runner.os }}-foundry-toolchain

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -45,6 +45,21 @@ runs:
       run: pnpm install -r --frozen-lockfile
       shell: bash
 
+    - name: Debug cache environment
+      run: |
+        echo "Runner OS: ${{ runner.os }}"
+        echo "Cache key: ${{ runner.os }}-foundry-stable"
+        echo "Restore keys:"
+        echo "${{ runner.os }}-foundry-stable-"
+        echo "Linux-foundry-stable-"
+        echo "Cache storage info:"
+        du -sh ~/.foundry/bin || echo "No cache directory"
+        echo "Current PATH:"
+        echo $PATH
+      shell: bash
+      env:
+        ACTIONS_CACHE_DEBUG: true
+
     - name: Cache Foundry binary
       id: cache-foundry
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -53,25 +68,46 @@ runs:
         key: ${{ runner.os }}-foundry-stable
         restore-keys: |
           ${{ runner.os }}-foundry-stable-
+          Linux-foundry-stable-
+      env:
+        ACTIONS_CACHE_DEBUG: true
 
     - name: Install Foundry
       if: steps.cache-foundry.outputs.cache-hit != 'true'
       run: |
-        # Download and extract Foundry to a temporary directory
+        set -euxo pipefail
+        echo "Cache miss, installing Foundry"
         curl -L https://github.com/foundry-rs/foundry/releases/download/stable/foundry_stable_linux_amd64.tar.gz -o foundry.tar.gz
+        ls -la foundry.tar.gz
         mkdir -p /tmp/foundry
         tar xz -C /tmp/foundry -f foundry.tar.gz
-        # Create ~/.foundry/bin and move binaries there
+        echo "Temporary directory contents:"
+        ls -la /tmp/foundry
         mkdir -p ~/.foundry/bin
         mv /tmp/foundry/* ~/.foundry/bin/
-        # Add ~/.foundry/bin to PATH
+        echo "Foundry bin directory contents:"
+        ls -la ~/.foundry/bin
+        chmod +x ~/.foundry/bin/*
         echo "$HOME/.foundry/bin" >> $GITHUB_PATH
-        # Clean up
+        echo "Updated PATH:"
+        cat $GITHUB_PATH
+        echo $PATH
         rm -rf /tmp/foundry foundry.tar.gz
+        echo "Verifying anvil installation:"
+        ~/.foundry/bin/anvil --version
+      shell: bash
+
+    - name: Verify Foundry cache save
+      if: steps.cache-foundry.outputs.cache-hit != 'true'
+      run: |
+        echo "Verifying cache contents before save"
+        ls -la ~/.foundry/bin || echo "No Foundry binaries found"
+        du -sh ~/.foundry/bin || echo "No cache directory"
       shell: bash
 
     - name: Debug Foundry cache
       run: |
+        echo "Cache hit: ${{ steps.cache-foundry.outputs.cache-hit }}"
         echo "Foundry binary location:"
         ls -la ~/.foundry/bin || echo "No Foundry binary found in ~/.foundry/bin"
         echo "Checking PATH for Foundry binaries:"
@@ -80,6 +116,8 @@ runs:
         which cast || echo "cast not found"
         echo "PATH contents:"
         echo $PATH
+        echo "GITHUB_PATH contents:"
+        cat $GITHUB_PATH || echo "No GITHUB_PATH file"
         echo "All binaries in PATH:"
         find $(echo $PATH | tr ':' ' ') -maxdepth 1 -type f -executable 2>/dev/null || echo "Error searching PATH"
         anvil --version || echo "anvil not installed"

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -79,12 +79,15 @@ runs:
         echo "Cache miss, installing Foundry"
         curl -L https://github.com/foundry-rs/foundry/releases/download/stable/foundry_stable_linux_amd64.tar.gz -o foundry.tar.gz
         ls -la foundry.tar.gz
+        echo "Inspecting archive contents:"
+        tar -tzf foundry.tar.gz
         mkdir -p /tmp/foundry
         tar xz -C /tmp/foundry -f foundry.tar.gz
         echo "Temporary directory contents:"
-        ls -la /tmp/foundry
+        find /tmp/foundry -ls
         mkdir -p ~/.foundry/bin
-        mv /tmp/foundry/* ~/.foundry/bin/
+        # Move binaries, accounting for possible nested structure
+        find /tmp/foundry -type f -executable -exec mv {} ~/.foundry/bin/ \;
         echo "Foundry bin directory contents:"
         ls -la ~/.foundry/bin
         chmod +x ~/.foundry/bin/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,17 @@ jobs:
 
       - name: Build
         run: pnpm run build-all
-
-      - name: Debug Foundry
-        run: anvil --version || echo "anvil not found"
+      - name: Debug Foundry setup
+        run: |
+          echo "Checking Foundry binaries:"
+          ls -la ~/.foundry/bin || echo "No Foundry binaries found"
+          which anvil || echo "anvil not found"
+          echo "PATH contents:"
+          echo $PATH
+          echo "GITHUB_PATH contents:"
+          cat $GITHUB_PATH || echo "No GITHUB_PATH file"
+          anvil --version || echo "anvil not installed"
+        shell: bash
 
       - name: Test (prod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,7 @@ jobs:
         with:
           version: pnpm --filter @turnkey/sdk-types run changeset version # Updates versions and changelog
           publish: pnpm --filter @turnkey/sdk-types publish --dry-run # dry run publish to npm
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links
           NPM_TOKEN: ${{ env.NPM_TOKEN }} # for npm publish
@@ -146,6 +147,7 @@ jobs:
       #   with:
       #     version: pnpm --filter @turnkey/sdk-types run changeset version
       #     publish: pnpm --filter @turnkey/sdk-types publish
+      #     createGithubReleases: false
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #     NPM_TOKEN: ${{ env.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
       - name: Test (preprod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
         env:
@@ -73,6 +81,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-pre-prod
     steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
       - name: Test (prod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
         env:
@@ -94,6 +110,14 @@ jobs:
     environment: production # require manual approval for production deployments
     needs: test-prod
     steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
       - name: Publish @turnkey/sdk-types to npm
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,17 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch: # Allows manual invocation
+  # TODO: Uncomment to trigger on tags
+  # push:
+  #   tags:
+  #     - "v*.*.*" # Triggers on tags like v1.0.0
 
 permissions:
   contents: write
   actions: read
   checks: write
   pull-requests: write
+  packages: write
 
 jobs:
   check-release-label:
@@ -137,26 +142,35 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # fetch all history for changelog generation
 
       # Install and cache JS toolchain and dependencies (node_modules)
       - name: Setup JS
         uses: ./.github/actions/js-setup
 
-      - name: Publish SDK packages to npm
+      - name: Debug changeset config
+        run: |
+          ls -la .changeset/
+          cat .changeset/config.json || echo "config.json not found"
+          ls -la .changeset/custom-changelog.js || echo "custom-changelog.js not found"
+
+      - name: Debug npm config
+        run: |
+          echo "NPM_TOKEN is set: ${NPM_TOKEN:+set}"
+          cat .npmrc || echo "No .npmrc found"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Version and Publish SDK packages to npm
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
-          version: pnpm changeset version # Updates versions and changelog
-          publish: pnpm publish --dry-run # dry run publish to npm
-          createGithubReleases: false
+          version: pnpm changeset version # updates package versions and changelogs
+          publish: pnpm publish # publish to npm
+          createGithubReleases: true
+          commit: "chore: release packages"
+          title: "Release ${{ github.ref_name }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for changelog links
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # for npm publish
-      # - name: Publish to npm (Push)
-      #   uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
-      #   with:
-      #     version: pnpm --filter @turnkey/sdk-types run changeset version
-      #     publish: pnpm --filter @turnkey/sdk-types publish
-      #     createGithubReleases: false
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ env.NPM_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # Full history for changelog generation
+
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Use corepack to activate pnpm
+        run: npm i -g corepack@0.31.0 && corepack enable
+        shell: bash
+
+      - name: Audit dependencies (before installing anything)
+        # Ignore "low" and "moderate" advisories for now.
+        run: pnpm audit --audit-level high
+        shell: bash
+
+      - name: Get pnpm store directory (for caching)
+        id: pnpm-cache-dir
+        run: |
+          echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      # https://github.com/actions/cache
+      - name: Setup pnpm store cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ${{ steps.pnpm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+
+      - name: Audit the lockfiles to catch peer dependency issues
+        run: pnpm install -r --lockfile-only
+        shell: bash
+
+      - name: Install dependencies
+        run: pnpm install -r --frozen-lockfile
+        shell: bash
+
+      - name: Create PR with changelog
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
+        with:
+          version: pnpm run changeset version # Updates versions and changelog
+          # publish: pnpm run changeset publish # Publishes to npm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links
+          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # For npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Setup JS
         uses: ./.github/actions/js-setup
 
+      - name: Build
+        run: pnpm run build-all
+
       - name: Debug Foundry
         run: anvil --version || echo "anvil not found"
 
@@ -94,6 +97,9 @@ jobs:
       # Install and cache JS toolchain and dependencies (node_modules)
       - name: Setup JS
         uses: ./.github/actions/js-setup
+
+      - name: Build
+        run: pnpm run build-all
 
       - name: Debug Foundry
         run: anvil --version || echo "anvil not found"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Build
         run: pnpm run build-all
+
       - name: Debug Foundry setup
         run: |
           echo "Checking Foundry binaries:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           version: pnpm run changeset version # Updates versions and changelog
-          # publish: pnpm run changeset publish # Publishes to npm
+          publish: pnpm run changeset publish # Publishes to npm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links
-          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # For npm publish
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # For npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,11 +133,11 @@ jobs:
       - name: Setup JS
         uses: ./.github/actions/js-setup
 
-      - name: Publish @turnkey/sdk-types to npm
+      - name: Publish SDK packages to npm
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
-          version: pnpm --filter @turnkey/sdk-types run changeset version # Updates versions and changelog
-          publish: pnpm --filter @turnkey/sdk-types publish --dry-run # dry run publish to npm
+          version: pnpm changeset version # Updates versions and changelog
+          publish: pnpm publish --dry-run # dry run publish to npm
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,65 +1,112 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*.*.*"
-      - "v*.*.*"
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch: # Allows manual invocation
+
+permissions:
+  contents: write
+  actions: read
+  checks: write
+  pull-requests: write
 
 jobs:
-  release:
+  check-release-label:
     runs-on: ubuntu-latest
-    environment: production
+    outputs:
+      has-release-label: ${{ steps.check-release-label.outputs.has-release-label }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0 # Full history for changelog generation
-
-      - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Use corepack to activate pnpm
-        run: npm i -g corepack@0.31.0 && corepack enable
-        shell: bash
-
-      - name: Audit dependencies (before installing anything)
-        # Ignore "low" and "moderate" advisories for now.
-        run: pnpm audit --audit-level high
-        shell: bash
-
-      - name: Get pnpm store directory (for caching)
-        id: pnpm-cache-dir
+      - name: Check for run-ci label
+        id: check-release-label
         run: |
-          echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-        shell: bash
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci-release') }}" == "true" ]]; then
+            echo "has-release-label=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-release-label=false" >> $GITHUB_OUTPUT
+          fi
 
-      # https://github.com/actions/cache
-      - name: Setup pnpm store cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: ${{ steps.pnpm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+  build:
+    needs: check-release-label
+    if: needs.check-release-label.outputs.has-release-label == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
+      - name: Build
+        run: pnpm run build-all
+
+      - name: Typecheck
+        run: pnpm run typecheck-all
+
+      - name: Prettier
+        run: pnpm run prettier-all:check
+
+  test-pre-prod:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Test (preprod)
+        run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+          API_PUBLIC_KEY: ${{ secrets.PREPROD_API_PUBLIC_KEY }}
+          API_PRIVATE_KEY: ${{ secrets.PREPROD_API_PRIVATE_KEY }}
+          BASE_URL: ${{ secrets.PREPROD_BASE_URL }}
+          ORGANIZATION_ID: ${{ secrets.PREPROD_ORGANIZATION_ID }}
+          PRIVATE_KEY_ID: ${{ secrets.PREPROD_PRIVATE_KEY_ID }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS: ${{ secrets.PREPROD_EXPECTED_PRIVATE_KEY_ETH_ADDRESS }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2: ${{ secrets.PREPROD_EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2 }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS: ${{ secrets.PREPROD_EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2: ${{ secrets.PREPROD_EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2 }}
+          BANNED_TO_ADDRESS: ${{ secrets.PREPROD_BANNED_TO_ADDRESS }}
+          SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
+          WALLET_ID: ${{ secrets.PREPROD_WALLET_ID }}
 
-      - name: Audit the lockfiles to catch peer dependency issues
-        run: pnpm install -r --lockfile-only
-        shell: bash
+  test-prod:
+    runs-on: ubuntu-latest
+    needs: test-pre-prod
+    steps:
+      - name: Test (prod)
+        run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
+        env:
+          API_PUBLIC_KEY: ${{ secrets.API_PUBLIC_KEY }}
+          API_PRIVATE_KEY: ${{ secrets.API_PRIVATE_KEY }}
+          BASE_URL: "https://api.turnkey.com"
+          ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
+          PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS: ${{ secrets.EXPECTED_PRIVATE_KEY_ETH_ADDRESS }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2: ${{ secrets.EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2 }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS: ${{ secrets.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2: ${{ secrets.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2 }}
+          BANNED_TO_ADDRESS: "0x6F72eDB2429820c2A0606a9FC3cA364f5E9b2375"
+          SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
+          WALLET_ID: ${{ secrets.WALLET_ID }}
 
-      - name: Install dependencies
-        run: pnpm install -r --frozen-lockfile
-        shell: bash
-
-      - name: Create PR with changelog
+  publish:
+    runs-on: ubuntu-latest
+    environment: production # require manual approval for production deployments
+    needs: test-prod
+    steps:
+      - name: Publish @turnkey/sdk-types to npm
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
-          version: pnpm run changeset version # Updates versions and changelog
-          publish: pnpm run changeset publish # Publishes to npm
+          version: pnpm --filter @turnkey/sdk-types run changeset version # Updates versions and changelog
+          publish: pnpm --filter @turnkey/sdk-types publish --dry-run # dry run publish to npm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # For npm publish
+          NPM_TOKEN: ${{ env.NPM_TOKEN }} # for npm publish
+      - name: Publish to npm (Push)
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
+        with:
+          version: pnpm --filter @turnkey/sdk-types run changeset version
+          publish: pnpm --filter @turnkey/sdk-types publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,20 @@
-name: Release
+name: release
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-  workflow_dispatch: # Allows manual invocation
-  # TODO: Uncomment to trigger on tags
-  # push:
-  #   tags:
-  #     - "v*.*.*" # Triggers on tags like v1.0.0
+  workflow_dispatch: # allows manual invocation
+  push:
+    tags:
+      - "test-v*.*.*" # triggers on tags like v1.0.0
 
 permissions:
   contents: write
-  actions: read
+  actions: write
   checks: write
   pull-requests: write
   packages: write
 
 jobs:
-  check-release-label:
-    runs-on: ubuntu-latest
-    outputs:
-      has-release-label: ${{ steps.check-release-label.outputs.has-release-label }}
-    steps:
-      - name: Check for run-ci label
-        id: check-release-label
-        run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci-release') }}" == "true" ]]; then
-            echo "has-release-label=true" >> $GITHUB_OUTPUT
-          else
-            echo "has-release-label=false" >> $GITHUB_OUTPUT
-          fi
-
   build:
-    needs: check-release-label
-    if: needs.check-release-label.outputs.has-release-label == 'true'
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    # environment: production # require manual approval for production deployments
+    environment: production # require manual approval for production deployments
     needs: test-prod
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,11 +102,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links
           NPM_TOKEN: ${{ env.NPM_TOKEN }} # for npm publish
-      - name: Publish to npm (Push)
-        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
-        with:
-          version: pnpm --filter @turnkey/sdk-types run changeset version
-          publish: pnpm --filter @turnkey/sdk-types publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ env.NPM_TOKEN }}
+      # - name: Publish to npm (Push)
+      #   uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
+      #   with:
+      #     version: pnpm --filter @turnkey/sdk-types run changeset version
+      #     publish: pnpm --filter @turnkey/sdk-types publish
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     NPM_TOKEN: ${{ env.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Setup JS
         uses: ./.github/actions/js-setup
 
+      - name: Debug Foundry
+        run: anvil --version || echo "anvil not found"
+
       - name: Build
         run: pnpm run build-all
 
@@ -60,6 +63,9 @@ jobs:
       # Install and cache JS toolchain and dependencies (node_modules)
       - name: Setup JS
         uses: ./.github/actions/js-setup
+
+      - name: Debug Foundry
+        run: anvil --version || echo "anvil not found"
 
       - name: Test (preprod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
@@ -88,6 +94,9 @@ jobs:
       # Install and cache JS toolchain and dependencies (node_modules)
       - name: Setup JS
         uses: ./.github/actions/js-setup
+
+      - name: Debug Foundry
+        run: anvil --version || echo "anvil not found"
 
       - name: Test (prod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    environment: production # require manual approval for production deployments
+    # environment: production # require manual approval for production deployments
     needs: test-prod
     steps:
       # https://github.com/actions/checkout
@@ -150,7 +150,7 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For changelog links
-          NPM_TOKEN: ${{ env.NPM_TOKEN }} # for npm publish
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # for npm publish
       # - name: Publish to npm (Push)
       #   uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
       #   with:

--- a/examples/email-auth-local-storage/package.json
+++ b/examples/email-auth-local-storage/package.json
@@ -28,6 +28,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/email-auth/package.json
+++ b/examples/email-auth/package.json
@@ -26,6 +26,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/oauth/package.json
+++ b/examples/oauth/package.json
@@ -28,6 +28,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/otp-auth/package.json
+++ b/examples/otp-auth/package.json
@@ -26,6 +26,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/react-components/package.json
+++ b/examples/react-components/package.json
@@ -39,6 +39,6 @@
     "react-international-phone": "^4.3.0",
     "sonner": "^1.4.41",
     "tweetnacl": "^1.0.3",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/sweeper/package.json
+++ b/examples/sweeper/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "@types/prompts": "^2.4.2",
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/trading-runner/package.json
+++ b/examples/trading-runner/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "@types/prompts": "^2.4.2",
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/wallet-import-export/package.json
+++ b/examples/wallet-import-export/package.json
@@ -25,7 +25,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   },
   "devDependencies": {
     "@types/node": "20.3.1",

--- a/examples/with-aptos/package.json
+++ b/examples/with-aptos/package.json
@@ -21,6 +21,6 @@
     "@types/async-retry": "^1.4.8",
     "@types/prompts": "^2.4.2",
     "tsx": "^3.12.7",
-    "typescript": "^5.0.4"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-eip-1193-provider/package.json
+++ b/examples/with-eip-1193-provider/package.json
@@ -43,6 +43,6 @@
     "eslint-config-next": "14.2.25",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-eth-passkeys-galore/package.json
+++ b/examples/with-eth-passkeys-galore/package.json
@@ -37,7 +37,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3",
+    "typescript": "5.4.3",
     "viem": "2.23.13"
   },
   "peerDependencies": {

--- a/examples/with-federated-passkeys/package.json
+++ b/examples/with-federated-passkeys/package.json
@@ -30,6 +30,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-movement/package.json
+++ b/examples/with-movement/package.json
@@ -21,6 +21,6 @@
     "@types/async-retry": "^1.4.8",
     "@types/prompts": "^2.4.2",
     "tsx": "^3.12.7",
-    "typescript": "^5.0.4"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-solana-passkeys/package.json
+++ b/examples/with-solana-passkeys/package.json
@@ -32,7 +32,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.1",
-    "typescript": "5.1.3"
+    "typescript": "5.4.3"
   },
   "devDependencies": {
     "@solana/web3.js": "^1.95.8",

--- a/examples/with-sui/package.json
+++ b/examples/with-sui/package.json
@@ -21,6 +21,6 @@
     "@types/async-retry": "^1.4.8",
     "@types/prompts": "^2.4.2",
     "tsx": "^3.12.7",
-    "typescript": "^5.0.4"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-ton/package.json
+++ b/examples/with-ton/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/async-retry": "^1.4.8",
     "tsx": "^3.12.7",
-    "typescript": "^5.0.4"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-tron/package.json
+++ b/examples/with-tron/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-uniswap/package.json
+++ b/examples/with-uniswap/package.json
@@ -19,6 +19,6 @@
     "jsbi": "^3.2.5"
   },
   "devDependencies": {
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-viem/package.json
+++ b/examples/with-viem/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@types/prompts": "^2.4.2",
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-wallet-stamper/package.json
+++ b/examples/with-wallet-stamper/package.json
@@ -58,6 +58,6 @@
     "pino-pretty": "^11.2.2",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/examples/with-zerodev-aa/package.json
+++ b/examples/with-zerodev-aa/package.json
@@ -18,7 +18,7 @@
     "ethers": "^6.10.0",
     "permissionless": "^0.1.45",
     "prompts": "^2.4.2",
-    "typescript": "5.1.5",
+    "typescript": "5.4.3",
     "viem": "^2.24.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pnpm": "^8.0.0"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.27.5",
     "@jest/globals": "^29.3.1",
     "@jest/types": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "turbo": "^2.4.4",
     "typedoc": "^0.28.1",
     "typedoc-plugin-markdown": "^4.6.0",
-    "typescript": "^5.1.4"
+    "typescript": "5.4.3"
   },
   "packageManager": "pnpm@8.4.0",
   "pnpm": {

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -57,6 +57,6 @@
   },
   "devDependencies": {
     "hardhat": "^2.22.2",
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "glob": "^8.0.3",
-    "typescript": "^5.1.5"
+    "typescript": "5.4.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -60,6 +60,7 @@
     "@turnkey/sdk-browser": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
     "@turnkey/wallet-stamper": "workspace:*",
+    "@turnkey/sdk-types": "workspace:*",
     "libphonenumber-js": "^1.11.14",
     "next": "^15.2.3 ",
     "react-apple-login": "^1.1.6",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -60,7 +60,6 @@
     "@turnkey/sdk-browser": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
     "@turnkey/wallet-stamper": "workspace:*",
-    "@turnkey/sdk-types": "workspace:*",
     "libphonenumber-js": "^1.11.14",
     "next": "^15.2.3 ",
     "react-apple-login": "^1.1.6",

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -244,7 +244,7 @@ const Auth: React.FC<AuthProps> = ({
   const handleOtpLogin = async (
     type: FilterType.Email | FilterType.PhoneNumber,
     value: string,
-    otpType: string
+    otpType: string,
   ) => {
     setLoading(otpType);
     const createSuborgData: Record<string, any> = {};

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -18,11 +18,8 @@ import { FilterType, OtpType, authErrors } from "./constants";
 import type { TurnkeyApiTypes, WalletAccount } from "@turnkey/sdk-browser";
 import { server } from "@turnkey/sdk-server";
 import parsePhoneNumberFromString from "libphonenumber-js";
+import { SessionType } from "@turnkey/sdk-types";
 
-export enum SessionType {
-  READ_ONLY = "SESSION_TYPE_READ_ONLY",
-  READ_WRITE = "SESSION_TYPE_READ_WRITE",
-}
 export interface PasskeyConfig {
   displayName?: string;
   name?: string;
@@ -244,7 +241,7 @@ const Auth: React.FC<AuthProps> = ({
   const handleOtpLogin = async (
     type: FilterType.Email | FilterType.PhoneNumber,
     value: string,
-    otpType: string,
+    otpType: string
   ) => {
     setLoading(otpType);
     const createSuborgData: Record<string, any> = {};

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -18,8 +18,11 @@ import { FilterType, OtpType, authErrors } from "./constants";
 import type { TurnkeyApiTypes, WalletAccount } from "@turnkey/sdk-browser";
 import { server } from "@turnkey/sdk-server";
 import parsePhoneNumberFromString from "libphonenumber-js";
-import { SessionType } from "@turnkey/sdk-types";
 
+export enum SessionType {
+  READ_ONLY = "SESSION_TYPE_READ_ONLY",
+  READ_WRITE = "SESSION_TYPE_READ_WRITE",
+}
 export interface PasskeyConfig {
   displayName?: string;
   name?: string;

--- a/packages/sdk-types/.changeset/kind-cheetahs-smile.md
+++ b/packages/sdk-types/.changeset/kind-cheetahs-smile.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-types": patch
+---
+
+Include changesets

--- a/packages/sdk-types/.changeset/kind-cheetahs-smile.md
+++ b/packages/sdk-types/.changeset/kind-cheetahs-smile.md
@@ -1,5 +1,0 @@
----
-"@turnkey/sdk-types": patch
----
-
-Include changesets

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.5",
-    "typescript": "^5.4.3"
+    "typescript": "5.4.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -9,7 +9,6 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "changeset": "changeset",
     "prepublishOnly": "pnpm run clean && pnpm run build",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc -p tsconfig.typecheck.json"
@@ -45,7 +44,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.27.5",
     "typescript": "5.4.3"
   },
   "engines": {

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@turnkey/sdk-types",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "pnpm run build",
+    "clean": "rimraf ./dist ./.cache",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
+  },
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "license": "Apache-2.0",
+  "description": "Turnkey SDK Types",
+  "keywords": [
+    "Turnkey"
+  ],
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com"
+  },
+  "homepage": "https://github.com/tkhq/sdk/packages/sdk-types#readme",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tkhq/sdk.git",
+    "directory": "packages/sdk-types"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "private": true,
+  "devDependencies": {
+    "typescript": "^5.4.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "changeset": "changeset",
     "prepublishOnly": "pnpm run clean && pnpm run build",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc -p tsconfig.typecheck.json"
@@ -44,6 +45,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.5",
     "typescript": "^5.4.3"
   },
   "engines": {

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "prepublishOnly": "pnpm run build",
+    "prepublishOnly": "pnpm run clean && pnpm run build",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },
@@ -41,9 +41,8 @@
     "directory": "packages/sdk-types"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
-  "private": true,
   "devDependencies": {
     "typescript": "^5.4.3"
   },

--- a/packages/sdk-types/rollup.config.mjs
+++ b/packages/sdk-types/rollup.config.mjs
@@ -1,0 +1,3 @@
+import rollup from "../../rollup.config.base.mjs";
+
+export default (options) => rollup();

--- a/packages/sdk-types/src/index.ts
+++ b/packages/sdk-types/src/index.ts
@@ -1,0 +1,23 @@
+export enum SessionType {
+  READ_ONLY = "SESSION_TYPE_READ_ONLY",
+  READ_WRITE = "SESSION_TYPE_READ_WRITE",
+}
+
+export type Session = {
+  sessionType: SessionType;
+  userId: string;
+  organizationId: string;
+  expiry: number;
+  token: string;
+};
+
+export type SessionResponse = {
+  session: Session;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    organizationId: string;
+    organizationName: string;
+  };
+};

--- a/packages/sdk-types/tsconfig.json
+++ b/packages/sdk-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sdk-types/tsconfig.typecheck.json
+++ b/packages/sdk-types/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.typecheck.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/sdk-types/turbo.json
+++ b/packages/sdk-types/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/packages/sdk-types/typedoc.json
+++ b/packages/sdk-types/typedoc.json
@@ -1,0 +1,16 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "excludeInternal": true,
+  "includeVersion": true,
+  "fileExtension": ".mdx",
+  "plugin": ["typedoc-plugin-markdown"],
+  "projectDocuments": ["documents/*.md"],
+  "outputs": [
+    {
+      // requires typedoc-plugin-markdown
+      "name": "markdown",
+      "path": "./docs/markdown",
+      "fileExtension": ".mdx"
+    }
+  ]
+}

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.3",
     "jest": "^29.3.1",
-    "typescript": "^5.1.3",
+    "typescript": "5.4.3",
     "viem": "^2.24.2"
   },
   "engines": {

--- a/packages/wallet-stamper/package.json
+++ b/packages/wallet-stamper/package.json
@@ -61,6 +61,6 @@
     "dotenv": "^16.0.3",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",
-    "typescript": "^5.1.3"
+    "typescript": "5.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,10 +730,10 @@ importers:
     dependencies:
       '@biconomy/account':
         specifier: ^4.5.6
-        version: 4.5.6(typescript@5.4.3)(viem@2.23.13)
+        version: 4.5.6(typescript@5.8.3)(viem@2.26.2)
       '@biconomy/sdk':
         specifier: ^0.0.10
-        version: 0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.4.3)(viem@2.23.13)
+        version: 0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.8.3)(viem@2.26.2)
       '@rhinestone/module-sdk':
         specifier: ^0.1.28
         version: 0.1.28(viem@2.26.2)
@@ -756,8 +756,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       viem:
-        specifier: 2.23.13
-        version: 2.23.13(typescript@5.4.3)
+        specifier: ^2.24.2
+        version: 2.26.2(typescript@5.8.3)
     devDependencies:
       '@types/prompts':
         specifier: ^2.4.2
@@ -1100,7 +1100,7 @@ importers:
     dependencies:
       '@safe-global/protocol-kit':
         specifier: ^3.0.1
-        version: 3.0.1(typescript@5.4.3)
+        version: 3.0.1(typescript@5.8.3)
       '@safe-global/safe-core-sdk-types':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1207,7 +1207,7 @@ importers:
         version: 0.26.0
       '@solana/spl-token':
         specifier: ^0.4.8
-        version: 0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+        version: 0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/web3.js':
         specifier: ^1.95.8
         version: 1.95.8(encoding@0.1.13)
@@ -1849,7 +1849,7 @@ importers:
         version: 4.9.0
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
+        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3)
       '@typechain/hardhat':
         specifier: ^9.1.0
         version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2)
@@ -1858,10 +1858,10 @@ importers:
         version: 6.10.0
       hardhat:
         specifier: ^2.19.4
-        version: 2.19.4(typescript@5.4.3)
+        version: 2.19.4(typescript@5.8.3)
       typechain:
         specifier: ^8.3.2
-        version: 8.3.2(typescript@5.4.3)
+        version: 8.3.2(typescript@5.8.3)
 
   packages/http:
     dependencies:
@@ -2070,7 +2070,7 @@ importers:
         version: 2.27.5
       typescript:
         specifier: ^5.4.3
-        version: 5.4.3
+        version: 5.8.3
 
   packages/solana:
     dependencies:
@@ -5249,33 +5249,33 @@ packages:
       - zod
     dev: false
 
-  /@biconomy/account@4.5.6(typescript@5.4.3)(viem@2.23.13):
+  /@biconomy/account@4.5.6(typescript@5.8.3)(viem@2.26.2):
     resolution: {integrity: sha512-Mq0X9HF4fsPTkf87eXklJJE/Hl3GQwQHN/2/D1fCA4Q4o4AM9HV7Tzpb+hBsh8cUJ+s2j0Q9wORXA1c0onAImQ==}
     peerDependencies:
       typescript: ^5
       viem: ^2
     dependencies:
-      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.4.3)
+      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.8.3)
       merkletreejs: 0.4.0
-      typescript: 5.4.3
-      viem: 2.23.13(typescript@5.4.3)
+      typescript: 5.8.3
+      viem: 2.26.2(typescript@5.8.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
     dev: false
 
-  /@biconomy/sdk@0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.4.3)(viem@2.23.13):
+  /@biconomy/sdk@0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.8.3)(viem@2.26.2):
     resolution: {integrity: sha512-HolZ2V95/Z/oE75qbbm2X+cGcWwh4S0oTgyDzd8XQBnnRDOGKlQuf5gxAz0AFvZTCfkjLqZe8E9cVhYPBI+2yQ==}
     peerDependencies:
       '@rhinestone/module-sdk': ^0.1.25
       typescript: ^5
       viem: ^2.20.0
     dependencies:
-      '@rhinestone/module-sdk': 0.1.28(viem@2.23.13)
-      '@silencelaboratories/walletprovider-sdk': 0.3.0(typescript@5.4.3)
-      typescript: 5.4.3
-      viem: 2.23.13(typescript@5.4.3)
+      '@rhinestone/module-sdk': 0.1.28(viem@2.26.2)
+      '@silencelaboratories/walletprovider-sdk': 0.3.0(typescript@5.8.3)
+      typescript: 5.8.3
+      viem: 2.26.2(typescript@5.8.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5364,7 +5364,7 @@ packages:
     resolution: {integrity: sha512-UVppOvzCjjylBenFcwcZNG5IaZ8jsIaEVraV/pbXgukYNb0Oqa0d8UWb0LkYzA1Bf1HmUrOfccFcRLheRuA7pA==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.26.10
       '@changesets/apply-release-plan': 7.0.3
       '@changesets/assemble-release-plan': 6.0.2
       '@changesets/changelog-git': 0.2.0
@@ -5377,7 +5377,7 @@ packages:
       '@changesets/pre': 2.0.0
       '@changesets/read': 0.6.0
       '@changesets/should-skip-package': 0.1.0
-      '@changesets/types': 6.1.0
+      '@changesets/types': 6.0.0
       '@changesets/write': 0.3.1
       '@manypkg/get-packages': 1.1.3
       '@types/semver': 7.5.8
@@ -5503,13 +5503,17 @@ packages:
   /@changesets/should-skip-package@0.1.0:
     resolution: {integrity: sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.26.10
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
     dev: true
 
   /@changesets/types@4.1.0:
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+    dev: true
+
+  /@changesets/types@6.0.0:
+    resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
     dev: true
 
   /@changesets/types@6.1.0:
@@ -5519,7 +5523,7 @@ packages:
   /@changesets/write@0.3.1:
     resolution: {integrity: sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.26.10
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -8577,7 +8581,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 6.10.0
-      hardhat: 2.19.4(typescript@5.4.3)
+      hardhat: 2.19.4(typescript@5.8.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -8589,7 +8593,7 @@ packages:
       hardhat: ^2.9.5
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.19.4(typescript@5.4.3)
+      hardhat: 2.19.4(typescript@5.8.3)
     dev: true
 
   /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0:
@@ -10845,7 +10849,7 @@ packages:
     dependencies:
       solady: 0.0.235
       tslib: 2.8.1
-      viem: 2.23.13(typescript@5.4.3)
+      viem: 2.26.2(typescript@5.8.3)
     dev: false
 
   /@rollup/plugin-alias@5.1.1(rollup@4.22.4):
@@ -11088,7 +11092,7 @@ packages:
   /@rushstack/eslint-patch@1.9.0:
     resolution: {integrity: sha512-AAWymnpvHbGty1BmgbdfbqQDboXs6xN6h2yAacO4yKVyyUUBnpYkp+P9jjPrV9zrAGw7JVVriRtGOHPInnfjZQ==}
 
-  /@safe-global/protocol-kit@3.0.1(typescript@5.4.3):
+  /@safe-global/protocol-kit@3.0.1(typescript@5.8.3):
     resolution: {integrity: sha512-7S2QCvIDw3NsErF0f8tIfiTBz32btCAkw7IYuQFPc+G7clLrvDNhDaZYSoDsa8F0EoEhn+605VA7XP//iL6AIg==}
     dependencies:
       '@noble/hashes': 1.4.0
@@ -11096,7 +11100,7 @@ packages:
       ethereumjs-util: 7.1.5
       ethers: 6.10.0
       semver: 7.5.4
-      web3: 4.7.0(typescript@5.4.3)
+      web3: 4.7.0(typescript@5.8.3)
       web3-core: 4.3.2
       web3-utils: 4.2.1
     transitivePeerDependencies:
@@ -11338,11 +11342,11 @@ packages:
       - zod
     dev: false
 
-  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.4.3):
+  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.8.3):
     resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
     dependencies:
-      '@noble/curves': 1.8.1
-      viem: 2.26.2(typescript@5.4.3)
+      '@noble/curves': 1.8.0
+      viem: 2.28.0(typescript@5.8.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11350,12 +11354,12 @@ packages:
       - zod
     dev: false
 
-  /@silencelaboratories/walletprovider-sdk@0.3.0(typescript@5.4.3):
+  /@silencelaboratories/walletprovider-sdk@0.3.0(typescript@5.8.3):
     resolution: {integrity: sha512-5+yS95DwIufP0qOPuk81cXZ8gepcARXwuKRDAtjtf50JVX0MOMy6pR8f/1j5PATPdImzgI8905x3ZBgXfi+FKw==}
     dependencies:
       '@noble/curves': 1.8.0
       js-base64: 3.7.7
-      viem: 2.21.32(typescript@5.4.3)
+      viem: 2.21.32(typescript@5.8.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11469,13 +11473,13 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-core@2.0.0-preview.4(typescript@5.4.3):
+  /@solana/codecs-core@2.0.0-preview.4(typescript@5.8.3):
     resolution: {integrity: sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
-      typescript: 5.4.3
+      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
+      typescript: 5.8.3
     dev: false
 
   /@solana/codecs-data-structures@2.0.0-preview.2:
@@ -11486,15 +11490,15 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.4.3):
+  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.8.3):
     resolution: {integrity: sha512-nt2k2eTeyzlI/ccutPcG36M/J8NAYfxBPI9h/nQjgJ+M+IgOKi31JV8StDDlG/1XvY0zyqugV3I0r3KAbZRJpA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
-      typescript: 5.4.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
+      typescript: 5.8.3
     dev: false
 
   /@solana/codecs-numbers@2.0.0-preview.2:
@@ -11504,14 +11508,14 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.4.3):
+  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.8.3):
     resolution: {integrity: sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
-      typescript: 5.4.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
+      typescript: 5.8.3
     dev: false
 
   /@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -11525,17 +11529,17 @@ packages:
       fastestsmallesttextencoderdecoder: 1.0.22
     dev: false
 
-  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
+  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
     resolution: {integrity: sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.4.3
+      typescript: 5.8.3
     dev: false
 
   /@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -11550,17 +11554,17 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
+  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
     resolution: {integrity: sha512-gLMupqI4i+G4uPi2SGF/Tc1aXcviZF2ybC81x7Q/fARamNSgNOCUUoSCg9nWu1Gid6+UhA7LH80sWI8XjKaRog==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      typescript: 5.4.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
@@ -11573,7 +11577,7 @@ packages:
       commander: 12.1.0
     dev: false
 
-  /@solana/errors@2.0.0-preview.4(typescript@5.4.3):
+  /@solana/errors@2.0.0-preview.4(typescript@5.8.3):
     resolution: {integrity: sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==}
     hasBin: true
     peerDependencies:
@@ -11581,7 +11585,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
-      typescript: 5.4.3
+      typescript: 5.8.3
     dev: false
 
   /@solana/options@2.0.0-preview.2:
@@ -11591,28 +11595,28 @@ packages:
       '@solana/codecs-numbers': 2.0.0-preview.2
     dev: false
 
-  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
+  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
     resolution: {integrity: sha512-tv2O/Frxql/wSe3jbzi5nVicIWIus/BftH+5ZR+r9r3FO0/htEllZS5Q9XdbmSboHu+St87584JXeDx3xm4jaA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
-      typescript: 5.4.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
+  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
     resolution: {integrity: sha512-CLJnWEcdoUBpQJfx9WEbX3h6nTdNiUzswfFdkABUik7HVwSNA98u5AYvBVK2H93d9PGMOHAak2lHW9xr+zAJGQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.94.0
     dependencies:
-      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/spl-type-length-value': 0.1.0
       '@solana/web3.js': 1.95.8(encoding@0.1.13)
     transitivePeerDependencies:
@@ -11633,7 +11637,7 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
+  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
     resolution: {integrity: sha512-RO0JD9vPRi4LsAbMUdNbDJ5/cv2z11MGhtAvFeRzT4+hAGE/FUzRi0tkkWtuCfSIU3twC6CtmAihRp/+XXjWsA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -11641,7 +11645,7 @@ packages:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0
-      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/web3.js': 1.95.8(encoding@0.1.13)
       buffer: 6.0.3
@@ -13030,7 +13034,11 @@ packages:
     deprecated: TypeScript 5.0 supports combining TSConfigs using array syntax in extends
     dev: true
 
-  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3):
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
+  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
@@ -13039,9 +13047,9 @@ packages:
     dependencies:
       ethers: 6.10.0
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.4.3)
-      typechain: 8.3.2(typescript@5.4.3)
-      typescript: 5.4.3
+      ts-essentials: 7.0.3(typescript@5.8.3)
+      typechain: 8.3.2(typescript@5.8.3)
+      typescript: 5.8.3
     dev: true
 
   /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2):
@@ -13052,11 +13060,11 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
+      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3)
       ethers: 6.10.0
       fs-extra: 9.1.0
-      hardhat: 2.19.4(typescript@5.4.3)
-      typechain: 8.3.2(typescript@5.4.3)
+      hardhat: 2.19.4(typescript@5.8.3)
+      typechain: 8.3.2(typescript@5.8.3)
     dev: true
 
   /@types/async-eventemitter@0.2.1:
@@ -14298,7 +14306,7 @@ packages:
     deprecated: Use your platform's native atob() and btoa() methods instead
     dev: true
 
-  /abitype@0.7.1(typescript@5.4.3):
+  /abitype@0.7.1(typescript@5.8.3):
     resolution: {integrity: sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -14307,7 +14315,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.4.3
+      typescript: 5.8.3
     dev: false
 
   /abitype@1.0.0(typescript@5.1.5):
@@ -14339,7 +14347,7 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /abitype@1.0.6(typescript@5.4.3):
+  /abitype@1.0.6(typescript@5.8.3):
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14350,7 +14358,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.4.3
+      typescript: 5.8.3
     dev: false
 
   /abitype@1.0.8(typescript@5.1.3):
@@ -14380,7 +14388,7 @@ packages:
     dependencies:
       typescript: 5.1.5
 
-  /abitype@1.0.8(typescript@5.4.3):
+  /abitype@1.0.8(typescript@5.8.3):
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14391,7 +14399,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.4.3
+      typescript: 5.8.3
     dev: false
 
   /abort-controller@3.0.0:
@@ -18394,7 +18402,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /hardhat@2.19.4(typescript@5.4.3):
+  /hardhat@2.19.4(typescript@5.8.3):
     resolution: {integrity: sha512-fTQJpqSt3Xo9Mn/WrdblNGAfcANM6XC3tAEi6YogB4s02DmTf93A8QsGb8uR0KR8TFcpcS8lgiW4ugAIYpnbrQ==}
     hasBin: true
     peerDependencies:
@@ -18451,7 +18459,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 5.4.3
+      typescript: 5.8.3
       undici: 5.24.0
       uuid: 8.3.2
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -21588,7 +21596,7 @@ packages:
     transitivePeerDependencies:
       - zod
 
-  /ox@0.6.9(typescript@5.4.3):
+  /ox@0.6.9(typescript@5.8.3):
     resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -21597,13 +21605,13 @@ packages:
         optional: true
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.0
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.4.3)
+      abitype: 1.0.8(typescript@5.8.3)
       eventemitter3: 5.0.1
-      typescript: 5.4.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - zod
     dev: false
@@ -24711,12 +24719,12 @@ packages:
       string-format: 2.0.0
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.4.3):
+  /ts-essentials@7.0.3(typescript@5.8.3):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.4.3
+      typescript: 5.8.3
     dev: true
 
   /ts-interface-checker@0.1.13:
@@ -24932,7 +24940,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typechain@8.3.2(typescript@5.4.3):
+  /typechain@8.3.2(typescript@5.8.3):
     resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
     hasBin: true
     peerDependencies:
@@ -24947,8 +24955,8 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.4.3)
-      typescript: 5.4.3
+      ts-essentials: 7.0.3(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -25038,8 +25046,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.4.3:
-    resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
+  /typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -25472,7 +25480,7 @@ packages:
       - zod
     dev: false
 
-  /viem@2.21.32(typescript@5.4.3):
+  /viem@2.21.32(typescript@5.8.3):
     resolution: {integrity: sha512-2oXt5JNIb683oy7C8wuIJ/SeL3XtHVMEQpy1U2TA6WMnJQ4ScssRvyPwYLcaP6mKlrGXE/cR/V7ncWpvLUVPYQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -25485,9 +25493,9 @@ packages:
       '@noble/hashes': 1.5.0
       '@scure/bip32': 1.5.0
       '@scure/bip39': 1.4.0
-      abitype: 1.0.6(typescript@5.4.3)
+      abitype: 1.0.6(typescript@5.8.3)
       isows: 1.0.6(ws@8.17.1)
-      typescript: 5.4.3
+      typescript: 5.8.3
       webauthn-p256: 0.0.10
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -25542,8 +25550,9 @@ packages:
       - utf-8-validate
       - zod
 
-  /viem@2.23.13(typescript@5.4.3):
-    resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}
+  /viem@2.26.2(typescript@5.8.3):
+    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
+    requiresBuild: true
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -25554,10 +25563,10 @@ packages:
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.4.3)
+      abitype: 1.0.8(typescript@5.8.3)
       isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.4.3)
-      typescript: 5.4.3
+      ox: 0.6.9(typescript@5.8.3)
+      typescript: 5.8.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25565,16 +25574,17 @@ packages:
       - zod
     dev: false
 
-  /viem@2.26.2(typescript@5.1.3):
-    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
+  /viem@2.28.0(typescript@5.1.3):
+    resolution: {integrity: sha512-Z4W5O1pe+6pirYTFm451FcZmfGAUxUWt2L/eWC+YfTF28j/8rd7q6MBAi05lMN4KhLJjhN0s5YGIPB+kf1L20g==}
+    requiresBuild: true
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.1.3)
@@ -25588,45 +25598,23 @@ packages:
       - zod
     dev: false
 
-  /viem@2.26.2(typescript@5.1.5):
-    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
+  /viem@2.28.0(typescript@5.8.3):
+    resolution: {integrity: sha512-Z4W5O1pe+6pirYTFm451FcZmfGAUxUWt2L/eWC+YfTF28j/8rd7q6MBAi05lMN4KhLJjhN0s5YGIPB+kf1L20g==}
+    requiresBuild: true
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.1.5)
+      abitype: 1.0.8(typescript@5.8.3)
       isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.1.5)
-      typescript: 5.1.5
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /viem@2.26.2(typescript@5.4.3):
-    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.4.3)
-      isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.4.3)
-      typescript: 5.4.3
+      ox: 0.6.9(typescript@5.8.3)
+      typescript: 5.8.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25735,11 +25723,11 @@ packages:
       web3-types: 1.5.0
     dev: false
 
-  /web3-eth-abi@4.2.0(typescript@5.4.3):
+  /web3-eth-abi@4.2.0(typescript@5.8.3):
     resolution: {integrity: sha512-x7dUCmk6th+5N63s5kUusoNtsDJKUUQgl9+jECvGTBOTiyHe/V6aOY0120FUjaAGaapOnR7BImQdhqHv6yT2YQ==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
-      abitype: 0.7.1(typescript@5.4.3)
+      abitype: 0.7.1(typescript@5.8.3)
       web3-errors: 1.1.4
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25762,14 +25750,14 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-contract@4.3.0(typescript@5.4.3):
+  /web3-eth-contract@4.3.0(typescript@5.8.3):
     resolution: {integrity: sha512-4fzSklA65zUn6SthU3T3tbVJacfP8/wkJmCuvmPaf2ZTFdnhsF96G5IQtCRf0+wASb4yk0A6IBvXZfk1B4R4HA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.4.3)
-      web3-eth-abi: 4.2.0(typescript@5.4.3)
+      web3-eth: 4.5.0(typescript@5.8.3)
+      web3-eth-abi: 4.2.0(typescript@5.8.3)
       web3-types: 1.5.0
       web3-utils: 4.2.1
       web3-validator: 2.0.5
@@ -25781,15 +25769,15 @@ packages:
       - zod
     dev: false
 
-  /web3-eth-ens@4.2.0(typescript@5.4.3):
+  /web3-eth-ens@4.2.0(typescript@5.8.3):
     resolution: {integrity: sha512-qYj34te2UctoObt8rlEIY/t2MuTMiMiiHhO2JAHRGqSLCQ7b8DM3RpvkiiSB0N0ZyEn+CetZqJCTYb8DNKBS/g==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.4.3)
-      web3-eth-contract: 4.3.0(typescript@5.4.3)
+      web3-eth: 4.5.0(typescript@5.8.3)
+      web3-eth-contract: 4.3.0(typescript@5.8.3)
       web3-net: 4.0.7
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25812,12 +25800,12 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-personal@4.0.8(typescript@5.4.3):
+  /web3-eth-personal@4.0.8(typescript@5.8.3):
     resolution: {integrity: sha512-sXeyLKJ7ddQdMxz1BZkAwImjqh7OmKxhXoBNF3isDmD4QDpMIwv/t237S3q4Z0sZQamPa/pHebJRWVuvP8jZdw==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
-      web3-eth: 4.5.0(typescript@5.4.3)
+      web3-eth: 4.5.0(typescript@5.8.3)
       web3-rpc-methods: 1.2.0
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25830,14 +25818,14 @@ packages:
       - zod
     dev: false
 
-  /web3-eth@4.5.0(typescript@5.4.3):
+  /web3-eth@4.5.0(typescript@5.8.3):
     resolution: {integrity: sha512-crisE46o/SHMVm+XHAXEaR8k76NCImq+hi0QQEJ+VaLZbDobI/Gvog1HwTukDUDRgnYSAFGqD0cTRyAwDurwpA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       setimmediate: 1.0.5
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth-abi: 4.2.0(typescript@5.4.3)
+      web3-eth-abi: 4.2.0(typescript@5.8.3)
       web3-eth-accounts: 4.1.1
       web3-net: 4.0.7
       web3-providers-ws: 4.0.7
@@ -25945,19 +25933,19 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /web3@4.7.0(typescript@5.4.3):
+  /web3@4.7.0(typescript@5.8.3):
     resolution: {integrity: sha512-3g+1e7B/IW0Nw9WP1dotrZKWD9o5IBfl27dxEnE1LxBZBax6ZkviiAwf18utIhlNBD07RgI+PPfKDXxfDBlHWA==}
     engines: {node: '>=14.0.0', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.4.3)
-      web3-eth-abi: 4.2.0(typescript@5.4.3)
+      web3-eth: 4.5.0(typescript@5.8.3)
+      web3-eth-abi: 4.2.0(typescript@5.8.3)
       web3-eth-accounts: 4.1.1
-      web3-eth-contract: 4.3.0(typescript@5.4.3)
-      web3-eth-ens: 4.2.0(typescript@5.4.3)
+      web3-eth-contract: 4.3.0(typescript@5.8.3)
+      web3-eth-ens: 4.2.0(typescript@5.8.3)
       web3-eth-iban: 4.0.7
-      web3-eth-personal: 4.0.8(typescript@5.4.3)
+      web3-eth-personal: 4.0.8(typescript@5.8.3)
       web3-net: 4.0.7
       web3-providers-http: 4.1.0
       web3-providers-ws: 4.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2065,6 +2065,9 @@ importers:
 
   packages/sdk-types:
     devDependencies:
+      '@changesets/cli':
+        specifier: ^2.27.5
+        version: 2.27.5
       typescript:
         specifier: ^5.4.3
         version: 5.4.3
@@ -5131,6 +5134,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
+    dev: false
 
   /@babel/runtime@7.24.8:
     resolution: {integrity: sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==}
@@ -5360,7 +5364,7 @@ packages:
     resolution: {integrity: sha512-UVppOvzCjjylBenFcwcZNG5IaZ8jsIaEVraV/pbXgukYNb0Oqa0d8UWb0LkYzA1Bf1HmUrOfccFcRLheRuA7pA==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.24.1
+      '@babel/runtime': 7.26.0
       '@changesets/apply-release-plan': 7.0.3
       '@changesets/assemble-release-plan': 6.0.2
       '@changesets/changelog-git': 0.2.0
@@ -5373,7 +5377,7 @@ packages:
       '@changesets/pre': 2.0.0
       '@changesets/read': 0.6.0
       '@changesets/should-skip-package': 0.1.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@changesets/write': 0.3.1
       '@manypkg/get-packages': 1.1.3
       '@types/semver': 7.5.8
@@ -5506,10 +5510,6 @@ packages:
 
   /@changesets/types@4.1.0:
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
-    dev: true
-
-  /@changesets/types@6.0.0:
-    resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
     dev: true
 
   /@changesets/types@6.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 16.0.0(rollup@4.22.4)
       '@rollup/plugin-typescript':
         specifier: ^11.1.5
-        version: 11.1.5(rollup@4.22.4)(typescript@5.1.5)
+        version: 11.1.5(rollup@4.22.4)(typescript@5.4.3)
       '@rollup/plugin-url':
         specifier: 8.0.2
         version: 8.0.2(rollup@4.22.4)
@@ -97,13 +97,13 @@ importers:
         version: 2.4.4
       typedoc:
         specifier: ^0.28.1
-        version: 0.28.1(typescript@5.1.5)
+        version: 0.28.1(typescript@5.4.3)
       typedoc-plugin-markdown:
         specifier: ^4.6.0
         version: 4.6.0(typedoc@0.28.1)
       typescript:
-        specifier: ^5.1.4
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/delegated-access:
     dependencies:
@@ -115,7 +115,7 @@ importers:
         version: 16.0.3
       viem:
         specifier: ^2.26.2
-        version: 2.26.2(typescript@5.1.5)
+        version: 2.26.2(typescript@5.4.3)
 
   examples/deployer:
     dependencies:
@@ -163,7 +163,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -186,8 +186,8 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/email-auth-local-storage:
     dependencies:
@@ -223,7 +223,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -246,8 +246,8 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/export-in-node:
     dependencies:
@@ -372,7 +372,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -395,8 +395,8 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/otp-auth:
     dependencies:
@@ -426,7 +426,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -449,8 +449,8 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/react-components:
     dependencies:
@@ -510,7 +510,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -542,8 +542,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/rebalancer:
     dependencies:
@@ -579,7 +579,7 @@ importers:
         version: 6.10.0
       hardhat:
         specifier: ^2.12.7
-        version: 2.12.7(typescript@5.1.5)
+        version: 2.12.7(typescript@5.4.3)
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -588,8 +588,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/trading-runner:
     dependencies:
@@ -625,8 +625,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/wallet-import-export:
     dependencies:
@@ -650,7 +650,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -673,8 +673,8 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
     devDependencies:
       '@types/node':
         specifier: 20.3.1
@@ -723,17 +723,17 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-biconomy-aa:
     dependencies:
       '@biconomy/account':
         specifier: ^4.5.6
-        version: 4.5.6(typescript@5.8.3)(viem@2.26.2)
+        version: 4.5.6(typescript@5.4.3)(viem@2.26.2)
       '@biconomy/sdk':
         specifier: ^0.0.10
-        version: 0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.8.3)(viem@2.26.2)
+        version: 0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.4.3)(viem@2.26.2)
       '@rhinestone/module-sdk':
         specifier: ^0.1.28
         version: 0.1.28(viem@2.26.2)
@@ -757,7 +757,7 @@ importers:
         version: 2.4.2
       viem:
         specifier: ^2.24.2
-        version: 2.26.2(typescript@5.8.3)
+        version: 2.26.2(typescript@5.4.3)
     devDependencies:
       '@types/prompts':
         specifier: ^2.4.2
@@ -891,7 +891,7 @@ importers:
         version: 1.0.7(tailwindcss@3.3.0)
       viem:
         specifier: ^2.9.5
-        version: 2.9.5(typescript@5.1.5)
+        version: 2.9.5(typescript@5.4.3)
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -910,7 +910,7 @@ importers:
         version: 8.43.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.43.0)(typescript@5.1.5)
+        version: 14.2.25(eslint@8.43.0)(typescript@5.4.3)
       postcss:
         specifier: ^8
         version: 8.4.38
@@ -918,14 +918,14 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(postcss@8.4.38)
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-eth-passkeys-galore:
     dependencies:
       '@biconomy/account':
         specifier: ^4.5.6
-        version: 4.5.6(typescript@5.1.3)(viem@2.23.13)
+        version: 4.5.6(typescript@5.4.3)(viem@2.23.13)
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../../packages/api-key-stamper
@@ -970,7 +970,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -996,11 +996,11 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
       viem:
         specifier: 2.23.13
-        version: 2.23.13(typescript@5.1.3)
+        version: 2.23.13(typescript@5.4.3)
 
   examples/with-ethers:
     dependencies:
@@ -1070,7 +1070,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -1093,14 +1093,14 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-gnosis:
     dependencies:
       '@safe-global/protocol-kit':
         specifier: ^3.0.1
-        version: 3.0.1(typescript@5.8.3)
+        version: 3.0.1(typescript@5.4.3)
       '@safe-global/safe-core-sdk-types':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1157,8 +1157,8 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-nonce-manager:
     dependencies:
@@ -1207,7 +1207,7 @@ importers:
         version: 0.26.0
       '@solana/spl-token':
         specifier: ^0.4.8
-        version: 0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+        version: 0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/web3.js':
         specifier: ^1.95.8
         version: 1.95.8(encoding@0.1.13)
@@ -1286,7 +1286,7 @@ importers:
         version: 8.56.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.56.0)(typescript@5.1.3)
+        version: 14.2.25(eslint@8.56.0)(typescript@5.4.3)
       esm:
         specifier: ^3.2.25
         version: 3.2.25
@@ -1309,8 +1309,8 @@ importers:
         specifier: ^7.45.1
         version: 7.45.1(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.4.3
+        version: 5.4.3
     devDependencies:
       '@solana/web3.js':
         specifier: ^1.95.8
@@ -1362,8 +1362,8 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-ton:
     dependencies:
@@ -1405,8 +1405,8 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
       typescript:
-        specifier: ^5.0.4
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-tron:
     dependencies:
@@ -1434,10 +1434,10 @@ importers:
     devDependencies:
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.3.1)(typescript@5.8.3)
+        version: 10.9.2(@types/node@20.3.1)(typescript@5.4.3)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-uniswap:
     dependencies:
@@ -1464,14 +1464,14 @@ importers:
         version: 6.10.0
       hardhat:
         specifier: ^2.12.7
-        version: 2.12.7(typescript@5.1.5)
+        version: 2.12.7(typescript@5.4.3)
       jsbi:
         specifier: ^3.2.5
         version: 3.2.5
     devDependencies:
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-viem:
     dependencies:
@@ -1504,14 +1504,14 @@ importers:
         version: 2.4.2
       viem:
         specifier: ^2.24.2
-        version: 2.26.2(typescript@5.1.5)
+        version: 2.26.2(typescript@5.4.3)
     devDependencies:
       '@types/prompts':
         specifier: ^2.4.2
         version: 2.4.2
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-wallet-stamper:
     dependencies:
@@ -1565,7 +1565,7 @@ importers:
         version: 1.95.8(encoding@0.1.13)
       '@t3-oss/env-nextjs':
         specifier: ^0.11.0
-        version: 0.11.0(typescript@5.1.5)(zod@3.23.8)
+        version: 0.11.0(typescript@5.4.3)(zod@3.23.8)
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../../packages/api-key-stamper
@@ -1625,7 +1625,7 @@ importers:
         version: 0.15.1
       viem:
         specifier: ^2.18.0
-        version: 2.18.0(typescript@5.1.5)(zod@3.23.8)
+        version: 2.18.0(typescript@5.4.3)(zod@3.23.8)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1644,7 +1644,7 @@ importers:
         version: 8.43.0
       eslint-config-next:
         specifier: 14.2.25
-        version: 14.2.25(eslint@8.43.0)(typescript@5.1.5)
+        version: 14.2.25(eslint@8.43.0)(typescript@5.4.3)
       pino-pretty:
         specifier: ^11.2.2
         version: 11.2.2
@@ -1655,8 +1655,8 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   examples/with-zerodev-aa:
     dependencies:
@@ -1688,11 +1688,11 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       typescript:
-        specifier: 5.1.5
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
       viem:
         specifier: ^2.24.2
-        version: 2.26.2(typescript@5.1.5)
+        version: 2.26.2(typescript@5.4.3)
     devDependencies:
       '@types/node':
         specifier: ^22.7.7
@@ -1812,14 +1812,14 @@ importers:
         version: link:../sdk-browser
       viem:
         specifier: 2.7.19
-        version: 2.7.19(typescript@5.1.5)
+        version: 2.7.19(typescript@5.4.3)
     devDependencies:
       hardhat:
         specifier: ^2.22.2
-        version: 2.22.2(typescript@5.1.5)
+        version: 2.22.2(typescript@5.4.3)
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   packages/encoding: {}
 
@@ -1849,7 +1849,7 @@ importers:
         version: 4.9.0
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3)
+        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
       '@typechain/hardhat':
         specifier: ^9.1.0
         version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2)
@@ -1858,10 +1858,10 @@ importers:
         version: 6.10.0
       hardhat:
         specifier: ^2.19.4
-        version: 2.19.4(typescript@5.8.3)
+        version: 2.19.4(typescript@5.4.3)
       typechain:
         specifier: ^8.3.2
-        version: 8.3.2(typescript@5.8.3)
+        version: 8.3.2(typescript@5.4.3)
 
   packages/http:
     dependencies:
@@ -1938,8 +1938,8 @@ importers:
         specifier: ^8.0.3
         version: 8.1.0
       typescript:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   packages/sdk-react:
     dependencies:
@@ -2069,8 +2069,8 @@ importers:
         specifier: ^2.27.5
         version: 2.27.5
       typescript:
-        specifier: ^5.4.3
-        version: 5.8.3
+        specifier: 5.4.3
+        version: 5.4.3
 
   packages/solana:
     dependencies:
@@ -2138,11 +2138,11 @@ importers:
         specifier: ^29.3.1
         version: 29.4.3(@types/node@18.18.2)
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
       viem:
         specifier: ^2.24.2
-        version: 2.26.2(typescript@5.1.5)
+        version: 2.26.2(typescript@5.4.3)
 
   packages/wallet-stamper:
     dependencies:
@@ -2155,7 +2155,7 @@ importers:
     optionalDependencies:
       viem:
         specifier: ^2.21.35
-        version: 2.26.2(typescript@5.1.5)
+        version: 2.26.2(typescript@5.4.3)
     devDependencies:
       '@solana/web3.js':
         specifier: ^1.95.8
@@ -2176,8 +2176,8 @@ importers:
         specifier: ^0.15.1
         version: 0.15.1
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.5
+        specifier: 5.4.3
+        version: 5.4.3
 
   packages/webauthn-stamper:
     dependencies:
@@ -5233,39 +5233,39 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@biconomy/account@4.5.6(typescript@5.1.3)(viem@2.23.13):
+  /@biconomy/account@4.5.6(typescript@5.4.3)(viem@2.23.13):
     resolution: {integrity: sha512-Mq0X9HF4fsPTkf87eXklJJE/Hl3GQwQHN/2/D1fCA4Q4o4AM9HV7Tzpb+hBsh8cUJ+s2j0Q9wORXA1c0onAImQ==}
     peerDependencies:
       typescript: ^5
       viem: ^2
     dependencies:
-      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.1.3)
+      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.4.3)
       merkletreejs: 0.4.0
-      typescript: 5.1.3
-      viem: 2.23.13(typescript@5.1.3)
+      typescript: 5.4.3
+      viem: 2.23.13(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
     dev: false
 
-  /@biconomy/account@4.5.6(typescript@5.8.3)(viem@2.26.2):
+  /@biconomy/account@4.5.6(typescript@5.4.3)(viem@2.26.2):
     resolution: {integrity: sha512-Mq0X9HF4fsPTkf87eXklJJE/Hl3GQwQHN/2/D1fCA4Q4o4AM9HV7Tzpb+hBsh8cUJ+s2j0Q9wORXA1c0onAImQ==}
     peerDependencies:
       typescript: ^5
       viem: ^2
     dependencies:
-      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.8.3)
+      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.4.3)
       merkletreejs: 0.4.0
-      typescript: 5.8.3
-      viem: 2.26.2(typescript@5.8.3)
+      typescript: 5.4.3
+      viem: 2.26.2(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
     dev: false
 
-  /@biconomy/sdk@0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.8.3)(viem@2.26.2):
+  /@biconomy/sdk@0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.4.3)(viem@2.26.2):
     resolution: {integrity: sha512-HolZ2V95/Z/oE75qbbm2X+cGcWwh4S0oTgyDzd8XQBnnRDOGKlQuf5gxAz0AFvZTCfkjLqZe8E9cVhYPBI+2yQ==}
     peerDependencies:
       '@rhinestone/module-sdk': ^0.1.25
@@ -5273,9 +5273,9 @@ packages:
       viem: ^2.20.0
     dependencies:
       '@rhinestone/module-sdk': 0.1.28(viem@2.26.2)
-      '@silencelaboratories/walletprovider-sdk': 0.3.0(typescript@5.8.3)
-      typescript: 5.8.3
-      viem: 2.26.2(typescript@5.8.3)
+      '@silencelaboratories/walletprovider-sdk': 0.3.0(typescript@5.4.3)
+      typescript: 5.4.3
+      viem: 2.26.2(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -8581,7 +8581,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 6.10.0
-      hardhat: 2.19.4(typescript@5.8.3)
+      hardhat: 2.19.4(typescript@5.4.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -8593,7 +8593,7 @@ packages:
       hardhat: ^2.9.5
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.19.4(typescript@5.8.3)
+      hardhat: 2.19.4(typescript@5.4.3)
     dev: true
 
   /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0:
@@ -10849,7 +10849,7 @@ packages:
     dependencies:
       solady: 0.0.235
       tslib: 2.8.1
-      viem: 2.26.2(typescript@5.8.3)
+      viem: 2.26.2(typescript@5.4.3)
     dev: false
 
   /@rollup/plugin-alias@5.1.1(rollup@4.22.4):
@@ -10900,7 +10900,7 @@ packages:
       rollup: 4.22.4
     dev: true
 
-  /@rollup/plugin-typescript@11.1.5(rollup@4.22.4)(typescript@5.1.5):
+  /@rollup/plugin-typescript@11.1.5(rollup@4.22.4)(typescript@5.4.3):
     resolution: {integrity: sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -10916,7 +10916,7 @@ packages:
       '@rollup/pluginutils': 5.0.5(rollup@4.22.4)
       resolve: 1.22.1
       rollup: 4.22.4
-      typescript: 5.1.5
+      typescript: 5.4.3
     dev: true
 
   /@rollup/plugin-url@8.0.2(rollup@4.22.4):
@@ -11092,7 +11092,7 @@ packages:
   /@rushstack/eslint-patch@1.9.0:
     resolution: {integrity: sha512-AAWymnpvHbGty1BmgbdfbqQDboXs6xN6h2yAacO4yKVyyUUBnpYkp+P9jjPrV9zrAGw7JVVriRtGOHPInnfjZQ==}
 
-  /@safe-global/protocol-kit@3.0.1(typescript@5.8.3):
+  /@safe-global/protocol-kit@3.0.1(typescript@5.4.3):
     resolution: {integrity: sha512-7S2QCvIDw3NsErF0f8tIfiTBz32btCAkw7IYuQFPc+G7clLrvDNhDaZYSoDsa8F0EoEhn+605VA7XP//iL6AIg==}
     dependencies:
       '@noble/hashes': 1.4.0
@@ -11100,7 +11100,7 @@ packages:
       ethereumjs-util: 7.1.5
       ethers: 6.10.0
       semver: 7.5.4
-      web3: 4.7.0(typescript@5.8.3)
+      web3: 4.7.0(typescript@5.4.3)
       web3-core: 4.3.2
       web3-utils: 4.2.1
     transitivePeerDependencies:
@@ -11330,11 +11330,11 @@ packages:
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
     dev: true
 
-  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.1.3):
+  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.4.3):
     resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
     dependencies:
       '@noble/curves': 1.8.0
-      viem: 2.28.0(typescript@5.1.3)
+      viem: 2.28.0(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11342,24 +11342,12 @@ packages:
       - zod
     dev: false
 
-  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.8.3):
-    resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
-    dependencies:
-      '@noble/curves': 1.8.0
-      viem: 2.28.0(typescript@5.8.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /@silencelaboratories/walletprovider-sdk@0.3.0(typescript@5.8.3):
+  /@silencelaboratories/walletprovider-sdk@0.3.0(typescript@5.4.3):
     resolution: {integrity: sha512-5+yS95DwIufP0qOPuk81cXZ8gepcARXwuKRDAtjtf50JVX0MOMy6pR8f/1j5PATPdImzgI8905x3ZBgXfi+FKw==}
     dependencies:
       '@noble/curves': 1.8.0
       js-base64: 3.7.7
-      viem: 2.21.32(typescript@5.8.3)
+      viem: 2.21.32(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11473,13 +11461,13 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-core@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/codecs-core@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs-data-structures@2.0.0-preview.2:
@@ -11490,15 +11478,15 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-nt2k2eTeyzlI/ccutPcG36M/J8NAYfxBPI9h/nQjgJ+M+IgOKi31JV8StDDlG/1XvY0zyqugV3I0r3KAbZRJpA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs-numbers@2.0.0-preview.2:
@@ -11508,14 +11496,14 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -11529,17 +11517,17 @@ packages:
       fastestsmallesttextencoderdecoder: 1.0.22
     dev: false
 
-  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -11554,17 +11542,17 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-gLMupqI4i+G4uPi2SGF/Tc1aXcviZF2ybC81x7Q/fARamNSgNOCUUoSCg9nWu1Gid6+UhA7LH80sWI8XjKaRog==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
@@ -11577,7 +11565,7 @@ packages:
       commander: 12.1.0
     dev: false
 
-  /@solana/errors@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/errors@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==}
     hasBin: true
     peerDependencies:
@@ -11585,7 +11573,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
   /@solana/options@2.0.0-preview.2:
@@ -11595,28 +11583,28 @@ packages:
       '@solana/codecs-numbers': 2.0.0-preview.2
     dev: false
 
-  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-tv2O/Frxql/wSe3jbzi5nVicIWIus/BftH+5ZR+r9r3FO0/htEllZS5Q9XdbmSboHu+St87584JXeDx3xm4jaA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-CLJnWEcdoUBpQJfx9WEbX3h6nTdNiUzswfFdkABUik7HVwSNA98u5AYvBVK2H93d9PGMOHAak2lHW9xr+zAJGQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.94.0
     dependencies:
-      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/spl-type-length-value': 0.1.0
       '@solana/web3.js': 1.95.8(encoding@0.1.13)
     transitivePeerDependencies:
@@ -11637,7 +11625,7 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-RO0JD9vPRi4LsAbMUdNbDJ5/cv2z11MGhtAvFeRzT4+hAGE/FUzRi0tkkWtuCfSIU3twC6CtmAihRp/+XXjWsA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -11645,7 +11633,7 @@ packages:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0
-      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/web3.js': 1.95.8(encoding@0.1.13)
       buffer: 6.0.3
@@ -12515,7 +12503,7 @@ packages:
       defer-to-connect: 2.0.1
     dev: false
 
-  /@t3-oss/env-core@0.11.0(typescript@5.1.5)(zod@3.23.8):
+  /@t3-oss/env-core@0.11.0(typescript@5.4.3)(zod@3.23.8):
     resolution: {integrity: sha512-PSalC5bG0a7XbyoLydiQdAnx3gICX6IQNctvh+TyLrdFxsxgocdj9Ui7sd061UlBzi+z4aIGjnem1kZx9QtUgQ==}
     peerDependencies:
       typescript: '>=5.0.0'
@@ -12524,11 +12512,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 5.1.5
+      typescript: 5.4.3
       zod: 3.23.8
     dev: false
 
-  /@t3-oss/env-nextjs@0.11.0(typescript@5.1.5)(zod@3.23.8):
+  /@t3-oss/env-nextjs@0.11.0(typescript@5.4.3)(zod@3.23.8):
     resolution: {integrity: sha512-gcRrY2CzSMSrxDf5+fKCUfzbBK125IxOcJHcoMVdjcTmYxEgIZFZ5qPPtngOY3UmTeXSqRZOGuNiosqWTFTkMw==}
     peerDependencies:
       typescript: '>=5.0.0'
@@ -12537,8 +12525,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@t3-oss/env-core': 0.11.0(typescript@5.1.5)(zod@3.23.8)
-      typescript: 5.1.5
+      '@t3-oss/env-core': 0.11.0(typescript@5.4.3)(zod@3.23.8)
+      typescript: 5.4.3
       zod: 3.23.8
     dev: false
 
@@ -13038,7 +13026,7 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3):
+  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
@@ -13047,9 +13035,9 @@ packages:
     dependencies:
       ethers: 6.10.0
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.8.3)
-      typechain: 8.3.2(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-essentials: 7.0.3(typescript@5.4.3)
+      typechain: 8.3.2(typescript@5.4.3)
+      typescript: 5.4.3
     dev: true
 
   /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2):
@@ -13060,11 +13048,11 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3)
+      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
       ethers: 6.10.0
       fs-extra: 9.1.0
-      hardhat: 2.19.4(typescript@5.8.3)
-      typechain: 8.3.2(typescript@5.8.3)
+      hardhat: 2.19.4(typescript@5.4.3)
+      typechain: 8.3.2(typescript@5.4.3)
     dev: true
 
   /@types/async-eventemitter@0.2.1:
@@ -13488,7 +13476,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.43.0)(typescript@5.1.5):
+  /@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.43.0)(typescript@5.4.3):
     resolution: {integrity: sha512-mdekAHOqS9UjlmyF/LSs6AIEvfceV749GFxoBAjwAv0nkevfKHWQFDMcBZWUiIC5ft6ePWivXoS36aKQ0Cy3sw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13500,10 +13488,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.1.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.4.3)
       '@typescript-eslint/scope-manager': 7.2.0
-      '@typescript-eslint/type-utils': 7.2.0(eslint@8.43.0)(typescript@5.1.5)
-      '@typescript-eslint/utils': 7.2.0(eslint@8.43.0)(typescript@5.1.5)
+      '@typescript-eslint/type-utils': 7.2.0(eslint@8.43.0)(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.2.0(eslint@8.43.0)(typescript@5.4.3)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.43.0
@@ -13511,13 +13499,13 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.1.5)
-      typescript: 5.1.5
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.1.3):
+  /@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.4.3):
     resolution: {integrity: sha512-mdekAHOqS9UjlmyF/LSs6AIEvfceV749GFxoBAjwAv0nkevfKHWQFDMcBZWUiIC5ft6ePWivXoS36aKQ0Cy3sw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13529,10 +13517,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.4.3)
       '@typescript-eslint/scope-manager': 7.2.0
-      '@typescript-eslint/type-utils': 7.2.0(eslint@8.56.0)(typescript@5.1.3)
-      '@typescript-eslint/utils': 7.2.0(eslint@8.56.0)(typescript@5.1.3)
+      '@typescript-eslint/type-utils': 7.2.0(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.2.0(eslint@8.56.0)(typescript@5.4.3)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
@@ -13540,13 +13528,13 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.1.3)
-      typescript: 5.1.3
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.43.0)(typescript@5.1.5):
+  /@typescript-eslint/parser@5.62.0(eslint@8.43.0)(typescript@5.4.3):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -13558,14 +13546,14 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.43.0
-      typescript: 5.1.5
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.1.3):
+  /@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.4.3):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -13577,10 +13565,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      typescript: 5.1.3
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -13599,7 +13587,7 @@ packages:
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/visitor-keys': 7.2.0
 
-  /@typescript-eslint/type-utils@7.2.0(eslint@8.43.0)(typescript@5.1.5):
+  /@typescript-eslint/type-utils@7.2.0(eslint@8.43.0)(typescript@5.4.3):
     resolution: {integrity: sha512-xHi51adBHo9O9330J8GQYQwrKBqbIPJGZZVQTHHmy200hvkLZFWJIFtAG/7IYTWUyun6DE6w5InDReePJYJlJA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13609,17 +13597,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.1.5)
-      '@typescript-eslint/utils': 7.2.0(eslint@8.43.0)(typescript@5.1.5)
+      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.2.0(eslint@8.43.0)(typescript@5.4.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.43.0
-      ts-api-utils: 1.3.0(typescript@5.1.5)
-      typescript: 5.1.5
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@7.2.0(eslint@8.56.0)(typescript@5.1.3):
+  /@typescript-eslint/type-utils@7.2.0(eslint@8.56.0)(typescript@5.4.3):
     resolution: {integrity: sha512-xHi51adBHo9O9330J8GQYQwrKBqbIPJGZZVQTHHmy200hvkLZFWJIFtAG/7IYTWUyun6DE6w5InDReePJYJlJA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13629,12 +13617,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.1.3)
-      '@typescript-eslint/utils': 7.2.0(eslint@8.56.0)(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.2.0(eslint@8.56.0)(typescript@5.4.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      ts-api-utils: 1.3.0(typescript@5.1.3)
-      typescript: 5.1.3
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -13647,7 +13635,7 @@ packages:
     resolution: {integrity: sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.3):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -13662,33 +13650,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.5):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.5)
-      typescript: 5.1.5
+      tsutils: 3.21.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@7.2.0(typescript@5.1.3):
+  /@typescript-eslint/typescript-estree@7.2.0(typescript@5.4.3):
     resolution: {integrity: sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13704,35 +13671,12 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.1.3)
-      typescript: 5.1.3
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
-  /@typescript-eslint/typescript-estree@7.2.0(typescript@5.1.5):
-    resolution: {integrity: sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/visitor-keys': 7.2.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.1.5)
-      typescript: 5.1.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@7.2.0(eslint@8.43.0)(typescript@5.1.5):
+  /@typescript-eslint/utils@7.2.0(eslint@8.43.0)(typescript@5.4.3):
     resolution: {integrity: sha512-YfHpnMAGb1Eekpm3XRK8hcMwGLGsnT6L+7b2XyRv6ouDuJU1tZir1GS2i0+VXRatMwSI1/UfcyPe53ADkU+IuA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13743,7 +13687,7 @@ packages:
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.1.5)
+      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.4.3)
       eslint: 8.43.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -13751,7 +13695,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@7.2.0(eslint@8.56.0)(typescript@5.1.3):
+  /@typescript-eslint/utils@7.2.0(eslint@8.56.0)(typescript@5.4.3):
     resolution: {integrity: sha512-YfHpnMAGb1Eekpm3XRK8hcMwGLGsnT6L+7b2XyRv6ouDuJU1tZir1GS2i0+VXRatMwSI1/UfcyPe53ADkU+IuA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13762,7 +13706,7 @@ packages:
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.4.3)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -14282,7 +14226,7 @@ packages:
       viem: ^2.28.0
     dependencies:
       '@zerodev/sdk': 5.4.32(viem@2.26.2)
-      viem: 2.26.2(typescript@5.1.5)
+      viem: 2.26.2(typescript@5.4.3)
     dev: false
 
   /@zerodev/sdk@5.4.32(viem@2.26.2):
@@ -14291,7 +14235,7 @@ packages:
       viem: ^2.28.0
     dependencies:
       semver: 7.5.4
-      viem: 2.26.2(typescript@5.1.5)
+      viem: 2.26.2(typescript@5.4.3)
     dev: false
 
   /JSONStream@1.3.5:
@@ -14306,7 +14250,7 @@ packages:
     deprecated: Use your platform's native atob() and btoa() methods instead
     dev: true
 
-  /abitype@0.7.1(typescript@5.8.3):
+  /abitype@0.7.1(typescript@5.4.3):
     resolution: {integrity: sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -14315,10 +14259,10 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
-  /abitype@1.0.0(typescript@5.1.5):
+  /abitype@1.0.0(typescript@5.4.3):
     resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14329,10 +14273,10 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.1.5
+      typescript: 5.4.3
     dev: false
 
-  /abitype@1.0.5(typescript@5.1.5)(zod@3.23.8):
+  /abitype@1.0.5(typescript@5.4.3)(zod@3.23.8):
     resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14343,11 +14287,11 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.1.5
+      typescript: 5.4.3
       zod: 3.23.8
     dev: false
 
-  /abitype@1.0.6(typescript@5.8.3):
+  /abitype@1.0.6(typescript@5.4.3):
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14358,10 +14302,10 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
-  /abitype@1.0.8(typescript@5.1.3):
+  /abitype@1.0.8(typescript@5.4.3):
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14372,35 +14316,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.1.3
-    dev: false
-
-  /abitype@1.0.8(typescript@5.1.5):
-    resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      typescript: 5.1.5
-
-  /abitype@1.0.8(typescript@5.8.3):
-    resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      typescript: 5.8.3
-    dev: false
+      typescript: 5.4.3
 
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -17011,7 +16927,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next@14.2.25(eslint@8.43.0)(typescript@5.1.5):
+  /eslint-config-next@14.2.25(eslint@8.43.0)(typescript@5.4.3):
     resolution: {integrity: sha512-BwuRQJeqw4xP/fkul/WWjivwbaLs8AjvuMzQCC+nJI65ZVhnVolWs6tk5VSD92xPHu96gSTahfaSkQjIRtJ3ag==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -17022,8 +16938,8 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.2.25
       '@rushstack/eslint-patch': 1.9.0
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.43.0)(typescript@5.1.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.1.5)
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.43.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.4.3)
       eslint: 8.43.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.43.0)
@@ -17031,13 +16947,13 @@ packages:
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.43.0)
       eslint-plugin-react: 7.34.1(eslint@8.43.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.43.0)
-      typescript: 5.1.5
+      typescript: 5.4.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /eslint-config-next@14.2.25(eslint@8.56.0)(typescript@5.1.3):
+  /eslint-config-next@14.2.25(eslint@8.56.0)(typescript@5.4.3):
     resolution: {integrity: sha512-BwuRQJeqw4xP/fkul/WWjivwbaLs8AjvuMzQCC+nJI65ZVhnVolWs6tk5VSD92xPHu96gSTahfaSkQjIRtJ3ag==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -17048,8 +16964,8 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.2.25
       '@rushstack/eslint-patch': 1.9.0
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.1.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.1.3)
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.4.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
@@ -17057,7 +16973,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.56.0)
       eslint-plugin-react: 7.34.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
-      typescript: 5.1.3
+      typescript: 5.4.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -17140,7 +17056,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.1.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.4.3)
       debug: 3.2.7
       eslint: 8.43.0
       eslint-import-resolver-node: 0.3.9
@@ -17169,7 +17085,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.4.3)
       debug: 3.2.7
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
@@ -17188,7 +17104,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.1.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@5.4.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -18320,7 +18236,7 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       chokidar: 3.5.3
-      hardhat: 2.12.7(typescript@5.1.5)
+      hardhat: 2.12.7(typescript@5.4.3)
     dev: false
 
   /hardhat-watcher@2.5.0(hardhat@2.22.2):
@@ -18329,10 +18245,10 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       chokidar: 3.5.3
-      hardhat: 2.22.2(typescript@5.1.5)
+      hardhat: 2.22.2(typescript@5.4.3)
     dev: false
 
-  /hardhat@2.12.7(typescript@5.1.5):
+  /hardhat@2.12.7(typescript@5.4.3):
     resolution: {integrity: sha512-voWoN6zn5d8BOEaczSyK/1PyfdeOeI3SbGCFb36yCHTJUt6OIqLb+ZDX30VhA1UsYKzLqG7UnWl3fKJUuANc6A==}
     engines: {node: ^14.0.0 || ^16.0.0 || ^18.0.0}
     hasBin: true
@@ -18392,7 +18308,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 5.1.5
+      typescript: 5.4.3
       undici: 5.19.1
       uuid: 8.3.2
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -18402,7 +18318,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /hardhat@2.19.4(typescript@5.8.3):
+  /hardhat@2.19.4(typescript@5.4.3):
     resolution: {integrity: sha512-fTQJpqSt3Xo9Mn/WrdblNGAfcANM6XC3tAEi6YogB4s02DmTf93A8QsGb8uR0KR8TFcpcS8lgiW4ugAIYpnbrQ==}
     hasBin: true
     peerDependencies:
@@ -18459,7 +18375,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 5.8.3
+      typescript: 5.4.3
       undici: 5.24.0
       uuid: 8.3.2
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -18469,7 +18385,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /hardhat@2.22.2(typescript@5.1.5):
+  /hardhat@2.22.2(typescript@5.4.3):
     resolution: {integrity: sha512-0xZ7MdCZ5sJem4MrvpQWLR3R3zGDoHw5lsR+pBFimqwagimIOn3bWuZv69KA+veXClwI1s/zpqgwPwiFrd4Dxw==}
     hasBin: true
     peerDependencies:
@@ -18521,7 +18437,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 5.1.5
+      typescript: 5.4.3
       undici: 5.24.0
       uuid: 8.3.2
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -21557,7 +21473,7 @@ packages:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
 
-  /ox@0.6.9(typescript@5.1.3):
+  /ox@0.6.9(typescript@5.4.3):
     resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -21570,51 +21486,11 @@ packages:
       '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.1.3)
+      abitype: 1.0.8(typescript@5.4.3)
       eventemitter3: 5.0.1
-      typescript: 5.1.3
+      typescript: 5.4.3
     transitivePeerDependencies:
       - zod
-    dev: false
-
-  /ox@0.6.9(typescript@5.1.5):
-    resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.2
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.1.5)
-      eventemitter3: 5.0.1
-      typescript: 5.1.5
-    transitivePeerDependencies:
-      - zod
-
-  /ox@0.6.9(typescript@5.8.3):
-    resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.2
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.3)
-      eventemitter3: 5.0.1
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - zod
-    dev: false
 
   /p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -21813,7 +21689,7 @@ packages:
     peerDependencies:
       viem: '>=2.14.1 <2.18.0'
     dependencies:
-      viem: 2.26.2(typescript@5.1.5)
+      viem: 2.26.2(typescript@5.4.3)
     dev: false
 
   /picocolors@1.0.0:
@@ -24691,23 +24567,13 @@ packages:
       - utf-8-validate
     dev: false
 
-  /ts-api-utils@1.3.0(typescript@5.1.3):
+  /ts-api-utils@1.3.0(typescript@5.4.3):
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.3
-    dev: false
-
-  /ts-api-utils@1.3.0(typescript@5.1.5):
-    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      typescript: '>=4.2.0'
-    dependencies:
-      typescript: 5.1.5
-    dev: true
+      typescript: 5.4.3
 
   /ts-command-line-args@2.5.1:
     resolution: {integrity: sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==}
@@ -24719,12 +24585,12 @@ packages:
       string-format: 2.0.0
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.8.3):
+  /ts-essentials@7.0.3(typescript@5.4.3):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: true
 
   /ts-interface-checker@0.1.13:
@@ -24734,7 +24600,7 @@ packages:
     resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
     dev: false
 
-  /ts-node@10.9.2(@types/node@20.3.1)(typescript@5.8.3):
+  /ts-node@10.9.2(@types/node@20.3.1)(typescript@5.4.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -24760,7 +24626,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.4.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -24793,24 +24659,14 @@ packages:
   /tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
 
-  /tsutils@3.21.0(typescript@5.1.3):
+  /tsutils@3.21.0(typescript@5.4.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.1.3
-    dev: false
-
-  /tsutils@3.21.0(typescript@5.1.5):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.5
+      typescript: 5.4.3
 
   /tsx@3.12.7:
     resolution: {integrity: sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==}
@@ -24940,7 +24796,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typechain@8.3.2(typescript@5.8.3):
+  /typechain@8.3.2(typescript@5.4.3):
     resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
     hasBin: true
     peerDependencies:
@@ -24955,8 +24811,8 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-essentials: 7.0.3(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -25007,10 +24863,10 @@ packages:
     peerDependencies:
       typedoc: 0.28.x
     dependencies:
-      typedoc: 0.28.1(typescript@5.1.5)
+      typedoc: 0.28.1(typescript@5.4.3)
     dev: true
 
-  /typedoc@0.28.1(typescript@5.1.5):
+  /typedoc@0.28.1(typescript@5.4.3):
     resolution: {integrity: sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
@@ -25021,7 +24877,7 @@ packages:
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
-      typescript: 5.1.5
+      typescript: 5.4.3
       yaml: 2.7.0
     dev: true
 
@@ -25035,19 +24891,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.1.3:
-    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: false
-
-  /typescript@5.1.5:
-    resolution: {integrity: sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  /typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  /typescript@5.4.3:
+    resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -25456,7 +25301,7 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /viem@2.18.0(typescript@5.1.5)(zod@3.23.8):
+  /viem@2.18.0(typescript@5.4.3)(zod@3.23.8):
     resolution: {integrity: sha512-HA4Dj+PCNWvvZDThWcUPg0sjiS8uwGRaxs3CMBOASL/j0p2pD4nR9vY/y/pAiRr491hGCnrSCVCmb/qqA57wIw==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -25469,9 +25314,9 @@ packages:
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
-      abitype: 1.0.5(typescript@5.1.5)(zod@3.23.8)
+      abitype: 1.0.5(typescript@5.4.3)(zod@3.23.8)
       isows: 1.0.4(ws@8.17.1)
-      typescript: 5.1.5
+      typescript: 5.4.3
       webauthn-p256: 0.0.5
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -25480,7 +25325,7 @@ packages:
       - zod
     dev: false
 
-  /viem@2.21.32(typescript@5.8.3):
+  /viem@2.21.32(typescript@5.4.3):
     resolution: {integrity: sha512-2oXt5JNIb683oy7C8wuIJ/SeL3XtHVMEQpy1U2TA6WMnJQ4ScssRvyPwYLcaP6mKlrGXE/cR/V7ncWpvLUVPYQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -25493,9 +25338,9 @@ packages:
       '@noble/hashes': 1.5.0
       '@scure/bip32': 1.5.0
       '@scure/bip39': 1.4.0
-      abitype: 1.0.6(typescript@5.8.3)
+      abitype: 1.0.6(typescript@5.4.3)
       isows: 1.0.6(ws@8.17.1)
-      typescript: 5.8.3
+      typescript: 5.4.3
       webauthn-p256: 0.0.10
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -25504,7 +25349,7 @@ packages:
       - zod
     dev: false
 
-  /viem@2.23.13(typescript@5.1.3):
+  /viem@2.23.13(typescript@5.4.3):
     resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -25516,10 +25361,10 @@ packages:
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.1.3)
+      abitype: 1.0.8(typescript@5.4.3)
       isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.1.3)
-      typescript: 5.1.3
+      ox: 0.6.9(typescript@5.4.3)
+      typescript: 5.4.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25527,7 +25372,7 @@ packages:
       - zod
     dev: false
 
-  /viem@2.26.2(typescript@5.1.5):
+  /viem@2.26.2(typescript@5.4.3):
     resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
     requiresBuild: true
     peerDependencies:
@@ -25540,41 +25385,17 @@ packages:
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.1.5)
+      abitype: 1.0.8(typescript@5.4.3)
       isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.1.5)
-      typescript: 5.1.5
+      ox: 0.6.9(typescript@5.4.3)
+      typescript: 5.4.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
 
-  /viem@2.26.2(typescript@5.8.3):
-    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
-    requiresBuild: true
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.3)
-      isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /viem@2.28.0(typescript@5.1.3):
+  /viem@2.28.0(typescript@5.4.3):
     resolution: {integrity: sha512-Z4W5O1pe+6pirYTFm451FcZmfGAUxUWt2L/eWC+YfTF28j/8rd7q6MBAi05lMN4KhLJjhN0s5YGIPB+kf1L20g==}
     requiresBuild: true
     peerDependencies:
@@ -25587,10 +25408,10 @@ packages:
       '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.1.3)
+      abitype: 1.0.8(typescript@5.4.3)
       isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.1.3)
-      typescript: 5.1.3
+      ox: 0.6.9(typescript@5.4.3)
+      typescript: 5.4.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25598,31 +25419,7 @@ packages:
       - zod
     dev: false
 
-  /viem@2.28.0(typescript@5.8.3):
-    resolution: {integrity: sha512-Z4W5O1pe+6pirYTFm451FcZmfGAUxUWt2L/eWC+YfTF28j/8rd7q6MBAi05lMN4KhLJjhN0s5YGIPB+kf1L20g==}
-    requiresBuild: true
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.8.2
-      '@noble/hashes': 1.7.2
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.3)
-      isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /viem@2.7.19(typescript@5.1.5):
+  /viem@2.7.19(typescript@5.4.3):
     resolution: {integrity: sha512-UOMeqy+8p2709ra2j9HEOL1NfjsXZzlJ8gwR6YO/zXH8KIZvyzW07t4iQARF5+ShVZ/7+/1ec8oPjVi1M//33A==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -25635,9 +25432,9 @@ packages:
       '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
-      abitype: 1.0.0(typescript@5.1.5)
+      abitype: 1.0.0(typescript@5.4.3)
       isows: 1.0.3(ws@8.17.1)
-      typescript: 5.1.5
+      typescript: 5.4.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25645,7 +25442,7 @@ packages:
       - zod
     dev: false
 
-  /viem@2.9.5(typescript@5.1.5):
+  /viem@2.9.5(typescript@5.4.3):
     resolution: {integrity: sha512-IKLmGZJEQkdt9fqvryjR+W1FsPZM+dhALT0pwR8xhBOLvVHM0/lEViGRWDpm2ArNsFszipFhc2EpKp80/PnXkw==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -25658,9 +25455,9 @@ packages:
       '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
-      abitype: 1.0.0(typescript@5.1.5)
+      abitype: 1.0.0(typescript@5.4.3)
       isows: 1.0.3(ws@8.17.1)
-      typescript: 5.1.5
+      typescript: 5.4.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25723,11 +25520,11 @@ packages:
       web3-types: 1.5.0
     dev: false
 
-  /web3-eth-abi@4.2.0(typescript@5.8.3):
+  /web3-eth-abi@4.2.0(typescript@5.4.3):
     resolution: {integrity: sha512-x7dUCmk6th+5N63s5kUusoNtsDJKUUQgl9+jECvGTBOTiyHe/V6aOY0120FUjaAGaapOnR7BImQdhqHv6yT2YQ==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
-      abitype: 0.7.1(typescript@5.8.3)
+      abitype: 0.7.1(typescript@5.4.3)
       web3-errors: 1.1.4
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25750,14 +25547,14 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-contract@4.3.0(typescript@5.8.3):
+  /web3-eth-contract@4.3.0(typescript@5.4.3):
     resolution: {integrity: sha512-4fzSklA65zUn6SthU3T3tbVJacfP8/wkJmCuvmPaf2ZTFdnhsF96G5IQtCRf0+wASb4yk0A6IBvXZfk1B4R4HA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.8.3)
-      web3-eth-abi: 4.2.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
+      web3-eth-abi: 4.2.0(typescript@5.4.3)
       web3-types: 1.5.0
       web3-utils: 4.2.1
       web3-validator: 2.0.5
@@ -25769,15 +25566,15 @@ packages:
       - zod
     dev: false
 
-  /web3-eth-ens@4.2.0(typescript@5.8.3):
+  /web3-eth-ens@4.2.0(typescript@5.4.3):
     resolution: {integrity: sha512-qYj34te2UctoObt8rlEIY/t2MuTMiMiiHhO2JAHRGqSLCQ7b8DM3RpvkiiSB0N0ZyEn+CetZqJCTYb8DNKBS/g==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.8.3)
-      web3-eth-contract: 4.3.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
+      web3-eth-contract: 4.3.0(typescript@5.4.3)
       web3-net: 4.0.7
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25800,12 +25597,12 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-personal@4.0.8(typescript@5.8.3):
+  /web3-eth-personal@4.0.8(typescript@5.4.3):
     resolution: {integrity: sha512-sXeyLKJ7ddQdMxz1BZkAwImjqh7OmKxhXoBNF3isDmD4QDpMIwv/t237S3q4Z0sZQamPa/pHebJRWVuvP8jZdw==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
-      web3-eth: 4.5.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
       web3-rpc-methods: 1.2.0
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25818,14 +25615,14 @@ packages:
       - zod
     dev: false
 
-  /web3-eth@4.5.0(typescript@5.8.3):
+  /web3-eth@4.5.0(typescript@5.4.3):
     resolution: {integrity: sha512-crisE46o/SHMVm+XHAXEaR8k76NCImq+hi0QQEJ+VaLZbDobI/Gvog1HwTukDUDRgnYSAFGqD0cTRyAwDurwpA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       setimmediate: 1.0.5
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth-abi: 4.2.0(typescript@5.8.3)
+      web3-eth-abi: 4.2.0(typescript@5.4.3)
       web3-eth-accounts: 4.1.1
       web3-net: 4.0.7
       web3-providers-ws: 4.0.7
@@ -25933,19 +25730,19 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /web3@4.7.0(typescript@5.8.3):
+  /web3@4.7.0(typescript@5.4.3):
     resolution: {integrity: sha512-3g+1e7B/IW0Nw9WP1dotrZKWD9o5IBfl27dxEnE1LxBZBax6ZkviiAwf18utIhlNBD07RgI+PPfKDXxfDBlHWA==}
     engines: {node: '>=14.0.0', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.8.3)
-      web3-eth-abi: 4.2.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
+      web3-eth-abi: 4.2.0(typescript@5.4.3)
       web3-eth-accounts: 4.1.1
-      web3-eth-contract: 4.3.0(typescript@5.8.3)
-      web3-eth-ens: 4.2.0(typescript@5.8.3)
+      web3-eth-contract: 4.3.0(typescript@5.4.3)
+      web3-eth-ens: 4.2.0(typescript@5.4.3)
       web3-eth-iban: 4.0.7
-      web3-eth-personal: 4.0.8(typescript@5.8.3)
+      web3-eth-personal: 4.0.8(typescript@5.4.3)
       web3-net: 4.0.7
       web3-providers-http: 4.1.0
       web3-providers-ws: 4.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   .:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@changesets/cli':
         specifier: ^2.27.5
         version: 2.27.5
@@ -5308,7 +5311,7 @@ packages:
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.0
       '@changesets/should-skip-package': 0.1.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       detect-indent: 6.1.0
       fs-extra: 7.0.1
@@ -5326,7 +5329,7 @@ packages:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.0
       '@changesets/should-skip-package': 0.1.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       semver: 7.5.4
     dev: true
@@ -5334,7 +5337,17 @@ packages:
   /@changesets/changelog-git@0.2.0:
     resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
     dependencies:
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
+    dev: true
+
+  /@changesets/changelog-github@0.5.1:
+    resolution: {integrity: sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==}
+    dependencies:
+      '@changesets/get-github-info': 0.6.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /@changesets/cli@2.27.5:
@@ -5382,7 +5395,7 @@ packages:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.0
       '@changesets/logger': 0.1.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
       micromatch: 4.0.5
@@ -5397,11 +5410,20 @@ packages:
   /@changesets/get-dependents-graph@2.1.0:
     resolution: {integrity: sha512-QOt6pQq9RVXKGHPVvyKimJDYJumx7p4DO5MO9AhRJYgAPgv0emhNqAqqysSVKHBm4sxKlGN4S1zXOIb5yCFuhQ==}
     dependencies:
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 7.5.4
+    dev: true
+
+  /@changesets/get-github-info@0.6.0:
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /@changesets/get-release-plan@4.0.2:
@@ -5412,7 +5434,7 @@ packages:
       '@changesets/config': 3.0.1
       '@changesets/pre': 2.0.0
       '@changesets/read': 0.6.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
     dev: true
 
@@ -5425,7 +5447,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.10
       '@changesets/errors': 0.2.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       is-subdir: 1.2.0
       micromatch: 4.0.5
@@ -5441,7 +5463,7 @@ packages:
   /@changesets/parse@0.4.0:
     resolution: {integrity: sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==}
     dependencies:
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       js-yaml: 3.14.1
     dev: true
 
@@ -5450,7 +5472,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.10
       '@changesets/errors': 0.2.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
     dev: true
@@ -5462,7 +5484,7 @@ packages:
       '@changesets/git': 3.0.0
       '@changesets/logger': 0.1.0
       '@changesets/parse': 0.4.0
-      '@changesets/types': 6.0.0
+      '@changesets/types': 6.1.0
       chalk: 2.4.2
       fs-extra: 7.0.1
       p-filter: 2.1.0
@@ -5471,8 +5493,8 @@ packages:
   /@changesets/should-skip-package@0.1.0:
     resolution: {integrity: sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==}
     dependencies:
-      '@babel/runtime': 7.26.10
-      '@changesets/types': 6.0.0
+      '@babel/runtime': 7.26.0
+      '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
     dev: true
 
@@ -5484,11 +5506,15 @@ packages:
     resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
     dev: true
 
+  /@changesets/types@6.1.0:
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+    dev: true
+
   /@changesets/write@0.3.1:
     resolution: {integrity: sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==}
     dependencies:
-      '@babel/runtime': 7.26.10
-      '@changesets/types': 6.0.0
+      '@babel/runtime': 7.26.0
+      '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
@@ -11309,8 +11335,8 @@ packages:
   /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.8.3):
     resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
     dependencies:
-      '@noble/curves': 1.8.0
-      viem: 2.28.0(typescript@5.8.3)
+      '@noble/curves': 1.8.1
+      viem: 2.23.13(typescript@5.1.5)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -16315,6 +16341,10 @@ packages:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  /dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+    dev: true
+
   /dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
     dev: false
@@ -16638,6 +16668,11 @@ packages:
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
+
+  /dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
+    dev: true
 
   /draggabilly@3.0.0:
     resolution: {integrity: sha512-aEs+B6prbMZQMxc9lgTpCBfyCUhRur/VFucHhIOvlvvdARTj7TcDmX/cdOUtqbjJJUh7+agyJXR5Z6IFe1MxwQ==}
@@ -25504,78 +25539,6 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
-
-  /viem@2.26.2(typescript@5.8.3):
-    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
-    requiresBuild: true
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.3)
-      isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /viem@2.28.0(typescript@5.1.3):
-    resolution: {integrity: sha512-Z4W5O1pe+6pirYTFm451FcZmfGAUxUWt2L/eWC+YfTF28j/8rd7q6MBAi05lMN4KhLJjhN0s5YGIPB+kf1L20g==}
-    requiresBuild: true
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.8.2
-      '@noble/hashes': 1.7.2
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.1.3)
-      isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.1.3)
-      typescript: 5.1.3
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /viem@2.28.0(typescript@5.8.3):
-    resolution: {integrity: sha512-Z4W5O1pe+6pirYTFm451FcZmfGAUxUWt2L/eWC+YfTF28j/8rd7q6MBAi05lMN4KhLJjhN0s5YGIPB+kf1L20g==}
-    requiresBuild: true
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.8.2
-      '@noble/hashes': 1.7.2
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.3)
-      isows: 1.0.6(ws@8.17.1)
-      ox: 0.6.9(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
 
   /viem@2.7.19(typescript@5.1.5):
     resolution: {integrity: sha512-UOMeqy+8p2709ra2j9HEOL1NfjsXZzlJ8gwR6YO/zXH8KIZvyzW07t4iQARF5+ShVZ/7+/1ec8oPjVi1M//33A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11336,7 +11336,7 @@ packages:
     resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
     dependencies:
       '@noble/curves': 1.8.1
-      viem: 2.23.13(typescript@5.1.5)
+      viem: 2.26.2(typescript@5.1.5)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -25539,6 +25539,52 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
+
+  /viem@2.26.2(typescript@5.1.3):
+    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.1.3)
+      isows: 1.0.6(ws@8.17.1)
+      ox: 0.6.9(typescript@5.1.3)
+      typescript: 5.1.3
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /viem@2.26.2(typescript@5.1.5):
+    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.1.5)
+      isows: 1.0.6(ws@8.17.1)
+      ox: 0.6.9(typescript@5.1.5)
+      typescript: 5.1.5
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
 
   /viem@2.7.19(typescript@5.1.5):
     resolution: {integrity: sha512-UOMeqy+8p2709ra2j9HEOL1NfjsXZzlJ8gwR6YO/zXH8KIZvyzW07t4iQARF5+ShVZ/7+/1ec8oPjVi1M//33A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1973,9 +1973,6 @@ importers:
       '@turnkey/sdk-server':
         specifier: workspace:*
         version: link:../sdk-server
-      '@turnkey/sdk-types':
-        specifier: workspace:*
-        version: link:../sdk-types
       '@turnkey/wallet-stamper':
         specifier: workspace:*
         version: link:../wallet-stamper

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2065,9 +2065,6 @@ importers:
 
   packages/sdk-types:
     devDependencies:
-      '@changesets/cli':
-        specifier: ^2.27.5
-        version: 2.27.5
       typescript:
         specifier: 5.4.3
         version: 5.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,10 +730,10 @@ importers:
     dependencies:
       '@biconomy/account':
         specifier: ^4.5.6
-        version: 4.5.6(typescript@5.8.3)(viem@2.26.2)
+        version: 4.5.6(typescript@5.4.3)(viem@2.23.13)
       '@biconomy/sdk':
         specifier: ^0.0.10
-        version: 0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.8.3)(viem@2.26.2)
+        version: 0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.4.3)(viem@2.23.13)
       '@rhinestone/module-sdk':
         specifier: ^0.1.28
         version: 0.1.28(viem@2.26.2)
@@ -756,8 +756,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       viem:
-        specifier: ^2.24.2
-        version: 2.26.2(typescript@5.8.3)
+        specifier: 2.23.13
+        version: 2.23.13(typescript@5.4.3)
     devDependencies:
       '@types/prompts':
         specifier: ^2.4.2
@@ -1100,7 +1100,7 @@ importers:
     dependencies:
       '@safe-global/protocol-kit':
         specifier: ^3.0.1
-        version: 3.0.1(typescript@5.8.3)
+        version: 3.0.1(typescript@5.4.3)
       '@safe-global/safe-core-sdk-types':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1207,7 +1207,7 @@ importers:
         version: 0.26.0
       '@solana/spl-token':
         specifier: ^0.4.8
-        version: 0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+        version: 0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/web3.js':
         specifier: ^1.95.8
         version: 1.95.8(encoding@0.1.13)
@@ -1849,7 +1849,7 @@ importers:
         version: 4.9.0
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3)
+        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
       '@typechain/hardhat':
         specifier: ^9.1.0
         version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2)
@@ -1858,10 +1858,10 @@ importers:
         version: 6.10.0
       hardhat:
         specifier: ^2.19.4
-        version: 2.19.4(typescript@5.8.3)
+        version: 2.19.4(typescript@5.4.3)
       typechain:
         specifier: ^8.3.2
-        version: 8.3.2(typescript@5.8.3)
+        version: 8.3.2(typescript@5.4.3)
 
   packages/http:
     dependencies:
@@ -1973,6 +1973,9 @@ importers:
       '@turnkey/sdk-server':
         specifier: workspace:*
         version: link:../sdk-server
+      '@turnkey/sdk-types':
+        specifier: workspace:*
+        version: link:../sdk-types
       '@turnkey/wallet-stamper':
         specifier: workspace:*
         version: link:../wallet-stamper
@@ -2062,6 +2065,12 @@ importers:
       glob:
         specifier: ^8.0.3
         version: 8.1.0
+
+  packages/sdk-types:
+    devDependencies:
+      typescript:
+        specifier: ^5.4.3
+        version: 5.4.3
 
   packages/solana:
     dependencies:
@@ -5239,33 +5248,33 @@ packages:
       - zod
     dev: false
 
-  /@biconomy/account@4.5.6(typescript@5.8.3)(viem@2.26.2):
+  /@biconomy/account@4.5.6(typescript@5.4.3)(viem@2.23.13):
     resolution: {integrity: sha512-Mq0X9HF4fsPTkf87eXklJJE/Hl3GQwQHN/2/D1fCA4Q4o4AM9HV7Tzpb+hBsh8cUJ+s2j0Q9wORXA1c0onAImQ==}
     peerDependencies:
       typescript: ^5
       viem: ^2
     dependencies:
-      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.8.3)
+      '@silencelaboratories/walletprovider-sdk': 0.1.0(typescript@5.4.3)
       merkletreejs: 0.4.0
-      typescript: 5.8.3
-      viem: 2.26.2(typescript@5.8.3)
+      typescript: 5.4.3
+      viem: 2.23.13(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
     dev: false
 
-  /@biconomy/sdk@0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.8.3)(viem@2.26.2):
+  /@biconomy/sdk@0.0.10(@rhinestone/module-sdk@0.1.28)(typescript@5.4.3)(viem@2.23.13):
     resolution: {integrity: sha512-HolZ2V95/Z/oE75qbbm2X+cGcWwh4S0oTgyDzd8XQBnnRDOGKlQuf5gxAz0AFvZTCfkjLqZe8E9cVhYPBI+2yQ==}
     peerDependencies:
       '@rhinestone/module-sdk': ^0.1.25
       typescript: ^5
       viem: ^2.20.0
     dependencies:
-      '@rhinestone/module-sdk': 0.1.28(viem@2.26.2)
-      '@silencelaboratories/walletprovider-sdk': 0.3.0(typescript@5.8.3)
-      typescript: 5.8.3
-      viem: 2.26.2(typescript@5.8.3)
+      '@rhinestone/module-sdk': 0.1.28(viem@2.23.13)
+      '@silencelaboratories/walletprovider-sdk': 0.3.0(typescript@5.4.3)
+      typescript: 5.4.3
+      viem: 2.23.13(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -8571,7 +8580,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 6.10.0
-      hardhat: 2.19.4(typescript@5.8.3)
+      hardhat: 2.19.4(typescript@5.4.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -8583,7 +8592,7 @@ packages:
       hardhat: ^2.9.5
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.19.4(typescript@5.8.3)
+      hardhat: 2.19.4(typescript@5.4.3)
     dev: true
 
   /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0:
@@ -10839,7 +10848,7 @@ packages:
     dependencies:
       solady: 0.0.235
       tslib: 2.8.1
-      viem: 2.26.2(typescript@5.8.3)
+      viem: 2.23.13(typescript@5.4.3)
     dev: false
 
   /@rollup/plugin-alias@5.1.1(rollup@4.22.4):
@@ -11082,7 +11091,7 @@ packages:
   /@rushstack/eslint-patch@1.9.0:
     resolution: {integrity: sha512-AAWymnpvHbGty1BmgbdfbqQDboXs6xN6h2yAacO4yKVyyUUBnpYkp+P9jjPrV9zrAGw7JVVriRtGOHPInnfjZQ==}
 
-  /@safe-global/protocol-kit@3.0.1(typescript@5.8.3):
+  /@safe-global/protocol-kit@3.0.1(typescript@5.4.3):
     resolution: {integrity: sha512-7S2QCvIDw3NsErF0f8tIfiTBz32btCAkw7IYuQFPc+G7clLrvDNhDaZYSoDsa8F0EoEhn+605VA7XP//iL6AIg==}
     dependencies:
       '@noble/hashes': 1.4.0
@@ -11090,7 +11099,7 @@ packages:
       ethereumjs-util: 7.1.5
       ethers: 6.10.0
       semver: 7.5.4
-      web3: 4.7.0(typescript@5.8.3)
+      web3: 4.7.0(typescript@5.4.3)
       web3-core: 4.3.2
       web3-utils: 4.2.1
     transitivePeerDependencies:
@@ -11332,11 +11341,11 @@ packages:
       - zod
     dev: false
 
-  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.8.3):
+  /@silencelaboratories/walletprovider-sdk@0.1.0(typescript@5.4.3):
     resolution: {integrity: sha512-53fV1noQJDUN9JNydDohyzsFl4+QYoWNkkkAfRzmIgtv+6DR+Dksb0fKmme2WdtA8MPEw/HsRwN3Lr6YC3iF7A==}
     dependencies:
       '@noble/curves': 1.8.1
-      viem: 2.26.2(typescript@5.1.5)
+      viem: 2.26.2(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11344,12 +11353,12 @@ packages:
       - zod
     dev: false
 
-  /@silencelaboratories/walletprovider-sdk@0.3.0(typescript@5.8.3):
+  /@silencelaboratories/walletprovider-sdk@0.3.0(typescript@5.4.3):
     resolution: {integrity: sha512-5+yS95DwIufP0qOPuk81cXZ8gepcARXwuKRDAtjtf50JVX0MOMy6pR8f/1j5PATPdImzgI8905x3ZBgXfi+FKw==}
     dependencies:
       '@noble/curves': 1.8.0
       js-base64: 3.7.7
-      viem: 2.21.32(typescript@5.8.3)
+      viem: 2.21.32(typescript@5.4.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11463,13 +11472,13 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-core@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/codecs-core@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-A0VVuDDA5kNKZUinOqHxJQK32aKTucaVbvn31YenGzHX1gPqq+SOnFwgaEY6pq4XEopSmaK16w938ZQS8IvCnw==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs-data-structures@2.0.0-preview.2:
@@ -11480,15 +11489,15 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-nt2k2eTeyzlI/ccutPcG36M/J8NAYfxBPI9h/nQjgJ+M+IgOKi31JV8StDDlG/1XvY0zyqugV3I0r3KAbZRJpA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs-numbers@2.0.0-preview.2:
@@ -11498,14 +11507,14 @@ packages:
       '@solana/errors': 2.0.0-preview.2
     dev: false
 
-  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/codecs-numbers@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-Q061rLtMadsO7uxpguT+Z7G4UHnjQ6moVIxAQxR58nLxDPCC7MB1Pk106/Z7NDhDLHTcd18uO6DZ7ajHZEn2XQ==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -11519,17 +11528,17 @@ packages:
       fastestsmallesttextencoderdecoder: 1.0.22
     dev: false
 
-  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-YDbsQePRWm+xnrfS64losSGRg8Wb76cjK1K6qfR8LPmdwIC3787x9uW5/E4icl/k+9nwgbIRXZ65lpF+ucZUnw==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
   /@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22):
@@ -11544,17 +11553,17 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-gLMupqI4i+G4uPi2SGF/Tc1aXcviZF2ybC81x7Q/fARamNSgNOCUUoSCg9nWu1Gid6+UhA7LH80sWI8XjKaRog==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
@@ -11567,7 +11576,7 @@ packages:
       commander: 12.1.0
     dev: false
 
-  /@solana/errors@2.0.0-preview.4(typescript@5.8.3):
+  /@solana/errors@2.0.0-preview.4(typescript@5.4.3):
     resolution: {integrity: sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==}
     hasBin: true
     peerDependencies:
@@ -11575,7 +11584,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
   /@solana/options@2.0.0-preview.2:
@@ -11585,28 +11594,28 @@ packages:
       '@solana/codecs-numbers': 2.0.0-preview.2
     dev: false
 
-  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-tv2O/Frxql/wSe3jbzi5nVicIWIus/BftH+5ZR+r9r3FO0/htEllZS5Q9XdbmSboHu+St87584JXeDx3xm4jaA==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.4.3)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/spl-token-group@0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-CLJnWEcdoUBpQJfx9WEbX3h6nTdNiUzswfFdkABUik7HVwSNA98u5AYvBVK2H93d9PGMOHAak2lHW9xr+zAJGQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.94.0
     dependencies:
-      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/spl-type-length-value': 0.1.0
       '@solana/web3.js': 1.95.8(encoding@0.1.13)
     transitivePeerDependencies:
@@ -11627,7 +11636,7 @@ packages:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3):
+  /@solana/spl-token@0.4.8(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3):
     resolution: {integrity: sha512-RO0JD9vPRi4LsAbMUdNbDJ5/cv2z11MGhtAvFeRzT4+hAGE/FUzRi0tkkWtuCfSIU3twC6CtmAihRp/+XXjWsA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -11635,7 +11644,7 @@ packages:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0
-      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.95.8)(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/web3.js': 1.95.8(encoding@0.1.13)
       buffer: 6.0.3
@@ -13024,11 +13033,7 @@ packages:
     deprecated: TypeScript 5.0 supports combining TSConfigs using array syntax in extends
     dev: true
 
-  /@tsconfig/node16@1.0.4:
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-    dev: true
-
-  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3):
+  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
@@ -13037,9 +13042,9 @@ packages:
     dependencies:
       ethers: 6.10.0
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.8.3)
-      typechain: 8.3.2(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-essentials: 7.0.3(typescript@5.4.3)
+      typechain: 8.3.2(typescript@5.4.3)
+      typescript: 5.4.3
     dev: true
 
   /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2):
@@ -13050,11 +13055,11 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.8.3)
+      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
       ethers: 6.10.0
       fs-extra: 9.1.0
-      hardhat: 2.19.4(typescript@5.8.3)
-      typechain: 8.3.2(typescript@5.8.3)
+      hardhat: 2.19.4(typescript@5.4.3)
+      typechain: 8.3.2(typescript@5.4.3)
     dev: true
 
   /@types/async-eventemitter@0.2.1:
@@ -14296,7 +14301,7 @@ packages:
     deprecated: Use your platform's native atob() and btoa() methods instead
     dev: true
 
-  /abitype@0.7.1(typescript@5.8.3):
+  /abitype@0.7.1(typescript@5.4.3):
     resolution: {integrity: sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -14305,7 +14310,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
   /abitype@1.0.0(typescript@5.1.5):
@@ -14337,7 +14342,7 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /abitype@1.0.6(typescript@5.8.3):
+  /abitype@1.0.6(typescript@5.4.3):
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14348,7 +14353,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
   /abitype@1.0.8(typescript@5.1.3):
@@ -14378,7 +14383,7 @@ packages:
     dependencies:
       typescript: 5.1.5
 
-  /abitype@1.0.8(typescript@5.8.3):
+  /abitype@1.0.8(typescript@5.4.3):
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -14389,7 +14394,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: false
 
   /abort-controller@3.0.0:
@@ -18392,7 +18397,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /hardhat@2.19.4(typescript@5.8.3):
+  /hardhat@2.19.4(typescript@5.4.3):
     resolution: {integrity: sha512-fTQJpqSt3Xo9Mn/WrdblNGAfcANM6XC3tAEi6YogB4s02DmTf93A8QsGb8uR0KR8TFcpcS8lgiW4ugAIYpnbrQ==}
     hasBin: true
     peerDependencies:
@@ -18449,7 +18454,7 @@ packages:
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       tsort: 0.0.1
-      typescript: 5.8.3
+      typescript: 5.4.3
       undici: 5.24.0
       uuid: 8.3.2
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -21586,7 +21591,7 @@ packages:
     transitivePeerDependencies:
       - zod
 
-  /ox@0.6.9(typescript@5.8.3):
+  /ox@0.6.9(typescript@5.4.3):
     resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -21595,13 +21600,13 @@ packages:
         optional: true
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.2
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.3)
+      abitype: 1.0.8(typescript@5.4.3)
       eventemitter3: 5.0.1
-      typescript: 5.8.3
+      typescript: 5.4.3
     transitivePeerDependencies:
       - zod
     dev: false
@@ -24709,12 +24714,12 @@ packages:
       string-format: 2.0.0
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.8.3):
+  /ts-essentials@7.0.3(typescript@5.4.3):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.4.3
     dev: true
 
   /ts-interface-checker@0.1.13:
@@ -24930,7 +24935,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typechain@8.3.2(typescript@5.8.3):
+  /typechain@8.3.2(typescript@5.4.3):
     resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
     hasBin: true
     peerDependencies:
@@ -24945,8 +24950,8 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-essentials: 7.0.3(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -25036,8 +25041,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  /typescript@5.4.3:
+    resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -25470,7 +25475,7 @@ packages:
       - zod
     dev: false
 
-  /viem@2.21.32(typescript@5.8.3):
+  /viem@2.21.32(typescript@5.4.3):
     resolution: {integrity: sha512-2oXt5JNIb683oy7C8wuIJ/SeL3XtHVMEQpy1U2TA6WMnJQ4ScssRvyPwYLcaP6mKlrGXE/cR/V7ncWpvLUVPYQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -25483,9 +25488,9 @@ packages:
       '@noble/hashes': 1.5.0
       '@scure/bip32': 1.5.0
       '@scure/bip39': 1.4.0
-      abitype: 1.0.6(typescript@5.8.3)
+      abitype: 1.0.6(typescript@5.4.3)
       isows: 1.0.6(ws@8.17.1)
-      typescript: 5.8.3
+      typescript: 5.4.3
       webauthn-p256: 0.0.10
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -25540,6 +25545,29 @@ packages:
       - utf-8-validate
       - zod
 
+  /viem@2.23.13(typescript@5.4.3):
+    resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.4.3)
+      isows: 1.0.6(ws@8.17.1)
+      ox: 0.6.9(typescript@5.4.3)
+      typescript: 5.4.3
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
   /viem@2.26.2(typescript@5.1.3):
     resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
     peerDependencies:
@@ -25579,6 +25607,29 @@ packages:
       isows: 1.0.6(ws@8.17.1)
       ox: 0.6.9(typescript@5.1.5)
       typescript: 5.1.5
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /viem@2.26.2(typescript@5.4.3):
+    resolution: {integrity: sha512-+yXSl1n+jV/Kn/zpETiNq0WOcINXti29nxdPIONvvNh+Es0VfeusW8bb2okVfa55pmuc8kOCOpB5wq3ZIUCTSA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.4.3)
+      isows: 1.0.6(ws@8.17.1)
+      ox: 0.6.9(typescript@5.4.3)
+      typescript: 5.4.3
       ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -25687,11 +25738,11 @@ packages:
       web3-types: 1.5.0
     dev: false
 
-  /web3-eth-abi@4.2.0(typescript@5.8.3):
+  /web3-eth-abi@4.2.0(typescript@5.4.3):
     resolution: {integrity: sha512-x7dUCmk6th+5N63s5kUusoNtsDJKUUQgl9+jECvGTBOTiyHe/V6aOY0120FUjaAGaapOnR7BImQdhqHv6yT2YQ==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
-      abitype: 0.7.1(typescript@5.8.3)
+      abitype: 0.7.1(typescript@5.4.3)
       web3-errors: 1.1.4
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25714,14 +25765,14 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-contract@4.3.0(typescript@5.8.3):
+  /web3-eth-contract@4.3.0(typescript@5.4.3):
     resolution: {integrity: sha512-4fzSklA65zUn6SthU3T3tbVJacfP8/wkJmCuvmPaf2ZTFdnhsF96G5IQtCRf0+wASb4yk0A6IBvXZfk1B4R4HA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.8.3)
-      web3-eth-abi: 4.2.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
+      web3-eth-abi: 4.2.0(typescript@5.4.3)
       web3-types: 1.5.0
       web3-utils: 4.2.1
       web3-validator: 2.0.5
@@ -25733,15 +25784,15 @@ packages:
       - zod
     dev: false
 
-  /web3-eth-ens@4.2.0(typescript@5.8.3):
+  /web3-eth-ens@4.2.0(typescript@5.4.3):
     resolution: {integrity: sha512-qYj34te2UctoObt8rlEIY/t2MuTMiMiiHhO2JAHRGqSLCQ7b8DM3RpvkiiSB0N0ZyEn+CetZqJCTYb8DNKBS/g==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.8.3)
-      web3-eth-contract: 4.3.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
+      web3-eth-contract: 4.3.0(typescript@5.4.3)
       web3-net: 4.0.7
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25764,12 +25815,12 @@ packages:
       web3-validator: 2.0.5
     dev: false
 
-  /web3-eth-personal@4.0.8(typescript@5.8.3):
+  /web3-eth-personal@4.0.8(typescript@5.4.3):
     resolution: {integrity: sha512-sXeyLKJ7ddQdMxz1BZkAwImjqh7OmKxhXoBNF3isDmD4QDpMIwv/t237S3q4Z0sZQamPa/pHebJRWVuvP8jZdw==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
-      web3-eth: 4.5.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
       web3-rpc-methods: 1.2.0
       web3-types: 1.5.0
       web3-utils: 4.2.1
@@ -25782,14 +25833,14 @@ packages:
       - zod
     dev: false
 
-  /web3-eth@4.5.0(typescript@5.8.3):
+  /web3-eth@4.5.0(typescript@5.4.3):
     resolution: {integrity: sha512-crisE46o/SHMVm+XHAXEaR8k76NCImq+hi0QQEJ+VaLZbDobI/Gvog1HwTukDUDRgnYSAFGqD0cTRyAwDurwpA==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
       setimmediate: 1.0.5
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth-abi: 4.2.0(typescript@5.8.3)
+      web3-eth-abi: 4.2.0(typescript@5.4.3)
       web3-eth-accounts: 4.1.1
       web3-net: 4.0.7
       web3-providers-ws: 4.0.7
@@ -25897,19 +25948,19 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /web3@4.7.0(typescript@5.8.3):
+  /web3@4.7.0(typescript@5.4.3):
     resolution: {integrity: sha512-3g+1e7B/IW0Nw9WP1dotrZKWD9o5IBfl27dxEnE1LxBZBax6ZkviiAwf18utIhlNBD07RgI+PPfKDXxfDBlHWA==}
     engines: {node: '>=14.0.0', npm: '>=6.12.0'}
     dependencies:
       web3-core: 4.3.2
       web3-errors: 1.1.4
-      web3-eth: 4.5.0(typescript@5.8.3)
-      web3-eth-abi: 4.2.0(typescript@5.8.3)
+      web3-eth: 4.5.0(typescript@5.4.3)
+      web3-eth-abi: 4.2.0(typescript@5.4.3)
       web3-eth-accounts: 4.1.1
-      web3-eth-contract: 4.3.0(typescript@5.8.3)
-      web3-eth-ens: 4.2.0(typescript@5.8.3)
+      web3-eth-contract: 4.3.0(typescript@5.4.3)
+      web3-eth-ens: 4.2.0(typescript@5.4.3)
       web3-eth-iban: 4.0.7
-      web3-eth-personal: 4.0.8(typescript@5.8.3)
+      web3-eth-personal: 4.0.8(typescript@5.4.3)
       web3-net: 4.0.7
       web3-providers-http: 4.1.0
       web3-providers-ws: 4.0.7


### PR DESCRIPTION
## Summary & Motivation

Created a release workflow via GitHub Action which will
- check for a specific label on the pull request in order to initiate the workflow
  - once we are comfortable with the workflow I will change the workflow to run on tag push to main e.g. release tags
- build the SDK artifacts
- test in preprod
- test in prod
- publish ONLY `@turnkey/sdk-types` for the time being as we test the workflow
  - the `environment: production` flag will pause the workflow at the publish step and will require a manual approval before performing the actual publish step

With @changesets/changelog-github, it includes GitHub PR and author links if run in CI with a GITHUB_TOKEN.

The new changelog format will look like this:
```
# my-package

## 1.1.0
### Minor Changes
- Added support for dark mode (#123) via @yourusername
```

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
