### PR TITLE
add optional timestampms

### DIFF
--- a/packages/solana/src/index.ts
+++ b/packages/solana/src/index.ts
@@ -61,6 +61,7 @@ export class TurnkeySigner {
     tx: Transaction | VersionedTransaction,
     fromAddress: string,
     organizationId?: string,
+    timestampMs?: number,
   ) {
     const fromKey = new PublicKey(fromAddress);
     const messageToSign: Buffer = this.getMessageToSign(tx);
@@ -68,6 +69,7 @@ export class TurnkeySigner {
       messageToSign.toString("hex"),
       fromAddress,
       organizationId ?? this.organizationId,
+      timestampMs,
     );
     const signature = `${signRawPayloadResult?.r}${signRawPayloadResult?.s}`;
 
@@ -84,11 +86,13 @@ export class TurnkeySigner {
     message: Uint8Array,
     fromAddress: string,
     organizationId?: string,
+    timestampMs?: number,
   ): Promise<Uint8Array> {
     const signRawPayloadResult = await this.signRawPayload(
       Buffer.from(message).toString("hex"),
       fromAddress,
       organizationId,
+      timestampMs,
     );
     return Buffer.from(
       `${signRawPayloadResult?.r}${signRawPayloadResult?.s}`,
@@ -107,6 +111,7 @@ export class TurnkeySigner {
     tx: Transaction | VersionedTransaction,
     fromAddress: string,
     organizationId?: string,
+    timestampMs?: number,
   ): Promise<Transaction | VersionedTransaction> {
     const payloadToSign = Buffer.from(
       tx.serialize({
@@ -119,6 +124,7 @@ export class TurnkeySigner {
       payloadToSign,
       fromAddress,
       organizationId,
+      timestampMs,
     );
 
     const decodedTransaction = Buffer.from(signedTransaction, "hex");
@@ -135,12 +141,13 @@ export class TurnkeySigner {
     unsignedTransaction: string,
     signWith: string,
     organizationId?: string,
+    timestampMs?: number
   ) {
     if (this.client instanceof TurnkeyClient) {
       const response = await this.client.signTransaction({
         type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
         organizationId: organizationId ?? this.organizationId,
-        timestampMs: String(Date.now()),
+        timestampMs: timestampMs ? String(timestampMs) : String(Date.now()),
         parameters: {
           signWith,
           unsignedTransaction,
@@ -175,12 +182,13 @@ export class TurnkeySigner {
     payload: string,
     signWith: string,
     organizationId?: string,
+    timestampMs?: number,
   ) {
     if (this.client instanceof TurnkeyClient) {
       const response = await this.client.signRawPayload({
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
         organizationId: organizationId ?? this.organizationId,
-        timestampMs: String(Date.now()),
+        timestampMs: timestampMs ? String(timestampMs) : String(Date.now()),
         parameters: {
           signWith,
           payload,
@@ -221,12 +229,13 @@ export class TurnkeySigner {
     payloads: string[],
     signWith: string,
     organizationId?: string,
+    timestampMs?: number,
   ) {
     if (this.client instanceof TurnkeyClient) {
       const response = await this.client.signRawPayloads({
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS",
         organizationId: organizationId ?? this.organizationId,
-        timestampMs: String(Date.now()),
+        timestampMs: timestampMs ? String(timestampMs) : String(Date.now()),
         parameters: {
           signWith,
           payloads,


### PR DESCRIPTION
## Summary & Motivation
A user ran into this error which is likely due to some client side date/time setting.
We want to be able to supply this param from a server timestamp to avoid this class of issue entirely. 

<img width="455" alt="Screenshot 2025-06-01 at 1 22 04 PM" src="https://github.com/user-attachments/assets/1eed4ede-7c7a-441f-a1f0-6504d0c5e449" />


## How I Tested These Changes
Using the local fork in our codebase

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
