### PR TITLE
sdk-react-native refreshSession bug fix

### DIFF
--- a/.changeset/eighty-clouds-check.md
+++ b/.changeset/eighty-clouds-check.md
@@ -7,4 +7,6 @@
 - The embedded key is now generated entirely in memory using `generateP256KeyPair`
 - Removed the need to store and immediately retrieve the private key from secure storage
 
-- `refreshSession` now accepts an optional parameter object
+- `refreshSession` now accepts a single optional parameter object
+
+- `StorageKeys.RefreshEmbeddedKey` is now deprecated and no longer used during session refresh

--- a/.changeset/eleven-jeans-flash.md
+++ b/.changeset/eleven-jeans-flash.md
@@ -1,0 +1,10 @@
+---
+"@turnkey/sdk-react-native": patch
+---
+
+- Eliminated a race condition in `refreshSession` that could throw:
+  `TurnkeyReactNativeError: Embedded key not found when refreshing the session`
+- The embedded key is now generated entirely in memory using `generateP256KeyPair`
+- Removed the need to store and immediately retrieve the private key from secure storage
+
+- `refreshSession` now accepts an optional parameter object

--- a/packages/sdk-react-native/README.md
+++ b/packages/sdk-react-native/README.md
@@ -72,7 +72,6 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
 To enable secure authentication, the following storage keys are used:
 
 - `@turnkey/embedded-key`: Stores the private key that corresponds to the public key used when initiating the session request to Turnkey.
-- `@turnkey/refresh-embedded-key`: Stores the private key that corresponds to the public key used when refreshing an active session.
 - `@turnkey/session`: Default session storage key, storing the session credentials, including the private key, public key, and expiry time, which are decrypted from the credential bundle after a session is created.
 - `@turnkey/session-keys`: Stores the list of stored session keys.
 - `@turnkey/selected-session`: Stores the currently selected session key.

--- a/packages/sdk-react-native/src/constants.ts
+++ b/packages/sdk-react-native/src/constants.ts
@@ -1,9 +1,11 @@
 export enum StorageKeys {
   DefaultSession = "@turnkey/session",
   EmbeddedKey = "@turnkey/embedded-key",
-  RefreshEmbeddedKey = "@turnkey/refresh-embedded-key",
   SessionKeys = "@turnkey/session-keys",
   SelectedSession = "@turnkey/selected-session",
+
+  // deprecrated
+  RefreshEmbeddedKey = "@turnkey/refresh-embedded-key",
 }
 
 export const OTP_AUTH_DEFAULT_EXPIRATION_SECONDS = 15 * 60;

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -627,9 +627,11 @@ export const TurnkeyProvider: FC<{
         );
       }
 
-      const targetPublicKey = await createEmbeddedKey({
-        sessionKey: StorageKeys.RefreshEmbeddedKey,
-      });
+      const {
+        publicKeyUncompressed: targetPublicKey,
+        privateKey: embeddedKey,
+      } = generateP256KeyPair();
+
       const currentClient = createClient(
         sessionToRefresh!.publicKey,
         sessionToRefresh!.privateKey,
@@ -650,16 +652,6 @@ export const TurnkeyProvider: FC<{
       if (!bundle) {
         throw new TurnkeyReactNativeError(
           "Failed to create read/write session when refreshing the session",
-        );
-      }
-
-      const embeddedKey = await getEmbeddedKey(
-        true,
-        StorageKeys.RefreshEmbeddedKey,
-      );
-      if (!embeddedKey) {
-        throw new TurnkeyReactNativeError(
-          "Embedded key not found when refreshing the session",
         );
       }
 

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -593,7 +593,7 @@ export const TurnkeyProvider: FC<{
    * This function refreshes an existing session by:
    *  - Retrieving the session using the provided or selected session key.
    *  - Verifying that the session is still valid.
-   *  - Generating a new embedded key (stored under StorageKeys.RefreshEmbeddedKey) for refreshing.
+   *  - Generating a new embedded key for refreshing.
    *  - Creating a new read/write session via the current session client.
    *  - Decrypting the returned credential bundle to derive new keys and expiry.
    *  - Fetching updated user information using the new credentials.
@@ -612,7 +612,7 @@ export const TurnkeyProvider: FC<{
     }: {
       expirationSeconds?: number;
       sessionKey?: string;
-    }): Promise<Session> => {
+    } = {}): Promise<Session> => {
       const keyToRefresh = sessionKey ?? (await getSelectedSessionKey());
       if (!keyToRefresh) {
         throw new TurnkeyReactNativeError(

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -75,7 +75,7 @@ export interface TurnkeyContextType {
     expirationSeconds?: number;
     sessionKey?: string;
   }) => Promise<Session>;
-  refreshSession: (params: {
+  refreshSession: (params?: {
     expirationSeconds?: number;
     sessionKey?: string;
   }) => Promise<Session>;


### PR DESCRIPTION
## Summary & Motivation

removed storing the embeddedKey in secure storage for refreshSession

Whats the reason?
- before we were creating it then getting it from secure storage right after, there is no need to store it
- Injective reported a `TurnkeyReactNativeError: Embedded key not found when refreshing the session` error sometimes. I am suspecting that since the two events are so close together on some slower devices this might be the cause.

slack thread can be found [here](https://turnkeycrypto.slack.com/archives/C08NZQ30FA6/p1746007618850369)

## How I Tested These Changes

## Did you add a changeset?

yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
