### PR TITLE
Return ActiveSession from authentication methods

### DIFF
--- a/.changeset/blue-adults-exist.md
+++ b/.changeset/blue-adults-exist.md
@@ -1,0 +1,90 @@
+---
+"@turnkey/sdk-browser": major
+"@turnkey/sdk-react": major
+---
+
+## @turnkey/sdk-browser
+
+the following SDK Browser client authentication methods will now return the `ActiveSession`
+
+`refreshSession()`
+`loginWithBundle()`
+`loginWithSession()`
+`loginWithPasskey()`
+`loginWithWallet()`
+`loginWithReadWriteSession()`
+`loginWithAuthBundle()`
+
+the `ActiveSession` type contains the following information:
+
+```ts
+export type ActiveSession = {
+  session: Session;
+  client: AuthClient;
+};
+
+/**
+ * The type of AuthClient used to authenticate the user.
+ */
+export enum AuthClient {
+  Passkey = "passkey",
+  Wallet = "wallet",
+  Iframe = "iframe",
+}
+
+export enum SessionType {
+  READ_ONLY = "SESSION_TYPE_READ_ONLY",
+  READ_WRITE = "SESSION_TYPE_READ_WRITE",
+}
+
+export type Session = {
+  sessionType: SessionType;
+  userId: string;
+  username?: string;
+  organizationId: string;
+  organizationName?: string;
+  expiry: number; // Unix timestamp representing the expiry of the session set by the server
+  token: string; // credentialBundle (read-write) or read token
+};
+```
+
+## @turnkey/sdk-react
+
+Updated OTP Verification components to default to a numeric OTP code with a length of 6.
+The OTP Verification Code can be configured in the following ways
+
+### `<Auth />` Component
+
+Via the `otpConfig` prop
+
+```tsx
+
+export interface OtpConfig {
+  otpLength?: number;
+  alphanumeric?: boolean;
+}
+
+<Auth
+  authConfig={authConfig}
+  configOrder={configOrder}
+  {...}
+  otpConfig={{
+    otpLength: 9,
+    alphanumeric: true
+  }}
+/>
+```
+
+### `<OtpVerification />` Component
+
+Via the `numBoxes` prop
+
+```tsx
+<OtpVerification
+  type={emailInput ? OtpType.Email : OtpType.Sms}
+  otpId={otpId!}
+  onValidateSuccess={handleOtpSuccess}
+  {...}
+  numBoxes={9}
+/>
+```

--- a/examples/react-components/src/app/dashboard/page.tsx
+++ b/examples/react-components/src/app/dashboard/page.tsx
@@ -308,7 +308,7 @@ export default function Dashboard() {
             return;
           }
 
-          await authIframeClient.injectCredentialBundle(session!.token);
+          await authIframeClient?.loginWithSession(session);
 
           const suborgId = session?.organizationId;
           setSuborgId(suborgId!);

--- a/examples/react-components/src/app/dashboard/page.tsx
+++ b/examples/react-components/src/app/dashboard/page.tsx
@@ -1094,6 +1094,7 @@ export default function Dashboard() {
               otpId={otpId!}
               onValidateSuccess={handleOtpSuccess}
               onResendCode={emailInput ? handleResendEmail : handleResendSms}
+              numBoxes={6}
             />
           </Box>
         </Modal>

--- a/examples/react-components/src/app/page.tsx
+++ b/examples/react-components/src/app/page.tsx
@@ -302,6 +302,9 @@ export default function AuthPage() {
           onAuthSuccess={handleAuthSuccess}
           onError={(errorMessage: string) => toast.error(errorMessage)}
           customSmsMessage={"Your Turnkey Demo OTP is {{.OtpCode}}"}
+          otpConfig={{
+            otpLength: 6,
+          }}
         />
       </div>
       <div>

--- a/packages/sdk-browser/src/__types__/base.ts
+++ b/packages/sdk-browser/src/__types__/base.ts
@@ -25,9 +25,16 @@ export enum SessionType {
 export type Session = {
   sessionType: SessionType;
   userId: string;
+  username?: string;
   organizationId: string;
+  organizationName?: string;
   expiry: number; // Unix timestamp representing the expiry of the session set by the server
   token: string; // credentialBundle (read-write) or read token
+};
+
+export type ActiveSession = {
+  session: Session;
+  client: AuthClient;
 };
 
 /**

--- a/packages/sdk-react/src/components/auth/OtpVerification.tsx
+++ b/packages/sdk-react/src/components/auth/OtpVerification.tsx
@@ -36,7 +36,7 @@ const OtpVerification: React.FC<OtpVerificationProps> = ({
   sessionLengthSeconds,
   onValidateSuccess,
   onResendCode,
-  numBoxes,
+  numBoxes = 6, // default to 6 boxes
 }) => {
   const { authIframeClient } = useTurnkey();
 

--- a/packages/sdk-react/src/components/auth/otp.tsx
+++ b/packages/sdk-react/src/components/auth/otp.tsx
@@ -9,12 +9,12 @@ interface OtpInputProps {
 }
 
 const OtpInput = forwardRef<unknown, OtpInputProps>(
-  ({ onComplete, hasError, alphanumeric, numBoxes }, ref) => {
-    const [otp, setOtp] = useState<string[]>(Array(numBoxes ?? 9).fill(""));
+  ({ onComplete, hasError, alphanumeric, numBoxes = 6 }, ref) => {
+    const [otp, setOtp] = useState<string[]>(Array(numBoxes).fill(""));
 
     useImperativeHandle(ref, () => ({
       resetOtp() {
-        setOtp(Array(numBoxes ?? 9).fill(""));
+        setOtp(Array(numBoxes).fill(""));
         const firstInput = document.getElementById("otp-input-0");
         if (firstInput) (firstInput as HTMLInputElement).focus();
       },
@@ -33,7 +33,7 @@ const OtpInput = forwardRef<unknown, OtpInputProps>(
         }
 
         // Move focus to the next box if current is filled
-        const count = numBoxes ? numBoxes - 1 : 8;
+        const count = numBoxes - 1;
         if (value && index < count) {
           const nextInput = document.getElementById(`otp-input-${index + 1}`);
           if (nextInput) (nextInput as HTMLInputElement).focus();
@@ -52,7 +52,7 @@ const OtpInput = forwardRef<unknown, OtpInputProps>(
       const pasteData = event.clipboardData
         .getData("Text")
         .replace(/[^a-zA-Z0-9]/g, "");
-      if (pasteData.length === (numBoxes ?? 9)) {
+      if (pasteData.length === numBoxes) {
         const newOtp = pasteData.split("");
         setOtp(newOtp);
         onComplete(newOtp.join(""));
@@ -110,7 +110,7 @@ const OtpInput = forwardRef<unknown, OtpInputProps>(
         ))}
       </Box>
     );
-  },
+  }
 );
 
 export default OtpInput;

--- a/packages/sdk-react/src/components/auth/otp.tsx
+++ b/packages/sdk-react/src/components/auth/otp.tsx
@@ -110,7 +110,7 @@ const OtpInput = forwardRef<unknown, OtpInputProps>(
         ))}
       </Box>
     );
-  }
+  },
 );
 
 export default OtpInput;


### PR DESCRIPTION
## Summary & Motivation

the following SDK Browser client authentication methods will now return the `ActiveSession`

- `refreshSession()`
- `loginWithBundle()`
- `loginWithSession()`
- `loginWithPasskey()`
- `loginWithWallet()`
- `loginWithReadWriteSession()`
- `loginWithAuthBundle()`

the `ActiveSession` type contains the following information:

```ts
export type ActiveSession = {
  session: Session;
  client: AuthClient;
};
```

Updated the `<Auth />` and `<OtpVerification />` components to default to a numeric OTP code with a length of 6.

## How I Tested These Changes

locally via `examples/email-auth` and `examples/react-components`

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
