### PR TITLE
chore: update release tag regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch: # allows manual invocation
   push:
     tags:
-      - 'v[0-9]{4}\.(0[1-9]|1[0-2]|[1-9])\.*' # triggers on tags like vYYYY.M.# or vYYYY.MM.# (e.g. v2025.10.1, v2025.3.231, v2025.03.10, v2025.03.hotfix-1)
+      - "v[0-9]{4}.[0-1][0-9].*" # triggers on tags like vYYYY.M.# or vYYYY.MM.# (e.g. v2025.10.1, v2025.3.231, v2025.03.10, v2025.03.hotfix-1)
+      - "v[0-9]{4}.[1-9].*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary & Motivation

updated release tag format to trigger on tags like vYYYY.M.# or vYYYY.MM.# (e.g. v2025.10.1, v2025.3.231, v2025.03.10, v2025.03.hotfix-1)

 - "v[0-9]{4}.[0-1][0-9].*"
 - "v[0-9]{4}.[1-9].*"

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
