### PR TITLE
docs: fix typo

### DIFF
--- a/docs/markdown/README.mdx
+++ b/docs/markdown/README.mdx
@@ -50,7 +50,7 @@ The following packages contain chain or ecosystem specific signers that take som
 
 ## Advanced Functionality SDK Packages
 
-For those with more specialized use cases, Turnkey exposes it's lower level-libraries stamping and encryption libraries to be used directly. Note: for most use-cases, these libraries are not meant to be used directly and we encourage working on designing your application mainlyusing our [Primary Turnkey Web SDK Packages](#primary-turnkey-web-sdk-packages) along with our [Chain and Ecosystem Specific SDK Packages](#chainecosystem-specific-signing-sdk-packages) as per your use case!
+For those with more specialized use cases, Turnkey exposes it's lower level-libraries stamping and encryption libraries to be used directly. Note: for most use-cases, these libraries are not meant to be used directly and we encourage working on designing your application mainly using our [Primary Turnkey Web SDK Packages](#primary-turnkey-web-sdk-packages) along with our [Chain and Ecosystem Specific SDK Packages](#chainecosystem-specific-signing-sdk-packages) as per your use case!
 
 ### Request Stamping
 


### PR DESCRIPTION
## Summary & Motivation

corrected a small typo "mainlyusing" was mistakenly written as one word.