### PR TITLE
Allow external keypair reset indexedDbStamper (enables refreshSession for RW)

### DIFF
--- a/.changeset/proud-keys-whisper.md
+++ b/.changeset/proud-keys-whisper.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/encoding": minor
+---
+
+Add pointEncode function

--- a/.changeset/sweet-onions-design.md
+++ b/.changeset/sweet-onions-design.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/indexed-db-stamper": minor
+"@turnkey/sdk-browser": patch
+---
+
+Allow external keys to be passed to resetKeyPair in the indexedDbClient/Stamper enabling refreshing RW sessions

--- a/examples/react-components/src/app/dashboard/page.tsx
+++ b/examples/react-components/src/app/dashboard/page.tsx
@@ -280,11 +280,10 @@ export default function Dashboard() {
   };
 
   const handleDeleteAccount: any = async () => {
-    await indexedDbClient?.refreshSession({});
-    // await indexedDbClient?.deleteSubOrganization({
-    //   deleteWithoutExport: true,
-    // });
-    // await handleLogout();
+    await indexedDbClient?.deleteSubOrganization({
+      deleteWithoutExport: true,
+    });
+    await handleLogout();
   };
 
   const handleLogout: any = async () => {

--- a/examples/react-components/src/app/dashboard/page.tsx
+++ b/examples/react-components/src/app/dashboard/page.tsx
@@ -280,10 +280,11 @@ export default function Dashboard() {
   };
 
   const handleDeleteAccount: any = async () => {
-    await indexedDbClient?.deleteSubOrganization({
-      deleteWithoutExport: true,
-    });
-    await handleLogout();
+    await indexedDbClient?.refreshSession({});
+    // await indexedDbClient?.deleteSubOrganization({
+    //   deleteWithoutExport: true,
+    // });
+    // await handleLogout();
   };
 
   const handleLogout: any = async () => {

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -3,6 +3,26 @@
  */
 export const DEFAULT_JWK_MEMBER_BYTE_LENGTH = 32;
 
+export function pointEncode(raw: Uint8Array): Uint8Array {
+  if (raw.length !== 65 || raw[0] !== 0x04) {
+    throw new Error("Invalid uncompressed P-256 key");
+  }
+
+  const x = raw.slice(1, 33);
+  const y = raw.slice(33, 65);
+
+  if (x.length !== 32 || y.length !== 32) {
+    throw new Error("Invalid x or y length");
+  }
+
+  const prefix = (y[31]! & 1) === 0 ? 0x02 : 0x03;
+
+  const compressed = new Uint8Array(33);
+  compressed[0] = prefix;
+  compressed.set(x, 1);
+  return compressed;
+}
+
 export function stringToBase64urlString(input: string): string {
   // string to base64 -- we do not rely on the browser's btoa since it's not present in React Native environments
   const base64String = btoa(input);

--- a/packages/sdk-browser/src/__clients__/browser-clients.ts
+++ b/packages/sdk-browser/src/__clients__/browser-clients.ts
@@ -132,7 +132,7 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
 
   /**
    * Attempts to refresh an existing Session. This method infers the current user's organization ID and target userId.
-   * This will use a passkeyStamper for `READ_ONLY` sessions or an `indexedDbStamper` for `READ_WRITE` sessions. The indexedDb
+   * This will use a passkeyStamper for `READ_ONLY` sessions or an `indexedDbStamper` for `READ_WRITE` sessions.
    *
    * @param RefreshSessionParams
    *   @param params.sessionType - The type of session that is being refreshed
@@ -170,7 +170,7 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
           );
         }
 
-        // 1️⃣ Generate new key pair (non-extractable)
+        // Generate new key pair (non-extractable)
         const newKeyPair = await crypto.subtle.generateKey(
           {
             name: "ECDSA",
@@ -180,23 +180,23 @@ export class TurnkeyBrowserClient extends TurnkeyBaseClient {
           ["sign", "verify"],
         );
 
-        // 2️⃣ Compress public key
+        // Compress public key
         const rawPubKey = new Uint8Array(
           await crypto.subtle.exportKey("raw", newKeyPair.publicKey),
         );
         const compressedPubKey = pointEncode(rawPubKey);
         const compressedHex = uint8ArrayToHexString(compressedPubKey);
 
-        // 3️⃣ Stamp login with new public key
+        // Stamp login with new public key
         const sessionResponse = await this.stampLogin({
           publicKey: compressedHex,
           expirationSeconds,
         });
 
-        // 4️⃣ Adopt new key into IndexedDb stamper
+        // Adopt new key into IndexedDb stamper
         await this.resetKeyPair(newKeyPair);
 
-        // 5️⃣ Store session
+        // Store session
         await storeSession(sessionResponse.session, AuthClient.IndexedDb);
       } else {
         throw new Error(`Invalid session type passed: ${sessionType}`);


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
