### PR TITLE
chore: create separate jobs for test suites

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -26,21 +26,34 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck-all
 
-      - name: Test (prod)
-        run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
-        env:
-          API_PUBLIC_KEY: ${{ secrets.API_PUBLIC_KEY }}
-          API_PRIVATE_KEY: ${{ secrets.API_PRIVATE_KEY }}
-          BASE_URL: "https://api.turnkey.com"
-          ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
-          PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
-          EXPECTED_PRIVATE_KEY_ETH_ADDRESS: ${{ secrets.EXPECTED_PRIVATE_KEY_ETH_ADDRESS }}
-          EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2: ${{ secrets.EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2 }}
-          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS: ${{ secrets.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS }}
-          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2: ${{ secrets.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2 }}
-          BANNED_TO_ADDRESS: "0x6F72eDB2429820c2A0606a9FC3cA364f5E9b2375"
-          SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
-          WALLET_ID: ${{ secrets.WALLET_ID }}
+      - name: Prettier
+        run: pnpm run prettier-all:check
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: build-artifacts
+          path: |
+            packages/*/dist/**
+          retention-days: 1
+
+  test-pre-prod:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: build-artifacts
+          path: packages/
 
       - name: Test (preprod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
@@ -57,9 +70,57 @@ jobs:
           BANNED_TO_ADDRESS: ${{ secrets.PREPROD_BANNED_TO_ADDRESS }}
           SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
           WALLET_ID: ${{ secrets.PREPROD_WALLET_ID }}
+  test-prod:
+    runs-on: ubuntu-latest
+    needs: test-pre-prod
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Prettier
-        run: pnpm run prettier-all:check
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: build-artifacts
+          path: packages/
+
+      - name: Test (prod)
+        run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
+        env:
+          API_PUBLIC_KEY: ${{ secrets.API_PUBLIC_KEY }}
+          API_PRIVATE_KEY: ${{ secrets.API_PRIVATE_KEY }}
+          BASE_URL: "https://api.turnkey.com"
+          ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
+          PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS: ${{ secrets.EXPECTED_PRIVATE_KEY_ETH_ADDRESS }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2: ${{ secrets.EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2 }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS: ${{ secrets.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2: ${{ secrets.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2 }}
+          BANNED_TO_ADDRESS: "0x6F72eDB2429820c2A0606a9FC3cA364f5E9b2375"
+          SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
+          WALLET_ID: ${{ secrets.WALLET_ID }}
+
+  validate-version:
+    runs-on: ubuntu-latest
+    needs: test-prod
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: build-artifacts
+          path: packages/
 
       # This is to catch when someone forgets to run `pnpm run version` after bumping package versions
       # If this happens this script will run and make git dirty

--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -29,6 +29,23 @@ jobs:
       - name: Prettier
         run: pnpm run prettier-all:check
 
+      # This is to catch when someone forgets to run `pnpm run version` after bumping package versions
+      # If this happens this script will run and make git dirty
+      - name: Run version script
+        run: pnpm run version
+
+      - name: Ensure git is clean
+        run: |
+          if [ -z "$( git status --porcelain )" ]; then
+            echo "Git is clean!"
+            exit 0
+          else
+            echo "Git is dirty!"
+            git add -A
+            git --no-pager diff HEAD
+            exit 1
+          fi
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -70,6 +87,7 @@ jobs:
           BANNED_TO_ADDRESS: ${{ secrets.PREPROD_BANNED_TO_ADDRESS }}
           SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
           WALLET_ID: ${{ secrets.PREPROD_WALLET_ID }}
+
   test-prod:
     runs-on: ubuntu-latest
     needs: test-pre-prod
@@ -103,38 +121,3 @@ jobs:
           BANNED_TO_ADDRESS: "0x6F72eDB2429820c2A0606a9FC3cA364f5E9b2375"
           SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
           WALLET_ID: ${{ secrets.WALLET_ID }}
-
-  validate-version:
-    runs-on: ubuntu-latest
-    needs: test-prod
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      # Install and cache JS toolchain and dependencies (node_modules)
-      - name: Setup JS
-        uses: ./.github/actions/js-setup
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: build-artifacts
-          path: packages/
-
-      # This is to catch when someone forgets to run `pnpm run version` after bumping package versions
-      # If this happens this script will run and make git dirty
-      - name: Run version script
-        run: pnpm run version
-
-      - name: Ensure git is clean
-        run: |
-          if [ -z "$( git status --porcelain )" ]; then
-            echo "Git is clean!"
-            exit 0
-          else
-            echo "Git is dirty!"
-            git add -A
-            git --no-pager diff HEAD
-            exit 1
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Build
         run: pnpm run build-all
 
+      - name: Typecheck
+        run: pnpm run typecheck-all
+
+      - name: Prettier
+        run: pnpm run prettier-all:check
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -35,12 +41,6 @@ jobs:
           path: |
             packages/*/dist/**
           retention-days: 1
-
-      - name: Typecheck
-        run: pnpm run typecheck-all
-
-      - name: Prettier
-        run: pnpm run prettier-all:check
 
   test-pre-prod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary & Motivation

- created separate workflow jobs for `test-pre-prod` and `test-prod` to reduce flakiness

## How I Tested These Changes

- Tested via [GitHub Action](https://github.com/tkhq/sdk/actions/runs/15123000969)

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
