### PR TITLE
dep updates

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -45,7 +45,7 @@
     "@noble/curves": "1.4.0",
     "@noble/hashes": "1.4.0",
     "bs58check": "3.0.1",
-    "bs58": "^5.0.0"
+    "bs58": "6.0.0"
   },
   "devDependencies": {
     "jest": "29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1746,8 +1746,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       bs58:
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: 6.0.0
+        version: 6.0.0
       bs58check:
         specifier: 3.0.1
         version: 3.0.1
@@ -14966,16 +14966,16 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  /base-x@3.0.9:
-    resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
+  /base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
     dependencies:
       safe-buffer: 5.2.1
 
-  /base-x@4.0.0:
-    resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
+  /base-x@4.0.1:
+    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
 
-  /base-x@5.0.0:
-    resolution: {integrity: sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==}
+  /base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
     dev: false
 
   /base64-js@1.5.1:
@@ -15265,17 +15265,17 @@ packages:
   /bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
-      base-x: 3.0.9
+      base-x: 3.0.11
 
   /bs58@5.0.0:
     resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
     dependencies:
-      base-x: 4.0.0
+      base-x: 4.0.1
 
   /bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
     dependencies:
-      base-x: 5.0.0
+      base-x: 5.0.1
     dev: false
 
   /bs58check@2.1.2:
@@ -23151,7 +23151,7 @@ packages:
     resolution: {integrity: sha512-Qa3+9wKVvpL/xYtT6+wANsn0A1QcC5CT6IMZbRJZ/1lGt7gmwIfsrCuz1X0+LCEO7zgb+3UT1I1dc0k/5dwKQQ==}
     engines: {node: '>= 10'}
     dependencies:
-      base-x: 3.0.9
+      base-x: 3.0.11
       create-hash: 1.2.0
     dev: false
 


### PR DESCRIPTION
## Summary & Motivation
solve:
- https://github.com/advisories/GHSA-xq7p-g2vc-g82p

```
pnpm audit
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ Homograph attack allows Unicode lookalike characters   │
│                     │ to bypass validation.                                  │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ base-x                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ =5.0.0                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.0.1                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ examples/delegated-access >                            │
│                     │ @turnkey/sdk-server@link:../../packages/sdk-server >   │
│                     │ @turnkey/wallet-stamper@link:../../packages/wallet-    │
│                     │ stamper > @turnkey/crypto@link:../../packages/crypto > │
│                     │ bs58@5.0.0 > base-x@5.0.0                              │
│                     │                                                        │
│                     │ examples/delegated-access >                            │
│                     │ @turnkey/sdk-server@link:../../packages/sdk-server >   │
│                     │ @turnkey/wallet-stamper@link:../../packages/wallet-    │
│                     │ stamper > @turnkey/crypto@link:../../packages/crypto > │
│                     │ bs58check@3.0.1 > bs58@5.0.0 > base-x@5.0.0            │
│                     │                                                        │
│                     │ examples/deployer >                                    │
│                     │ @turnkey/ethers@link:../../packages/ethers >           │
│                     │ @turnkey/sdk-browser@link:../../packages/sdk-browser > │
│                     │ @turnkey/crypto@link:../../packages/crypto >           │
│                     │ bs58@5.0.0 > base-x@5.0.0                              │
│                     │                                                        │
│                     │ ... Found 444 paths, run `pnpm why base-x` for more    │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-xq7p-g2vc-g82p      │
```

## How I Tested These Changes
`pnpm audit`

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
