### PR TITLE
update packages and changelogs

### DIFF
--- a/.changeset/chilly-turkeys-begin.md
+++ b/.changeset/chilly-turkeys-begin.md
@@ -1,7 +1,0 @@
----
-"@turnkey/sdk-browser": minor
-"@turnkey/sdk-server": minor
-"@turnkey/http": minor
----
-
-Release per mono v2025.4.4

--- a/.changeset/lucky-terms-pump.md
+++ b/.changeset/lucky-terms-pump.md
@@ -1,5 +1,0 @@
----
-"@turnkey/viem": minor
----
-
-Add support for signing Type 3 (EIP-4844) transactions

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/cosmjs
 
+## 0.7.6
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/sdk-browser@4.1.0
+  - @turnkey/sdk-server@3.1.0
+  - @turnkey/http@3.1.0
+
 ## 0.7.5
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/eip-1193-provider
 
+## 3.3.6
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/sdk-browser@4.1.0
+  - @turnkey/http@3.1.0
+
 ## 3.3.5
 
 ### Patch Changes

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/src/version.ts
+++ b/packages/eip-1193-provider/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/eip-1193-provider@3.3.5";
+export const VERSION = "@turnkey/eip-1193-provider@3.3.6";

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/ethers
 
+## 1.1.23
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/sdk-browser@4.1.0
+  - @turnkey/sdk-server@3.1.0
+  - @turnkey/http@3.1.0
+
 ## 1.1.22
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/http
 
+## 3.1.0
+
+### Minor Changes
+
+- 3e4a482: Release per mono v2025.4.4
+  - Adds parsing and policy engine support for Ethereum Type 3 (EIP-4844) and Type 4 (EIP-7702) transactions. There is no change to any signing interface or API; you simply can now use Turnkey's signing endpoints to sign those transaction types. See [with-viem](https://github.com/tkhq/sdk/blob/main/examples/with-viem/) for examples.
+  - New wallet account creations will now automatically derive the underlying derived account's public key. For example: previously, if derived an Ethereum wallet account, you would get the resulting Ethereum address (`0x...`). If you also wanted the public key associated with that underlying key, you would've had to derive an additional wallet account with `ADDRESS_FORMAT_COMPRESSED`. Now, this will automatically be derived for you. It is now a property that has been added to the wallet account primitive (i.e. accessible via `walletAccount.publicKey`).
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@3.0.0";
+export const VERSION = "@turnkey/http@3.1.0";

--- a/packages/react-native-passkey-stamper/CHANGELOG.md
+++ b/packages/react-native-passkey-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/react-native-passkey-stamper
 
+## 1.0.11
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/http@3.1.0
+
 ## 1.0.10
 
 ### Patch Changes

--- a/packages/react-native-passkey-stamper/package.json
+++ b/packages/react-native-passkey-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-native-passkey-stamper",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/CHANGELOG.md
+++ b/packages/sdk-browser/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @turnkey/sdk-browser
 
+## 4.1.0
+
+### Minor Changes
+
+- 3e4a482: Release per mono v2025.4.4
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/http@3.1.0
+  - @turnkey/crypto@2.3.1
+  - @turnkey/wallet-stamper@1.0.3
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-browser",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/src/__generated__/version.ts
+++ b/packages/sdk-browser/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-browser@4.0.0";
+export const VERSION = "@turnkey/sdk-browser@4.1.0";

--- a/packages/sdk-react-native/CHANGELOG.md
+++ b/packages/sdk-react-native/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/sdk-react-native
 
+## 1.2.1
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/http@3.1.0
+  - @turnkey/crypto@2.3.1
+  - @turnkey/react-native-passkey-stamper@1.0.11
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react-native",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React Native SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/sdk-react
 
+## 4.2.4
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/sdk-browser@4.1.0
+  - @turnkey/sdk-server@3.1.0
+  - @turnkey/crypto@2.3.1
+  - @turnkey/wallet-stamper@1.0.3
+
 ## 4.2.3
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/CHANGELOG.md
+++ b/packages/sdk-server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @turnkey/sdk-server
 
+## 3.1.0
+
+### Minor Changes
+
+- 3e4a482: Release per mono v2025.4.4
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/http@3.1.0
+  - @turnkey/wallet-stamper@1.0.3
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/src/__generated__/version.ts
+++ b/packages/sdk-server/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-server@3.0.1";
+export const VERSION = "@turnkey/sdk-server@3.1.0";

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/solana
 
+## 1.0.22
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/sdk-browser@4.1.0
+  - @turnkey/sdk-server@3.1.0
+  - @turnkey/http@3.1.0
+
 ## 1.0.21
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @turnkey/viem
 
+## 0.9.0
+
+### Minor Changes
+
+- 2f75cf1: Add support for signing Type 3 (EIP-4844) transactions
+
+### Patch Changes
+
+- Updated dependencies [3e4a482]
+  - @turnkey/sdk-browser@4.1.0
+  - @turnkey/sdk-server@3.1.0
+  - @turnkey/http@3.1.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Minor Changes
 
 - 2f75cf1: Add support for signing Type 3 (EIP-4844) transactions
+  - Note the inline comments on the `signTransaction` [implementation](https://github.com/tkhq/sdk/blob/5e5666aba978f756e2021c261830effc5559811f/packages/viem/src/index.ts#L392): when signing Type 3 transactions, our Viem implementation will extract the transaction payload (not including blobs, commitments, or proofs), sign it, extract the signature, and then reassemble the entire transaction payload.
+  - See [with-viem](https://github.com/tkhq/sdk/tree/main/examples/with-viem/) for examples.
 
 ### Patch Changes
 

--- a/packages/viem/README.md
+++ b/packages/viem/README.md
@@ -108,3 +108,7 @@ main().catch((error) => {
 - [`@turnkey/http`](https://www.npmjs.com/package/@turnkey/http): lower-level fully typed HTTP client for interacting with Turnkey API
 - [`@turnkey/api-key-stamper`](https://www.npmjs.com/package/@turnkey/api-key-stamper): package to authenticate to Turnkey using API key credentials
 - [`@turnkey/webauthn-stamper`](https://www.npmjs.com/package/@turnkey/webauthn-stamper): package to authenticate to Turnkey using Webauthn/passkeys.
+
+## Transaction types supported
+
+- Turnkey's Viem implementation now supports all transaction types: legacy, EIP-2930 (Type 1), EIP-1559 (Type 2), EIP-4844 (Type 3), and EIP-7702 (Type 4). See [with-viem](https://github.com/tkhq/sdk/tree/main/examples/with-viem/) for examples of scripts that sign using those various types.

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
$title

Releases mono v2025.4.4, and corresponding changes

Also bumps @turnkey/viem

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
