### PR TITLE
ensure presence of iframe embedded key

### DIFF
--- a/.changeset/nine-tigers-grab.md
+++ b/.changeset/nine-tigers-grab.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react": patch
+---
+
+Ensure that iframe has an embedded key

--- a/packages/sdk-react/src/components/auth/OtpVerification.tsx
+++ b/packages/sdk-react/src/components/auth/OtpVerification.tsx
@@ -47,11 +47,13 @@ const OtpVerification: React.FC<OtpVerificationProps> = ({
     setOtpError(null);
     setIsLoading(true);
     try {
+      const iframePublicKey = await authIframeClient!.initEmbeddedKey();
+
       const authSession = await server.verifyOtp({
         suborgID: suborgId,
         otpId,
         otpCode: otp,
-        targetPublicKey: authIframeClient!.iframePublicKey!,
+        targetPublicKey: iframePublicKey!,
         sessionLengthSeconds,
       });
 


### PR DESCRIPTION
## Summary & Motivation
$title

This will ensure that whenever users take auth-related actions, there will be a target embedded key to use

## How I Tested These Changes
- locally, via `examples/react-components`

## Did you add a changeset?
yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
