### PR TITLE
add validations to uncompressRawPublicKey

### DIFF
--- a/.changeset/two-papayas-juggle.md
+++ b/.changeset/two-papayas-juggle.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": patch
+---
+
+Add validations to uncompressRawPublicKey method

--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -227,6 +227,36 @@ describe("Turnkey Crypto Primitives", () => {
 
     expect(verified).toEqual(true);
   });
+
+  describe("uncompressRawPublicKey", () => {
+    test("happy path", async () => {
+      const keypair = generateP256KeyPair();
+      const uncompressedPublicKey = uncompressRawPublicKey(
+        uint8ArrayFromHexString(keypair.publicKey),
+      );
+      expect(uncompressedPublicKey.length).toEqual(65);
+    });
+
+    test("invalid prefix", async () => {
+      const invalidPrefix = uint8ArrayFromHexString(
+        "77c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+      );
+
+      expect(() => uncompressRawPublicKey(invalidPrefix)).toThrow(
+        "failed to uncompress raw public key: invalid prefix",
+      );
+    });
+
+    test("invalid length", async () => {
+      const keypair = generateP256KeyPair();
+
+      expect(() =>
+        uncompressRawPublicKey(
+          uint8ArrayFromHexString(keypair.publicKey + keypair.publicKey),
+        ),
+      ).toThrow("failed to uncompress raw public key: invalid length");
+    });
+  });
 });
 
 describe("Session JWT signature", () => {

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -342,6 +342,14 @@ export const compressRawPublicKey = (rawPublicKey: Uint8Array): Uint8Array => {
 export const uncompressRawPublicKey = (
   rawPublicKey: Uint8Array,
 ): Uint8Array => {
+  if (rawPublicKey.length !== 33) {
+    throw new Error("failed to uncompress raw public key: invalid length");
+  }
+
+  if (!(rawPublicKey[0] === 2 || rawPublicKey[0] === 3)) {
+    throw new Error("failed to uncompress raw public key: invalid prefix");
+  }
+
   // point[0] must be 2 (false) or 3 (true).
   // this maps to the initial "02" or "03" prefix
   const lsb = rawPublicKey[0] === 3;


### PR DESCRIPTION
## Summary & Motivation
$title

## How I Tested These Changes
- unit

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
