### PR TITLE
Implement signer.authorize for EIP-7702 transactions

### DIFF
--- a/.changeset/gold-glasses-reflect.md
+++ b/.changeset/gold-glasses-reflect.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/ethers": minor
+---
+
+Implement signer.authorize for EIP-7702 transactions

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -59,13 +59,13 @@
     "@turnkey/sdk-server": "workspace:*"
   },
   "devDependencies": {
-    "@nomicfoundation/hardhat-ethers": "3.0.5",
-    "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
+    "@nomicfoundation/hardhat-ethers": "3.0.9",
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.12",
     "@openzeppelin/contracts": "^4.9.0",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
     "ethers": "^6.14.4",
-    "hardhat": "^2.19.4",
+    "hardhat": "^2.24.3",
     "typechain": "^8.3.2"
   },
   "engines": {

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -64,7 +64,7 @@
     "@openzeppelin/contracts": "^4.9.0",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
-    "ethers": "^6.10.0",
+    "ethers": "^6.14.4",
     "hardhat": "^2.19.4",
     "typechain": "^8.3.2"
   },

--- a/packages/ethers/src/__tests__/index-test.ts
+++ b/packages/ethers/src/__tests__/index-test.ts
@@ -1,5 +1,5 @@
 import { setBalance } from "@nomicfoundation/hardhat-network-helpers";
-import { parseEther, verifyMessage, verifyTypedData } from "ethers";
+import { ethers, parseEther, verifyMessage, verifyTypedData } from "ethers";
 import hre from "hardhat";
 import { test, expect, beforeEach, describe } from "@jest/globals";
 import { TurnkeySigner, TurnkeyActivityError } from "../";
@@ -18,6 +18,14 @@ const testCase: typeof test = (...argList) => {
   return test(...argList);
 };
 
+// Custom type for EIP-7702 compliance
+export interface EIP7702AuthorizationRequest {
+  address: string;
+  chainId: number | bigint | string;
+  nonce: number | bigint | string;
+  code?: string; // EIP-7702 requires code field
+}
+
 describe("TurnkeySigner", () => {
   let connectedSigner: TurnkeySigner;
   let signerWithProvider: TurnkeySigner;
@@ -26,35 +34,35 @@ describe("TurnkeySigner", () => {
 
   const apiPublicKey = assertNonEmptyString(
     process.env.API_PUBLIC_KEY,
-    `process.env.API_PUBLIC_KEY`,
+    `process.env.API_PUBLIC_KEY`
   );
   const apiPrivateKey = assertNonEmptyString(
     process.env.API_PRIVATE_KEY,
-    `process.env.API_PRIVATE_KEY`,
+    `process.env.API_PRIVATE_KEY`
   );
   const baseUrl = assertNonEmptyString(
     process.env.BASE_URL,
-    `process.env.BASE_URL`,
+    `process.env.BASE_URL`
   );
   const organizationId = assertNonEmptyString(
     process.env.ORGANIZATION_ID,
-    `process.env.ORGANIZATION_ID`,
+    `process.env.ORGANIZATION_ID`
   );
   const privateKeyId = assertNonEmptyString(
     process.env.PRIVATE_KEY_ID,
-    `process.env.PRIVATE_KEY_ID`,
+    `process.env.PRIVATE_KEY_ID`
   );
   const expectedPrivateKeyEthAddress = assertNonEmptyString(
     process.env.EXPECTED_PRIVATE_KEY_ETH_ADDRESS,
-    `process.env.EXPECTED_PRIVATE_KEY_ETH_ADDRESS`,
+    `process.env.EXPECTED_PRIVATE_KEY_ETH_ADDRESS`
   );
   const expectedWalletAccountEthAddress = assertNonEmptyString(
     process.env.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS,
-    `process.env.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS`,
+    `process.env.EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS`
   );
   const bannedToAddress = assertNonEmptyString(
     process.env.BANNED_TO_ADDRESS,
-    `process.env.BANNED_TO_ADDRESS`,
+    `process.env.BANNED_TO_ADDRESS`
   );
 
   [
@@ -87,7 +95,7 @@ describe("TurnkeySigner", () => {
           new ApiKeyStamper({
             apiPublicKey,
             apiPrivateKey,
-          }),
+          })
         );
 
         connectedSigner = new TurnkeySigner({
@@ -102,7 +110,7 @@ describe("TurnkeySigner", () => {
             organizationId,
             signWith: signingConfig.signWith,
           },
-          provider,
+          provider
         );
 
         chainId = (await connectedSigner.provider!.getNetwork()).chainId;
@@ -115,14 +123,14 @@ describe("TurnkeySigner", () => {
       testCase("basics for connected signer", async () => {
         expect(connectedSigner.signMessage).toBeTruthy();
         expect(await connectedSigner.getAddress()).toBe(
-          signingConfig.expectedEthAddress,
+          signingConfig.expectedEthAddress
         );
       });
 
       testCase("basics for connected signer via constructor", async () => {
         expect(connectedSigner.signMessage).toBeTruthy();
         expect(await signerWithProvider.getAddress()).toBe(
-          signingConfig.expectedEthAddress,
+          signingConfig.expectedEthAddress
         );
       });
 
@@ -174,7 +182,7 @@ describe("TurnkeySigner", () => {
           expect("this-should-never-be").toBe("reached");
         } catch (error) {
           expect((error as any as Error).message).toBe(
-            `Transaction \`tx.from\` address mismatch. Self address: ${signingConfig.expectedEthAddress}; \`tx.from\` address: ${badFromAddress}`,
+            `Transaction \`tx.from\` address mismatch. Self address: ${signingConfig.expectedEthAddress}; \`tx.from\` address: ${badFromAddress}`
           );
         }
       });
@@ -231,7 +239,7 @@ describe("TurnkeySigner", () => {
             }
           `);
           }
-        },
+        }
       );
 
       testCase("it signs messages, `eth_sign` style", async () => {
@@ -241,7 +249,7 @@ describe("TurnkeySigner", () => {
 
         expect(signMessageSignature).toMatch(/^0x/);
         expect(verifyMessage(message, signMessageSignature)).toEqual(
-          signingConfig.expectedEthAddress,
+          signingConfig.expectedEthAddress
         );
       });
 
@@ -269,7 +277,7 @@ describe("TurnkeySigner", () => {
         const signTypedDataSignature = await connectedSigner.signTypedData(
           typedData.domain,
           typedData.types,
-          typedData.message,
+          typedData.message
         );
 
         expect(signTypedDataSignature).toMatch(/^0x/);
@@ -278,8 +286,8 @@ describe("TurnkeySigner", () => {
             typedData.domain,
             typedData.types,
             typedData.message,
-            signTypedDataSignature,
-          ),
+            signTypedDataSignature
+          )
         ).toEqual(signingConfig.expectedEthAddress);
       });
 
@@ -322,12 +330,12 @@ describe("TurnkeySigner", () => {
 
         expect(deploymentAddress).toMatch(/^0x/);
         expect(deploymentTransaction?.from).toEqual(
-          signingConfig.expectedEthAddress,
+          signingConfig.expectedEthAddress
         );
 
         // Mint
         const mintTx = await contract.safeMint(
-          signingConfig.expectedEthAddress,
+          signingConfig.expectedEthAddress
         );
 
         expect(mintTx.hash).toMatch(/^0x/);
@@ -337,13 +345,211 @@ describe("TurnkeySigner", () => {
         // Approve
         const approveTx = await contract.approve(
           "0x2Ad9eA1E677949a536A270CEC812D6e868C88108",
-          0, // `tokenId` is `0` because we've only minted once
+          0 // `tokenId` is `0` because we've only minted once
         );
         await approveTx.wait();
 
         expect(approveTx.hash).toMatch(/^0x/);
         expect(approveTx.from).toEqual(signingConfig.expectedEthAddress);
         expect(approveTx.to).toEqual(deploymentAddress);
+      });
+      // testCase("it signs authorization (EIP-712 permit style)", async () => {
+      //   // Define the EIP-712 domain for EIP-7702
+      //   const domain = {
+      //     name: "EIP7702Authorization",
+      //     version: "1",
+      //     chainId: chainId,
+      //     verifyingContract: "0x0000000000000000000000000000000000000000",
+      //   };
+
+      //   // Define the EIP-7702 AuthorizationRequest
+      //   const authRequest: ethers.AuthorizationRequest = {
+      //     address: signingConfig.expectedEthAddress,
+      //     chainId: chainId,
+      //     nonce: 0,
+      //   };
+
+      //   try {
+      //     // Sign the authorization
+      //     const signatureAuthorization =
+      //       await connectedSigner.signAuthorization(authRequest);
+
+      //     // Log for debugging
+      //     console.log(
+      //       "Signature Authorization:",
+      //       JSON.stringify(
+      //         signatureAuthorization,
+      //         (key, value) => {
+      //           if (typeof value === "bigint") return value.toString();
+      //           return value;
+      //         },
+      //         2
+      //       )
+      //     );
+      //     console.log(
+      //       "Expected Signer Address:",
+      //       signingConfig.expectedEthAddress
+      //     );
+
+      //     // Extract signature components
+      //     const { r, s, v } = signatureAuthorization.signature;
+      //     expect(r).toMatch(/^0x/);
+      //     expect(s).toMatch(/^0x/);
+      //     expect(v).toBeGreaterThanOrEqual(27);
+      //     expect(v).toBeLessThanOrEqual(28);
+
+      //     // Get serialized signature
+      //     const signatureToVerify = ethers.Signature.from(
+      //       signatureAuthorization.signature
+      //     ).serialized;
+      //     expect(signatureToVerify).toMatch(/^0x/);
+
+      //     // Define EIP-712 types
+      //     const types = {
+      //       Authorization: [
+      //         { name: "contract", type: "address" },
+      //         { name: "chainId", type: "uint256" },
+      //         { name: "nonce", type: "uint256" },
+      //       ],
+      //     };
+
+      //     // Define EIP-712 message
+      //     const message = {
+      //       contract: authRequest.address,
+      //       chainId: authRequest.chainId,
+      //       nonce: authRequest.nonce,
+      //     };
+
+      //     // Verify the signature
+      //     const recoveredAddress = verifyTypedData(
+      //       domain,
+      //       types,
+      //       message,
+      //       signatureToVerify
+      //     );
+      //     console.log("Recovered Address (Test):", recoveredAddress);
+      //     expect(recoveredAddress).toEqual(signingConfig.expectedEthAddress);
+
+      //     // Verify the authorization object
+      //     expect(signatureAuthorization.address).toEqual(
+      //       signingConfig.expectedEthAddress
+      //     );
+      //     expect(signatureAuthorization.chainId).toEqual(chainId);
+      //     expect(signatureAuthorization.nonce).toEqual(BigInt(0));
+      //   } catch (error) {
+      //     console.error(
+      //       "Error:",
+      //       JSON.stringify(
+      //         {
+      //           name: error instanceof Error ? error.name : "Unknown",
+      //           message: error instanceof Error ? error.message : String(error),
+      //           cause:
+      //             error instanceof TurnkeyActivityError
+      //               ? error.cause
+      //               : undefined,
+      //           stack: error instanceof Error ? error.stack : undefined,
+      //         },
+      //         (key, value) => {
+      //           if (typeof value === "bigint") return value.toString();
+      //           return value;
+      //         },
+      //         2
+      //       )
+      //     );
+      //     throw error; // Re-throw to inspect
+      //   }
+      // });
+      testCase("it signs EIP-7702 authorization", async () => {
+        // Define the EIP-712 domain for EIP-7702
+        const domain = {
+          name: "EIP7702Authorization",
+          version: "1",
+          chainId: chainId,
+          verifyingContract: "0x0000000000000000000000000000000000000000",
+        };
+
+        // Define the EIP-7702 AuthorizationRequest
+        const authRequest: EIP7702AuthorizationRequest = {
+          address: signingConfig.expectedEthAddress,
+          chainId: chainId,
+          nonce: 0,
+          code: "0x1234", // Example bytecode
+        };
+
+        try {
+          // Sign the authorization
+          const signatureAuthorization =
+            await connectedSigner.signAuthorization(authRequest);
+
+          // Extract signature components
+          const { r, s, v } = signatureAuthorization.signature;
+          expect(r).toMatch(/^0x/);
+          expect(s).toMatch(/^0x/);
+          expect(v).toBeGreaterThanOrEqual(27);
+          expect(v).toBeLessThanOrEqual(28);
+
+          // Get serialized signature
+          const signatureToVerify = ethers.Signature.from(
+            signatureAuthorization.signature
+          ).serialized;
+          expect(signatureToVerify).toMatch(/^0x/);
+
+          // Define EIP-712 types
+          const types = {
+            Authorization: [
+              { name: "contract", type: "address" },
+              { name: "chainId", type: "uint256" },
+              { name: "nonce", type: "uint256" },
+              { name: "code", type: "bytes" },
+            ],
+          };
+
+          // Define EIP-712 message
+          const message = {
+            contract: authRequest.address,
+            chainId: authRequest.chainId,
+            nonce: authRequest.nonce,
+            code: authRequest.code || "0x",
+          };
+
+          // Verify the signature
+          const recoveredAddress = verifyTypedData(
+            domain,
+            types,
+            message,
+            signatureToVerify
+          );
+
+          expect(recoveredAddress).toEqual(signingConfig.expectedEthAddress);
+
+          // Verify the authorization object
+          expect(signatureAuthorization.address).toEqual(
+            signingConfig.expectedEthAddress
+          );
+          expect(signatureAuthorization.chainId).toEqual(chainId);
+          expect(signatureAuthorization.nonce).toEqual(BigInt(0));
+        } catch (error) {
+          console.error(
+            "Error:",
+            JSON.stringify(
+              {
+                name: error instanceof Error ? error.name : "Unknown",
+                message: error instanceof Error ? error.message : String(error),
+                cause:
+                  error instanceof TurnkeyActivityError
+                    ? String(error.cause)
+                    : undefined,
+                stack: error instanceof Error ? error.stack : undefined,
+              },
+              (key, value) => {
+                if (typeof value === "bigint") return value.toString();
+                return value;
+              },
+              2
+            )
+          );
+          throw error;
+        }
       });
     });
   });

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -2,6 +2,7 @@ import {
   type TypedDataDomain,
   type TypedDataField,
   type Provider,
+  type Authorization as SignAuthorizationReturnType,
   AbstractSigner,
   isAddress,
   getAddress,
@@ -44,6 +45,14 @@ type TConfig = {
   signWith: string;
 };
 
+// Custom types for EIP-7702 compliance
+interface TSignAuthorizationParameters {
+  address: string;
+  chainId: number | bigint | string;
+  nonce: number | bigint | string;
+  code?: string;
+}
+
 export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
   private readonly client:
     | TurnkeyClient
@@ -61,6 +70,22 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
     this.signWith = config.signWith;
   }
 
+  async signRawHash(hash: string): Promise<string> {
+    try {
+      return await this.signRawPayload({
+        signWith: this.signWith,
+        payload: hash,
+        encoding: "PAYLOAD_ENCODING_HEXADECIMAL" as const,
+        hashFunction: "HASH_FUNCTION_NO_OP" as const,
+      });
+    } catch (error) {
+      throw new TurnkeyActivityError({
+        message: `Failed to sign raw hash: ${error instanceof Error ? error.message : String(error)}`,
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
+
   connect(provider: Provider): TurnkeySigner {
     return new TurnkeySigner(
       {
@@ -68,7 +93,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
         organizationId: this.organizationId,
         signWith: this.signWith,
       },
-      provider,
+      provider
     );
   }
 
@@ -93,7 +118,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
       });
 
       ethereumAddress = data.privateKey.addresses.find(
-        (item: any) => item.format === "ADDRESS_FORMAT_ETHEREUM",
+        (item: any) => item.format === "ADDRESS_FORMAT_ETHEREUM"
       )?.address;
 
       if (typeof ethereumAddress !== "string" || !ethereumAddress) {
@@ -107,7 +132,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
   }
 
   private async _signTransactionImpl(
-    unsignedTransaction: string,
+    unsignedTransaction: string
   ): Promise<string> {
     if (isHttpClient(this.client)) {
       const { activity } = await this.client.signTransaction({
@@ -124,7 +149,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
       assertActivityCompleted(activity);
 
       return assertNonNull(
-        activity?.result?.signTransactionResult?.signedTransaction,
+        activity?.result?.signTransactionResult?.signedTransaction
       );
     } else {
       const { activity, signedTransaction } = await this.client.signTransaction(
@@ -132,7 +157,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
           signWith: this.signWith,
           type: "TRANSACTION_TYPE_ETHEREUM",
           unsignedTransaction,
-        },
+        }
       );
 
       assertActivityCompleted(activity);
@@ -142,7 +167,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
   }
 
   private async _signTransactionWithErrorWrapping(
-    message: string,
+    message: string
   ): Promise<string> {
     let signedTx: string;
     try {
@@ -184,7 +209,7 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
       const selfAddress = await this.getAddress();
       if (getAddress(from) !== selfAddress) {
         throw new Error(
-          `Transaction \`tx.from\` address mismatch. Self address: ${selfAddress}; \`tx.from\` address: ${from}`,
+          `Transaction \`tx.from\` address mismatch. Self address: ${selfAddress}; \`tx.from\` address: ${from}`
         );
       }
     }
@@ -234,47 +259,46 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
 
   async _signMessageImpl(message: string): Promise<string> {
     let result;
+    try {
+      if (isHttpClient(this.client)) {
+        const { activity } = await this.client.signRawPayload({
+          type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+          organizationId: this.organizationId,
+          parameters: {
+            signWith: this.signWith,
+            payload: message,
+            encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
+            hashFunction: "HASH_FUNCTION_NO_OP",
+          },
+          timestampMs: String(Date.now()),
+        });
 
-    if (isHttpClient(this.client)) {
-      const { activity } = await this.client.signRawPayload({
-        type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
-        organizationId: this.organizationId,
-        parameters: {
+        assertActivityCompleted(activity);
+        result = assertNonNull(activity?.result?.signRawPayloadResult);
+      } else {
+        const { activity, r, s, v } = await this.client.signRawPayload({
           signWith: this.signWith,
           payload: message,
           encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
           hashFunction: "HASH_FUNCTION_NO_OP",
-        },
-        timestampMs: String(Date.now()), // millisecond timestamp
+        });
+
+        assertActivityCompleted(activity);
+        result = { r, s, v };
+      }
+      return serializeSignature(result);
+    } catch (error) {
+      throw new TurnkeyActivityError({
+        message: `Failed to sign raw payload: ${error instanceof Error ? error.message : String(error)}`,
+        cause: error instanceof Error ? error : undefined,
       });
-
-      assertActivityCompleted(activity);
-
-      result = assertNonNull(activity?.result?.signRawPayloadResult);
-    } else {
-      const { activity, r, s, v } = await this.client.signRawPayload({
-        signWith: this.signWith,
-        payload: message,
-        encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
-        hashFunction: "HASH_FUNCTION_NO_OP",
-      });
-
-      assertActivityCompleted(activity);
-
-      result = {
-        r,
-        s,
-        v,
-      };
     }
-
-    return serializeSignature(result);
   }
 
   async signTypedData(
     domain: TypedDataDomain,
     types: Record<string, Array<TypedDataField>>,
-    value: Record<string, any>,
+    value: Record<string, any>
   ): Promise<string> {
     const populated = await TypedDataEncoder.resolveNames(
       domain,
@@ -287,22 +311,212 @@ export class TurnkeySigner extends AbstractSigner implements ethers.Signer {
         assertNonNull(address);
 
         return address ?? "";
-      },
+      }
     );
 
     return this._signMessageWithErrorWrapping(
-      TypedDataEncoder.hash(populated.domain, types, populated.value),
+      TypedDataEncoder.hash(populated.domain, types, populated.value)
     );
   }
 
   _signTypedData = this.signTypedData.bind(this);
+
+  async signAuthorization(
+    parameters: TSignAuthorizationParameters
+  ): Promise<SignAuthorizationReturnType> {
+    try {
+      const { address, chainId, nonce, code = "0x" } = parameters;
+
+      if (!isAddress(address)) {
+        throw new TurnkeyActivityError({
+          message: `Invalid Ethereum address: ${address}`,
+        });
+      }
+      const normalizedAddress = getAddress(address);
+
+      if (
+        typeof chainId !== "number" &&
+        typeof chainId !== "bigint" &&
+        (typeof chainId !== "string" || isNaN(parseInt(chainId)))
+      ) {
+        throw new TurnkeyActivityError({
+          message: `Invalid chainId: ${chainId}`,
+        });
+      }
+      const normalizedChainId =
+        typeof chainId === "bigint" ? chainId : BigInt(chainId);
+
+      if (
+        typeof nonce !== "number" &&
+        typeof nonce !== "bigint" &&
+        (typeof nonce !== "string" || isNaN(parseInt(nonce)))
+      ) {
+        throw new TurnkeyActivityError({
+          message: `Invalid nonce: ${nonce}`,
+        });
+      }
+      const normalizedNonce = typeof nonce === "bigint" ? nonce : BigInt(nonce);
+
+      if (typeof code !== "string" || !code.match(/^0x[0-9a-fA-F]*$/)) {
+        throw new TurnkeyActivityError({
+          message: `Invalid code: ${code}`,
+        });
+      }
+
+      // Validate chainId against provider
+      if (this.provider) {
+        const network = await this.provider.getNetwork();
+        if (BigInt(network.chainId) !== normalizedChainId) {
+          throw new TurnkeyActivityError({
+            message: `chainId mismatch: expected ${network.chainId}, got ${normalizedChainId}`,
+          });
+        }
+      }
+
+      // Define EIP-712 structure
+      const domain: TypedDataDomain = {
+        name: "EIP7702Authorization",
+        version: "1",
+        chainId: normalizedChainId,
+        verifyingContract: "0x0000000000000000000000000000000000000000",
+      };
+      const types: Record<string, Array<TypedDataField>> = {
+        Authorization: [
+          { name: "contract", type: "address" },
+          { name: "chainId", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+          { name: "code", type: "bytes" },
+        ],
+      };
+      const message = {
+        contract: normalizedAddress,
+        chainId: normalizedChainId,
+        nonce: normalizedNonce,
+        code,
+      };
+
+      // Compute EIP-712 hash
+      const authHash = TypedDataEncoder.hash(domain, types, message);
+
+      // Sign the hash using Turnkey
+      const signatureString = await this.signRawPayload({
+        signWith: this.signWith,
+        payload: authHash,
+        encoding: "PAYLOAD_ENCODING_HEXADECIMAL" as const,
+        hashFunction: "HASH_FUNCTION_NO_OP" as const,
+      });
+
+      // Verify the signature
+      const recoveredAddress = ethers.verifyTypedData(
+        domain,
+        types,
+        message,
+        signatureString
+      );
+      const expectedAddress = await this.getAddress();
+
+      if (getAddress(recoveredAddress) !== getAddress(expectedAddress)) {
+        throw new TurnkeyActivityError({
+          message: `Signature verification failed: recovered address ${recoveredAddress} does not match signer ${expectedAddress}`,
+        });
+      }
+
+      // Verify with hashAuthorization for comparison
+      ethers.hashAuthorization({
+        address: normalizedAddress,
+        chainId: normalizedChainId,
+        nonce: normalizedNonce,
+        code,
+      } as ethers.AuthorizationRequest);
+
+      return {
+        address: normalizedAddress,
+        chainId: normalizedChainId,
+        nonce: normalizedNonce,
+        signature: Signature.from(signatureString),
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorCause =
+        error instanceof Error
+          ? error
+          : error !== undefined
+            ? new Error(String(error))
+            : undefined;
+      throw new TurnkeyActivityError({
+        message: `Failed to sign authorization: ${errorMessage}`,
+        cause: errorCause,
+      });
+    }
+  }
+
+  async signRawPayload(params: {
+    signWith: string;
+    payload: string;
+    encoding: "PAYLOAD_ENCODING_HEXADECIMAL" | "PAYLOAD_ENCODING_TEXT_UTF8";
+    hashFunction:
+      | "HASH_FUNCTION_NO_OP"
+      | "HASH_FUNCTION_SHA256"
+      | "HASH_FUNCTION_KECCAK256"
+      | "HASH_FUNCTION_NOT_APPLICABLE";
+  }): Promise<string> {
+    let signResult: any;
+    try {
+      if (isHttpClient(this.client)) {
+        const result = await this.client.signRawPayload({
+          type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+          organizationId: this.organizationId,
+          parameters: {
+            signWith: params.signWith,
+            payload: params.payload,
+            encoding: params.encoding,
+            hashFunction: params.hashFunction,
+          },
+          timestampMs: String(Date.now()),
+        });
+
+        assertActivityCompleted(result.activity);
+        signResult = assertNonNull(result.activity.result.signRawPayloadResult);
+      } else {
+        const { activity, r, s, v } = await this.client.signRawPayload({
+          signWith: params.signWith,
+          payload: params.payload,
+          encoding: params.encoding,
+          hashFunction: params.hashFunction,
+        });
+
+        assertActivityCompleted(activity);
+        signResult = { r, s, v };
+      }
+      return serializeSignature(signResult);
+    } catch (error) {
+      throw new TurnkeyActivityError({
+        message: `Turnkey signRawPayload failed: ${error instanceof Error ? error.message : String(error)}`,
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
 }
 
 export function serializeSignature(signature: TSignature) {
+  if (!signature.r || !signature.s || !signature.v) {
+    throw new TurnkeyActivityError({
+      message: "Invalid signature format: missing r, s, or v",
+    });
+  }
+
+  const vNum = parseInt(signature.v);
+  if (vNum !== 0 && vNum !== 1) {
+    throw new TurnkeyActivityError({
+      message: `Invalid v value: ${signature.v}`,
+    });
+  }
+
   const assembled = Signature.from({
     r: `0x${signature.r}`,
     s: `0x${signature.s}`,
-    v: parseInt(signature.v) + 27,
+    v: vNum + 27,
   }).serialized;
 
   return assertNonNull(assembled);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,7 +613,7 @@ importers:
         version: 1.0.1
       '@uniswap/v3-sdk':
         specifier: ^3.9.0
-        version: 3.9.0(hardhat@2.22.2)
+        version: 3.9.0(hardhat@2.24.3)
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
@@ -1902,11 +1902,11 @@ importers:
         version: link:../sdk-server
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
-        specifier: 3.0.5
-        version: 3.0.5(ethers@6.14.4)(hardhat@2.19.4)
+        specifier: 3.0.9
+        version: 3.0.9(ethers@6.14.4)(hardhat@2.24.3)
       '@nomicfoundation/hardhat-network-helpers':
-        specifier: ^1.0.8
-        version: 1.0.8(hardhat@2.19.4)
+        specifier: ^1.0.12
+        version: 1.0.12(hardhat@2.24.3)
       '@openzeppelin/contracts':
         specifier: ^4.9.0
         version: 4.9.0
@@ -1915,13 +1915,13 @@ importers:
         version: 0.5.1(ethers@6.14.4)(typechain@8.3.2)(typescript@5.4.3)
       '@typechain/hardhat':
         specifier: ^9.1.0
-        version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.14.4)(hardhat@2.19.4)(typechain@8.3.2)
+        version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.14.4)(hardhat@2.24.3)(typechain@8.3.2)
       ethers:
         specifier: ^6.14.4
         version: 6.14.4
       hardhat:
-        specifier: ^2.19.4
-        version: 2.19.4(typescript@5.4.3)
+        specifier: ^2.24.3
+        version: 2.24.3(typescript@5.4.3)
       typechain:
         specifier: ^8.3.2
         version: 8.3.2(typescript@5.4.3)
@@ -5370,37 +5370,6 @@ packages:
       - zod
     dev: false
 
-  /@chainsafe/as-sha256@0.3.1:
-    resolution: {integrity: sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==}
-    dev: true
-
-  /@chainsafe/persistent-merkle-tree@0.4.2:
-    resolution: {integrity: sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==}
-    dependencies:
-      '@chainsafe/as-sha256': 0.3.1
-    dev: true
-
-  /@chainsafe/persistent-merkle-tree@0.5.0:
-    resolution: {integrity: sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==}
-    dependencies:
-      '@chainsafe/as-sha256': 0.3.1
-    dev: true
-
-  /@chainsafe/ssz@0.10.2:
-    resolution: {integrity: sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==}
-    dependencies:
-      '@chainsafe/as-sha256': 0.3.1
-      '@chainsafe/persistent-merkle-tree': 0.5.0
-    dev: true
-
-  /@chainsafe/ssz@0.9.4:
-    resolution: {integrity: sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==}
-    dependencies:
-      '@chainsafe/as-sha256': 0.3.1
-      '@chainsafe/persistent-merkle-tree': 0.4.2
-      case: 1.6.3
-    dev: true
-
   /@changesets/apply-release-plan@7.0.3:
     resolution: {integrity: sha512-klL6LCdmfbEe9oyfLxnidIf/stFXmrbFO/3gT5LU5pcyoZytzJe4gWpTBx3BPmyNPl16dZ1xrkcW7b98e3tYkA==}
     dependencies:
@@ -6232,7 +6201,7 @@ packages:
   /@ethereumjs/common@4.3.0:
     resolution: {integrity: sha512-shBNJ0ewcPNTUfZduHiczPmqkfJDn0Dh/9BR5fq7xUFTuIq7Fu1Vx00XDwQVIrpVL70oycZocOhBM6nDO+4FEQ==}
     dependencies:
-      '@ethereumjs/util': 9.0.3
+      '@ethereumjs/util': 9.1.0
     dev: false
 
   /@ethereumjs/rlp@4.0.1:
@@ -6245,7 +6214,6 @@ packages:
     resolution: {integrity: sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==}
     engines: {node: '>=18'}
     hasBin: true
-    dev: false
 
   /@ethereumjs/tx@4.2.0:
     resolution: {integrity: sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==}
@@ -6263,7 +6231,7 @@ packages:
     dependencies:
       '@ethereumjs/common': 4.3.0
       '@ethereumjs/rlp': 5.0.2
-      '@ethereumjs/util': 9.0.3
+      '@ethereumjs/util': 9.1.0
       ethereum-cryptography: 2.2.1
     dev: false
 
@@ -6276,13 +6244,12 @@ packages:
       micro-ftch: 0.3.1
     dev: false
 
-  /@ethereumjs/util@9.0.3:
-    resolution: {integrity: sha512-PmwzWDflky+7jlZIFqiGsBPap12tk9zK5SVH9YW2OEnDN7OEhCjUOMzbOqwuClrbkSIkM2ERivd7sXZ48Rh/vg==}
+  /@ethereumjs/util@9.1.0:
+    resolution: {integrity: sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==}
     engines: {node: '>=18'}
     dependencies:
       '@ethereumjs/rlp': 5.0.2
       ethereum-cryptography: 2.2.1
-    dev: false
 
   /@ethersproject/abi@5.7.0:
     resolution: {integrity: sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==}
@@ -6336,6 +6303,7 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/properties': 5.7.0
+    dev: false
 
   /@ethersproject/bignumber@5.7.0:
     resolution: {integrity: sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==}
@@ -6367,6 +6335,7 @@ packages:
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       '@ethersproject/transactions': 5.7.0
+    dev: false
 
   /@ethersproject/hash@5.7.0:
     resolution: {integrity: sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==}
@@ -6396,6 +6365,7 @@ packages:
       '@ethersproject/strings': 5.7.0
       '@ethersproject/transactions': 5.7.0
       '@ethersproject/wordlists': 5.7.0
+    dev: false
 
   /@ethersproject/json-wallets@5.7.0:
     resolution: {integrity: sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==}
@@ -6413,6 +6383,7 @@ packages:
       '@ethersproject/transactions': 5.7.0
       aes-js: 3.0.0
       scrypt-js: 3.0.1
+    dev: false
 
   /@ethersproject/keccak256@5.7.0:
     resolution: {integrity: sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==}
@@ -6433,6 +6404,7 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/sha2': 5.7.0
+    dev: false
 
   /@ethersproject/properties@5.7.0:
     resolution: {integrity: sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==}
@@ -6465,12 +6437,14 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
 
   /@ethersproject/random@5.7.0:
     resolution: {integrity: sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==}
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
+    dev: false
 
   /@ethersproject/rlp@5.7.0:
     resolution: {integrity: sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==}
@@ -6484,6 +6458,7 @@ packages:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
       hash.js: 1.1.7
+    dev: false
 
   /@ethersproject/signing-key@5.7.0:
     resolution: {integrity: sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==}
@@ -6504,6 +6479,7 @@ packages:
       '@ethersproject/logger': 5.7.0
       '@ethersproject/sha2': 5.7.0
       '@ethersproject/strings': 5.7.0
+    dev: false
 
   /@ethersproject/strings@5.7.0:
     resolution: {integrity: sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==}
@@ -6531,6 +6507,7 @@ packages:
       '@ethersproject/bignumber': 5.7.0
       '@ethersproject/constants': 5.7.0
       '@ethersproject/logger': 5.7.0
+    dev: false
 
   /@ethersproject/wallet@5.7.0:
     resolution: {integrity: sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==}
@@ -6550,6 +6527,7 @@ packages:
       '@ethersproject/signing-key': 5.7.0
       '@ethersproject/transactions': 5.7.0
       '@ethersproject/wordlists': 5.7.0
+    dev: false
 
   /@ethersproject/web@5.7.1:
     resolution: {integrity: sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==}
@@ -6568,6 +6546,7 @@ packages:
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       '@ethersproject/strings': 5.7.0
+    dev: false
 
   /@fivebinaries/coin-selection@2.2.1:
     resolution: {integrity: sha512-iYFsYr7RY7TEvTqP9NKR4p/yf3Iybf9abUDR7lRjzanGsrLwVsREvIuyE05iRYFrvqarlk+gWRPsdR1N2hUBrg==}
@@ -8158,7 +8137,6 @@ packages:
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
     dependencies:
       '@noble/hashes': 1.4.0
-    dev: false
 
   /@noble/curves@1.6.0:
     resolution: {integrity: sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==}
@@ -8253,13 +8231,22 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
+  /@nomicfoundation/edr-darwin-arm64@0.11.1:
+    resolution: {integrity: sha512-vjca7gkl1o0yYqMjwxQpMEtdsb20nWHBnnxDO8ZBCTD5IwfYT5LiMxFaJo8NUJ7ODIRkF/zuEtAF3W7+ZlC5RA==}
+    engines: {node: '>= 18'}
+
   /@nomicfoundation/edr-darwin-arm64@0.3.2:
     resolution: {integrity: sha512-l6wfSBUUbGJiCENT6272CDI8yoMuf0sZH56H5qz3HnAyVzenkOvmzyF6/lar54m986kdAQqWls4cLvDxiOuLxg==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
+
+  /@nomicfoundation/edr-darwin-x64@0.11.1:
+    resolution: {integrity: sha512-0aGStHq9XePXX9UqdU1w60HGO9AfYCgkNEir5sBpntU5E0TvZEK6jwyYr667+s90n2mihdeP97QSA0O/6PT6PA==}
+    engines: {node: '>= 18'}
 
   /@nomicfoundation/edr-darwin-x64@0.3.2:
     resolution: {integrity: sha512-OboExL7vEw+TRJQl3KkaEKU4K7PTdZPTInZ0fxMAtOpcWp7EKR+dQo68vc/iAOusB3xszHKxt7t+WpisItfdcg==}
@@ -8267,7 +8254,12 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
+
+  /@nomicfoundation/edr-linux-arm64-gnu@0.11.1:
+    resolution: {integrity: sha512-OWhCETc03PVdtzatW/c2tpOPx+GxlBfBaLmMuGRD1soAr1nMOmg2WZAlo4i6Up9fkQYl+paiYMMFVat1meaMvQ==}
+    engines: {node: '>= 18'}
 
   /@nomicfoundation/edr-linux-arm64-gnu@0.3.2:
     resolution: {integrity: sha512-xtEK+1eg++3pHi6405NDXd80S3CGOFEGQIyVGCwjMGQFOLSzBGGCsrb/0GB4J19zd1o/8ftCd/HjZcbVAWWTLQ==}
@@ -8275,7 +8267,12 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
+
+  /@nomicfoundation/edr-linux-arm64-musl@0.11.1:
+    resolution: {integrity: sha512-p0qvtIvDA2eZ8pQ5XUKnWdW1IrwFzSrjyrO88oYx6Lkw8nYwf2JEeETo5o5W84DDfimfoBGP7RWPTPcTBKCaLQ==}
+    engines: {node: '>= 18'}
 
   /@nomicfoundation/edr-linux-arm64-musl@0.3.2:
     resolution: {integrity: sha512-3cIsskJOXQ1yEVsImmCacY7O03tUTiWrmd54F05PnPFrDLkjbzodQ3b2gUWzfbzUZWl67ZTJd1CvVSzpe7XGzw==}
@@ -8283,7 +8280,12 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
+
+  /@nomicfoundation/edr-linux-x64-gnu@0.11.1:
+    resolution: {integrity: sha512-V4Us7Q0E8kng3O/czd5GRcxmZxWX+USgqz9yQ3o7DVq7FP96idaKvtcbMQp64tjHf2zNtX2y77sGzgbVau7Bww==}
+    engines: {node: '>= 18'}
 
   /@nomicfoundation/edr-linux-x64-gnu@0.3.2:
     resolution: {integrity: sha512-ouPdphHNsyO7wqwa4hwahC5WqBglK/fIvMmhR/SXNZ9qruIpsA8ZZKIURaHMOv/2h2BbNGcyTX9uEk6+5rK/MQ==}
@@ -8291,7 +8293,12 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
+
+  /@nomicfoundation/edr-linux-x64-musl@0.11.1:
+    resolution: {integrity: sha512-lCSXsF10Kjjvs5duGbM6pi1WciWHXFNWkMgDAY4pg6ZRIy4gh+uGC6CONMfP4BDZwfrALo2p6+LwyotrJEqpyg==}
+    engines: {node: '>= 18'}
 
   /@nomicfoundation/edr-linux-x64-musl@0.3.2:
     resolution: {integrity: sha512-sRhwhiPbkpJMOUwXW1FZw9ks6xWyQhIhM0E8o3TXEXKSPKTE6whQLEk1R37iFITaI36vb6rSwLKTU1cb32gCoA==}
@@ -8299,6 +8306,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@nomicfoundation/edr-win32-arm64-msvc@0.3.2:
@@ -8307,6 +8315,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@nomicfoundation/edr-win32-ia32-msvc@0.3.2:
@@ -8315,7 +8324,12 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
+
+  /@nomicfoundation/edr-win32-x64-msvc@0.11.1:
+    resolution: {integrity: sha512-sNSmmRTURAd1sdKuyO5tqrFiJvHHVPZLM4HB53F21makGoyInFGhejdo3qZrkoinM8k0ewEJDbUp0YuMEgMOhQ==}
+    engines: {node: '>= 18'}
 
   /@nomicfoundation/edr-win32-x64-msvc@0.3.2:
     resolution: {integrity: sha512-Byn4QuWczRy/DUUQM3WjglgX/jGVUURVFaUsmIhnGg//MPlCLawubBGRqsrMuvaYedlIIJ4I2rgKvZlxdgHrqg==}
@@ -8323,7 +8337,20 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
+
+  /@nomicfoundation/edr@0.11.1:
+    resolution: {integrity: sha512-P97XwcD9DdMMZm9aqw89+mzqzlKmqzSPM3feBES2WVRm5/LOiBYorhpeAX+ANj0X8532SKgxoZK/CN5OWv9vZA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@nomicfoundation/edr-darwin-arm64': 0.11.1
+      '@nomicfoundation/edr-darwin-x64': 0.11.1
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.11.1
+      '@nomicfoundation/edr-linux-arm64-musl': 0.11.1
+      '@nomicfoundation/edr-linux-x64-gnu': 0.11.1
+      '@nomicfoundation/edr-linux-x64-musl': 0.11.1
+      '@nomicfoundation/edr-win32-x64-msvc': 0.11.1
 
   /@nomicfoundation/edr@0.3.2:
     resolution: {integrity: sha512-HGWtjibAK1mo4I2A7nJ/fXqe/J9G54OrSPJnnkY2K8TiXotYLShGd9GvHkae3PuFjTJKm6ZgBy7tveJj5yrCfw==}
@@ -8338,6 +8365,7 @@ packages:
       '@nomicfoundation/edr-win32-arm64-msvc': 0.3.2
       '@nomicfoundation/edr-win32-ia32-msvc': 0.3.2
       '@nomicfoundation/edr-win32-x64-msvc': 0.3.2
+    dev: true
 
   /@nomicfoundation/ethereumjs-block@4.0.0:
     resolution: {integrity: sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==}
@@ -8350,22 +8378,6 @@ packages:
       '@nomicfoundation/ethereumjs-util': 8.0.0
       ethereum-cryptography: 0.1.3
     dev: false
-
-  /@nomicfoundation/ethereumjs-block@5.0.2:
-    resolution: {integrity: sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@nomicfoundation/ethereumjs-common': 4.0.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      '@nomicfoundation/ethereumjs-trie': 6.0.2
-      '@nomicfoundation/ethereumjs-tx': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      ethereum-cryptography: 0.1.3
-      ethers: 5.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
 
   /@nomicfoundation/ethereumjs-blockchain@6.0.0:
     resolution: {integrity: sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==}
@@ -8387,29 +8399,6 @@ packages:
       - supports-color
     dev: false
 
-  /@nomicfoundation/ethereumjs-blockchain@7.0.2:
-    resolution: {integrity: sha512-8UUsSXJs+MFfIIAKdh3cG16iNmWzWC/91P40sazNvrqhhdR/RtGDlFk2iFTGbBAZPs2+klZVzhRX8m2wvuvz3w==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@nomicfoundation/ethereumjs-block': 5.0.2
-      '@nomicfoundation/ethereumjs-common': 4.0.2
-      '@nomicfoundation/ethereumjs-ethash': 3.0.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      '@nomicfoundation/ethereumjs-trie': 6.0.2
-      '@nomicfoundation/ethereumjs-tx': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      abstract-level: 1.0.3
-      debug: 4.3.4(supports-color@8.1.1)
-      ethereum-cryptography: 0.1.3
-      level: 8.0.0
-      lru-cache: 5.1.1
-      memory-level: 1.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@nomicfoundation/ethereumjs-common@3.0.0:
     resolution: {integrity: sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==}
     dependencies:
@@ -8417,19 +8406,13 @@ packages:
       crc-32: 1.2.2
     dev: false
 
-  /@nomicfoundation/ethereumjs-common@4.0.2:
-    resolution: {integrity: sha512-I2WGP3HMGsOoycSdOTSqIaES0ughQTueOsddJ36aYVpI3SN8YSusgRFLwzDJwRFVIYDKx/iJz0sQ5kBHVgdDwg==}
-    dependencies:
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      crc-32: 1.2.2
-    dev: true
-
   /@nomicfoundation/ethereumjs-common@4.0.4:
     resolution: {integrity: sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==}
     dependencies:
       '@nomicfoundation/ethereumjs-util': 9.0.4
     transitivePeerDependencies:
       - c-kzg
+    dev: true
 
   /@nomicfoundation/ethereumjs-ethash@2.0.0:
     resolution: {integrity: sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==}
@@ -8442,21 +8425,6 @@ packages:
       bigint-crypto-utils: 3.3.0
       ethereum-cryptography: 0.1.3
     dev: false
-
-  /@nomicfoundation/ethereumjs-ethash@3.0.2:
-    resolution: {integrity: sha512-8PfoOQCcIcO9Pylq0Buijuq/O73tmMVURK0OqdjhwqcGHYC2PwhbajDh7GZ55ekB0Px197ajK3PQhpKoiI/UPg==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@nomicfoundation/ethereumjs-block': 5.0.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      abstract-level: 1.0.3
-      bigint-crypto-utils: 3.3.0
-      ethereum-cryptography: 0.1.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
 
   /@nomicfoundation/ethereumjs-evm@1.0.0:
     resolution: {integrity: sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==}
@@ -8474,40 +8442,17 @@ packages:
       - supports-color
     dev: false
 
-  /@nomicfoundation/ethereumjs-evm@2.0.2:
-    resolution: {integrity: sha512-rBLcUaUfANJxyOx9HIdMX6uXGin6lANCulIm/pjMgRqfiCRMZie3WKYxTSd8ZE/d+qT+zTedBF4+VHTdTSePmQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@ethersproject/providers': 5.7.2
-      '@nomicfoundation/ethereumjs-common': 4.0.2
-      '@nomicfoundation/ethereumjs-tx': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      debug: 4.3.4(supports-color@8.1.1)
-      ethereum-cryptography: 0.1.3
-      mcl-wasm: 0.7.9
-      rustbn.js: 0.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@nomicfoundation/ethereumjs-rlp@4.0.0:
     resolution: {integrity: sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
 
-  /@nomicfoundation/ethereumjs-rlp@5.0.2:
-    resolution: {integrity: sha512-QwmemBc+MMsHJ1P1QvPl8R8p2aPvvVcKBbvHnQOKBpBztEo0omN0eaob6FeZS/e3y9NSe+mfu3nNFBHszqkjTA==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
   /@nomicfoundation/ethereumjs-rlp@5.0.4:
     resolution: {integrity: sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw==}
     engines: {node: '>=18'}
     hasBin: true
+    dev: true
 
   /@nomicfoundation/ethereumjs-statemanager@1.0.0:
     resolution: {integrity: sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==}
@@ -8523,21 +8468,6 @@ packages:
       - supports-color
     dev: false
 
-  /@nomicfoundation/ethereumjs-statemanager@2.0.2:
-    resolution: {integrity: sha512-dlKy5dIXLuDubx8Z74sipciZnJTRSV/uHG48RSijhgm1V7eXYFC567xgKtsKiVZB1ViTP9iFL4B6Je0xD6X2OA==}
-    dependencies:
-      '@nomicfoundation/ethereumjs-common': 4.0.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      debug: 4.3.4(supports-color@8.1.1)
-      ethereum-cryptography: 0.1.3
-      ethers: 5.7.2
-      js-sdsl: 4.4.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@nomicfoundation/ethereumjs-trie@5.0.0:
     resolution: {integrity: sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==}
     engines: {node: '>=14'}
@@ -8548,17 +8478,6 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /@nomicfoundation/ethereumjs-trie@6.0.2:
-    resolution: {integrity: sha512-yw8vg9hBeLYk4YNg5MrSJ5H55TLOv2FSWUTROtDtTMMmDGROsAu+0tBjiNGTnKRi400M6cEzoFfa89Fc5k8NTQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      '@types/readable-stream': 2.3.15
-      ethereum-cryptography: 0.1.3
-      readable-stream: 3.6.2
-    dev: true
-
   /@nomicfoundation/ethereumjs-tx@4.0.0:
     resolution: {integrity: sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==}
     engines: {node: '>=14'}
@@ -8568,21 +8487,6 @@ packages:
       '@nomicfoundation/ethereumjs-util': 8.0.0
       ethereum-cryptography: 0.1.3
     dev: false
-
-  /@nomicfoundation/ethereumjs-tx@5.0.2:
-    resolution: {integrity: sha512-T+l4/MmTp7VhJeNloMkM+lPU3YMUaXdcXgTGCf8+ZFvV9NYZTRLFekRwlG6/JMmVfIfbrW+dRRJ9A6H5Q/Z64g==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@chainsafe/ssz': 0.9.4
-      '@ethersproject/providers': 5.7.2
-      '@nomicfoundation/ethereumjs-common': 4.0.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      ethereum-cryptography: 0.1.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
 
   /@nomicfoundation/ethereumjs-tx@5.0.4:
     resolution: {integrity: sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==}
@@ -8597,6 +8501,7 @@ packages:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       '@nomicfoundation/ethereumjs-util': 9.0.4
       ethereum-cryptography: 0.1.3
+    dev: true
 
   /@nomicfoundation/ethereumjs-util@8.0.0:
     resolution: {integrity: sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==}
@@ -8605,15 +8510,6 @@ packages:
       '@nomicfoundation/ethereumjs-rlp': 4.0.0
       ethereum-cryptography: 0.1.3
     dev: false
-
-  /@nomicfoundation/ethereumjs-util@9.0.2:
-    resolution: {integrity: sha512-4Wu9D3LykbSBWZo8nJCnzVIYGvGCuyiYLIJa9XXNVt1q1jUzHdB+sJvx95VGCpPkCT+IbLecW6yfzy3E1bQrwQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@chainsafe/ssz': 0.10.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      ethereum-cryptography: 0.1.3
-    dev: true
 
   /@nomicfoundation/ethereumjs-util@9.0.4:
     resolution: {integrity: sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==}
@@ -8626,6 +8522,7 @@ packages:
     dependencies:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
+    dev: true
 
   /@nomicfoundation/ethereumjs-vm@6.0.0:
     resolution: {integrity: sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==}
@@ -8651,50 +8548,27 @@ packages:
       - supports-color
     dev: false
 
-  /@nomicfoundation/ethereumjs-vm@7.0.2:
-    resolution: {integrity: sha512-Bj3KZT64j54Tcwr7Qm/0jkeZXJMfdcAtRBedou+Hx0dPOSIgqaIr0vvLwP65TpHbak2DmAq+KJbW2KNtIoFwvA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@nomicfoundation/ethereumjs-block': 5.0.2
-      '@nomicfoundation/ethereumjs-blockchain': 7.0.2
-      '@nomicfoundation/ethereumjs-common': 4.0.2
-      '@nomicfoundation/ethereumjs-evm': 2.0.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      '@nomicfoundation/ethereumjs-statemanager': 2.0.2
-      '@nomicfoundation/ethereumjs-trie': 6.0.2
-      '@nomicfoundation/ethereumjs-tx': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      debug: 4.3.4(supports-color@8.1.1)
-      ethereum-cryptography: 0.1.3
-      mcl-wasm: 0.7.9
-      rustbn.js: 0.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.14.4)(hardhat@2.19.4):
-    resolution: {integrity: sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==}
+  /@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.14.4)(hardhat@2.24.3):
+    resolution: {integrity: sha512-xBJdRUiCwKpr0OYrOzPwAyNGtsVzoBx32HFPJVv6S+sFA9TmBIBDaqNlFPmBH58ZjgNnGhEr/4oBZvGr4q4TjQ==}
     peerDependencies:
-      ethers: ^6.1.0
+      ethers: ^6.14.0
       hardhat: ^2.0.0
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 6.14.4
-      hardhat: 2.19.4(typescript@5.4.3)
+      hardhat: 2.24.3(typescript@5.4.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@nomicfoundation/hardhat-network-helpers@1.0.8(hardhat@2.19.4):
-    resolution: {integrity: sha512-MNqQbzUJZnCMIYvlniC3U+kcavz/PhhQSsY90tbEtUyMj/IQqsLwIRZa4ctjABh3Bz0KCh9OXUZ7Yk/d9hr45Q==}
+  /@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.24.3):
+    resolution: {integrity: sha512-xTNQNI/9xkHvjmCJnJOTyqDSl8uq1rKb2WOVmixQxFtRd7Oa3ecO8zM0cyC2YmOK+jHB9WPZ+F/ijkHg1CoORA==}
     peerDependencies:
       hardhat: ^2.9.5
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.19.4(typescript@5.4.3)
+      hardhat: 2.24.3(typescript@5.4.3)
     dev: true
 
   /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0:
@@ -11279,6 +11153,9 @@ packages:
   /@scure/base@1.2.4:
     resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
 
+  /@scure/base@1.2.6:
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   /@scure/bip32@1.1.5:
     resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
     dependencies:
@@ -11300,7 +11177,6 @@ packages:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
-    dev: false
 
   /@scure/bip32@1.5.0:
     resolution: {integrity: sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==}
@@ -11335,7 +11211,6 @@ packages:
     dependencies:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
-    dev: false
 
   /@scure/bip39@1.4.0:
     resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
@@ -13141,7 +13016,7 @@ packages:
       typescript: 5.4.3
     dev: true
 
-  /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.14.4)(hardhat@2.19.4)(typechain@8.3.2):
+  /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.14.4)(hardhat@2.24.3)(typechain@8.3.2):
     resolution: {integrity: sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==}
     peerDependencies:
       '@typechain/ethers-v6': ^0.5.1
@@ -13152,7 +13027,7 @@ packages:
       '@typechain/ethers-v6': 0.5.1(ethers@6.14.4)(typechain@8.3.2)(typescript@5.4.3)
       ethers: 6.14.4
       fs-extra: 9.1.0
-      hardhat: 2.19.4(typescript@5.4.3)
+      hardhat: 2.24.3(typescript@5.4.3)
       typechain: 8.3.2(typescript@5.4.3)
     dev: true
 
@@ -13481,13 +13356,6 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.5
       csstype: 3.1.2
-
-  /@types/readable-stream@2.3.15:
-    resolution: {integrity: sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==}
-    dependencies:
-      '@types/node': 20.3.1
-      safe-buffer: 5.1.2
-    dev: true
 
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -13995,16 +13863,16 @@ packages:
       - hardhat
     dev: false
 
-  /@uniswap/swap-router-contracts@1.3.0(hardhat@2.22.2):
+  /@uniswap/swap-router-contracts@1.3.0(hardhat@2.24.3):
     resolution: {integrity: sha512-iKvCuRkHXEe0EMjOf8HFUISTIhlxI57kKFllf3C3PUIE0HmwxrayyoflwAz5u/TRsFGYqJ9IjX2UgzLCsrNa5A==}
     engines: {node: '>=10'}
     dependencies:
       '@openzeppelin/contracts': 3.4.2-solc-0.7
       '@uniswap/v2-core': 1.0.1
       '@uniswap/v3-core': 1.0.0
-      '@uniswap/v3-periphery': 1.4.1(hardhat@2.22.2)
+      '@uniswap/v3-periphery': 1.4.1(hardhat@2.24.3)
       dotenv: 14.3.2
-      hardhat-watcher: 2.5.0(hardhat@2.22.2)
+      hardhat-watcher: 2.5.0(hardhat@2.24.3)
     transitivePeerDependencies:
       - hardhat
     dev: false
@@ -14038,7 +13906,7 @@ packages:
       - hardhat
     dev: false
 
-  /@uniswap/v3-periphery@1.4.1(hardhat@2.22.2):
+  /@uniswap/v3-periphery@1.4.1(hardhat@2.24.3):
     resolution: {integrity: sha512-Ab0ZCKOQrQMKIcpBTezTsEhWfQjItd0TtkCG8mPhoQu+wC67nPaf4hYUhM6wGHeFUmDiYY5MpEQuokB0ENvoTg==}
     engines: {node: '>=10'}
     dependencies:
@@ -14047,7 +13915,7 @@ packages:
       '@uniswap/v2-core': 1.0.1
       '@uniswap/v3-core': 1.0.0
       base64-sol: 1.0.1
-      hardhat-watcher: 2.5.0(hardhat@2.22.2)
+      hardhat-watcher: 2.5.0(hardhat@2.24.3)
     transitivePeerDependencies:
       - hardhat
     dev: false
@@ -14079,14 +13947,14 @@ packages:
       - hardhat
     dev: false
 
-  /@uniswap/v3-sdk@3.9.0(hardhat@2.22.2):
+  /@uniswap/v3-sdk@3.9.0(hardhat@2.24.3):
     resolution: {integrity: sha512-LuoF3UcY1DxSAQKJ3E4/1Eq4HaNp+x+7q9mvbpiu+/PBj+O1DjLforAMrKxu+RsA0aarmZtz7yBnAPy+akgfgQ==}
     engines: {node: '>=10'}
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/solidity': 5.7.0
       '@uniswap/sdk-core': 3.1.1
-      '@uniswap/swap-router-contracts': 1.3.0(hardhat@2.22.2)
+      '@uniswap/swap-router-contracts': 1.3.0(hardhat@2.24.3)
       '@uniswap/v3-periphery': 1.4.3
       '@uniswap/v3-staker': 1.0.0
       tiny-invariant: 1.3.1
@@ -14567,6 +14435,7 @@ packages:
       level-transcoder: 1.0.1
       module-error: 1.0.2
       queue-microtask: 1.2.3
+    dev: false
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -14608,6 +14477,7 @@ packages:
 
   /aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+    dev: false
 
   /aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
@@ -15287,6 +15157,7 @@ packages:
 
   /bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
+    dev: false
 
   /bech32@2.0.0:
     resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
@@ -15322,6 +15193,7 @@ packages:
   /bigint-crypto-utils@3.3.0:
     resolution: {integrity: sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==}
     engines: {node: '>=14.0.0'}
+    dev: false
 
   /bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
@@ -15472,6 +15344,7 @@ packages:
       catering: 2.1.1
       module-error: 1.0.2
       run-parallel-limit: 1.1.0
+    dev: false
 
   /browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
@@ -15750,11 +15623,6 @@ packages:
   /caniuse-lite@1.0.30001700:
     resolution: {integrity: sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==}
 
-  /case@1.6.3:
-    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
-    engines: {node: '>= 0.8.0'}
-    dev: true
-
   /cashaddrjs@0.4.4:
     resolution: {integrity: sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==}
     dependencies:
@@ -15764,6 +15632,7 @@ packages:
   /catering@2.1.1:
     resolution: {integrity: sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==}
     engines: {node: '>=6'}
+    dev: false
 
   /cbor-sync@1.0.4:
     resolution: {integrity: sha512-GWlXN4wiz0vdWWXBU71Dvc1q3aBo0HytqwAZnXF1wOwjqNnDWA1vZ1gDMFLlqohak31VQzmhiYfiCX5QSSfagA==}
@@ -15825,6 +15694,12 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: false
+
+  /chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+    dependencies:
+      readdirp: 4.1.2
 
   /chrome-launcher@0.15.2:
     resolution: {integrity: sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==}
@@ -15891,6 +15766,7 @@ packages:
       module-error: 1.0.2
       napi-macros: 2.0.0
       node-gyp-build: 4.6.0
+    dev: false
 
   /classnames@2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
@@ -16102,7 +15978,6 @@ packages:
   /commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
-    dev: false
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -16208,6 +16083,7 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
+    dev: false
 
   /crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
@@ -17737,7 +17613,6 @@ packages:
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
-    dev: false
 
   /ethereumjs-abi@0.6.8:
     resolution: {integrity: sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==}
@@ -17802,6 +17677,7 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
 
   /ethers@6.10.0:
     resolution: {integrity: sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==}
@@ -18022,6 +17898,16 @@ packages:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
       bser: 2.1.1
+
+  /fdir@6.4.6(picomatch@4.0.2):
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.2
 
   /fetch@1.1.0:
     resolution: {integrity: sha512-5O8TwrGzoNblBG/jtK4NFuZwNCkZX6s5GfRNOaGtm+QGJEuNakSC/i2RW0R93KX6E0jVjNXm6O3CRN4Ql3K+yA==}
@@ -18254,6 +18140,7 @@ packages:
 
   /functional-red-black-tree@1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+    dev: false
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -18524,17 +18411,17 @@ packages:
     peerDependencies:
       hardhat: ^2.0.0
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       hardhat: 2.12.7(typescript@5.4.3)
     dev: false
 
-  /hardhat-watcher@2.5.0(hardhat@2.22.2):
+  /hardhat-watcher@2.5.0(hardhat@2.24.3):
     resolution: {integrity: sha512-Su2qcSMIo2YO2PrmJ0/tdkf+6pSt8zf9+4URR5edMVti6+ShI8T3xhPrwugdyTOFuyj8lKHrcTZNKUFYowYiyA==}
     peerDependencies:
       hardhat: ^2.0.0
     dependencies:
-      chokidar: 3.5.3
-      hardhat: 2.22.2(typescript@5.4.3)
+      chokidar: 3.6.0
+      hardhat: 2.24.3(typescript@5.4.3)
     dev: false
 
   /hardhat@2.12.7(typescript@5.4.3):
@@ -18607,73 +18494,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /hardhat@2.19.4(typescript@5.4.3):
-    resolution: {integrity: sha512-fTQJpqSt3Xo9Mn/WrdblNGAfcANM6XC3tAEi6YogB4s02DmTf93A8QsGb8uR0KR8TFcpcS8lgiW4ugAIYpnbrQ==}
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@metamask/eth-sig-util': 4.0.1
-      '@nomicfoundation/ethereumjs-block': 5.0.2
-      '@nomicfoundation/ethereumjs-blockchain': 7.0.2
-      '@nomicfoundation/ethereumjs-common': 4.0.2
-      '@nomicfoundation/ethereumjs-evm': 2.0.2
-      '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      '@nomicfoundation/ethereumjs-statemanager': 2.0.2
-      '@nomicfoundation/ethereumjs-trie': 6.0.2
-      '@nomicfoundation/ethereumjs-tx': 5.0.2
-      '@nomicfoundation/ethereumjs-util': 9.0.2
-      '@nomicfoundation/ethereumjs-vm': 7.0.2
-      '@nomicfoundation/solidity-analyzer': 0.1.1
-      '@sentry/node': 5.30.0
-      '@types/bn.js': 5.1.2
-      '@types/lru-cache': 5.1.1
-      adm-zip: 0.4.16
-      aggregate-error: 3.1.0
-      ansi-escapes: 4.3.2
-      chalk: 2.4.2
-      chokidar: 3.5.3
-      ci-info: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
-      enquirer: 2.4.1
-      env-paths: 2.2.1
-      ethereum-cryptography: 1.2.0
-      ethereumjs-abi: 0.6.8
-      find-up: 2.1.0
-      fp-ts: 1.19.3
-      fs-extra: 7.0.1
-      glob: 7.2.0
-      immutable: 4.3.4
-      io-ts: 1.10.4
-      keccak: 3.0.3
-      lodash: 4.17.21
-      mnemonist: 0.38.5
-      mocha: 10.2.0
-      p-map: 4.0.0
-      raw-body: 2.5.2
-      resolve: 1.17.0
-      semver: 6.3.1
-      solc: 0.7.3(debug@4.3.4)
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.10
-      tsort: 0.0.1
-      typescript: 5.4.3
-      undici: 5.24.0
-      uuid: 8.3.2
-      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /hardhat@2.22.2(typescript@5.4.3):
     resolution: {integrity: sha512-0xZ7MdCZ5sJem4MrvpQWLR3R3zGDoHw5lsR+pBFimqwagimIOn3bWuZv69KA+veXClwI1s/zpqgwPwiFrd4Dxw==}
     hasBin: true
@@ -18733,6 +18553,66 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - c-kzg
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /hardhat@2.24.3(typescript@5.4.3):
+    resolution: {integrity: sha512-2dhniQ1wW8/Wh3mP91kKcEnVva93mWYRaYLkV+a0ATkUEKrByGF2P5hCrlNHbqYP//D7L0CGYLtDjPQY6ILaVA==}
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@ethereumjs/util': 9.1.0
+      '@ethersproject/abi': 5.7.0
+      '@nomicfoundation/edr': 0.11.1
+      '@nomicfoundation/solidity-analyzer': 0.1.1
+      '@sentry/node': 5.30.0
+      '@types/bn.js': 5.1.2
+      '@types/lru-cache': 5.1.1
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      boxen: 5.1.2
+      chokidar: 4.0.3
+      ci-info: 2.0.0
+      debug: 4.3.4(supports-color@8.1.1)
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      ethereum-cryptography: 1.2.0
+      find-up: 5.0.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      immutable: 4.3.4
+      io-ts: 1.10.4
+      json-stream-stringify: 3.1.6
+      keccak: 3.0.3
+      lodash: 4.17.21
+      micro-eth-signer: 0.14.0
+      mnemonist: 0.38.5
+      mocha: 10.2.0
+      p-map: 4.0.0
+      picocolors: 1.1.1
+      raw-body: 2.5.2
+      resolve: 1.17.0
+      semver: 7.5.4
+      solc: 0.8.26(debug@4.3.4)
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.10
+      tinyglobby: 0.2.14
+      tsort: 0.0.1
+      typescript: 5.4.3
+      undici: 5.24.0
+      uuid: 8.3.2
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
       - supports-color
       - utf-8-validate
 
@@ -19131,6 +19011,7 @@ packages:
   /is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
+    dev: false
 
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -20090,10 +19971,6 @@ packages:
     resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
     dev: false
 
-  /js-sdsl@4.4.2:
-    resolution: {integrity: sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==}
-    dev: true
-
   /js-sha256@0.9.0:
     resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
     dev: false
@@ -20256,6 +20133,10 @@ packages:
       object-keys: 1.1.1
     dev: false
 
+  /json-stream-stringify@3.1.6:
+    resolution: {integrity: sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==}
+    engines: {node: '>=7.10.1'}
+
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -20374,6 +20255,7 @@ packages:
   /level-supports@4.0.1:
     resolution: {integrity: sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==}
     engines: {node: '>=12'}
+    dev: false
 
   /level-transcoder@1.0.1:
     resolution: {integrity: sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==}
@@ -20381,6 +20263,7 @@ packages:
     dependencies:
       buffer: 6.0.3
       module-error: 1.0.2
+    dev: false
 
   /level@8.0.0:
     resolution: {integrity: sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==}
@@ -20388,6 +20271,7 @@ packages:
     dependencies:
       browser-level: 1.0.1
       classic-level: 1.2.0
+    dev: false
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -20522,6 +20406,7 @@ packages:
 
   /lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   /lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -20679,6 +20564,7 @@ packages:
   /mcl-wasm@0.7.9:
     resolution: {integrity: sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==}
     engines: {node: '>=8.9.0'}
+    dev: false
 
   /md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
@@ -20710,6 +20596,7 @@ packages:
       abstract-level: 1.0.3
       functional-red-black-tree: 1.0.1
       module-error: 1.0.2
+    dev: false
 
   /memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -20975,9 +20862,21 @@ packages:
       - utf-8-validate
     dev: false
 
+  /micro-eth-signer@0.14.0:
+    resolution: {integrity: sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw==}
+    dependencies:
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
+      micro-packed: 0.7.3
+
   /micro-ftch@0.3.1:
     resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
     dev: false
+
+  /micro-packed@0.7.3:
+    resolution: {integrity: sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==}
+    dependencies:
+      '@scure/base': 1.2.6
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -21144,6 +21043,7 @@ packages:
   /module-error@1.0.2:
     resolution: {integrity: sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==}
     engines: {node: '>=10'}
+    dev: false
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -21192,6 +21092,7 @@ packages:
 
   /napi-macros@2.0.0:
     resolution: {integrity: sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==}
+    dev: false
 
   /napi-wasm@1.1.0:
     resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
@@ -21961,6 +21862,10 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  /picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -23242,6 +23147,10 @@ packages:
     dependencies:
       picomatch: 2.3.1
 
+  /readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   /readline@1.3.0:
     resolution: {integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==}
     dev: false
@@ -23656,6 +23565,7 @@ packages:
     resolution: {integrity: sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: false
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -23664,6 +23574,7 @@ packages:
 
   /rustbn.js@0.2.0:
     resolution: {integrity: sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==}
+    dev: false
 
   /rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -23683,6 +23594,7 @@ packages:
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+    dev: false
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -24056,6 +23968,21 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: false
+
+  /solc@0.8.26(debug@4.3.4):
+    resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dependencies:
+      command-exists: 1.2.9
+      commander: 8.3.0
+      follow-redirects: 1.15.4(debug@4.3.4)
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      semver: 7.5.4
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
 
   /sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
@@ -24711,6 +24638,13 @@ packages:
   /tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
+
+  /tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1903,7 +1903,7 @@ importers:
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: 3.0.5
-        version: 3.0.5(ethers@6.10.0)(hardhat@2.19.4)
+        version: 3.0.5(ethers@6.14.4)(hardhat@2.19.4)
       '@nomicfoundation/hardhat-network-helpers':
         specifier: ^1.0.8
         version: 1.0.8(hardhat@2.19.4)
@@ -1912,13 +1912,13 @@ importers:
         version: 4.9.0
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
+        version: 0.5.1(ethers@6.14.4)(typechain@8.3.2)(typescript@5.4.3)
       '@typechain/hardhat':
         specifier: ^9.1.0
-        version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2)
+        version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.14.4)(hardhat@2.19.4)(typechain@8.3.2)
       ethers:
-        specifier: ^6.10.0
-        version: 6.10.0
+        specifier: ^6.14.4
+        version: 6.14.4
       hardhat:
         specifier: ^2.19.4
         version: 2.19.4(typescript@5.4.3)
@@ -2281,10 +2281,10 @@ packages:
 
   /@adraffy/ens-normalize@1.10.0:
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
+    dev: false
 
   /@adraffy/ens-normalize@1.10.1:
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
-    dev: false
 
   /@adraffy/ens-normalize@1.11.0:
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
@@ -8674,14 +8674,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.10.0)(hardhat@2.19.4):
+  /@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.14.4)(hardhat@2.19.4):
     resolution: {integrity: sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==}
     peerDependencies:
       ethers: ^6.1.0
       hardhat: ^2.0.0
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
-      ethers: 6.10.0
+      ethers: 6.14.4
       hardhat: 2.19.4(typescript@5.4.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
@@ -13127,21 +13127,21 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3):
+  /@typechain/ethers-v6@0.5.1(ethers@6.14.4)(typechain@8.3.2)(typescript@5.4.3):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
       typechain: ^8.3.2
       typescript: '>=4.7.0'
     dependencies:
-      ethers: 6.10.0
+      ethers: 6.14.4
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@5.4.3)
       typechain: 8.3.2(typescript@5.4.3)
       typescript: 5.4.3
     dev: true
 
-  /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.19.4)(typechain@8.3.2):
+  /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.14.4)(hardhat@2.19.4)(typechain@8.3.2):
     resolution: {integrity: sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==}
     peerDependencies:
       '@typechain/ethers-v6': ^0.5.1
@@ -13149,8 +13149,8 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.4.3)
-      ethers: 6.10.0
+      '@typechain/ethers-v6': 0.5.1(ethers@6.14.4)(typechain@8.3.2)(typescript@5.4.3)
+      ethers: 6.14.4
       fs-extra: 9.1.0
       hardhat: 2.19.4(typescript@5.4.3)
       typechain: 8.3.2(typescript@5.4.3)
@@ -13382,6 +13382,7 @@ packages:
 
   /@types/node@18.15.13:
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
+    dev: false
 
   /@types/node@18.18.2:
     resolution: {integrity: sha512-u1cis+7wLZMPI62EozwsqvgMZyauczyiqRRu/vcqZKI5N5yidrJHqOFxEg5seT8adc96Q6Yczg1c0DlqGtMJMw==}
@@ -13400,7 +13401,6 @@ packages:
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
     dependencies:
       undici-types: 6.19.8
-    dev: false
 
   /@types/node@22.7.7:
     resolution: {integrity: sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==}
@@ -17817,6 +17817,7 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
 
   /ethers@6.13.5:
     resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
@@ -17833,6 +17834,22 @@ packages:
       - bufferutil
       - utf-8-validate
     dev: false
+
+  /ethers@6.14.4:
+    resolution: {integrity: sha512-Jm/dzRs2Z9iBrT6e9TvGxyb5YVKAPLlpna7hjxH7KH/++DSh2T/JVmQUv7iHI5E55hDbp/gEVvstWYXVxXFzsA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
 
   /ethjs-util@0.1.6:
     resolution: {integrity: sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==}
@@ -24909,6 +24926,7 @@ packages:
 
   /tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: false
 
   /tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
@@ -24916,7 +24934,6 @@ packages:
 
   /tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
-    dev: false
 
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
