### PR TITLE
Better error message and JS docs for API key import

### DIFF
--- a/.changeset/small-dragons-repair.md
+++ b/.changeset/small-dragons-repair.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/api-key-stamper": patch
+---
+
+Better error message and docstring for API key import

--- a/packages/api-key-stamper/src/utils.ts
+++ b/packages/api-key-stamper/src/utils.ts
@@ -5,6 +5,15 @@ import {
   DEFAULT_JWK_MEMBER_BYTE_LENGTH,
 } from "@turnkey/encoding";
 
+/**
+ * Converts a Turnkey API key pair into a JSON Web Key (JWK) format.
+ * This function accepts P-256 API keys only.
+ *
+ * @param {Object} input - The Turnkey API key components.
+ * @param {string} input.uncompressedPrivateKeyHex - Hexadecimal-encoded uncompressed private key (32-byte scalar).
+ * @param {string} input.compressedPublicKeyHex - Hexadecimal-encoded compressed public key (33 bytes).
+ * @returns {JsonWebKey} A JSON Web Key object representing the EC P-256 key.
+ */
 export function convertTurnkeyApiKeyToJwk(input: {
   uncompressedPrivateKeyHex: string;
   compressedPublicKeyHex: string;
@@ -16,7 +25,7 @@ export function convertTurnkeyApiKeyToJwk(input: {
     jwk = pointDecode(uint8ArrayFromHexString(compressedPublicKeyHex));
   } catch (e) {
     throw new Error(
-      `unable to load API key: invalid public key. Did you switch your public and private key?`,
+      `unable to load API key: invalid public key. Did you switch your public and private key by accident? Is your public key a valid, compressed P-256 public key?`,
     );
   }
 

--- a/packages/api-key-stamper/src/webcrypto.ts
+++ b/packages/api-key-stamper/src/webcrypto.ts
@@ -16,6 +16,14 @@ export const signWithApiKey = async (input: {
   return await signMessage({ key, content });
 };
 
+/**
+ * Imports a P-256 Turnkey API key into a WebCrypto `CryptoKey`.
+ *
+ * @param {Object} input - The Turnkey API key components.
+ * @param {string} input.uncompressedPrivateKeyHex - Hexadecimal-encoded uncompressed private key (32-byte scalar).
+ * @param {string} input.compressedPublicKeyHex - Hexadecimal-encoded compressed public key (33 bytes).
+ * @returns {Promise<CryptoKey>} A `CryptoKey` object representing a P-256 key.
+ */
 async function importTurnkeyApiKey(input: {
   uncompressedPrivateKeyHex: string;
   compressedPublicKeyHex: string;


### PR DESCRIPTION
## Summary & Motivation
Clarifying in error messages and docs that our API key import assumes a P-256 API key.
