### PR TITLE
update publish.yml and add changeset

### DIFF
--- a/.changeset/lovely-rings-live.md
+++ b/.changeset/lovely-rings-live.md
@@ -1,0 +1,12 @@
+---
+"@turnkey/cosmjs": patch
+"@turnkey/eip-1193-provider": patch
+"@turnkey/ethers": patch
+"@turnkey/http": patch
+"@turnkey/solana": patch
+"@turnkey/viem": patch
+---
+
+Exposed `isHttpClient` function for determining if a passed in client is from turnkey/http
+
+Fix for `no runner registered` error when using mismatched versions of turnkey/http

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish Packages
 
 on:
+  workflow_dispatch: # allows manual invocation
   pull_request:
     types: [closed]
     branches:


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
