### PR TITLE
Configure Git User for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,10 @@ jobs:
             echo "No changesets found, exiting"
             exit 0
           fi
+      - name: Configure Git User
+        run: |
+          git config user.name "tkhq-deploy"
+          git config user.email "github@turnkey.engineering"
 
       - name: Version and Publish
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
@@ -160,6 +164,7 @@ jobs:
           createGithubReleases: true
           commit: "chore: release packages"
           title: "Release ${{ github.ref_name }}"
+          setupGitUser: false # Disable default Git user setup
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for changelog links
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # for npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,6 @@ jobs:
             rm .npmrc
           createGithubReleases: true
           commit: "chore: release packages"
-          title: "Release ${{ github.ref_name }}"
           setupGitUser: false # Disable default Git user setup
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for changelog links


### PR DESCRIPTION
## Summary & Motivation
 - set github user to be used during release workflow
 - remove title to prevent PR creation
 
## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
