### PR TITLE
release eip-1193-provider and sdk-react

### DIFF
--- a/.changeset/fifty-plants-grin.md
+++ b/.changeset/fifty-plants-grin.md
@@ -1,5 +1,0 @@
----
-"@turnkey/eip-1193-provider": patch
----
-
-Fix type resolution

--- a/.changeset/nine-tigers-grab.md
+++ b/.changeset/nine-tigers-grab.md
@@ -1,5 +1,0 @@
----
-"@turnkey/sdk-react": patch
----
-
-Ensure that iframe has an embedded key

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/eip-1193-provider
 
+## 3.3.5
+
+### Patch Changes
+
+- 7a89040: Fix type resolution
+
 ## 3.3.4
 
 ### Patch Changes

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/src/version.ts
+++ b/packages/eip-1193-provider/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/eip-1193-provider@3.3.4";
+export const VERSION = "@turnkey/eip-1193-provider@3.3.5";

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/sdk-react
 
+## 4.2.2
+
+### Patch Changes
+
+- 7755413: Ensure that iframe has an embedded key
+
 ## 4.2.1
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
