### PR TITLE
Removed unnecessary params for create sub org

### DIFF
--- a/examples/oauth/src/pages/api/createSuborg.ts
+++ b/examples/oauth/src/pages/api/createSuborg.ts
@@ -38,8 +38,6 @@ export default async function createSuborg(
         rootUsers: [
           {
             userName: `example-user-${String(Date.now())}`,
-            userEmail: "",
-            userPhoneNumber: "",
             apiKeys: [],
             authenticators: [],
             oauthProviders: request.oauthProviders,


### PR DESCRIPTION
## Summary & Motivation
Remove the un-used phone number and email parameters from an oauth create sub org example. This gave a customer an error because of an improperly formatted phone number since it should be omitted.
## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
