### PR TITLE
refreshSession

### DIFF
--- a/.changeset/ninety-spies-sing.md
+++ b/.changeset/ninety-spies-sing.md
@@ -1,0 +1,10 @@
+---
+"@turnkey/sdk-react-native": patch
+---
+
+- Adds optional parameter for createEmbeddedKey():
+  - You can now pass a sessionKey to createEmbeddedKey() to generate separate embedded keys for different sessions, which is helpful when running multiple authentication flows concurrently.
+- Introduces onSessionExpiryWarning():
+  - You can now add a callback via the provider config that triggers 15 seconds before a session expires.
+- Introduces refreshSession():
+  - You now can refresh an active session that is about to expire.

--- a/packages/sdk-react-native/README.md
+++ b/packages/sdk-react-native/README.md
@@ -55,7 +55,6 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
     },
     onSessionExpiryWarning: (session) => {
       console.log("Session is expiring in 15 seconds", session);
-      refreshSession({ sessionKey: session.key });
     },
   };
 

--- a/packages/sdk-react-native/README.md
+++ b/packages/sdk-react-native/README.md
@@ -53,6 +53,10 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
       console.log("Session Cleared", session);
       router.push("/");
     },
+    onSessionExpiryWarning: (session) => {
+      console.log("Session is expiring in 15 seconds", session);
+      refreshSession({ sessionKey: session.key });
+    },
   };
 
   return <TurnkeyProvider config={turnkeyConfig}>{children}</TurnkeyProvider>;
@@ -76,11 +80,17 @@ To enable secure authentication, the following storage keys are used:
 
 ### **Session Management**
 
-- `createEmbeddedKey()`: Generates a new embedded key pair and securely stores the private key.
+- `createEmbeddedKey({ sessionKey? })`: Generates a new embedded key pair and securely stores the private key.
+  - If `sessionKey` is provided, the embedded key will be stored under that key in secure storage.
+  - This allows for creating different embedded keys for different sessions, which is useful when initiating multiple authentication flows simultaneously.
 - `createSession({ bundle, expirationSeconds?, sessionKey? })`: Creates a session. [(API Docs)](https://docs.turnkey.com/api#tag/Sessions/operation/CreateReadWriteSession)
   - If `sessionKey` is provided, the session will be stored under that key in secure storage.
   - If no session exists, the first session created is **automatically selected**.
   - If a session with the same `sessionKey` already exists in secure storage, an error is thrown.
+- `refreshSession({ expirationSeconds?, sessionKey? })`: Refreshes and extends the expiration time of an existing session.
+  - Uses the current session to create a new session with an updated expiration time.
+  - If `sessionKey` is not provided, the currently selected session is refreshed.
+  - If `expirationSeconds` is not provided, the default expiration time is used.
 - `setSelectedSession({ sessionKey })`: Selects a session by its key (Used when handling multiple sessions).
 - `clearSession({ sessionKey? })`: Removes the specified session from secure storage. If no `sessionKey` is provided, the currently selected session is removed.
 - `clearAllSessions()`: Clears all sessions from secure storage.
@@ -120,6 +130,7 @@ This SDK supports **multiple sessions**, allowing you to create and switch betwe
   - `onSessionSelected`: Called when a session is selected.
   - `onSessionExpired`: Called when a session expires.
   - `onSessionCleared`: Called when a session is cleared.
+  - `onSessionExpiryWarning`: Called 15 seconds before a session expires, giving you an opportunity to refresh the session or notify the user.
 
 **When are multiple sessions useful?**
 

--- a/packages/sdk-react-native/README.md
+++ b/packages/sdk-react-native/README.md
@@ -69,6 +69,7 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
 To enable secure authentication, the following storage keys are used:
 
 - `@turnkey/embedded-key`: Stores the private key that corresponds to the public key used when initiating the session request to Turnkey.
+- `@turnkey/refresh-embedded-key`: Stores the private key that corresponds to the public key used when refreshing an active session.
 - `@turnkey/session`: Default session storage key, storing the session credentials, including the private key, public key, and expiry time, which are decrypted from the credential bundle after a session is created.
 - `@turnkey/session-keys`: Stores the list of stored session keys.
 - `@turnkey/selected-session`: Stores the currently selected session key.

--- a/packages/sdk-react-native/src/constants.ts
+++ b/packages/sdk-react-native/src/constants.ts
@@ -1,9 +1,11 @@
 export enum StorageKeys {
   DefaultSession = "@turnkey/session",
   EmbeddedKey = "@turnkey/embedded-key",
+  RefreshEmbeddedKey = "@turnkey/refresh-embedded-key",
   SessionKeys = "@turnkey/session-keys",
   SelectedSession = "@turnkey/selected-session",
 }
 
 export const OTP_AUTH_DEFAULT_EXPIRATION_SECONDS = 15 * 60;
 export const MAX_SESSIONS = 15;
+export const SESSION_WARNING_THRESHOLD_SECONDS = 15;

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -497,7 +497,7 @@ export const TurnkeyProvider: FC<{
       const keyToRefresh = sessionKey ?? (await getSelectedSessionKey());
       if (!keyToRefresh) {
         throw new TurnkeyReactNativeError(
-          "Session not found. Either the provided sessionKey is invalid, or no session is currently selected.",
+          "Session not found when refreshing the session. Either the provided sessionKey is invalid, or no session is currently selected.",
         );
       }
 
@@ -530,7 +530,7 @@ export const TurnkeyProvider: FC<{
           ?.credentialBundle;
       if (!bundle) {
         throw new TurnkeyReactNativeError(
-          "Failed to create read/write session.",
+          "Failed to create read/write session when refreshing the session",
         );
       }
 
@@ -539,7 +539,7 @@ export const TurnkeyProvider: FC<{
         StorageKeys.RefreshEmbeddedKey,
       );
       if (!embeddedKey) {
-        throw new TurnkeyReactNativeError("Embedded key not found.");
+        throw new TurnkeyReactNativeError("Embedded key not found when refreshing the session");
       }
 
       const newPrivateKey = decryptCredentialBundle(bundle, embeddedKey);
@@ -553,7 +553,7 @@ export const TurnkeyProvider: FC<{
       );
       const user = await fetchUser(newClient, config.organizationId);
       if (!user) {
-        throw new TurnkeyReactNativeError("User not found.");
+        throw new TurnkeyReactNativeError("User not found when refreshing the session");
       }
 
       const newSession: Session = {

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -56,7 +56,7 @@ export interface TurnkeyContextType {
   }) => Promise<Session | undefined>;
   updateUser: (params: { email?: string; phone?: string }) => Promise<Activity>;
   refreshUser: () => Promise<void>;
-  createEmbeddedKey: () => Promise<string>;
+  createEmbeddedKey: (params?: { sessionKey?: string }) => Promise<string>;
   createSession: (params: {
     bundle: string;
     expirationSeconds?: number;
@@ -84,7 +84,7 @@ export interface TurnkeyContextType {
 }
 
 export const TurnkeyContext = createContext<TurnkeyContextType | undefined>(
-  undefined,
+  undefined
 );
 
 export interface TurnkeyConfig {
@@ -132,7 +132,7 @@ export const TurnkeyProvider: FC<{
           }
 
           scheduleSessionExpiration(sessionKey, session!.expiry);
-        }),
+        })
       );
 
       // load the selected session if it's still valid
@@ -145,7 +145,7 @@ export const TurnkeyProvider: FC<{
           const clientInstance = createClient(
             selectedSession!.publicKey,
             selectedSession!.privateKey,
-            config.apiBaseUrl,
+            config.apiBaseUrl
           );
 
           setSession(selectedSession!);
@@ -156,7 +156,7 @@ export const TurnkeyProvider: FC<{
           await clearSession({ sessionKey: selectedSessionKey });
 
           config.onSessionExpired?.(
-            selectedSession ?? ({ key: selectedSessionKey } as Session),
+            selectedSession ?? ({ key: selectedSessionKey } as Session)
           );
         }
       }
@@ -177,7 +177,7 @@ export const TurnkeyProvider: FC<{
    */
   const clearTimeouts = () => {
     Object.values(expiryTimeoutsRef.current).forEach((timer) =>
-      clearTimeout(timer),
+      clearTimeout(timer)
     );
     expiryTimeoutsRef.current = {};
   };
@@ -196,7 +196,7 @@ export const TurnkeyProvider: FC<{
    */
   const scheduleSessionExpiration = async (
     sessionKey: string,
-    expiryTime: number,
+    expiryTime: number
   ) => {
     // clear existing timeout if it exists
     if (expiryTimeoutsRef.current[sessionKey]) {
@@ -221,7 +221,7 @@ export const TurnkeyProvider: FC<{
       // schedule expiration
       expiryTimeoutsRef.current[sessionKey] = setTimeout(
         expireSession,
-        timeUntilExpiry,
+        timeUntilExpiry
       );
     }
   };
@@ -245,7 +245,7 @@ export const TurnkeyProvider: FC<{
         const clientInstance = createClient(
           session!.publicKey,
           session!.privateKey,
-          config.apiBaseUrl,
+          config.apiBaseUrl
         );
 
         setClient(clientInstance);
@@ -260,7 +260,7 @@ export const TurnkeyProvider: FC<{
         return undefined;
       }
     },
-    [createClient, config],
+    [createClient, config]
   );
 
   /**
@@ -321,7 +321,7 @@ export const TurnkeyProvider: FC<{
 
       return activity;
     },
-    [client, session, refreshUser],
+    [client, session, refreshUser]
   );
 
   /**
@@ -330,13 +330,21 @@ export const TurnkeyProvider: FC<{
    * @returns The public key corresponding to the generated embedded key pair.
    * @throws If saving the private key fails.
    */
-  const createEmbeddedKey = useCallback(async () => {
-    const key = generateP256KeyPair();
-    const embeddedPrivateKey = key.privateKey;
-    const publicKey = key.publicKeyUncompressed;
-    await saveEmbeddedKey(embeddedPrivateKey);
-    return publicKey;
-  }, []);
+  const createEmbeddedKey = useCallback(
+    async ({
+      sessionKey = StorageKeys.EmbeddedKey,
+    }: {
+      sessionKey?: string;
+    } = {}) => {
+      const key = generateP256KeyPair();
+      const embeddedPrivateKey = key.privateKey;
+      const publicKey = key.publicKeyUncompressed;
+      await saveEmbeddedKey(embeddedPrivateKey, sessionKey);
+      return publicKey;
+    },
+    []
+  );
+
   /**
    * Creates a new session and securely stores it.
    *
@@ -373,13 +381,13 @@ export const TurnkeyProvider: FC<{
 
       if (existingSessionKeys.length >= MAX_SESSIONS) {
         throw new TurnkeyReactNativeError(
-          `Maximum session limit of ${MAX_SESSIONS} reached. Please clear an existing session before creating a new one.`,
+          `Maximum session limit of ${MAX_SESSIONS} reached. Please clear an existing session before creating a new one.`
         );
       }
 
       if (existingSessionKeys.includes(sessionKey)) {
         throw new TurnkeyReactNativeError(
-          `session key "${sessionKey}" already exists. Please choose a unique session key or clear the existing session.`,
+          `session key "${sessionKey}" already exists. Please choose a unique session key or clear the existing session.`
         );
       }
 
@@ -395,7 +403,7 @@ export const TurnkeyProvider: FC<{
       const clientInstance = createClient(
         publicKey,
         privateKey,
-        config.apiBaseUrl,
+        config.apiBaseUrl
       );
       const user = await fetchUser(clientInstance, config.organizationId);
       if (!user) {
@@ -422,7 +430,7 @@ export const TurnkeyProvider: FC<{
       config.onSessionCreated?.(newSession);
       return newSession;
     },
-    [config, setSelectedSession],
+    [config, setSelectedSession]
   );
 
   /**
@@ -447,7 +455,7 @@ export const TurnkeyProvider: FC<{
 
       if (!keyToClear) {
         throw new TurnkeyReactNativeError(
-          "Session not found. Either the provided sessionKey is invalid, or no session is currently selected.",
+          "Session not found. Either the provided sessionKey is invalid, or no session is currently selected."
         );
       }
 
@@ -467,10 +475,10 @@ export const TurnkeyProvider: FC<{
       delete expiryTimeoutsRef.current[keyToClear];
 
       config.onSessionCleared?.(
-        clearedSession ?? ({ key: keyToClear } as Session),
+        clearedSession ?? ({ key: keyToClear } as Session)
       );
     },
-    [session, config],
+    [session, config]
   );
 
   /**
@@ -547,7 +555,7 @@ export const TurnkeyProvider: FC<{
 
       return activity;
     },
-    [client, session, refreshUser],
+    [client, session, refreshUser]
   );
 
   /**
@@ -615,7 +623,7 @@ export const TurnkeyProvider: FC<{
 
       return activity;
     },
-    [client, session, refreshUser],
+    [client, session, refreshUser]
   );
 
   /**
@@ -649,7 +657,7 @@ export const TurnkeyProvider: FC<{
 
       if (exportBundle == null || embeddedKey == null) {
         throw new TurnkeyReactNativeError(
-          "Export bundle or embedded key not initialized",
+          "Export bundle or embedded key not initialized"
         );
       }
 
@@ -660,7 +668,7 @@ export const TurnkeyProvider: FC<{
         returnMnemonic: true,
       });
     },
-    [client, session],
+    [client, session]
   );
 
   /**
@@ -706,7 +714,7 @@ export const TurnkeyProvider: FC<{
 
       return signRawPayloadResult;
     },
-    [client, session],
+    [client, session]
   );
 
   const providerValue = useMemo(
@@ -741,7 +749,7 @@ export const TurnkeyProvider: FC<{
       importWallet,
       exportWallet,
       signRawPayload,
-    ],
+    ]
   );
 
   return (

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -539,7 +539,9 @@ export const TurnkeyProvider: FC<{
         StorageKeys.RefreshEmbeddedKey,
       );
       if (!embeddedKey) {
-        throw new TurnkeyReactNativeError("Embedded key not found when refreshing the session");
+        throw new TurnkeyReactNativeError(
+          "Embedded key not found when refreshing the session",
+        );
       }
 
       const newPrivateKey = decryptCredentialBundle(bundle, embeddedKey);
@@ -553,7 +555,9 @@ export const TurnkeyProvider: FC<{
       );
       const user = await fetchUser(newClient, config.organizationId);
       if (!user) {
-        throw new TurnkeyReactNativeError("User not found when refreshing the session");
+        throw new TurnkeyReactNativeError(
+          "User not found when refreshing the session",
+        );
       }
 
       const newSession: Session = {

--- a/packages/sdk-react-native/src/storage.ts
+++ b/packages/sdk-react-native/src/storage.ts
@@ -47,11 +47,11 @@ export const getEmbeddedKey = async (
  * @param key The private key to store securely.
  * @throws If saving the key fails.
  */
-export const saveEmbeddedKey = async (key: string): Promise<void> => {
+export const saveEmbeddedKey = async (key: string, sessionKey: string): Promise<void> => {
   try {
-    await Keychain.setGenericPassword(StorageKeys.EmbeddedKey, key, {
+    await Keychain.setGenericPassword(sessionKey, key, {
       accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
-      service: StorageKeys.EmbeddedKey,
+      service: sessionKey,
     });
   } catch (error) {
     throw new TurnkeyReactNativeError(

--- a/packages/sdk-react-native/src/storage.ts
+++ b/packages/sdk-react-native/src/storage.ts
@@ -12,25 +12,29 @@ import { StorageKeys } from "./constants";
 // it is simply a secure storage location for sensitive string data.
 
 /**
- * Retrieves the stored embedded key from secure storage.
- * Optionally deletes the key from storage after retrieval.
+ * Retrieves the embedded key from secure storage.
  *
- * @param deleteKey Whether to remove the embedded key after retrieval. Defaults to `false`.
- * @returns The embedded private key if found, otherwise `null`.
- * @throws If retrieving or deleting the key fails.
+ * - Attempts to retrieve the stored embedded private key using Keychain.
+ * - Optionally deletes the key from storage after retrieval if `deleteKey` is true.
+ *
+ * @param deleteKey - Whether to remove the embedded key after retrieval (defaults to false).
+ * @param sessionKey - The service key for the embedded key (defaults to StorageKeys.EmbeddedKey).
+ * @returns The embedded private key if found, otherwise null.
+ * @throws {TurnkeyReactNativeError} If retrieving or deleting the key fails.
  */
 export const getEmbeddedKey = async (
   deleteKey = false,
+  sessionKey: string = StorageKeys.EmbeddedKey,
 ): Promise<string | null> => {
   try {
     const credentials = await Keychain.getGenericPassword({
-      service: StorageKeys.EmbeddedKey,
+      service: sessionKey,
     });
 
     if (credentials) {
       if (deleteKey) {
         await Keychain.resetGenericPassword({
-          service: StorageKeys.EmbeddedKey,
+          service: sessionKey,
         });
       }
       return credentials.password;
@@ -42,12 +46,18 @@ export const getEmbeddedKey = async (
 };
 
 /**
- * Saves the private key component of an embedded key securely in storage.
+ * Saves the provided embedded key (private key) securely in storage.
  *
- * @param key The private key to store securely.
- * @throws If saving the key fails.
+ * - Uses Keychain to store the private key for the given service key.
+ *
+ * @param key - The private key to store securely.
+ * @param sessionKey - The key under which to store the embedded key.
+ * @throws {TurnkeyReactNativeError} If saving the key fails.
  */
-export const saveEmbeddedKey = async (key: string, sessionKey: string): Promise<void> => {
+export const saveEmbeddedKey = async (
+  key: string,
+  sessionKey: string,
+): Promise<void> => {
   try {
     await Keychain.setGenericPassword(sessionKey, key, {
       accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,


### PR DESCRIPTION
## Summary & Motivation

client asked for abstraction to be able to refresh sessions before they expire (i.e extend the session)

![image](https://github.com/user-attachments/assets/66378207-efd1-4cdd-8894-a16fa8d5e1fb)


went a step up and also added a warning function that runs 15 seconds before the session expiries - to make these an even easier process

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
