### PR TITLE
chore: checkout main

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Check for pending releases
         run: |
           echo "Checking for pending changesets..."
-          CHANGES_STATUS=$(pnpm changeset status --verbose --since=origin/main)
+          git fetch origin main
+          CHANGES_STATUS=$(pnpm changeset status --verbose)
           echo "$CHANGES_STATUS"
           if echo "$CHANGES_STATUS" | grep -qi "packages to be bumped"; then
             echo "Changesets found, continuing"
           else
-            echo "No unreleased changesets found, exiting"
-            exit 0
+            echo "No unreleased changesets found, continuing anyway"
           fi
 
       - name: Debug Foundry

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -35,7 +35,8 @@ jobs:
           if echo "$CHANGES_STATUS" | grep -qi "packages to be bumped"; then
             echo "Changesets found, continuing"
           else
-            echo "No unreleased changesets found, continuing anyway"
+            echo "No unreleased changesets found, exiting"
+            exit 1
           fi
 
       - name: Debug Foundry


### PR DESCRIPTION
## Summary & Motivation

- explicitly checkout main before processing changesets

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
