### PR TITLE
Release Workflow Polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # allows manual invocation
   push:
     tags:
-      - "test-v*.*.*" # triggers on tags like v1.0.0
+      - "v*.*.*" # triggers on tags like v1.0.0
 
 permissions:
   contents: write
@@ -60,9 +60,6 @@ jobs:
           name: build-artifacts
           path: packages/
 
-      - name: Debug Foundry
-        run: anvil --version || echo "anvil not found"
-
       - name: Test (preprod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
         env:
@@ -96,18 +93,6 @@ jobs:
         with:
           name: build-artifacts
           path: packages/
-
-      - name: Debug Foundry setup
-        run: |
-          echo "Checking Foundry binaries:"
-          ls -la ~/.foundry/bin || echo "No Foundry binaries found"
-          which anvil || echo "anvil not found"
-          echo "PATH contents:"
-          echo $PATH
-          echo "GITHUB_PATH contents:"
-          cat $GITHUB_PATH || echo "No GITHUB_PATH file"
-          anvil --version || echo "anvil not installed"
-        shell: bash
 
       - name: Test (prod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
@@ -146,12 +131,6 @@ jobs:
           name: build-artifacts
           path: packages/
 
-      - name: Debug changeset config
-        run: |
-          ls -la .changeset/
-          cat .changeset/config.json || echo "config.json not found"
-          ls -la .changeset/custom-changelog.js || echo "custom-changelog.js not found"
-
       - name: Debug npm config
         run: |
           echo "NPM_TOKEN is set: ${NPM_TOKEN:+set}"
@@ -180,21 +159,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Dry Run Publish packages
+      - name: Publish packages to NPM and GitHub (dry run)
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> .npmrc
           pnpm publish -r --dry-run --no-git-checks
           rm .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish packages
+      - name: Publish packages to NPM
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-          pnpm publish -r --no-git-checks
+          pnpm publish -r --no-git-checks --report-summary
+          mv publish-summary.json publish-npm.txt
+          cat publish-npm.txt
           rm .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish packages to GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > .npmrc
+          pnpm publish -r --no-git-checks --report-summary
+          mv publish-summary.json publish-github.txt
+          cat publish-github.txt
+          rm .npmrc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push changes to release branch
         run: |

--- a/packages/api-key-stamper/package.json
+++ b/packages/api-key-stamper/package.json
@@ -30,12 +30,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/api-key-stamper"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -29,12 +29,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/cosmjs"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -20,12 +20,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/crypto"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -39,12 +39,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "eip-1193-provider"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -20,12 +20,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/encoding"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -29,12 +29,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/ethers"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -27,12 +27,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/http"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/iframe-stamper/package.json
+++ b/packages/iframe-stamper/package.json
@@ -29,12 +29,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/iframe-stamper"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/react-native-passkey-stamper/package.json
+++ b/packages/react-native-passkey-stamper/package.json
@@ -32,12 +32,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/react-native-passkey-stamper"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -27,12 +27,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/sdk-browser"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -27,12 +27,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/sdk-react-native"
   },
   "files": [
     "dist/",
     "CHANGELOG.md",
+    "README.md",
     "README.md"
   ],
   "publishConfig": {

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -32,12 +32,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/sdk-react"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -27,12 +27,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/sdk-server"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -5,7 +5,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "scripts": {
     "build": "rollup -c",

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -30,12 +30,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/solana"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/telegram-cloud-storage-stamper/package.json
+++ b/packages/telegram-cloud-storage-stamper/package.json
@@ -30,12 +30,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/telegram-cloud-storage-stamper"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -32,12 +32,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/viem"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/wallet-stamper/package.json
+++ b/packages/wallet-stamper/package.json
@@ -30,12 +30,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/wallet-stamper"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/webauthn-stamper/package.json
+++ b/packages/webauthn-stamper/package.json
@@ -29,12 +29,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkhq/sdk.git",
+    "url": "git+https://github.com/tkhq/sdk.git",
     "directory": "packages/webauthn-stamper"
   },
   "files": [
     "dist/",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary & Motivation

- add version comment for `softprops/action-gh-release`
- updated the release workflow to run using a tag format of `v*.*.*` vs `test-v*.*.*`
- removed workflow debugging steps
- added step to publish packages to [GitHub Packages](https://github.com/orgs/tkhq/packages?repo_name=sdk)
- updated `packages/*/package.json` 
  - `repository.url` to use NPM convention of `"git+https://github.com/tkhq/sdk.git"` vs `"https://github.com/tkhq/sdk.git"`
  - included package `README.md` in published artifacts

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
