### PR TITLE
"No runner registered" fix for turnkey/viem, cosmjs, eip-1193, ethers, solana

### DIFF
--- a/.changeset/fluffy-doors-film.md
+++ b/.changeset/fluffy-doors-film.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/http": patch
+---
+
+Exposed `isHttpClient` function for determining if a passed in client is from turnkey/http

--- a/.changeset/lucky-spiders-hammer.md
+++ b/.changeset/lucky-spiders-hammer.md
@@ -1,0 +1,9 @@
+---
+"@turnkey/eip-1193-provider": patch
+"@turnkey/cosmjs": patch
+"@turnkey/ethers": patch
+"@turnkey/solana": patch
+"@turnkey/viem": patch
+---
+
+Fix for `no runner registered` error when using mismatched versions of turnkey/http

--- a/packages/cosmjs/src/index.ts
+++ b/packages/cosmjs/src/index.ts
@@ -14,6 +14,7 @@ import {
   TurnkeyClient,
   TurnkeyActivityError,
   TurnkeyRequestError,
+  isHttpClient,
 } from "@turnkey/http";
 import type { TurnkeyBrowserClient } from "@turnkey/sdk-browser";
 import type { TurnkeyServerClient } from "@turnkey/sdk-server";
@@ -165,7 +166,7 @@ export class TurnkeyDirectWallet implements OfflineDirectSigner {
     const messageHex = toHex(message);
     let result;
 
-    if (this.client instanceof TurnkeyClient) {
+    if (isHttpClient(this.client)) {
       const { activity } = await this.client.signRawPayload({
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
         organizationId: this.organizationId,

--- a/packages/eip-1193-provider/src/turnkey.ts
+++ b/packages/eip-1193-provider/src/turnkey.ts
@@ -1,4 +1,4 @@
-import { TurnkeyClient } from "@turnkey/http";
+import { TurnkeyClient, isHttpClient } from "@turnkey/http";
 import type { TurnkeyBrowserClient } from "@turnkey/sdk-browser";
 import type {
   TSignRawPayloadResponse,
@@ -49,7 +49,7 @@ export async function signMessage({
 }): Promise<string> {
   let activityResponse;
 
-  if (client instanceof TurnkeyClient) {
+  if (isHttpClient(client)) {
     activityResponse = await client.signRawPayload({
       type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
       organizationId,
@@ -100,7 +100,7 @@ export async function signTransaction({
 }): Promise<string> {
   let activityResponse;
 
-  if (client instanceof TurnkeyClient) {
+  if (isHttpClient(client)) {
     activityResponse = await client.signTransaction({
       type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
       organizationId: organizationId,

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -24,6 +24,7 @@ import {
   assertActivityCompleted,
   assertNonNull,
   type TSignature,
+  isHttpClient,
 } from "@turnkey/http";
 import type { TurnkeyBrowserClient } from "@turnkey/sdk-browser";
 import type { TurnkeyServerClient } from "@turnkey/sdk-server";
@@ -108,7 +109,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
   private async _signTransactionImpl(
     unsignedTransaction: string,
   ): Promise<string> {
-    if (this.client instanceof TurnkeyClient) {
+    if (isHttpClient(this.client)) {
       const { activity } = await this.client.signTransaction({
         type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
         organizationId: this.organizationId,
@@ -234,7 +235,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
   async _signMessageImpl(message: string): Promise<string> {
     let result;
 
-    if (this.client instanceof TurnkeyClient) {
+    if (isHttpClient(this.client)) {
       const { activity } = await this.client.signRawPayload({
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
         organizationId: this.organizationId,

--- a/packages/http/src/base.ts
+++ b/packages/http/src/base.ts
@@ -6,6 +6,7 @@ import {
   getWebAuthnAssertion,
   TurnkeyCredentialRequestOptions,
 } from "./webauthn";
+import type { TurnkeyClient } from ".";
 
 export type { TurnkeyCredentialRequestOptions };
 export { fetch };
@@ -252,6 +253,11 @@ export async function sealAndStampRequestBody(input: {
     sealedBody,
     xStamp,
   };
+}
+
+// Check if the client is an instance of TurnkeyClient. We check the constructor name here since the 'instanceof' operator does not work across if the http client isn't EXACTLY the same (mismatching versions).
+export function isHttpClient(client: any): client is TurnkeyClient {
+  return client?.constructor?.name === "TurnkeyClient";
 }
 
 export type THttpConfig = {

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -35,6 +35,6 @@ export { withAsyncPolling, createActivityPoller } from "./async";
 
 export { TurnkeyApi };
 
-export { sealAndStampRequestBody } from "./base";
+export { sealAndStampRequestBody, isHttpClient } from "./base";
 
 export { VERSION } from "./version";

--- a/packages/solana/src/index.ts
+++ b/packages/solana/src/index.ts
@@ -4,6 +4,7 @@ import {
   assertActivityCompleted,
   TurnkeyClient,
   type TSignature,
+  isHttpClient,
 } from "@turnkey/http";
 import type { TurnkeyBrowserClient } from "@turnkey/sdk-browser";
 import type { TurnkeyServerClient, TurnkeyApiTypes } from "@turnkey/sdk-server";
@@ -136,7 +137,7 @@ export class TurnkeySigner {
     signWith: string,
     organizationId?: string,
   ) {
-    if (this.client instanceof TurnkeyClient) {
+    if (isHttpClient(this.client)) {
       const response = await this.client.signTransaction({
         type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
         organizationId: organizationId ?? this.organizationId,
@@ -176,7 +177,7 @@ export class TurnkeySigner {
     signWith: string,
     organizationId?: string,
   ) {
-    if (this.client instanceof TurnkeyClient) {
+    if (isHttpClient(this.client)) {
       const response = await this.client.signRawPayload({
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
         organizationId: organizationId ?? this.organizationId,
@@ -222,7 +223,7 @@ export class TurnkeySigner {
     signWith: string,
     organizationId?: string,
   ) {
-    if (this.client instanceof TurnkeyClient) {
+    if (isHttpClient(this.client)) {
       const response = await this.client.signRawPayloads({
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS",
         organizationId: organizationId ?? this.organizationId,

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -28,6 +28,7 @@ import { secp256k1 } from "@noble/curves/secp256k1";
 import {
   assertNonNull,
   assertActivityCompleted,
+  isHttpClient,
   TActivityStatus,
   TActivityId,
   TSignature,
@@ -100,11 +101,6 @@ export class TurnkeyActivityError extends BaseError {
     this.activityId = activityId;
     this.activityStatus = activityStatus;
   }
-}
-
-// Check if the client is an instance of TurnkeyClient. We check the constructor name here since the 'instanceof' operator does not work across if the http client isn't EXACTLY the same (mismatching versions).
-function isHttpClient(client: any): client is TurnkeyClient {
-  return client?.constructor?.name === "TurnkeyClient";
 }
 
 export function createAccountWithAddress(input: {

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -102,6 +102,11 @@ export class TurnkeyActivityError extends BaseError {
   }
 }
 
+// Check if the client is an instance of TurnkeyClient. We check the constructor name here since the 'instanceof' operator does not work across if the http client isn't EXACTLY the same (mismatching versions).
+function isHttpClient(client: any): client is TurnkeyClient {
+  return client?.constructor?.name === "TurnkeyClient";
+}
+
 export function createAccountWithAddress(input: {
   client: TurnkeyClient | TurnkeyBrowserClient | TurnkeyServerClient;
   organizationId: string;
@@ -493,7 +498,7 @@ async function signTransactionImpl(
   organizationId: string,
   signWith: string,
 ): Promise<string> {
-  if (client instanceof TurnkeyClient) {
+  if (isHttpClient(client)) {
     const { activity } = await client.signTransaction({
       type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
       organizationId: organizationId,
@@ -576,7 +581,7 @@ async function signMessageImpl(
 ): Promise<TSignMessageResult> {
   let result: TSignature;
 
-  if (client instanceof TurnkeyClient) {
+  if (isHttpClient(client)) {
     const { activity } = await client.signRawPayload({
       type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
       organizationId: organizationId,


### PR DESCRIPTION
## Summary & Motivation

Now checking the constructor name of the class instead of using `instanceof`. 

Before we were checking `client instanceof TurnkeyClient` which would return false if turnkey/viem, cosmjs, eip-1193, ethers, or solana and turnkey/http were on different versions


## How I Tested These Changes

Console log the constructor name when signing:
![image](https://github.com/user-attachments/assets/fd048ce1-43cf-45a0-8006-51259b72a3de)

When TurnkeyHttp client is passed in:
![image](https://github.com/user-attachments/assets/27c8adad-63ad-454e-965a-3f34f106563f)

When api client from sdk-server is passed in:
![image](https://github.com/user-attachments/assets/772a92e4-5baa-4f66-9bab-4c12a1005600)

Basically, the constructor name should be sufficient for checking what client is passed in 

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
