### PR TITLE
add FiatOnRampProvider type

### DIFF
--- a/.changeset/open-drinks-grow.md
+++ b/.changeset/open-drinks-grow.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-types": minor
+---
+
+Add FiatOnRampProvider Type

--- a/packages/sdk-types/src/index.ts
+++ b/packages/sdk-types/src/index.ts
@@ -21,3 +21,8 @@ export type SessionResponse = {
     organizationName: string;
   };
 };
+
+export enum FiatOnRampProvider {
+  COINBASE = "FIAT_ON_RAMP_PROVIDER_COINBASE",
+  MOONPAY = "FIAT_ON_RAMP_PROVIDER_MOONPAY",
+}


### PR DESCRIPTION
## Summary & Motivation

- Add type def for `FiatOnRampProvider`

## How I Tested These Changes

- locally via `examples/react-components`

## Did you add a changeset?

- minor

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
