### PR TITLE
chore: use github-api for the commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           find packages -name CHANGELOG.md -exec cat {} \; >> RELEASE_NOTES.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 #v2.2.2
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,17 +153,46 @@ jobs:
           git config user.name "tkhq-deploy"
           git config user.email "github@turnkey.engineering"
 
-      - name: Version and Publish
-        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
+      - name: Version packages
+        uses: changesets/action@e0538e686673de0265c8a3e2904b8c76beaa43fd # v1.5.2
         with:
           version: pnpm changeset version # updates package versions and changelogs
-          publish: |
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-            pnpm publish --no-git-checks
-            rm .npmrc
-          createGithubReleases: true
           commit: "chore: release packages"
-          setupGitUser: false # Disable default Git user setup
+          setupGitUser: false
+          createGithubReleases: true
+          commitMode: "github-api"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for changelog links
+
+      - name: Publish packages
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+          pnpm publish --no-git-checks
+          rm .npmrc
+        env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # for npm publish
+
+      - name: Combine changelogs
+        run: |
+          echo -e "# Changelog\n" > RELEASE_NOTES.md
+          find packages -name CHANGELOG.md -exec cat {} \; >> RELEASE_NOTES.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body_path: RELEASE_NOTES.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push changes to release branch
+        run: |
+          git checkout -b release/${{ github.ref_name }}
+          git add .
+          git commit -m "chore: release ${{ github.ref_name }}"
+          git push origin release/${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary & Motivation

- use `github-api` for `commitMode` to leverage `tkhq-deploy` perms
- separate version, publish, and github release steps

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
