### PR TITLE
remove browser spin buttons from number input in auth component

### DIFF
--- a/.changeset/three-beers-check.md
+++ b/.changeset/three-beers-check.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react": patch
+---
+
+Updated the styling of the OtpInput component in the Auth component to remove spinner buttons from numeric inputs.

--- a/packages/sdk-react/src/components/auth/otp.tsx
+++ b/packages/sdk-react/src/components/auth/otp.tsx
@@ -105,6 +105,16 @@ const OtpInput = forwardRef<unknown, OtpInputProps>(
                   border: "1px solid",
                 },
               },
+              // this removes the spin buttons from the number input
+              "& input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button":
+                {
+                  "-webkit-appearance": "none",
+                  margin: 0,
+                },
+              "& input[type=number]": {
+                // for Firefox
+                "-moz-appearance": "textfield",
+              },
             }}
           />
         ))}


### PR DESCRIPTION
## Summary & Motivation

sdk-react auth component update

before:
<img width="507" alt="image" src="https://github.com/user-attachments/assets/1dc6e975-047c-420e-97d4-21ba11a07b0b" />


after:
<img width="525" alt="image" src="https://github.com/user-attachments/assets/37d038f8-f262-4bd0-afee-b428018605e3" />

tested on chrome, safari, firefox. All good 👍 

## How I Tested These Changes

## Did you add a changeset?

yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
