### PR TITLE
Added option for oAuth to replace window. Fixed keyboard input on mobile

### DIFF
--- a/.changeset/eight-geckos-scream.md
+++ b/.changeset/eight-geckos-scream.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/sdk-react": patch
+---
+
+- Added `openOAuthInPage` to the `authConfig`. This makes the Google, Apple and Facebook login pages replace the current URL, rather than opening in a popup.
+- Fixed keyboard input type on mobile. Now, the keyboard will correctly default to "number" input for numeric OTP codes and "text" input for alphanumeric OTP codes.

--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -78,6 +78,7 @@ interface AuthProps {
     facebookEnabled: boolean;
     googleEnabled: boolean;
     walletEnabled: boolean;
+    openOAuthInPage?: boolean;
     sessionLengthSeconds?: number; // Desired expiration time in seconds for the generated API key
     googleClientId?: string; // will default to NEXT_PUBLIC_GOOGLE_CLIENT_ID
     appleClientId?: string; // will default to NEXT_PUBLIC_APPLE_CLIENT_ID
@@ -422,6 +423,7 @@ const Auth: React.FC<AuthProps> = ({
               process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!
             }
             iframePublicKey={authIframeClient!.iframePublicKey!}
+            openInPage={authConfig.openOAuthInPage}
             onSuccess={(response: any) =>
               handleOAuthLogin(response.idToken, "Google")
             }
@@ -435,6 +437,7 @@ const Auth: React.FC<AuthProps> = ({
               process.env.NEXT_PUBLIC_APPLE_CLIENT_ID!
             }
             iframePublicKey={authIframeClient!.iframePublicKey!}
+            openInPage={authConfig.openOAuthInPage}
             onSuccess={(response: any) =>
               handleOAuthLogin(response.idToken, "Apple")
             }
@@ -448,6 +451,7 @@ const Auth: React.FC<AuthProps> = ({
               process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID!
             }
             iframePublicKey={authIframeClient!.iframePublicKey!}
+            openInPage={authConfig.openOAuthInPage}
             onSuccess={(response: any) =>
               handleOAuthLogin(response.id_token, "Facebook")
             }
@@ -726,6 +730,7 @@ const Auth: React.FC<AuthProps> = ({
                     contact={step === OtpType.Email ? email : phone}
                     suborgId={suborgId}
                     otpId={otpId!}
+                    alphanumeric={otpConfig?.alphanumeric ?? false}
                     sessionLengthSeconds={authConfig.sessionLengthSeconds}
                     onValidateSuccess={onAuthSuccess}
                     onResendCode={handleResendCode}

--- a/packages/sdk-react/src/components/auth/Facebook.tsx
+++ b/packages/sdk-react/src/components/auth/Facebook.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styles from "./Socials.module.css";
 import { exchangeCodeForToken, generateChallengePair } from "./facebookUtils";
 import { sha256 } from "@noble/hashes/sha256";
@@ -14,6 +14,7 @@ interface FacebookAuthButtonProps {
   clientId: string;
   onSuccess: (response: any) => void;
   layout: "inline" | "stacked";
+  openInPage?: boolean | undefined;
 }
 
 const FacebookAuthButton: React.FC<FacebookAuthButtonProps> = ({
@@ -21,11 +22,31 @@ const FacebookAuthButton: React.FC<FacebookAuthButtonProps> = ({
   onSuccess,
   clientId,
   layout,
+  openInPage = false,
 }) => {
   const [loading, setLoading] = useState(false);
-
   const [tokenExchanged, setTokenExchanged] = useState<boolean>(false);
   const redirectURI = process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI!;
+
+  // Check for code param on component mount for in-page authentication
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const authCode = urlParams.get("code");
+    const state = urlParams.get("state");
+    const provider = state?.split("=")[1];
+
+    if (authCode && state && provider === "facebook") {
+      // Clear the URL params so they don't get processed again on refresh
+      window.history.replaceState(
+        null,
+        document.title,
+        window.location.pathname,
+      );
+
+      // Handle the code exchange
+      handleTokenExchange(authCode);
+    }
+  }, []);
 
   const initiateFacebookLogin = async () => {
     setLoading(true);
@@ -35,7 +56,7 @@ const FacebookAuthButton: React.FC<FacebookAuthButtonProps> = ({
     const params = new URLSearchParams({
       client_id: clientId,
       redirect_uri: redirectURI,
-      state: verifier,
+      state: `${verifier}:provider=facebook`,
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
       nonce: bytesToHex(sha256(iframePublicKey)),
@@ -45,43 +66,48 @@ const FacebookAuthButton: React.FC<FacebookAuthButtonProps> = ({
 
     const facebookOAuthURL = `${FACEBOOK_AUTH_URL}?${params.toString()}`;
 
-    const width = popupWidth;
-    const height = popupHeight;
-    const left = window.screenX + (window.innerWidth - width) / 2;
-    const top = window.screenY + (window.innerHeight - height) / 2;
+    if (openInPage) {
+      // Open in the current page
+      window.location.href = facebookOAuthURL;
+    } else {
+      const width = popupWidth;
+      const height = popupHeight;
+      const left = window.screenX + (window.innerWidth - width) / 2;
+      const top = window.screenY + (window.innerHeight - height) / 2;
 
-    // Open the login flow in a new window
-    const popup = window.open(
-      facebookOAuthURL,
-      "_blank",
-      `width=${width},height=${height},top=${top},left=${left},scrollbars=yes,resizable=yes`,
-    );
+      // Open the login flow in a new window
+      const popup = window.open(
+        facebookOAuthURL,
+        "_blank",
+        `width=${width},height=${height},top=${top},left=${left},scrollbars=yes,resizable=yes`,
+      );
 
-    if (popup) {
-      const interval = setInterval(async () => {
-        try {
-          if (popup.closed) {
-            setLoading(false);
-            clearInterval(interval);
-            return;
+      if (popup) {
+        const interval = setInterval(async () => {
+          try {
+            if (popup.closed) {
+              setLoading(false);
+              clearInterval(interval);
+              return;
+            }
+
+            const popupUrl = new URL(popup.location.href);
+            const authCode = popupUrl.searchParams.get("code");
+
+            if (authCode) {
+              setLoading(false);
+              popup.close();
+              clearInterval(interval);
+              handleTokenExchange(authCode);
+            }
+          } catch (error) {
+            // Ignore cross-origin errors until the popup redirects to the same origin.
+            // These errors occur because the script attempts to access the URL of the popup window while it's on a different domain.
+            // Due to browser security policies (Same-Origin Policy), accessing properties like location.href on a window that is on a different domain will throw an exception.
+            // Once the popup redirects to the same origin as the parent window, these errors will no longer occur, and the script can safely access the popup's location to extract parameters.
           }
-
-          const popupUrl = new URL(popup.location.href);
-          const authCode = popupUrl.searchParams.get("code");
-
-          if (authCode) {
-            setLoading(false);
-            popup.close();
-            clearInterval(interval);
-            handleTokenExchange(authCode);
-          }
-        } catch (error) {
-          // Ignore cross-origin errors until the popup redirects to the same origin.
-          // These errors occur because the script attempts to access the URL of the popup window while it's on a different domain.
-          // Due to browser security policies (Same-Origin Policy), accessing properties like location.href on a window that is on a different domain will throw an exception.
-          // Once the popup redirects to the same origin as the parent window, these errors will no longer occur, and the script can safely access the popup's location to extract parameters.
-        }
-      }, 250);
+        }, 250);
+      }
     }
   };
 
@@ -107,6 +133,8 @@ const FacebookAuthButton: React.FC<FacebookAuthButtonProps> = ({
       setTokenExchanged(true);
     } catch (error) {
       console.error("Error during token exchange:", error);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -128,6 +156,7 @@ const FacebookAuthButton: React.FC<FacebookAuthButtonProps> = ({
             className={
               layout === "inline" ? styles.iconLarge : styles.iconSmall
             }
+            alt="Facebook"
           />
           {layout === "stacked" && <span>Continue with Facebook</span>}
         </>

--- a/packages/sdk-react/src/components/auth/Google.tsx
+++ b/packages/sdk-react/src/components/auth/Google.tsx
@@ -5,7 +5,7 @@ import { bytesToHex } from "@noble/hashes/utils";
 import styles from "./Socials.module.css";
 import googleIcon from "assets/google.svg";
 import { GOOGLE_AUTH_URL, popupHeight, popupWidth } from "./constants";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CircularProgress } from "@mui/material";
 
 interface GoogleAuthButtonProps {
@@ -13,6 +13,7 @@ interface GoogleAuthButtonProps {
   clientId: string;
   onSuccess: (response: any) => void;
   layout: "inline" | "stacked";
+  openInPage?: boolean | undefined;
 }
 declare global {
   interface Window {
@@ -25,8 +26,31 @@ const GoogleAuthButton: React.FC<GoogleAuthButtonProps> = ({
   clientId,
   onSuccess,
   layout,
+  openInPage = false,
 }) => {
   const [loading, setLoading] = useState(false);
+
+  // Check for hash params on component mount for in-page authentication
+  useEffect(() => {
+    // If there's a hash in the URL, parse it
+    if (window.location.hash) {
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      const idToken = hashParams.get("id_token");
+      const state = hashParams.get("state");
+      const provider = state?.split("=")[1];
+
+      if (idToken && provider === "google") {
+        // Handle the token
+        onSuccess({ idToken });
+        // Clear the hash so it doesn’t re-trigger on page refresh
+        window.history.replaceState(
+          null,
+          document.title,
+          window.location.pathname + window.location.search,
+        );
+      }
+    }
+  }, [onSuccess]);
 
   const handleLogin = async () => {
     setLoading(true);
@@ -43,48 +67,55 @@ const GoogleAuthButton: React.FC<GoogleAuthButtonProps> = ({
     googleAuthUrl.searchParams.set("scope", "openid email profile"); // Scopes required for OpenID
     googleAuthUrl.searchParams.set("nonce", nonce);
     googleAuthUrl.searchParams.set("prompt", "select_account");
-    const width = popupWidth;
-    const height = popupHeight;
-    const left = window.screenX + (window.innerWidth - width) / 2;
-    const top = window.screenY + (window.innerHeight - height) / 2;
+    googleAuthUrl.searchParams.set("state", "provider=google");
 
-    // Open the login flow in a new window
-    const authWindow = window.open(
-      googleAuthUrl.toString(),
-      "_blank",
-      `width=${width},height=${height},top=${top},left=${left},scrollbars=yes,resizable=yes`,
-    );
+    if (openInPage) {
+      window.location.href = googleAuthUrl.toString();
+    } else {
+      const width = popupWidth;
+      const height = popupHeight;
+      const left = window.screenX + (window.innerWidth - width) / 2;
+      const top = window.screenY + (window.innerHeight - height) / 2;
 
-    if (!authWindow) {
-      console.error("Failed to open Google login window.");
-      return;
-    }
+      // Open the login flow in a new window
+      const authWindow = window.open(
+        googleAuthUrl.toString(),
+        "_blank",
+        `width=${width},height=${height},top=${top},left=${left},scrollbars=yes,resizable=yes`,
+      );
 
-    // Monitor the child window for redirect and extract tokens
-    const interval = setInterval(() => {
-      try {
-        const url = authWindow?.location.href || "";
-        if (url.startsWith(window.location.origin)) {
-          const hashParams = new URLSearchParams(url.split("#")[1]);
-          const idToken = hashParams.get("id_token");
-          if (idToken) {
-            authWindow?.close();
-            clearInterval(interval);
-            onSuccess({ idToken });
-          }
-        }
-      } catch (error) {
-        // Ignore cross-origin errors until the popup redirects to the same origin.
-        // These errors occur because the script attempts to access the URL of the popup window while it's on a different domain.
-        // Due to browser security policies (Same-Origin Policy), accessing properties like location.href on a window that is on a different domain will throw an exception.
-        // Once the popup redirects to the same origin as the parent window, these errors will no longer occur, and the script can safely access the popup's location to extract parameters.
-      }
-
-      if (authWindow?.closed) {
+      if (!authWindow) {
+        console.error("Failed to open Google login window.");
         setLoading(false);
-        clearInterval(interval);
+        return;
       }
-    }, 500);
+
+      // Monitor the child window for redirect and extract tokens
+      const interval = setInterval(() => {
+        try {
+          const url = authWindow?.location.href || "";
+          if (url.startsWith(window.location.origin)) {
+            const hashParams = new URLSearchParams(url.split("#")[1]);
+            const idToken = hashParams.get("id_token");
+            if (idToken) {
+              authWindow?.close();
+              clearInterval(interval);
+              onSuccess({ idToken });
+            }
+          }
+        } catch (error) {
+          // Ignore cross-origin errors until the popup redirects to the same origin.
+          // These errors occur because the script attempts to access the URL of the popup window while it's on a different domain.
+          // Due to browser security policies (Same-Origin Policy), accessing properties like location.href on a window that is on a different domain will throw an exception.
+          // Once the popup redirects to the same origin as the parent window, these errors will no longer occur, and the script can safely access the popup's location to extract parameters.
+        }
+
+        if (authWindow?.closed) {
+          setLoading(false);
+          clearInterval(interval);
+        }
+      }, 500);
+    }
   };
 
   return (

--- a/packages/sdk-react/src/components/auth/OtpVerification.tsx
+++ b/packages/sdk-react/src/components/auth/OtpVerification.tsx
@@ -17,6 +17,7 @@ interface OtpVerificationProps {
   contact: string;
   suborgId: string;
   otpId: string;
+  alphanumeric?: boolean | undefined;
   sessionLengthSeconds?: number | undefined;
   numBoxes?: number | undefined;
   onValidateSuccess: () => Promise<void>;
@@ -31,6 +32,7 @@ const OtpVerification: React.FC<OtpVerificationProps> = ({
   contact,
   suborgId,
   otpId,
+  alphanumeric = false,
   sessionLengthSeconds,
   onValidateSuccess,
   onResendCode,
@@ -135,6 +137,7 @@ const OtpVerification: React.FC<OtpVerificationProps> = ({
             ref={otpInputRef}
             onComplete={handleValidateOtp}
             numBoxes={numBoxes}
+            alphanumeric={alphanumeric}
             hasError={!!otpError}
           />
         </div>

--- a/packages/sdk-react/src/components/auth/otp.tsx
+++ b/packages/sdk-react/src/components/auth/otp.tsx
@@ -4,11 +4,12 @@ import { TextField, Box } from "@mui/material";
 interface OtpInputProps {
   onComplete: (otp: string) => void;
   hasError: boolean;
+  alphanumeric?: boolean | undefined;
   numBoxes?: number | undefined;
 }
 
 const OtpInput = forwardRef<unknown, OtpInputProps>(
-  ({ onComplete, hasError, numBoxes }, ref) => {
+  ({ onComplete, hasError, alphanumeric, numBoxes }, ref) => {
     const [otp, setOtp] = useState<string[]>(Array(numBoxes ?? 9).fill(""));
 
     useImperativeHandle(ref, () => ({
@@ -71,6 +72,7 @@ const OtpInput = forwardRef<unknown, OtpInputProps>(
             autoComplete="off"
             key={index}
             id={`otp-input-${index}`}
+            type={alphanumeric ? "text" : "number"}
             value={digit}
             onChange={(e) => handleChange(e.target.value, index)}
             onKeyDown={(e) => handleKeyDown(e, index)}


### PR DESCRIPTION
## Summary & Motivation
You can now pass in `openInPage` into the `authConfig` to replace the current page with the oAuth login. 
Otp input not properly changes the keyboard type on mobile depending on if the otp is alphanumeric or not

Requested by Spyre
## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
