### PR TITLE
Improve Node.js Environment Detection for API Key Stamper

### DIFF
--- a/packages/api-key-stamper/src/index.ts
+++ b/packages/api-key-stamper/src/index.ts
@@ -43,17 +43,20 @@ export const signWithApiKey = async (input: {
   privateKey: string;
 }): Promise<string> => {
   if (isCryptoEnabledBrowser) {
+    console.log("Using WebCrypto for signing with API key");
     const fn = await import("./webcrypto").then((m) => m.signWithApiKey);
     return fn(input);
   }
 
   if (detectIsNode()) {
+    console.log("Using NodeJS crypto for signing with API key");
     const fn = await import("./nodecrypto").then((m) => m.signWithApiKey);
     return fn(input);
   }
 
   // If we don't have NodeJS or web crypto at our disposal, default to pure JS implementation
   // This is the case for old browsers and react native environments
+  console.log("Using PureJS for signing with API key");
   const fn = await import("./purejs").then((m) => m.signWithApiKey);
   return fn(input);
 };

--- a/packages/api-key-stamper/src/index.ts
+++ b/packages/api-key-stamper/src/index.ts
@@ -7,6 +7,7 @@ const stampHeaderName = "X-Stamp";
 export type TApiKeyStamperConfig = {
   apiPublicKey: string;
   apiPrivateKey: string;
+  forceBrowserCrypto?: boolean;
 };
 
 // `window.document` ensures that we're in a browser context
@@ -41,8 +42,9 @@ export const signWithApiKey = async (input: {
   content: string;
   publicKey: string;
   privateKey: string;
+  forceBrowserCrypto?: boolean;
 }): Promise<string> => {
-  if (isCryptoEnabledBrowser) {
+  if (isCryptoEnabledBrowser || input.forceBrowserCrypto) {
     console.log("Using WebCrypto for signing with API key");
     const fn = await import("./webcrypto").then((m) => m.signWithApiKey);
     return fn(input);
@@ -67,16 +69,19 @@ export const signWithApiKey = async (input: {
 export class ApiKeyStamper {
   apiPublicKey: string;
   apiPrivateKey: string;
+  forceBrowserCrypto: boolean;
 
   constructor(config: TApiKeyStamperConfig) {
     this.apiPublicKey = config.apiPublicKey;
     this.apiPrivateKey = config.apiPrivateKey;
+    this.forceBrowserCrypto = config.forceBrowserCrypto ?? false;
   }
 
   async stamp(payload: string) {
     const signature = await signWithApiKey({
       publicKey: this.apiPublicKey,
       privateKey: this.apiPrivateKey,
+      forceBrowserCrypto: this.forceBrowserCrypto,
       content: payload,
     });
 

--- a/packages/api-key-stamper/src/nodecrypto.ts
+++ b/packages/api-key-stamper/src/nodecrypto.ts
@@ -1,6 +1,49 @@
 import * as crypto from "crypto";
 import { convertTurnkeyApiKeyToJwk } from "./utils";
 
+function normalizeDerSignature(signature: Buffer): Buffer {
+  // minimum valid ECDSA P-256 DER signature length
+  const MIN_DER_LENGTH = 8;
+
+  // we check basic DER structure
+  if (signature.length < MIN_DER_LENGTH || signature[0] !== 0x30) {
+    // not DER so we don't modify
+    return signature;
+  }
+
+  const declaredLength = signature[1];
+
+  // if we can't determine length, don't modify
+  if (declaredLength === undefined) {
+    return signature;
+  }
+
+  const expectedLength = 2 + declaredLength;
+
+  // we only trim if:
+  // 1. buffer is longer than DER declared length
+  // 2. the extra bytes are all zeros
+  if (signature.length > expectedLength) {
+    const paddingStart = expectedLength;
+    const paddingEnd = signature.length;
+
+    // verify all extra bytes are zero
+    let isZeroPadding = true;
+    for (let i = paddingStart; i < paddingEnd; i++) {
+      if (signature[i] !== 0) {
+        isZeroPadding = false;
+        break;
+      }
+    }
+
+    if (isZeroPadding) {
+      return signature.subarray(0, expectedLength);
+    }
+  }
+
+  return signature;
+}
+
 export const signWithApiKey = async (input: {
   content: string;
   publicKey: string;
@@ -22,5 +65,12 @@ export const signWithApiKey = async (input: {
   sign.write(Buffer.from(content));
   sign.end();
 
-  return sign.sign(privateKeyObject, "hex");
+  const signatureBuffer = sign.sign(privateKeyObject);
+
+  // we normalize the signature
+  // this is needed to fix the polyfill bug in Cloudflare Workers
+  // where ECDSA signatures are zero-padded to 72 bytes,
+  const normalizedBuffer = normalizeDerSignature(signatureBuffer);
+
+  return normalizedBuffer.toString("hex");
 };


### PR DESCRIPTION
## Summary & Motivation

This improves how we detect whether the code is running in a Node.js environment. Previously, we relied on checking `process.versions.node`, based on a common pattern from `browser-or-node`. 

The issue is this incorrectly identified environments like `Cloudflare Workers (via Wrangler)` as `Node.js`, even though they don’t support Node APIs like `crypto.createSign` (which we use). 



## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
