### PR TITLE
feat: add debugging to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,15 +142,24 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Version and Publish SDK packages to npm
+      - name: Check for changesets
+        run: |
+          if [ -z "$(ls -A .changeset/*.md 2>/dev/null)" ]; then
+            echo "No changesets found, exiting"
+            exit 0
+          fi
+
+      - name: Version and Publish
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           version: pnpm changeset version # updates package versions and changelogs
-          publish: pnpm publish # publish to npm
+          publish: |
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+            pnpm publish --no-git-checks
+            rm .npmrc
           createGithubReleases: true
           commit: "chore: release packages"
           title: "Release ${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for changelog links
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # for npm publish
-

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/sdk-types"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary & Motivation
 - adding debugging to ensure chaangeset is present to avoid PR creation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
