### PR TITLE
add optional param to override runtime environment in sdk-server 

### DIFF
--- a/.changeset/three-frogs-travel.md
+++ b/.changeset/three-frogs-travel.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/api-key-stamper": patch
+"@turnkey/sdk-server": patch
+---
+
+Introduces an optional `runtimeOverride` parameter that allows the ability to explicitly specify the crypto environment: `"browser"`, `"node"`, or `"purejs"`.

--- a/packages/api-key-stamper/src/index.ts
+++ b/packages/api-key-stamper/src/index.ts
@@ -57,10 +57,13 @@ export const signWithApiKey = async (
 
   switch (runtime) {
     case "browser":
+      console.log(`Using browser runtime for signing with API key`);
       return (await import("./webcrypto")).signWithApiKey(input);
     case "node":
+      console.log(`Using NodeJS runtime for signing with API key`);
       return (await import("./nodecrypto")).signWithApiKey(input);
     case "purejs":
+      console.log(`Using pure JS runtime for signing with API key`);
       return (await import("./purejs")).signWithApiKey(input);
     default:
       throw new Error(`Unsupported runtime: ${runtime}`);

--- a/packages/api-key-stamper/src/index.ts
+++ b/packages/api-key-stamper/src/index.ts
@@ -57,13 +57,10 @@ export const signWithApiKey = async (
 
   switch (runtime) {
     case "browser":
-      console.log(`Using browser runtime for signing with API key`);
       return (await import("./webcrypto")).signWithApiKey(input);
     case "node":
-      console.log(`Using NodeJS runtime for signing with API key`);
       return (await import("./nodecrypto")).signWithApiKey(input);
     case "purejs":
-      console.log(`Using pure JS runtime for signing with API key`);
       return (await import("./purejs")).signWithApiKey(input);
     default:
       throw new Error(`Unsupported runtime: ${runtime}`);

--- a/packages/sdk-server/src/__types__/base.ts
+++ b/packages/sdk-server/src/__types__/base.ts
@@ -1,4 +1,4 @@
-import { Runtime } from "@turnkey/api-key-stamper";
+import type { Runtime } from "@turnkey/api-key-stamper";
 import type {
   TActivityId,
   TActivityStatus,

--- a/packages/sdk-server/src/__types__/base.ts
+++ b/packages/sdk-server/src/__types__/base.ts
@@ -1,3 +1,4 @@
+import { Runtime } from "@turnkey/api-key-stamper";
 import type {
   TActivityId,
   TActivityStatus,
@@ -91,6 +92,7 @@ export interface TurnkeySDKServerConfig {
   apiPublicKey: string;
   defaultOrganizationId: string;
   activityPoller?: TActivityPollerConfig | undefined;
+  runtimeOverride?: Runtime | undefined;
 }
 
 export interface TurnkeyProxyHandlerConfig {

--- a/packages/sdk-server/src/sdk-client.ts
+++ b/packages/sdk-server/src/sdk-client.ts
@@ -37,6 +37,7 @@ export class TurnkeyServerSDK {
     this.stamper = new ApiKeyStamper({
       apiPublicKey: apiCredentials?.apiPublicKey ?? this.config.apiPublicKey,
       apiPrivateKey: apiCredentials?.apiPrivateKey ?? this.config.apiPrivateKey,
+      runtimeOverride: this.config.runtimeOverride,
     });
 
     return new TurnkeyApiClient({


### PR DESCRIPTION
## Summary & Motivation

This introduces a `runtimeOverride` option in both `ApiKeyStamper` and `TurnkeyServerSDK` that allows users to explicitly select the crypto environment: "browser", "node", or "purejs"

**Note**: this was added based on an ad-hoc request 

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
