### PR TITLE
Added onSessionEmpty callback when initial TurnekyContext effect doesn't detect any valid session

### DIFF
--- a/.changeset/witty-rabbits-relax.md
+++ b/.changeset/witty-rabbits-relax.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react-native": patch
+---
+
+There is no information from the context, that there is no active session available from the context. I added a callback function, which is invoked when useEffect in TurnkeyContext doesn't detect any active session.

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -119,6 +119,7 @@ export interface TurnkeyConfig {
   onSessionSelected?: (session: Session) => void;
   onSessionExpired?: (session: Session) => void;
   onSessionCleared?: (session: Session) => void;
+  onSessionEmpty?: () => void;
   onSessionExpiryWarning?: (session: Session) => void;
 }
 
@@ -185,6 +186,8 @@ export const TurnkeyProvider: FC<{
             selectedSession ?? ({ key: selectedSessionKey } as Session),
           );
         }
+      } else {
+        config.onSessionEmpty?.()
       }
     };
 


### PR DESCRIPTION
## Summary & Motivation

There is no information from the TurnkeyContext, that there is no active session available from the context. I added a callback function, which is invoked when useEffect in TurnkeyContext doesn't detect any active session.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
