### PR TITLE
export types and models from @turnkey/sdk-browser

### DIFF
--- a/.changeset/nine-shrimps-listen.md
+++ b/.changeset/nine-shrimps-listen.md
@@ -1,0 +1,7 @@
+---
+"@turnkey/sdk-browser": patch
+"@turnkey/wallet-stamper": patch
+"@turnkey/webauthn-stamper": patch
+---
+
+export types and models from @turnkey/sdk-browser

--- a/packages/sdk-browser/src/index.ts
+++ b/packages/sdk-browser/src/index.ts
@@ -120,11 +120,11 @@ export {
 /** @internal */
 export type { WalletAccount } from "./turnkey-helpers";
 
-export {
-  type TurnkeySDKClientConfig,
-  type TurnkeySDKBrowserConfig,
-  AuthClient,
-} from "./__types__/base";
+// Export all types and values from __types__/base
+export * from "./__types__/base";
+
+// Export all models from models
+export * from "@models";
 
 export { type Session, SessionType } from "@turnkey/sdk-types";
 


### PR DESCRIPTION
## Summary & Motivation

- export types and models declared in `@turnkey/sdk-browser` for better type support

## How I Tested These Changes

- locally via `examples/react-components`

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
