### PR TITLE
remove BrokenPasskeyCreateResult as it's no longer needed

### DIFF
--- a/packages/react-native-passkey-stamper/src/index.ts
+++ b/packages/react-native-passkey-stamper/src/index.ts
@@ -125,7 +125,6 @@ export function isSupported(): boolean {
 }
 
 // Context: https://github.com/f-23/react-native-passkey/issues/54
-type BrokenPasskeyCreateResult = PasskeyCreateResult | string;
 type BrokenPasskeyGetResult = PasskeyGetResult | string;
 
 /**
@@ -171,15 +170,6 @@ export async function createPasskey(
       },
     ],
   });
-
-  // See https://github.com/f-23/react-native-passkey/issues/54
-  // On Android the typedef lies. Registration result is actually a string!
-  // TODO: remove me once the above is resolved.
-  const brokenRegistrationResult =
-    registrationResult as BrokenPasskeyCreateResult;
-  if (typeof brokenRegistrationResult === "string") {
-    registrationResult = JSON.parse(brokenRegistrationResult);
-  }
 
   return {
     authenticatorName: config.authenticatorName,


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
