### PR TITLE
Manually version packages due to NPM publish

### DIFF
--- a/.changeset/poor-trainers-burn.md
+++ b/.changeset/poor-trainers-burn.md
@@ -1,8 +1,0 @@
----
-"@turnkey/sdk-browser": minor
-"@turnkey/sdk-react": minor
-"@turnkey/sdk-types": minor
-"@turnkey/sdk-server": patch
----
-
-Update @turnkey/sdk-types readme and install dependency in packages with common types

--- a/examples/delegated-access/CHANGELOG.md
+++ b/examples/delegated-access/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/delegated-access
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-server@4.0.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/examples/delegated-access/package.json
+++ b/examples/delegated-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/delegated-access",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "build": "pnpm -w run build-all",

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/cosmjs
 
+## 0.7.10
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-browser@5.1.0
+  - @turnkey/sdk-server@4.0.1
+
 ## 0.7.9
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/eip-1193-provider
 
+## 3.3.10
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-browser@5.1.0
+
 ## 3.3.9
 
 ### Patch Changes

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/src/version.ts
+++ b/packages/eip-1193-provider/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/eip-1193-provider@3.3.9";
+export const VERSION = "@turnkey/eip-1193-provider@3.3.10";

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/ethers
 
+## 1.1.27
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-browser@5.1.0
+  - @turnkey/sdk-server@4.0.1
+
 ## 1.1.26
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/CHANGELOG.md
+++ b/packages/sdk-browser/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @turnkey/sdk-browser
 
+## 5.1.0
+
+### Minor Changes
+
+- Update @turnkey/sdk-types readme and install dependency in packages with common types
+
+- [#650](https://github.com/tkhq/sdk/pull/650) [`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412) Author [@turnekybc](https://github.com/turnekybc) - Update @turnkey/sdk-types readme and install dependency in packages with common types
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-types@0.1.0
+
 ## 5.0.0
 
 ### Major Changes

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-browser",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/src/__generated__/version.ts
+++ b/packages/sdk-browser/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-browser@5.0.0";
+export const VERSION = "@turnkey/sdk-browser@5.1.0";

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @turnkey/sdk-react
 
+## 5.1.0
+
+### Minor Changes
+
+- Update @turnkey/sdk-types readme and install dependency in packages with common types
+
+- [#650](https://github.com/tkhq/sdk/pull/650) [`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412) Author [@turnekybc](https://github.com/turnekybc) - Update @turnkey/sdk-types readme and install dependency in packages with common types
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-browser@5.1.0
+  - @turnkey/sdk-types@0.1.0
+  - @turnkey/sdk-server@4.0.1
+
 ## 5.0.2
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/CHANGELOG.md
+++ b/packages/sdk-server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/sdk-server
 
+## 4.0.1
+
+### Patch Changes
+
+- Update @turnkey/sdk-types readme and install dependency in packages with common types
+
+- [#650](https://github.com/tkhq/sdk/pull/650) [`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412) Author [@turnekybc](https://github.com/turnekybc) - Update @turnkey/sdk-types readme and install dependency in packages with common types
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-server",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/src/__generated__/version.ts
+++ b/packages/sdk-server/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-server@4.0.0";
+export const VERSION = "@turnkey/sdk-server@4.0.1";

--- a/packages/sdk-types/CHANGELOG.md
+++ b/packages/sdk-types/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/sdk-types
 
+## 0.1.0
+
+### Minor Changes
+
+- Update @turnkey/sdk-types readme and install dependency in packages with common types
+
+- [#650](https://github.com/tkhq/sdk/pull/650) [`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412) Author [@turnekybc](https://github.com/turnekybc) - Update @turnkey/sdk-types readme and install dependency in packages with common types
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-types",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/solana
 
+## 1.0.26
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-browser@5.1.0
+  - @turnkey/sdk-server@4.0.1
+
 ## 1.0.25
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/viem
 
+## 0.9.5
+
+### Patch Changes
+
+- Updated dependencies [[`27fe590`](https://github.com/tkhq/sdk/commit/27fe590cdc3eb6a8cde093eeefda2ee1cdc79412)]:
+  - @turnkey/sdk-browser@5.1.0
+  - @turnkey/sdk-server@4.0.1
+
 ## 0.9.4
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation
- The CI step to publish to NPM failed to complete successfully. The updated packages were published to NPM but the package.json's in the git repo were not versioned.
- This PR brings the versions back in line
  - https://www.npmjs.com/package/@turnkey/sdk-types?activeTab=versions latest version is 0.1.0
  - package.json version is 0.0.2

## How I Tested These Changes
- checked out latest from main locally
- ran `pnpm changeset version && pnpm run version`
- ran `corepack enable pnpm && pnpm install -r`
- ran `pnpm run clean-all && pnpm run build-all`

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
