### PR TITLE
remove nextjs dependency from sdk-server

### DIFF
--- a/.changeset/twenty-ants-yawn.md
+++ b/.changeset/twenty-ants-yawn.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/sdk-server": patch
+---
+
+Remove unused Next.js dependency
+- while the `"use server"` directive in `actions.ts` is to be used specifically with Next, removing it from this package (`@turnkey/sdk-server`) is fine, though applications *using* this package will need Next.js

--- a/.changeset/twenty-ants-yawn.md
+++ b/.changeset/twenty-ants-yawn.md
@@ -3,4 +3,5 @@
 ---
 
 Remove unused Next.js dependency
-- while the `"use server"` directive in `actions.ts` is to be used specifically with Next, removing it from this package (`@turnkey/sdk-server`) is fine, though applications *using* this package will need Next.js
+
+- while the `"use server"` directive in `actions.ts` is to be used specifically with Next, removing it from this package (`@turnkey/sdk-server`) is fine, though applications _using_ this package will need Next.js

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -49,8 +49,7 @@
     "@turnkey/http": "workspace:*",
     "@turnkey/wallet-stamper": "workspace:*",
     "buffer": "^6.0.3",
-    "cross-fetch": "^3.1.5",
-    "next": "^15.2.3"
+    "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2049,9 +2049,6 @@ importers:
       cross-fetch:
         specifier: ^3.1.5
         version: 3.1.5
-      next:
-        specifier: ^15.2.3
-        version: 15.2.3(@babel/core@7.26.9)(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -21082,51 +21079,6 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next@15.2.3(@babel/core@7.26.9)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 15.2.3
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.15
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001700
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.26.9)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.2.3
-      '@next/swc-darwin-x64': 15.2.3
-      '@next/swc-linux-arm64-gnu': 15.2.3
-      '@next/swc-linux-arm64-musl': 15.2.3
-      '@next/swc-linux-x64-gnu': 15.2.3
-      '@next/swc-linux-x64-musl': 15.2.3
-      '@next/swc-win32-arm64-msvc': 15.2.3
-      '@next/swc-win32-x64-msvc': 15.2.3
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
-
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -24244,24 +24196,6 @@ packages:
       '@babel/core': 7.26.9
       client-only: 0.0.1
       react: 18.2.0
-    dev: false
-
-  /styled-jsx@5.1.6(@babel/core@7.26.9)(react@18.3.1):
-    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
-      '@babel/core': 7.26.9
-      client-only: 0.0.1
-      react: 18.3.1
     dev: false
 
   /stylehacks@5.1.1(postcss@8.4.38):


### PR DESCRIPTION
## Summary & Motivation
$title

Q: https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/actions.ts
actions.ts will still work right? I assume so but just a sanity check. It has "use server"  at the top

A: Good catch; I believe it should still work because the “parent” application should be able to interpret it correctly, as long as that application has next installed

## How I Tested These Changes
- Local example: `examples/react-components`

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
