### PR TITLE
chore: checkout default branch

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -5,7 +5,6 @@ on:
   push:
     tags:
       - "v*.*.*" # triggers on tags like v1.0.0
-  pull_request:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary & Motivation

- explicitly check out the main branch to process changesets `ref: ${{ github.event.repository.default_branch }}`

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
