### PR TITLE
Added name to constructor of http client

### DIFF
--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -225,6 +225,10 @@ import type {
   TImportWalletResponse,
 } from "./public_api.fetcher";
 import type {
+  TInitFiatOnRampBody,
+  TInitFiatOnRampResponse,
+} from "./public_api.fetcher";
+import type {
   TInitImportPrivateKeyBody,
   TInitImportPrivateKeyResponse,
 } from "./public_api.fetcher";
@@ -297,6 +301,18 @@ import type {
   TUpdateUserResponse,
 } from "./public_api.fetcher";
 import type {
+  TUpdateUserEmailBody,
+  TUpdateUserEmailResponse,
+} from "./public_api.fetcher";
+import type {
+  TUpdateUserNameBody,
+  TUpdateUserNameResponse,
+} from "./public_api.fetcher";
+import type {
+  TUpdateUserPhoneNumberBody,
+  TUpdateUserPhoneNumberResponse,
+} from "./public_api.fetcher";
+import type {
   TUpdateUserTagBody,
   TUpdateUserTagResponse,
 } from "./public_api.fetcher";
@@ -313,6 +329,7 @@ import type {
 export class TurnkeyClient {
   config: THttpConfig;
   stamper: TStamper;
+  name = "TurnkeyClient";
 
   constructor(config: THttpConfig, stamper: TStamper) {
     if (!config.baseUrl) {
@@ -2172,6 +2189,37 @@ export class TurnkeyClient {
   };
 
   /**
+   * Initiate a fiat on ramp flow
+   *
+   * Sign the provided `TInitFiatOnRampBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/init_fiat_on_ramp).
+   *
+   * See also {@link stampInitFiatOnRamp}.
+   */
+  initFiatOnRamp = async (
+    input: TInitFiatOnRampBody,
+  ): Promise<TInitFiatOnRampResponse> => {
+    return this.request("/public/v1/submit/init_fiat_on_ramp", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TInitFiatOnRampBody` by using the client's `stamp` function.
+   *
+   * See also {@link InitFiatOnRamp}.
+   */
+  stampInitFiatOnRamp = async (
+    input: TInitFiatOnRampBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/submit/init_fiat_on_ramp";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * Initializes a new private key import
    *
    * Sign the provided `TInitImportPrivateKeyBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/init_import_private_key).
@@ -2792,6 +2840,100 @@ export class TurnkeyClient {
    */
   stampUpdateUser = async (input: TUpdateUserBody): Promise<TSignedRequest> => {
     const fullUrl = this.config.baseUrl + "/public/v1/submit/update_user";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Update a User's email in an existing Organization
+   *
+   * Sign the provided `TUpdateUserEmailBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/update_user_email).
+   *
+   * See also {@link stampUpdateUserEmail}.
+   */
+  updateUserEmail = async (
+    input: TUpdateUserEmailBody,
+  ): Promise<TUpdateUserEmailResponse> => {
+    return this.request("/public/v1/submit/update_user_email", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TUpdateUserEmailBody` by using the client's `stamp` function.
+   *
+   * See also {@link UpdateUserEmail}.
+   */
+  stampUpdateUserEmail = async (
+    input: TUpdateUserEmailBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/submit/update_user_email";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Update a User's name in an existing Organization
+   *
+   * Sign the provided `TUpdateUserNameBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/update_user_name).
+   *
+   * See also {@link stampUpdateUserName}.
+   */
+  updateUserName = async (
+    input: TUpdateUserNameBody,
+  ): Promise<TUpdateUserNameResponse> => {
+    return this.request("/public/v1/submit/update_user_name", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TUpdateUserNameBody` by using the client's `stamp` function.
+   *
+   * See also {@link UpdateUserName}.
+   */
+  stampUpdateUserName = async (
+    input: TUpdateUserNameBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/submit/update_user_name";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Update a User's phone number in an existing Organization
+   *
+   * Sign the provided `TUpdateUserPhoneNumberBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/update_user_phone_number).
+   *
+   * See also {@link stampUpdateUserPhoneNumber}.
+   */
+  updateUserPhoneNumber = async (
+    input: TUpdateUserPhoneNumberBody,
+  ): Promise<TUpdateUserPhoneNumberResponse> => {
+    return this.request("/public/v1/submit/update_user_phone_number", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TUpdateUserPhoneNumberBody` by using the client's `stamp` function.
+   *
+   * See also {@link UpdateUserPhoneNumber}.
+   */
+  stampUpdateUserPhoneNumber = async (
+    input: TUpdateUserPhoneNumberBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/submit/update_user_phone_number";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -2896,6 +2896,52 @@ export const signImportWallet = (
   });
 
 /**
+ * `POST /public/v1/submit/init_fiat_on_ramp`
+ */
+export type TInitFiatOnRampResponse =
+  operations["PublicApiService_InitFiatOnRamp"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/init_fiat_on_ramp`
+ */
+export type TInitFiatOnRampInput = { body: TInitFiatOnRampBody };
+
+/**
+ * `POST /public/v1/submit/init_fiat_on_ramp`
+ */
+export type TInitFiatOnRampBody =
+  operations["PublicApiService_InitFiatOnRamp"]["parameters"]["body"]["body"];
+
+/**
+ * Init Fiat On Ramp
+ *
+ * Initiate a fiat on ramp flow
+ *
+ * `POST /public/v1/submit/init_fiat_on_ramp`
+ */
+export const initFiatOnRamp = (input: TInitFiatOnRampInput) =>
+  request<TInitFiatOnRampResponse, TInitFiatOnRampBody, never, never, never>({
+    uri: "/public/v1/submit/init_fiat_on_ramp",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `InitFiatOnRamp` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link InitFiatOnRamp}
+ */
+export const signInitFiatOnRamp = (
+  input: TInitFiatOnRampInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TInitFiatOnRampBody, never, never>({
+    uri: "/public/v1/submit/init_fiat_on_ramp",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/submit/init_import_private_key`
  */
 export type TInitImportPrivateKeyResponse =
@@ -3905,6 +3951,150 @@ export const signUpdateUser = (
 ) =>
   signedRequest<TUpdateUserBody, never, never>({
     uri: "/public/v1/submit/update_user",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/submit/update_user_email`
+ */
+export type TUpdateUserEmailResponse =
+  operations["PublicApiService_UpdateUserEmail"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/update_user_email`
+ */
+export type TUpdateUserEmailInput = { body: TUpdateUserEmailBody };
+
+/**
+ * `POST /public/v1/submit/update_user_email`
+ */
+export type TUpdateUserEmailBody =
+  operations["PublicApiService_UpdateUserEmail"]["parameters"]["body"]["body"];
+
+/**
+ * Update User's Email
+ *
+ * Update a User's email in an existing Organization
+ *
+ * `POST /public/v1/submit/update_user_email`
+ */
+export const updateUserEmail = (input: TUpdateUserEmailInput) =>
+  request<TUpdateUserEmailResponse, TUpdateUserEmailBody, never, never, never>({
+    uri: "/public/v1/submit/update_user_email",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `UpdateUserEmail` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link UpdateUserEmail}
+ */
+export const signUpdateUserEmail = (
+  input: TUpdateUserEmailInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TUpdateUserEmailBody, never, never>({
+    uri: "/public/v1/submit/update_user_email",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/submit/update_user_name`
+ */
+export type TUpdateUserNameResponse =
+  operations["PublicApiService_UpdateUserName"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/update_user_name`
+ */
+export type TUpdateUserNameInput = { body: TUpdateUserNameBody };
+
+/**
+ * `POST /public/v1/submit/update_user_name`
+ */
+export type TUpdateUserNameBody =
+  operations["PublicApiService_UpdateUserName"]["parameters"]["body"]["body"];
+
+/**
+ * Update User's Name
+ *
+ * Update a User's name in an existing Organization
+ *
+ * `POST /public/v1/submit/update_user_name`
+ */
+export const updateUserName = (input: TUpdateUserNameInput) =>
+  request<TUpdateUserNameResponse, TUpdateUserNameBody, never, never, never>({
+    uri: "/public/v1/submit/update_user_name",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `UpdateUserName` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link UpdateUserName}
+ */
+export const signUpdateUserName = (
+  input: TUpdateUserNameInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TUpdateUserNameBody, never, never>({
+    uri: "/public/v1/submit/update_user_name",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/submit/update_user_phone_number`
+ */
+export type TUpdateUserPhoneNumberResponse =
+  operations["PublicApiService_UpdateUserPhoneNumber"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/update_user_phone_number`
+ */
+export type TUpdateUserPhoneNumberInput = { body: TUpdateUserPhoneNumberBody };
+
+/**
+ * `POST /public/v1/submit/update_user_phone_number`
+ */
+export type TUpdateUserPhoneNumberBody =
+  operations["PublicApiService_UpdateUserPhoneNumber"]["parameters"]["body"]["body"];
+
+/**
+ * Update User's Phone Number
+ *
+ * Update a User's phone number in an existing Organization
+ *
+ * `POST /public/v1/submit/update_user_phone_number`
+ */
+export const updateUserPhoneNumber = (input: TUpdateUserPhoneNumberInput) =>
+  request<
+    TUpdateUserPhoneNumberResponse,
+    TUpdateUserPhoneNumberBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/submit/update_user_phone_number",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `UpdateUserPhoneNumber` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link UpdateUserPhoneNumber}
+ */
+export const signUpdateUserPhoneNumber = (
+  input: TUpdateUserPhoneNumberInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TUpdateUserPhoneNumberBody, never, never>({
+    uri: "/public/v1/submit/update_user_phone_number",
     body: input.body,
     options,
   });

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -1956,6 +1956,38 @@
         "tags": ["Wallets"]
       }
     },
+    "/public/v1/submit/init_fiat_on_ramp": {
+      "post": {
+        "summary": "Init Fiat On Ramp",
+        "description": "Initiate a fiat on ramp flow",
+        "operationId": "PublicApiService_InitFiatOnRamp",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1InitFiatOnRampRequest"
+            }
+          }
+        ],
+        "tags": ["On Ramp"]
+      }
+    },
     "/public/v1/submit/init_import_private_key": {
       "post": {
         "summary": "Init Import Private Key",
@@ -2628,6 +2660,102 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/update_user_email": {
+      "post": {
+        "summary": "Update User's Email",
+        "description": "Update a User's email in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserEmail",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserEmailRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
+    "/public/v1/submit/update_user_name": {
+      "post": {
+        "summary": "Update User's Name",
+        "description": "Update a User's name in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserName",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserNameRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
+    "/public/v1/submit/update_user_phone_number": {
+      "post": {
+        "summary": "Update User's Phone Number",
+        "description": "Update a User's phone number in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserPhoneNumber",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserPhoneNumberRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
     "/public/v1/submit/update_user_tag": {
       "post": {
         "summary": "Update User Tag",
@@ -3261,7 +3389,11 @@
         "ACTIVITY_TYPE_VERIFY_OTP",
         "ACTIVITY_TYPE_OTP_LOGIN",
         "ACTIVITY_TYPE_STAMP_LOGIN",
-        "ACTIVITY_TYPE_OAUTH_LOGIN"
+        "ACTIVITY_TYPE_OAUTH_LOGIN",
+        "ACTIVITY_TYPE_UPDATE_USER_NAME",
+        "ACTIVITY_TYPE_UPDATE_USER_EMAIL",
+        "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER",
+        "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP"
       ]
     },
     "v1AddressFormat": {
@@ -5954,6 +6086,88 @@
         "FEATURE_NAME_OTP_EMAIL_AUTH"
       ]
     },
+    "v1FiatOnRampBlockchainNetwork": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BITCOIN",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_ETHEREUM",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_SOLANA",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BASE"
+      ]
+    },
+    "v1FiatOnRampCryptoCurrency": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_BTC",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_ETH",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_SOL",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_USDC"
+      ]
+    },
+    "v1FiatOnRampCurrency": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_CURRENCY_AUD",
+        "FIAT_ON_RAMP_CURRENCY_BGN",
+        "FIAT_ON_RAMP_CURRENCY_BRL",
+        "FIAT_ON_RAMP_CURRENCY_CAD",
+        "FIAT_ON_RAMP_CURRENCY_CHF",
+        "FIAT_ON_RAMP_CURRENCY_COP",
+        "FIAT_ON_RAMP_CURRENCY_CZK",
+        "FIAT_ON_RAMP_CURRENCY_DKK",
+        "FIAT_ON_RAMP_CURRENCY_DOP",
+        "FIAT_ON_RAMP_CURRENCY_EGP",
+        "FIAT_ON_RAMP_CURRENCY_EUR",
+        "FIAT_ON_RAMP_CURRENCY_GBP",
+        "FIAT_ON_RAMP_CURRENCY_HKD",
+        "FIAT_ON_RAMP_CURRENCY_IDR",
+        "FIAT_ON_RAMP_CURRENCY_ILS",
+        "FIAT_ON_RAMP_CURRENCY_JOD",
+        "FIAT_ON_RAMP_CURRENCY_KES",
+        "FIAT_ON_RAMP_CURRENCY_KWD",
+        "FIAT_ON_RAMP_CURRENCY_LKR",
+        "FIAT_ON_RAMP_CURRENCY_MXN",
+        "FIAT_ON_RAMP_CURRENCY_NGN",
+        "FIAT_ON_RAMP_CURRENCY_NOK",
+        "FIAT_ON_RAMP_CURRENCY_NZD",
+        "FIAT_ON_RAMP_CURRENCY_OMR",
+        "FIAT_ON_RAMP_CURRENCY_PEN",
+        "FIAT_ON_RAMP_CURRENCY_PLN",
+        "FIAT_ON_RAMP_CURRENCY_RON",
+        "FIAT_ON_RAMP_CURRENCY_SEK",
+        "FIAT_ON_RAMP_CURRENCY_THB",
+        "FIAT_ON_RAMP_CURRENCY_TRY",
+        "FIAT_ON_RAMP_CURRENCY_TWD",
+        "FIAT_ON_RAMP_CURRENCY_USD",
+        "FIAT_ON_RAMP_CURRENCY_VND",
+        "FIAT_ON_RAMP_CURRENCY_ZAR"
+      ]
+    },
+    "v1FiatOnRampPaymentMethod": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_PAYMENT_METHOD_CREDIT_DEBIT_CARD",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_APPLE_PAY",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_BANK_TRANSFER",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_OPEN_BANKING_PAYMENT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GOOGLE_PAY",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_SEPA_BANK_TRANSFER",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_PIX_INSTANT_PAYMENT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_PAYPAL",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_VENMO",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_MOONPAY_BALANCE",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_CRYPTO_ACCOUNT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_FIAT_WALLET",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_ACH_BANK_ACCOUNT"
+      ]
+    },
+    "v1FiatOnRampProvider": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_PROVIDER_COINBASE",
+        "FIAT_ON_RAMP_PROVIDER_MOONPAY"
+      ]
+    },
     "v1GetActivitiesRequest": {
       "type": "object",
       "properties": {
@@ -6712,6 +6926,88 @@
       },
       "required": ["walletId", "addresses"]
     },
+    "v1InitFiatOnRampIntent": {
+      "type": "object",
+      "properties": {
+        "onrampProvider": {
+          "$ref": "#/definitions/v1FiatOnRampProvider",
+          "description": "Enum to specifiy which on-ramp provider to use"
+        },
+        "walletAddress": {
+          "type": "string",
+          "description": "Destination wallet address for the buy transaction."
+        },
+        "network": {
+          "$ref": "#/definitions/v1FiatOnRampBlockchainNetwork",
+          "description": "Blockchain network to be used for the transaction, e.g., bitcoin, ethereum. Maps to MoonPay's network or Coinbase's defaultNetwork."
+        },
+        "cryptoCurrencyCode": {
+          "$ref": "#/definitions/v1FiatOnRampCryptoCurrency",
+          "description": "Code for the cryptocurrency to be purchased, e.g., btc, eth. Maps to MoonPay's currencyCode or Coinbase's defaultAsset."
+        },
+        "fiatCurrencyCode": {
+          "$ref": "#/definitions/v1FiatOnRampCurrency",
+          "description": "Code for the fiat currency to be used in the transaction, e.g., USD, EUR."
+        },
+        "fiatCurrencyAmount": {
+          "type": "string",
+          "description": "Specifies a preset fiat amount for the transaction, e.g., '100'. Must be greater than '20'. If not provided, the user will be prompted to enter an amount."
+        },
+        "paymentMethod": {
+          "$ref": "#/definitions/v1FiatOnRampPaymentMethod",
+          "description": "Pre-selected payment method, e.g., CREDIT_DEBIT_CARD, APPLE_PAY. Validated against the chosen provider."
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 two-digit country code for Coinbase representing the purchasing user’s country of residence, e.g., US, GB."
+        },
+        "countrySubdivisionCode": {
+          "type": "string",
+          "description": "ISO 3166-2 two-digit country subdivision code for Coinbase representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if country_code=US."
+        }
+      },
+      "required": [
+        "onrampProvider",
+        "walletAddress",
+        "network",
+        "cryptoCurrencyCode"
+      ]
+    },
+    "v1InitFiatOnRampRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_INIT_FIAT_ON_RAMP"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1InitFiatOnRampIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1InitFiatOnRampResult": {
+      "type": "object",
+      "properties": {
+        "onRampUrl": {
+          "type": "string",
+          "description": "Unique URL for a given fiat on-ramp flow."
+        },
+        "onRampTransactionId": {
+          "type": "string",
+          "description": "Unique identifier used to retrieve transaction statuses for a given fiat on-ramp flow."
+        }
+      },
+      "required": ["onRampUrl", "onRampTransactionId"]
+    },
     "v1InitImportPrivateKeyIntent": {
       "type": "object",
       "properties": {
@@ -7321,6 +7617,18 @@
         },
         "oauthLoginIntent": {
           "$ref": "#/definitions/v1OauthLoginIntent"
+        },
+        "updateUserNameIntent": {
+          "$ref": "#/definitions/v1UpdateUserNameIntent"
+        },
+        "updateUserEmailIntent": {
+          "$ref": "#/definitions/v1UpdateUserEmailIntent"
+        },
+        "updateUserPhoneNumberIntent": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberIntent"
+        },
+        "initFiatOnRampIntent": {
+          "$ref": "#/definitions/v1InitFiatOnRampIntent"
         }
       }
     },
@@ -7887,7 +8195,11 @@
     },
     "v1PayloadEncoding": {
       "type": "string",
-      "enum": ["PAYLOAD_ENCODING_HEXADECIMAL", "PAYLOAD_ENCODING_TEXT_UTF8"]
+      "enum": [
+        "PAYLOAD_ENCODING_HEXADECIMAL",
+        "PAYLOAD_ENCODING_TEXT_UTF8",
+        "PAYLOAD_ENCODING_EIP712"
+      ]
     },
     "v1Policy": {
       "type": "object",
@@ -8416,6 +8728,18 @@
         },
         "oauthLoginResult": {
           "$ref": "#/definitions/v1OauthLoginResult"
+        },
+        "updateUserNameResult": {
+          "$ref": "#/definitions/v1UpdateUserNameResult"
+        },
+        "updateUserEmailResult": {
+          "$ref": "#/definitions/v1UpdateUserEmailResult"
+        },
+        "updateUserPhoneNumberResult": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberResult"
+        },
+        "initFiatOnRampResult": {
+          "$ref": "#/definitions/v1InitFiatOnRampResult"
         }
       }
     },
@@ -9176,6 +9500,55 @@
     "v1UpdateRootQuorumResult": {
       "type": "object"
     },
+    "v1UpdateUserEmailIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userEmail": {
+          "type": "string",
+          "description": "The user's email address. Setting this to an empty string will remove the user's email."
+        },
+        "verificationToken": {
+          "type": "string",
+          "description": "Signed JWT containing a unique id, expiry, verification type, contact"
+        }
+      },
+      "required": ["userId", "userEmail"]
+    },
+    "v1UpdateUserEmailRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_EMAIL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserEmailIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserEmailResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose email was updated."
+        }
+      },
+      "required": ["userId"]
+    },
     "v1UpdateUserIntent": {
       "type": "object",
       "properties": {
@@ -9201,6 +9574,100 @@
         "userPhoneNumber": {
           "type": "string",
           "description": "The user's phone number in E.164 format e.g. +13214567890"
+        }
+      },
+      "required": ["userId"]
+    },
+    "v1UpdateUserNameIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userName": {
+          "type": "string",
+          "description": "Human-readable name for a User."
+        }
+      },
+      "required": ["userId", "userName"]
+    },
+    "v1UpdateUserNameRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_NAME"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserNameIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserNameResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose name was updated."
+        }
+      },
+      "required": ["userId"]
+    },
+    "v1UpdateUserPhoneNumberIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userPhoneNumber": {
+          "type": "string",
+          "description": "The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number."
+        },
+        "verificationToken": {
+          "type": "string",
+          "description": "Signed JWT containing a unique id, expiry, verification type, contact"
+        }
+      },
+      "required": ["userId", "userPhoneNumber"]
+    },
+    "v1UpdateUserPhoneNumberRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserPhoneNumberResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose phone number was updated."
         }
       },
       "required": ["userId"]

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -240,6 +240,10 @@ export type paths = {
     /** Imports a wallet */
     post: operations["PublicApiService_ImportWallet"];
   };
+  "/public/v1/submit/init_fiat_on_ramp": {
+    /** Initiate a fiat on ramp flow */
+    post: operations["PublicApiService_InitFiatOnRamp"];
+  };
   "/public/v1/submit/init_import_private_key": {
     /** Initializes a new private key import */
     post: operations["PublicApiService_InitImportPrivateKey"];
@@ -323,6 +327,18 @@ export type paths = {
   "/public/v1/submit/update_user": {
     /** Update a User in an existing Organization */
     post: operations["PublicApiService_UpdateUser"];
+  };
+  "/public/v1/submit/update_user_email": {
+    /** Update a User's email in an existing Organization */
+    post: operations["PublicApiService_UpdateUserEmail"];
+  };
+  "/public/v1/submit/update_user_name": {
+    /** Update a User's name in an existing Organization */
+    post: operations["PublicApiService_UpdateUserName"];
+  };
+  "/public/v1/submit/update_user_phone_number": {
+    /** Update a User's phone number in an existing Organization */
+    post: operations["PublicApiService_UpdateUserPhoneNumber"];
   };
   "/public/v1/submit/update_user_tag": {
     /** Update human-readable name or associated users. Note that this activity is atomic: all of the updates will succeed at once, or all of them will fail. */
@@ -593,7 +609,11 @@ export type definitions = {
     | "ACTIVITY_TYPE_VERIFY_OTP"
     | "ACTIVITY_TYPE_OTP_LOGIN"
     | "ACTIVITY_TYPE_STAMP_LOGIN"
-    | "ACTIVITY_TYPE_OAUTH_LOGIN";
+    | "ACTIVITY_TYPE_OAUTH_LOGIN"
+    | "ACTIVITY_TYPE_UPDATE_USER_NAME"
+    | "ACTIVITY_TYPE_UPDATE_USER_EMAIL"
+    | "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"
+    | "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1680,6 +1700,73 @@ export type definitions = {
     | "FEATURE_NAME_WEBHOOK"
     | "FEATURE_NAME_SMS_AUTH"
     | "FEATURE_NAME_OTP_EMAIL_AUTH";
+  /** @enum {string} */
+  v1FiatOnRampBlockchainNetwork:
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BITCOIN"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_ETHEREUM"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_SOLANA"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BASE";
+  /** @enum {string} */
+  v1FiatOnRampCryptoCurrency:
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_BTC"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_ETH"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_SOL"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_USDC";
+  /** @enum {string} */
+  v1FiatOnRampCurrency:
+    | "FIAT_ON_RAMP_CURRENCY_AUD"
+    | "FIAT_ON_RAMP_CURRENCY_BGN"
+    | "FIAT_ON_RAMP_CURRENCY_BRL"
+    | "FIAT_ON_RAMP_CURRENCY_CAD"
+    | "FIAT_ON_RAMP_CURRENCY_CHF"
+    | "FIAT_ON_RAMP_CURRENCY_COP"
+    | "FIAT_ON_RAMP_CURRENCY_CZK"
+    | "FIAT_ON_RAMP_CURRENCY_DKK"
+    | "FIAT_ON_RAMP_CURRENCY_DOP"
+    | "FIAT_ON_RAMP_CURRENCY_EGP"
+    | "FIAT_ON_RAMP_CURRENCY_EUR"
+    | "FIAT_ON_RAMP_CURRENCY_GBP"
+    | "FIAT_ON_RAMP_CURRENCY_HKD"
+    | "FIAT_ON_RAMP_CURRENCY_IDR"
+    | "FIAT_ON_RAMP_CURRENCY_ILS"
+    | "FIAT_ON_RAMP_CURRENCY_JOD"
+    | "FIAT_ON_RAMP_CURRENCY_KES"
+    | "FIAT_ON_RAMP_CURRENCY_KWD"
+    | "FIAT_ON_RAMP_CURRENCY_LKR"
+    | "FIAT_ON_RAMP_CURRENCY_MXN"
+    | "FIAT_ON_RAMP_CURRENCY_NGN"
+    | "FIAT_ON_RAMP_CURRENCY_NOK"
+    | "FIAT_ON_RAMP_CURRENCY_NZD"
+    | "FIAT_ON_RAMP_CURRENCY_OMR"
+    | "FIAT_ON_RAMP_CURRENCY_PEN"
+    | "FIAT_ON_RAMP_CURRENCY_PLN"
+    | "FIAT_ON_RAMP_CURRENCY_RON"
+    | "FIAT_ON_RAMP_CURRENCY_SEK"
+    | "FIAT_ON_RAMP_CURRENCY_THB"
+    | "FIAT_ON_RAMP_CURRENCY_TRY"
+    | "FIAT_ON_RAMP_CURRENCY_TWD"
+    | "FIAT_ON_RAMP_CURRENCY_USD"
+    | "FIAT_ON_RAMP_CURRENCY_VND"
+    | "FIAT_ON_RAMP_CURRENCY_ZAR";
+  /** @enum {string} */
+  v1FiatOnRampPaymentMethod:
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_CREDIT_DEBIT_CARD"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_APPLE_PAY"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_BANK_TRANSFER"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_OPEN_BANKING_PAYMENT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GOOGLE_PAY"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_SEPA_BANK_TRANSFER"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_PIX_INSTANT_PAYMENT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_PAYPAL"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_VENMO"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_MOONPAY_BALANCE"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_CRYPTO_ACCOUNT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_FIAT_WALLET"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_ACH_BANK_ACCOUNT";
+  /** @enum {string} */
+  v1FiatOnRampProvider:
+    | "FIAT_ON_RAMP_PROVIDER_COINBASE"
+    | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
   v1GetActivitiesRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -1977,6 +2064,41 @@ export type definitions = {
     /** @description A list of account addresses. */
     addresses: string[];
   };
+  v1InitFiatOnRampIntent: {
+    /** @description Enum to specifiy which on-ramp provider to use */
+    onrampProvider: definitions["v1FiatOnRampProvider"];
+    /** @description Destination wallet address for the buy transaction. */
+    walletAddress: string;
+    /** @description Blockchain network to be used for the transaction, e.g., bitcoin, ethereum. Maps to MoonPay's network or Coinbase's defaultNetwork. */
+    network: definitions["v1FiatOnRampBlockchainNetwork"];
+    /** @description Code for the cryptocurrency to be purchased, e.g., btc, eth. Maps to MoonPay's currencyCode or Coinbase's defaultAsset. */
+    cryptoCurrencyCode: definitions["v1FiatOnRampCryptoCurrency"];
+    /** @description Code for the fiat currency to be used in the transaction, e.g., USD, EUR. */
+    fiatCurrencyCode?: definitions["v1FiatOnRampCurrency"];
+    /** @description Specifies a preset fiat amount for the transaction, e.g., '100'. Must be greater than '20'. If not provided, the user will be prompted to enter an amount. */
+    fiatCurrencyAmount?: string;
+    /** @description Pre-selected payment method, e.g., CREDIT_DEBIT_CARD, APPLE_PAY. Validated against the chosen provider. */
+    paymentMethod?: definitions["v1FiatOnRampPaymentMethod"];
+    /** @description ISO 3166-1 two-digit country code for Coinbase representing the purchasing user’s country of residence, e.g., US, GB. */
+    countryCode?: string;
+    /** @description ISO 3166-2 two-digit country subdivision code for Coinbase representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if country_code=US. */
+    countrySubdivisionCode?: string;
+  };
+  v1InitFiatOnRampRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1InitFiatOnRampIntent"];
+  };
+  v1InitFiatOnRampResult: {
+    /** @description Unique URL for a given fiat on-ramp flow. */
+    onRampUrl: string;
+    /** @description Unique identifier used to retrieve transaction statuses for a given fiat on-ramp flow. */
+    onRampTransactionId: string;
+  };
   v1InitImportPrivateKeyIntent: {
     /** @description The ID of the User importing a Private Key. */
     userId: string;
@@ -2223,6 +2345,10 @@ export type definitions = {
     otpLoginIntent?: definitions["v1OtpLoginIntent"];
     stampLoginIntent?: definitions["v1StampLoginIntent"];
     oauthLoginIntent?: definitions["v1OauthLoginIntent"];
+    updateUserNameIntent?: definitions["v1UpdateUserNameIntent"];
+    updateUserEmailIntent?: definitions["v1UpdateUserEmailIntent"];
+    updateUserPhoneNumberIntent?: definitions["v1UpdateUserPhoneNumberIntent"];
+    initFiatOnRampIntent?: definitions["v1InitFiatOnRampIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -2453,7 +2579,8 @@ export type definitions = {
   /** @enum {string} */
   v1PayloadEncoding:
     | "PAYLOAD_ENCODING_HEXADECIMAL"
-    | "PAYLOAD_ENCODING_TEXT_UTF8";
+    | "PAYLOAD_ENCODING_TEXT_UTF8"
+    | "PAYLOAD_ENCODING_EIP712";
   v1Policy: {
     /** @description Unique identifier for a given Policy. */
     policyId: string;
@@ -2637,6 +2764,10 @@ export type definitions = {
     otpLoginResult?: definitions["v1OtpLoginResult"];
     stampLoginResult?: definitions["v1StampLoginResult"];
     oauthLoginResult?: definitions["v1OauthLoginResult"];
+    updateUserNameResult?: definitions["v1UpdateUserNameResult"];
+    updateUserEmailResult?: definitions["v1UpdateUserEmailResult"];
+    updateUserPhoneNumberResult?: definitions["v1UpdateUserPhoneNumberResult"];
+    initFiatOnRampResult?: definitions["v1InitFiatOnRampResult"];
   };
   v1RootUserParams: {
     /** @description Human-readable name for a User. */
@@ -2941,6 +3072,27 @@ export type definitions = {
     parameters: definitions["v1UpdateRootQuorumIntent"];
   };
   v1UpdateRootQuorumResult: { [key: string]: unknown };
+  v1UpdateUserEmailIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description The user's email address. Setting this to an empty string will remove the user's email. */
+    userEmail: string;
+    /** @description Signed JWT containing a unique id, expiry, verification type, contact */
+    verificationToken?: string;
+  };
+  v1UpdateUserEmailRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_EMAIL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserEmailIntent"];
+  };
+  v1UpdateUserEmailResult: {
+    /** @description Unique identifier of the User whose email was updated. */
+    userId: string;
+  };
   v1UpdateUserIntent: {
     /** @description Unique identifier for a given User. */
     userId: string;
@@ -2952,6 +3104,46 @@ export type definitions = {
     userTagIds?: string[];
     /** @description The user's phone number in E.164 format e.g. +13214567890 */
     userPhoneNumber?: string;
+  };
+  v1UpdateUserNameIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Human-readable name for a User. */
+    userName: string;
+  };
+  v1UpdateUserNameRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_NAME";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserNameIntent"];
+  };
+  v1UpdateUserNameResult: {
+    /** @description Unique identifier of the User whose name was updated. */
+    userId: string;
+  };
+  v1UpdateUserPhoneNumberIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number. */
+    userPhoneNumber: string;
+    /** @description Signed JWT containing a unique id, expiry, verification type, contact */
+    verificationToken?: string;
+  };
+  v1UpdateUserPhoneNumberRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserPhoneNumberIntent"];
+  };
+  v1UpdateUserPhoneNumberResult: {
+    /** @description Unique identifier of the User whose phone number was updated. */
+    userId: string;
   };
   v1UpdateUserRequest: {
     /** @enum {string} */
@@ -4247,6 +4439,24 @@ export type operations = {
       };
     };
   };
+  /** Initiate a fiat on ramp flow */
+  PublicApiService_InitFiatOnRamp: {
+    parameters: {
+      body: {
+        body: definitions["v1InitFiatOnRampRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Initializes a new private key import */
   PublicApiService_InitImportPrivateKey: {
     parameters: {
@@ -4612,6 +4822,60 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1UpdateUserRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's email in an existing Organization */
+  PublicApiService_UpdateUserEmail: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserEmailRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's name in an existing Organization */
+  PublicApiService_UpdateUserName: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserNameRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's phone number in an existing Organization */
+  PublicApiService_UpdateUserPhoneNumber: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserPhoneNumberRequest"];
       };
     };
     responses: {

--- a/packages/http/src/base.ts
+++ b/packages/http/src/base.ts
@@ -255,9 +255,9 @@ export async function sealAndStampRequestBody(input: {
   };
 }
 
-// Check if the client is an instance of TurnkeyClient. We check the constructor name here since the 'instanceof' operator does not work across if the http client isn't EXACTLY the same (mismatching versions).
+// Check if the client is an instance of TurnkeyClient. We check the name field here since the 'instanceof' operator does not work across if the http client isn't EXACTLY the same (mismatching versions).
 export function isHttpClient(client: any): client is TurnkeyClient {
-  return client?.constructor?.name === "TurnkeyClient";
+  return client?.name === "TurnkeyClient";
 }
 
 export type THttpConfig = {

--- a/packages/sdk-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-browser/src/__generated__/sdk-client-base.ts
@@ -2222,6 +2222,45 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  initFiatOnRamp = async (
+    input: SdkApiTypes.TInitFiatOnRampBody,
+  ): Promise<SdkApiTypes.TInitFiatOnRampResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    let session = await getStorageValue(StorageKeys.Session);
+    session = parseSession(session!);
+
+    return this.command(
+      "/public/v1/submit/init_fiat_on_ramp",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP",
+      },
+      "initFiatOnRampResult",
+    );
+  };
+
+  stampInitFiatOnRamp = async (
+    input: SdkApiTypes.TInitFiatOnRampBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/init_fiat_on_ramp";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   initImportPrivateKey = async (
     input: SdkApiTypes.TInitImportPrivateKeyBody,
   ): Promise<SdkApiTypes.TInitImportPrivateKeyResponse> => {
@@ -3015,6 +3054,123 @@ export class TurnkeySDKClientBase {
       return undefined;
     }
     const fullUrl = this.config.apiBaseUrl + "/public/v1/submit/update_user";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateUserEmail = async (
+    input: SdkApiTypes.TUpdateUserEmailBody,
+  ): Promise<SdkApiTypes.TUpdateUserEmailResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    let session = await getStorageValue(StorageKeys.Session);
+    session = parseSession(session!);
+
+    return this.command(
+      "/public/v1/submit/update_user_email",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_USER_EMAIL",
+      },
+      "updateUserEmailResult",
+    );
+  };
+
+  stampUpdateUserEmail = async (
+    input: SdkApiTypes.TUpdateUserEmailBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_user_email";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateUserName = async (
+    input: SdkApiTypes.TUpdateUserNameBody,
+  ): Promise<SdkApiTypes.TUpdateUserNameResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    let session = await getStorageValue(StorageKeys.Session);
+    session = parseSession(session!);
+
+    return this.command(
+      "/public/v1/submit/update_user_name",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_USER_NAME",
+      },
+      "updateUserNameResult",
+    );
+  };
+
+  stampUpdateUserName = async (
+    input: SdkApiTypes.TUpdateUserNameBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_user_name";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateUserPhoneNumber = async (
+    input: SdkApiTypes.TUpdateUserPhoneNumberBody,
+  ): Promise<SdkApiTypes.TUpdateUserPhoneNumberResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    let session = await getStorageValue(StorageKeys.Session);
+    session = parseSession(session!);
+
+    return this.command(
+      "/public/v1/submit/update_user_phone_number",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER",
+      },
+      "updateUserPhoneNumberResult",
+    );
+  };
+
+  stampUpdateUserPhoneNumber = async (
+    input: SdkApiTypes.TUpdateUserPhoneNumberBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_user_phone_number";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {

--- a/packages/sdk-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-browser/src/__generated__/sdk_api_types.ts
@@ -628,6 +628,16 @@ export type TImportWalletBody =
   operations["PublicApiService_ImportWallet"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
+export type TInitFiatOnRampResponse =
+  operations["PublicApiService_InitFiatOnRamp"]["responses"]["200"]["schema"]["activity"]["result"]["initFiatOnRampResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TInitFiatOnRampInput = { body: TInitFiatOnRampBody };
+
+export type TInitFiatOnRampBody =
+  operations["PublicApiService_InitFiatOnRamp"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
 export type TInitImportPrivateKeyResponse =
   operations["PublicApiService_InitImportPrivateKey"]["responses"]["200"]["schema"]["activity"]["result"]["initImportPrivateKeyResult"] &
     definitions["v1ActivityResponse"];
@@ -840,6 +850,36 @@ export type TUpdateUserInput = { body: TUpdateUserBody };
 
 export type TUpdateUserBody =
   operations["PublicApiService_UpdateUser"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpdateUserEmailResponse =
+  operations["PublicApiService_UpdateUserEmail"]["responses"]["200"]["schema"]["activity"]["result"]["updateUserEmailResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpdateUserEmailInput = { body: TUpdateUserEmailBody };
+
+export type TUpdateUserEmailBody =
+  operations["PublicApiService_UpdateUserEmail"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpdateUserNameResponse =
+  operations["PublicApiService_UpdateUserName"]["responses"]["200"]["schema"]["activity"]["result"]["updateUserNameResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpdateUserNameInput = { body: TUpdateUserNameBody };
+
+export type TUpdateUserNameBody =
+  operations["PublicApiService_UpdateUserName"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpdateUserPhoneNumberResponse =
+  operations["PublicApiService_UpdateUserPhoneNumber"]["responses"]["200"]["schema"]["activity"]["result"]["updateUserPhoneNumberResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpdateUserPhoneNumberInput = { body: TUpdateUserPhoneNumberBody };
+
+export type TUpdateUserPhoneNumberBody =
+  operations["PublicApiService_UpdateUserPhoneNumber"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TUpdateUserTagResponse =

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -1956,6 +1956,38 @@
         "tags": ["Wallets"]
       }
     },
+    "/public/v1/submit/init_fiat_on_ramp": {
+      "post": {
+        "summary": "Init Fiat On Ramp",
+        "description": "Initiate a fiat on ramp flow",
+        "operationId": "PublicApiService_InitFiatOnRamp",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1InitFiatOnRampRequest"
+            }
+          }
+        ],
+        "tags": ["On Ramp"]
+      }
+    },
     "/public/v1/submit/init_import_private_key": {
       "post": {
         "summary": "Init Import Private Key",
@@ -2628,6 +2660,102 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/update_user_email": {
+      "post": {
+        "summary": "Update User's Email",
+        "description": "Update a User's email in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserEmail",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserEmailRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
+    "/public/v1/submit/update_user_name": {
+      "post": {
+        "summary": "Update User's Name",
+        "description": "Update a User's name in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserName",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserNameRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
+    "/public/v1/submit/update_user_phone_number": {
+      "post": {
+        "summary": "Update User's Phone Number",
+        "description": "Update a User's phone number in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserPhoneNumber",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserPhoneNumberRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
     "/public/v1/submit/update_user_tag": {
       "post": {
         "summary": "Update User Tag",
@@ -3261,7 +3389,11 @@
         "ACTIVITY_TYPE_VERIFY_OTP",
         "ACTIVITY_TYPE_OTP_LOGIN",
         "ACTIVITY_TYPE_STAMP_LOGIN",
-        "ACTIVITY_TYPE_OAUTH_LOGIN"
+        "ACTIVITY_TYPE_OAUTH_LOGIN",
+        "ACTIVITY_TYPE_UPDATE_USER_NAME",
+        "ACTIVITY_TYPE_UPDATE_USER_EMAIL",
+        "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER",
+        "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP"
       ]
     },
     "v1AddressFormat": {
@@ -5954,6 +6086,88 @@
         "FEATURE_NAME_OTP_EMAIL_AUTH"
       ]
     },
+    "v1FiatOnRampBlockchainNetwork": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BITCOIN",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_ETHEREUM",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_SOLANA",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BASE"
+      ]
+    },
+    "v1FiatOnRampCryptoCurrency": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_BTC",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_ETH",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_SOL",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_USDC"
+      ]
+    },
+    "v1FiatOnRampCurrency": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_CURRENCY_AUD",
+        "FIAT_ON_RAMP_CURRENCY_BGN",
+        "FIAT_ON_RAMP_CURRENCY_BRL",
+        "FIAT_ON_RAMP_CURRENCY_CAD",
+        "FIAT_ON_RAMP_CURRENCY_CHF",
+        "FIAT_ON_RAMP_CURRENCY_COP",
+        "FIAT_ON_RAMP_CURRENCY_CZK",
+        "FIAT_ON_RAMP_CURRENCY_DKK",
+        "FIAT_ON_RAMP_CURRENCY_DOP",
+        "FIAT_ON_RAMP_CURRENCY_EGP",
+        "FIAT_ON_RAMP_CURRENCY_EUR",
+        "FIAT_ON_RAMP_CURRENCY_GBP",
+        "FIAT_ON_RAMP_CURRENCY_HKD",
+        "FIAT_ON_RAMP_CURRENCY_IDR",
+        "FIAT_ON_RAMP_CURRENCY_ILS",
+        "FIAT_ON_RAMP_CURRENCY_JOD",
+        "FIAT_ON_RAMP_CURRENCY_KES",
+        "FIAT_ON_RAMP_CURRENCY_KWD",
+        "FIAT_ON_RAMP_CURRENCY_LKR",
+        "FIAT_ON_RAMP_CURRENCY_MXN",
+        "FIAT_ON_RAMP_CURRENCY_NGN",
+        "FIAT_ON_RAMP_CURRENCY_NOK",
+        "FIAT_ON_RAMP_CURRENCY_NZD",
+        "FIAT_ON_RAMP_CURRENCY_OMR",
+        "FIAT_ON_RAMP_CURRENCY_PEN",
+        "FIAT_ON_RAMP_CURRENCY_PLN",
+        "FIAT_ON_RAMP_CURRENCY_RON",
+        "FIAT_ON_RAMP_CURRENCY_SEK",
+        "FIAT_ON_RAMP_CURRENCY_THB",
+        "FIAT_ON_RAMP_CURRENCY_TRY",
+        "FIAT_ON_RAMP_CURRENCY_TWD",
+        "FIAT_ON_RAMP_CURRENCY_USD",
+        "FIAT_ON_RAMP_CURRENCY_VND",
+        "FIAT_ON_RAMP_CURRENCY_ZAR"
+      ]
+    },
+    "v1FiatOnRampPaymentMethod": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_PAYMENT_METHOD_CREDIT_DEBIT_CARD",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_APPLE_PAY",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_BANK_TRANSFER",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_OPEN_BANKING_PAYMENT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GOOGLE_PAY",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_SEPA_BANK_TRANSFER",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_PIX_INSTANT_PAYMENT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_PAYPAL",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_VENMO",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_MOONPAY_BALANCE",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_CRYPTO_ACCOUNT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_FIAT_WALLET",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_ACH_BANK_ACCOUNT"
+      ]
+    },
+    "v1FiatOnRampProvider": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_PROVIDER_COINBASE",
+        "FIAT_ON_RAMP_PROVIDER_MOONPAY"
+      ]
+    },
     "v1GetActivitiesRequest": {
       "type": "object",
       "properties": {
@@ -6712,6 +6926,88 @@
       },
       "required": ["walletId", "addresses"]
     },
+    "v1InitFiatOnRampIntent": {
+      "type": "object",
+      "properties": {
+        "onrampProvider": {
+          "$ref": "#/definitions/v1FiatOnRampProvider",
+          "description": "Enum to specifiy which on-ramp provider to use"
+        },
+        "walletAddress": {
+          "type": "string",
+          "description": "Destination wallet address for the buy transaction."
+        },
+        "network": {
+          "$ref": "#/definitions/v1FiatOnRampBlockchainNetwork",
+          "description": "Blockchain network to be used for the transaction, e.g., bitcoin, ethereum. Maps to MoonPay's network or Coinbase's defaultNetwork."
+        },
+        "cryptoCurrencyCode": {
+          "$ref": "#/definitions/v1FiatOnRampCryptoCurrency",
+          "description": "Code for the cryptocurrency to be purchased, e.g., btc, eth. Maps to MoonPay's currencyCode or Coinbase's defaultAsset."
+        },
+        "fiatCurrencyCode": {
+          "$ref": "#/definitions/v1FiatOnRampCurrency",
+          "description": "Code for the fiat currency to be used in the transaction, e.g., USD, EUR."
+        },
+        "fiatCurrencyAmount": {
+          "type": "string",
+          "description": "Specifies a preset fiat amount for the transaction, e.g., '100'. Must be greater than '20'. If not provided, the user will be prompted to enter an amount."
+        },
+        "paymentMethod": {
+          "$ref": "#/definitions/v1FiatOnRampPaymentMethod",
+          "description": "Pre-selected payment method, e.g., CREDIT_DEBIT_CARD, APPLE_PAY. Validated against the chosen provider."
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 two-digit country code for Coinbase representing the purchasing user’s country of residence, e.g., US, GB."
+        },
+        "countrySubdivisionCode": {
+          "type": "string",
+          "description": "ISO 3166-2 two-digit country subdivision code for Coinbase representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if country_code=US."
+        }
+      },
+      "required": [
+        "onrampProvider",
+        "walletAddress",
+        "network",
+        "cryptoCurrencyCode"
+      ]
+    },
+    "v1InitFiatOnRampRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_INIT_FIAT_ON_RAMP"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1InitFiatOnRampIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1InitFiatOnRampResult": {
+      "type": "object",
+      "properties": {
+        "onRampUrl": {
+          "type": "string",
+          "description": "Unique URL for a given fiat on-ramp flow."
+        },
+        "onRampTransactionId": {
+          "type": "string",
+          "description": "Unique identifier used to retrieve transaction statuses for a given fiat on-ramp flow."
+        }
+      },
+      "required": ["onRampUrl", "onRampTransactionId"]
+    },
     "v1InitImportPrivateKeyIntent": {
       "type": "object",
       "properties": {
@@ -7321,6 +7617,18 @@
         },
         "oauthLoginIntent": {
           "$ref": "#/definitions/v1OauthLoginIntent"
+        },
+        "updateUserNameIntent": {
+          "$ref": "#/definitions/v1UpdateUserNameIntent"
+        },
+        "updateUserEmailIntent": {
+          "$ref": "#/definitions/v1UpdateUserEmailIntent"
+        },
+        "updateUserPhoneNumberIntent": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberIntent"
+        },
+        "initFiatOnRampIntent": {
+          "$ref": "#/definitions/v1InitFiatOnRampIntent"
         }
       }
     },
@@ -7887,7 +8195,11 @@
     },
     "v1PayloadEncoding": {
       "type": "string",
-      "enum": ["PAYLOAD_ENCODING_HEXADECIMAL", "PAYLOAD_ENCODING_TEXT_UTF8"]
+      "enum": [
+        "PAYLOAD_ENCODING_HEXADECIMAL",
+        "PAYLOAD_ENCODING_TEXT_UTF8",
+        "PAYLOAD_ENCODING_EIP712"
+      ]
     },
     "v1Policy": {
       "type": "object",
@@ -8416,6 +8728,18 @@
         },
         "oauthLoginResult": {
           "$ref": "#/definitions/v1OauthLoginResult"
+        },
+        "updateUserNameResult": {
+          "$ref": "#/definitions/v1UpdateUserNameResult"
+        },
+        "updateUserEmailResult": {
+          "$ref": "#/definitions/v1UpdateUserEmailResult"
+        },
+        "updateUserPhoneNumberResult": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberResult"
+        },
+        "initFiatOnRampResult": {
+          "$ref": "#/definitions/v1InitFiatOnRampResult"
         }
       }
     },
@@ -9176,6 +9500,55 @@
     "v1UpdateRootQuorumResult": {
       "type": "object"
     },
+    "v1UpdateUserEmailIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userEmail": {
+          "type": "string",
+          "description": "The user's email address. Setting this to an empty string will remove the user's email."
+        },
+        "verificationToken": {
+          "type": "string",
+          "description": "Signed JWT containing a unique id, expiry, verification type, contact"
+        }
+      },
+      "required": ["userId", "userEmail"]
+    },
+    "v1UpdateUserEmailRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_EMAIL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserEmailIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserEmailResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose email was updated."
+        }
+      },
+      "required": ["userId"]
+    },
     "v1UpdateUserIntent": {
       "type": "object",
       "properties": {
@@ -9201,6 +9574,100 @@
         "userPhoneNumber": {
           "type": "string",
           "description": "The user's phone number in E.164 format e.g. +13214567890"
+        }
+      },
+      "required": ["userId"]
+    },
+    "v1UpdateUserNameIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userName": {
+          "type": "string",
+          "description": "Human-readable name for a User."
+        }
+      },
+      "required": ["userId", "userName"]
+    },
+    "v1UpdateUserNameRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_NAME"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserNameIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserNameResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose name was updated."
+        }
+      },
+      "required": ["userId"]
+    },
+    "v1UpdateUserPhoneNumberIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userPhoneNumber": {
+          "type": "string",
+          "description": "The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number."
+        },
+        "verificationToken": {
+          "type": "string",
+          "description": "Signed JWT containing a unique id, expiry, verification type, contact"
+        }
+      },
+      "required": ["userId", "userPhoneNumber"]
+    },
+    "v1UpdateUserPhoneNumberRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserPhoneNumberResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose phone number was updated."
         }
       },
       "required": ["userId"]

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -240,6 +240,10 @@ export type paths = {
     /** Imports a wallet */
     post: operations["PublicApiService_ImportWallet"];
   };
+  "/public/v1/submit/init_fiat_on_ramp": {
+    /** Initiate a fiat on ramp flow */
+    post: operations["PublicApiService_InitFiatOnRamp"];
+  };
   "/public/v1/submit/init_import_private_key": {
     /** Initializes a new private key import */
     post: operations["PublicApiService_InitImportPrivateKey"];
@@ -323,6 +327,18 @@ export type paths = {
   "/public/v1/submit/update_user": {
     /** Update a User in an existing Organization */
     post: operations["PublicApiService_UpdateUser"];
+  };
+  "/public/v1/submit/update_user_email": {
+    /** Update a User's email in an existing Organization */
+    post: operations["PublicApiService_UpdateUserEmail"];
+  };
+  "/public/v1/submit/update_user_name": {
+    /** Update a User's name in an existing Organization */
+    post: operations["PublicApiService_UpdateUserName"];
+  };
+  "/public/v1/submit/update_user_phone_number": {
+    /** Update a User's phone number in an existing Organization */
+    post: operations["PublicApiService_UpdateUserPhoneNumber"];
   };
   "/public/v1/submit/update_user_tag": {
     /** Update human-readable name or associated users. Note that this activity is atomic: all of the updates will succeed at once, or all of them will fail. */
@@ -593,7 +609,11 @@ export type definitions = {
     | "ACTIVITY_TYPE_VERIFY_OTP"
     | "ACTIVITY_TYPE_OTP_LOGIN"
     | "ACTIVITY_TYPE_STAMP_LOGIN"
-    | "ACTIVITY_TYPE_OAUTH_LOGIN";
+    | "ACTIVITY_TYPE_OAUTH_LOGIN"
+    | "ACTIVITY_TYPE_UPDATE_USER_NAME"
+    | "ACTIVITY_TYPE_UPDATE_USER_EMAIL"
+    | "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"
+    | "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1680,6 +1700,73 @@ export type definitions = {
     | "FEATURE_NAME_WEBHOOK"
     | "FEATURE_NAME_SMS_AUTH"
     | "FEATURE_NAME_OTP_EMAIL_AUTH";
+  /** @enum {string} */
+  v1FiatOnRampBlockchainNetwork:
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BITCOIN"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_ETHEREUM"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_SOLANA"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BASE";
+  /** @enum {string} */
+  v1FiatOnRampCryptoCurrency:
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_BTC"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_ETH"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_SOL"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_USDC";
+  /** @enum {string} */
+  v1FiatOnRampCurrency:
+    | "FIAT_ON_RAMP_CURRENCY_AUD"
+    | "FIAT_ON_RAMP_CURRENCY_BGN"
+    | "FIAT_ON_RAMP_CURRENCY_BRL"
+    | "FIAT_ON_RAMP_CURRENCY_CAD"
+    | "FIAT_ON_RAMP_CURRENCY_CHF"
+    | "FIAT_ON_RAMP_CURRENCY_COP"
+    | "FIAT_ON_RAMP_CURRENCY_CZK"
+    | "FIAT_ON_RAMP_CURRENCY_DKK"
+    | "FIAT_ON_RAMP_CURRENCY_DOP"
+    | "FIAT_ON_RAMP_CURRENCY_EGP"
+    | "FIAT_ON_RAMP_CURRENCY_EUR"
+    | "FIAT_ON_RAMP_CURRENCY_GBP"
+    | "FIAT_ON_RAMP_CURRENCY_HKD"
+    | "FIAT_ON_RAMP_CURRENCY_IDR"
+    | "FIAT_ON_RAMP_CURRENCY_ILS"
+    | "FIAT_ON_RAMP_CURRENCY_JOD"
+    | "FIAT_ON_RAMP_CURRENCY_KES"
+    | "FIAT_ON_RAMP_CURRENCY_KWD"
+    | "FIAT_ON_RAMP_CURRENCY_LKR"
+    | "FIAT_ON_RAMP_CURRENCY_MXN"
+    | "FIAT_ON_RAMP_CURRENCY_NGN"
+    | "FIAT_ON_RAMP_CURRENCY_NOK"
+    | "FIAT_ON_RAMP_CURRENCY_NZD"
+    | "FIAT_ON_RAMP_CURRENCY_OMR"
+    | "FIAT_ON_RAMP_CURRENCY_PEN"
+    | "FIAT_ON_RAMP_CURRENCY_PLN"
+    | "FIAT_ON_RAMP_CURRENCY_RON"
+    | "FIAT_ON_RAMP_CURRENCY_SEK"
+    | "FIAT_ON_RAMP_CURRENCY_THB"
+    | "FIAT_ON_RAMP_CURRENCY_TRY"
+    | "FIAT_ON_RAMP_CURRENCY_TWD"
+    | "FIAT_ON_RAMP_CURRENCY_USD"
+    | "FIAT_ON_RAMP_CURRENCY_VND"
+    | "FIAT_ON_RAMP_CURRENCY_ZAR";
+  /** @enum {string} */
+  v1FiatOnRampPaymentMethod:
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_CREDIT_DEBIT_CARD"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_APPLE_PAY"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_BANK_TRANSFER"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_OPEN_BANKING_PAYMENT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GOOGLE_PAY"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_SEPA_BANK_TRANSFER"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_PIX_INSTANT_PAYMENT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_PAYPAL"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_VENMO"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_MOONPAY_BALANCE"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_CRYPTO_ACCOUNT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_FIAT_WALLET"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_ACH_BANK_ACCOUNT";
+  /** @enum {string} */
+  v1FiatOnRampProvider:
+    | "FIAT_ON_RAMP_PROVIDER_COINBASE"
+    | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
   v1GetActivitiesRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -1977,6 +2064,41 @@ export type definitions = {
     /** @description A list of account addresses. */
     addresses: string[];
   };
+  v1InitFiatOnRampIntent: {
+    /** @description Enum to specifiy which on-ramp provider to use */
+    onrampProvider: definitions["v1FiatOnRampProvider"];
+    /** @description Destination wallet address for the buy transaction. */
+    walletAddress: string;
+    /** @description Blockchain network to be used for the transaction, e.g., bitcoin, ethereum. Maps to MoonPay's network or Coinbase's defaultNetwork. */
+    network: definitions["v1FiatOnRampBlockchainNetwork"];
+    /** @description Code for the cryptocurrency to be purchased, e.g., btc, eth. Maps to MoonPay's currencyCode or Coinbase's defaultAsset. */
+    cryptoCurrencyCode: definitions["v1FiatOnRampCryptoCurrency"];
+    /** @description Code for the fiat currency to be used in the transaction, e.g., USD, EUR. */
+    fiatCurrencyCode?: definitions["v1FiatOnRampCurrency"];
+    /** @description Specifies a preset fiat amount for the transaction, e.g., '100'. Must be greater than '20'. If not provided, the user will be prompted to enter an amount. */
+    fiatCurrencyAmount?: string;
+    /** @description Pre-selected payment method, e.g., CREDIT_DEBIT_CARD, APPLE_PAY. Validated against the chosen provider. */
+    paymentMethod?: definitions["v1FiatOnRampPaymentMethod"];
+    /** @description ISO 3166-1 two-digit country code for Coinbase representing the purchasing user’s country of residence, e.g., US, GB. */
+    countryCode?: string;
+    /** @description ISO 3166-2 two-digit country subdivision code for Coinbase representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if country_code=US. */
+    countrySubdivisionCode?: string;
+  };
+  v1InitFiatOnRampRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1InitFiatOnRampIntent"];
+  };
+  v1InitFiatOnRampResult: {
+    /** @description Unique URL for a given fiat on-ramp flow. */
+    onRampUrl: string;
+    /** @description Unique identifier used to retrieve transaction statuses for a given fiat on-ramp flow. */
+    onRampTransactionId: string;
+  };
   v1InitImportPrivateKeyIntent: {
     /** @description The ID of the User importing a Private Key. */
     userId: string;
@@ -2223,6 +2345,10 @@ export type definitions = {
     otpLoginIntent?: definitions["v1OtpLoginIntent"];
     stampLoginIntent?: definitions["v1StampLoginIntent"];
     oauthLoginIntent?: definitions["v1OauthLoginIntent"];
+    updateUserNameIntent?: definitions["v1UpdateUserNameIntent"];
+    updateUserEmailIntent?: definitions["v1UpdateUserEmailIntent"];
+    updateUserPhoneNumberIntent?: definitions["v1UpdateUserPhoneNumberIntent"];
+    initFiatOnRampIntent?: definitions["v1InitFiatOnRampIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -2453,7 +2579,8 @@ export type definitions = {
   /** @enum {string} */
   v1PayloadEncoding:
     | "PAYLOAD_ENCODING_HEXADECIMAL"
-    | "PAYLOAD_ENCODING_TEXT_UTF8";
+    | "PAYLOAD_ENCODING_TEXT_UTF8"
+    | "PAYLOAD_ENCODING_EIP712";
   v1Policy: {
     /** @description Unique identifier for a given Policy. */
     policyId: string;
@@ -2637,6 +2764,10 @@ export type definitions = {
     otpLoginResult?: definitions["v1OtpLoginResult"];
     stampLoginResult?: definitions["v1StampLoginResult"];
     oauthLoginResult?: definitions["v1OauthLoginResult"];
+    updateUserNameResult?: definitions["v1UpdateUserNameResult"];
+    updateUserEmailResult?: definitions["v1UpdateUserEmailResult"];
+    updateUserPhoneNumberResult?: definitions["v1UpdateUserPhoneNumberResult"];
+    initFiatOnRampResult?: definitions["v1InitFiatOnRampResult"];
   };
   v1RootUserParams: {
     /** @description Human-readable name for a User. */
@@ -2941,6 +3072,27 @@ export type definitions = {
     parameters: definitions["v1UpdateRootQuorumIntent"];
   };
   v1UpdateRootQuorumResult: { [key: string]: unknown };
+  v1UpdateUserEmailIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description The user's email address. Setting this to an empty string will remove the user's email. */
+    userEmail: string;
+    /** @description Signed JWT containing a unique id, expiry, verification type, contact */
+    verificationToken?: string;
+  };
+  v1UpdateUserEmailRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_EMAIL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserEmailIntent"];
+  };
+  v1UpdateUserEmailResult: {
+    /** @description Unique identifier of the User whose email was updated. */
+    userId: string;
+  };
   v1UpdateUserIntent: {
     /** @description Unique identifier for a given User. */
     userId: string;
@@ -2952,6 +3104,46 @@ export type definitions = {
     userTagIds?: string[];
     /** @description The user's phone number in E.164 format e.g. +13214567890 */
     userPhoneNumber?: string;
+  };
+  v1UpdateUserNameIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Human-readable name for a User. */
+    userName: string;
+  };
+  v1UpdateUserNameRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_NAME";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserNameIntent"];
+  };
+  v1UpdateUserNameResult: {
+    /** @description Unique identifier of the User whose name was updated. */
+    userId: string;
+  };
+  v1UpdateUserPhoneNumberIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number. */
+    userPhoneNumber: string;
+    /** @description Signed JWT containing a unique id, expiry, verification type, contact */
+    verificationToken?: string;
+  };
+  v1UpdateUserPhoneNumberRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserPhoneNumberIntent"];
+  };
+  v1UpdateUserPhoneNumberResult: {
+    /** @description Unique identifier of the User whose phone number was updated. */
+    userId: string;
   };
   v1UpdateUserRequest: {
     /** @enum {string} */
@@ -4247,6 +4439,24 @@ export type operations = {
       };
     };
   };
+  /** Initiate a fiat on ramp flow */
+  PublicApiService_InitFiatOnRamp: {
+    parameters: {
+      body: {
+        body: definitions["v1InitFiatOnRampRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Initializes a new private key import */
   PublicApiService_InitImportPrivateKey: {
     parameters: {
@@ -4612,6 +4822,60 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1UpdateUserRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's email in an existing Organization */
+  PublicApiService_UpdateUserEmail: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserEmailRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's name in an existing Organization */
+  PublicApiService_UpdateUserName: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserNameRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's phone number in an existing Organization */
+  PublicApiService_UpdateUserPhoneNumber: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserPhoneNumberRequest"];
       };
     };
     responses: {

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -1883,6 +1883,39 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  initFiatOnRamp = async (
+    input: SdkApiTypes.TInitFiatOnRampBody,
+  ): Promise<SdkApiTypes.TInitFiatOnRampResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/init_fiat_on_ramp",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP",
+      },
+      "initFiatOnRampResult",
+    );
+  };
+
+  stampInitFiatOnRamp = async (
+    input: SdkApiTypes.TInitFiatOnRampBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/init_fiat_on_ramp";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   initImportPrivateKey = async (
     input: SdkApiTypes.TInitImportPrivateKeyBody,
   ): Promise<SdkApiTypes.TInitImportPrivateKeyResponse> => {
@@ -2553,6 +2586,105 @@ export class TurnkeySDKClientBase {
       return undefined;
     }
     const fullUrl = this.config.apiBaseUrl + "/public/v1/submit/update_user";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateUserEmail = async (
+    input: SdkApiTypes.TUpdateUserEmailBody,
+  ): Promise<SdkApiTypes.TUpdateUserEmailResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/update_user_email",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_USER_EMAIL",
+      },
+      "updateUserEmailResult",
+    );
+  };
+
+  stampUpdateUserEmail = async (
+    input: SdkApiTypes.TUpdateUserEmailBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_user_email";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateUserName = async (
+    input: SdkApiTypes.TUpdateUserNameBody,
+  ): Promise<SdkApiTypes.TUpdateUserNameResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/update_user_name",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_USER_NAME",
+      },
+      "updateUserNameResult",
+    );
+  };
+
+  stampUpdateUserName = async (
+    input: SdkApiTypes.TUpdateUserNameBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_user_name";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateUserPhoneNumber = async (
+    input: SdkApiTypes.TUpdateUserPhoneNumberBody,
+  ): Promise<SdkApiTypes.TUpdateUserPhoneNumberResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/update_user_phone_number",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER",
+      },
+      "updateUserPhoneNumberResult",
+    );
+  };
+
+  stampUpdateUserPhoneNumber = async (
+    input: SdkApiTypes.TUpdateUserPhoneNumberBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_user_phone_number";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {

--- a/packages/sdk-server/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-server/src/__generated__/sdk_api_types.ts
@@ -628,6 +628,16 @@ export type TImportWalletBody =
   operations["PublicApiService_ImportWallet"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
+export type TInitFiatOnRampResponse =
+  operations["PublicApiService_InitFiatOnRamp"]["responses"]["200"]["schema"]["activity"]["result"]["initFiatOnRampResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TInitFiatOnRampInput = { body: TInitFiatOnRampBody };
+
+export type TInitFiatOnRampBody =
+  operations["PublicApiService_InitFiatOnRamp"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
 export type TInitImportPrivateKeyResponse =
   operations["PublicApiService_InitImportPrivateKey"]["responses"]["200"]["schema"]["activity"]["result"]["initImportPrivateKeyResult"] &
     definitions["v1ActivityResponse"];
@@ -840,6 +850,36 @@ export type TUpdateUserInput = { body: TUpdateUserBody };
 
 export type TUpdateUserBody =
   operations["PublicApiService_UpdateUser"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpdateUserEmailResponse =
+  operations["PublicApiService_UpdateUserEmail"]["responses"]["200"]["schema"]["activity"]["result"]["updateUserEmailResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpdateUserEmailInput = { body: TUpdateUserEmailBody };
+
+export type TUpdateUserEmailBody =
+  operations["PublicApiService_UpdateUserEmail"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpdateUserNameResponse =
+  operations["PublicApiService_UpdateUserName"]["responses"]["200"]["schema"]["activity"]["result"]["updateUserNameResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpdateUserNameInput = { body: TUpdateUserNameBody };
+
+export type TUpdateUserNameBody =
+  operations["PublicApiService_UpdateUserName"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpdateUserPhoneNumberResponse =
+  operations["PublicApiService_UpdateUserPhoneNumber"]["responses"]["200"]["schema"]["activity"]["result"]["updateUserPhoneNumberResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpdateUserPhoneNumberInput = { body: TUpdateUserPhoneNumberBody };
+
+export type TUpdateUserPhoneNumberBody =
+  operations["PublicApiService_UpdateUserPhoneNumber"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TUpdateUserTagResponse =

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -1956,6 +1956,38 @@
         "tags": ["Wallets"]
       }
     },
+    "/public/v1/submit/init_fiat_on_ramp": {
+      "post": {
+        "summary": "Init Fiat On Ramp",
+        "description": "Initiate a fiat on ramp flow",
+        "operationId": "PublicApiService_InitFiatOnRamp",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1InitFiatOnRampRequest"
+            }
+          }
+        ],
+        "tags": ["On Ramp"]
+      }
+    },
     "/public/v1/submit/init_import_private_key": {
       "post": {
         "summary": "Init Import Private Key",
@@ -2628,6 +2660,102 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/update_user_email": {
+      "post": {
+        "summary": "Update User's Email",
+        "description": "Update a User's email in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserEmail",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserEmailRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
+    "/public/v1/submit/update_user_name": {
+      "post": {
+        "summary": "Update User's Name",
+        "description": "Update a User's name in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserName",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserNameRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
+    "/public/v1/submit/update_user_phone_number": {
+      "post": {
+        "summary": "Update User's Phone Number",
+        "description": "Update a User's phone number in an existing Organization",
+        "operationId": "PublicApiService_UpdateUserPhoneNumber",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserPhoneNumberRequest"
+            }
+          }
+        ],
+        "tags": ["Users"]
+      }
+    },
     "/public/v1/submit/update_user_tag": {
       "post": {
         "summary": "Update User Tag",
@@ -3261,7 +3389,11 @@
         "ACTIVITY_TYPE_VERIFY_OTP",
         "ACTIVITY_TYPE_OTP_LOGIN",
         "ACTIVITY_TYPE_STAMP_LOGIN",
-        "ACTIVITY_TYPE_OAUTH_LOGIN"
+        "ACTIVITY_TYPE_OAUTH_LOGIN",
+        "ACTIVITY_TYPE_UPDATE_USER_NAME",
+        "ACTIVITY_TYPE_UPDATE_USER_EMAIL",
+        "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER",
+        "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP"
       ]
     },
     "v1AddressFormat": {
@@ -5954,6 +6086,88 @@
         "FEATURE_NAME_OTP_EMAIL_AUTH"
       ]
     },
+    "v1FiatOnRampBlockchainNetwork": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BITCOIN",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_ETHEREUM",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_SOLANA",
+        "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BASE"
+      ]
+    },
+    "v1FiatOnRampCryptoCurrency": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_BTC",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_ETH",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_SOL",
+        "FIAT_ON_RAMP_CRYPTO_CURRENCY_USDC"
+      ]
+    },
+    "v1FiatOnRampCurrency": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_CURRENCY_AUD",
+        "FIAT_ON_RAMP_CURRENCY_BGN",
+        "FIAT_ON_RAMP_CURRENCY_BRL",
+        "FIAT_ON_RAMP_CURRENCY_CAD",
+        "FIAT_ON_RAMP_CURRENCY_CHF",
+        "FIAT_ON_RAMP_CURRENCY_COP",
+        "FIAT_ON_RAMP_CURRENCY_CZK",
+        "FIAT_ON_RAMP_CURRENCY_DKK",
+        "FIAT_ON_RAMP_CURRENCY_DOP",
+        "FIAT_ON_RAMP_CURRENCY_EGP",
+        "FIAT_ON_RAMP_CURRENCY_EUR",
+        "FIAT_ON_RAMP_CURRENCY_GBP",
+        "FIAT_ON_RAMP_CURRENCY_HKD",
+        "FIAT_ON_RAMP_CURRENCY_IDR",
+        "FIAT_ON_RAMP_CURRENCY_ILS",
+        "FIAT_ON_RAMP_CURRENCY_JOD",
+        "FIAT_ON_RAMP_CURRENCY_KES",
+        "FIAT_ON_RAMP_CURRENCY_KWD",
+        "FIAT_ON_RAMP_CURRENCY_LKR",
+        "FIAT_ON_RAMP_CURRENCY_MXN",
+        "FIAT_ON_RAMP_CURRENCY_NGN",
+        "FIAT_ON_RAMP_CURRENCY_NOK",
+        "FIAT_ON_RAMP_CURRENCY_NZD",
+        "FIAT_ON_RAMP_CURRENCY_OMR",
+        "FIAT_ON_RAMP_CURRENCY_PEN",
+        "FIAT_ON_RAMP_CURRENCY_PLN",
+        "FIAT_ON_RAMP_CURRENCY_RON",
+        "FIAT_ON_RAMP_CURRENCY_SEK",
+        "FIAT_ON_RAMP_CURRENCY_THB",
+        "FIAT_ON_RAMP_CURRENCY_TRY",
+        "FIAT_ON_RAMP_CURRENCY_TWD",
+        "FIAT_ON_RAMP_CURRENCY_USD",
+        "FIAT_ON_RAMP_CURRENCY_VND",
+        "FIAT_ON_RAMP_CURRENCY_ZAR"
+      ]
+    },
+    "v1FiatOnRampPaymentMethod": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_PAYMENT_METHOD_CREDIT_DEBIT_CARD",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_APPLE_PAY",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_BANK_TRANSFER",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_OPEN_BANKING_PAYMENT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_GOOGLE_PAY",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_SEPA_BANK_TRANSFER",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_PIX_INSTANT_PAYMENT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_PAYPAL",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_VENMO",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_MOONPAY_BALANCE",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_CRYPTO_ACCOUNT",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_FIAT_WALLET",
+        "FIAT_ON_RAMP_PAYMENT_METHOD_ACH_BANK_ACCOUNT"
+      ]
+    },
+    "v1FiatOnRampProvider": {
+      "type": "string",
+      "enum": [
+        "FIAT_ON_RAMP_PROVIDER_COINBASE",
+        "FIAT_ON_RAMP_PROVIDER_MOONPAY"
+      ]
+    },
     "v1GetActivitiesRequest": {
       "type": "object",
       "properties": {
@@ -6712,6 +6926,88 @@
       },
       "required": ["walletId", "addresses"]
     },
+    "v1InitFiatOnRampIntent": {
+      "type": "object",
+      "properties": {
+        "onrampProvider": {
+          "$ref": "#/definitions/v1FiatOnRampProvider",
+          "description": "Enum to specifiy which on-ramp provider to use"
+        },
+        "walletAddress": {
+          "type": "string",
+          "description": "Destination wallet address for the buy transaction."
+        },
+        "network": {
+          "$ref": "#/definitions/v1FiatOnRampBlockchainNetwork",
+          "description": "Blockchain network to be used for the transaction, e.g., bitcoin, ethereum. Maps to MoonPay's network or Coinbase's defaultNetwork."
+        },
+        "cryptoCurrencyCode": {
+          "$ref": "#/definitions/v1FiatOnRampCryptoCurrency",
+          "description": "Code for the cryptocurrency to be purchased, e.g., btc, eth. Maps to MoonPay's currencyCode or Coinbase's defaultAsset."
+        },
+        "fiatCurrencyCode": {
+          "$ref": "#/definitions/v1FiatOnRampCurrency",
+          "description": "Code for the fiat currency to be used in the transaction, e.g., USD, EUR."
+        },
+        "fiatCurrencyAmount": {
+          "type": "string",
+          "description": "Specifies a preset fiat amount for the transaction, e.g., '100'. Must be greater than '20'. If not provided, the user will be prompted to enter an amount."
+        },
+        "paymentMethod": {
+          "$ref": "#/definitions/v1FiatOnRampPaymentMethod",
+          "description": "Pre-selected payment method, e.g., CREDIT_DEBIT_CARD, APPLE_PAY. Validated against the chosen provider."
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 two-digit country code for Coinbase representing the purchasing user’s country of residence, e.g., US, GB."
+        },
+        "countrySubdivisionCode": {
+          "type": "string",
+          "description": "ISO 3166-2 two-digit country subdivision code for Coinbase representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if country_code=US."
+        }
+      },
+      "required": [
+        "onrampProvider",
+        "walletAddress",
+        "network",
+        "cryptoCurrencyCode"
+      ]
+    },
+    "v1InitFiatOnRampRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_INIT_FIAT_ON_RAMP"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1InitFiatOnRampIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1InitFiatOnRampResult": {
+      "type": "object",
+      "properties": {
+        "onRampUrl": {
+          "type": "string",
+          "description": "Unique URL for a given fiat on-ramp flow."
+        },
+        "onRampTransactionId": {
+          "type": "string",
+          "description": "Unique identifier used to retrieve transaction statuses for a given fiat on-ramp flow."
+        }
+      },
+      "required": ["onRampUrl", "onRampTransactionId"]
+    },
     "v1InitImportPrivateKeyIntent": {
       "type": "object",
       "properties": {
@@ -7321,6 +7617,18 @@
         },
         "oauthLoginIntent": {
           "$ref": "#/definitions/v1OauthLoginIntent"
+        },
+        "updateUserNameIntent": {
+          "$ref": "#/definitions/v1UpdateUserNameIntent"
+        },
+        "updateUserEmailIntent": {
+          "$ref": "#/definitions/v1UpdateUserEmailIntent"
+        },
+        "updateUserPhoneNumberIntent": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberIntent"
+        },
+        "initFiatOnRampIntent": {
+          "$ref": "#/definitions/v1InitFiatOnRampIntent"
         }
       }
     },
@@ -7887,7 +8195,11 @@
     },
     "v1PayloadEncoding": {
       "type": "string",
-      "enum": ["PAYLOAD_ENCODING_HEXADECIMAL", "PAYLOAD_ENCODING_TEXT_UTF8"]
+      "enum": [
+        "PAYLOAD_ENCODING_HEXADECIMAL",
+        "PAYLOAD_ENCODING_TEXT_UTF8",
+        "PAYLOAD_ENCODING_EIP712"
+      ]
     },
     "v1Policy": {
       "type": "object",
@@ -8416,6 +8728,18 @@
         },
         "oauthLoginResult": {
           "$ref": "#/definitions/v1OauthLoginResult"
+        },
+        "updateUserNameResult": {
+          "$ref": "#/definitions/v1UpdateUserNameResult"
+        },
+        "updateUserEmailResult": {
+          "$ref": "#/definitions/v1UpdateUserEmailResult"
+        },
+        "updateUserPhoneNumberResult": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberResult"
+        },
+        "initFiatOnRampResult": {
+          "$ref": "#/definitions/v1InitFiatOnRampResult"
         }
       }
     },
@@ -9176,6 +9500,55 @@
     "v1UpdateRootQuorumResult": {
       "type": "object"
     },
+    "v1UpdateUserEmailIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userEmail": {
+          "type": "string",
+          "description": "The user's email address. Setting this to an empty string will remove the user's email."
+        },
+        "verificationToken": {
+          "type": "string",
+          "description": "Signed JWT containing a unique id, expiry, verification type, contact"
+        }
+      },
+      "required": ["userId", "userEmail"]
+    },
+    "v1UpdateUserEmailRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_EMAIL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserEmailIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserEmailResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose email was updated."
+        }
+      },
+      "required": ["userId"]
+    },
     "v1UpdateUserIntent": {
       "type": "object",
       "properties": {
@@ -9201,6 +9574,100 @@
         "userPhoneNumber": {
           "type": "string",
           "description": "The user's phone number in E.164 format e.g. +13214567890"
+        }
+      },
+      "required": ["userId"]
+    },
+    "v1UpdateUserNameIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userName": {
+          "type": "string",
+          "description": "Human-readable name for a User."
+        }
+      },
+      "required": ["userId", "userName"]
+    },
+    "v1UpdateUserNameRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_NAME"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserNameIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserNameResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose name was updated."
+        }
+      },
+      "required": ["userId"]
+    },
+    "v1UpdateUserPhoneNumberIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "userPhoneNumber": {
+          "type": "string",
+          "description": "The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number."
+        },
+        "verificationToken": {
+          "type": "string",
+          "description": "Signed JWT containing a unique id, expiry, verification type, contact"
+        }
+      },
+      "required": ["userId", "userPhoneNumber"]
+    },
+    "v1UpdateUserPhoneNumberRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateUserPhoneNumberIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateUserPhoneNumberResult": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier of the User whose phone number was updated."
         }
       },
       "required": ["userId"]

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -240,6 +240,10 @@ export type paths = {
     /** Imports a wallet */
     post: operations["PublicApiService_ImportWallet"];
   };
+  "/public/v1/submit/init_fiat_on_ramp": {
+    /** Initiate a fiat on ramp flow */
+    post: operations["PublicApiService_InitFiatOnRamp"];
+  };
   "/public/v1/submit/init_import_private_key": {
     /** Initializes a new private key import */
     post: operations["PublicApiService_InitImportPrivateKey"];
@@ -323,6 +327,18 @@ export type paths = {
   "/public/v1/submit/update_user": {
     /** Update a User in an existing Organization */
     post: operations["PublicApiService_UpdateUser"];
+  };
+  "/public/v1/submit/update_user_email": {
+    /** Update a User's email in an existing Organization */
+    post: operations["PublicApiService_UpdateUserEmail"];
+  };
+  "/public/v1/submit/update_user_name": {
+    /** Update a User's name in an existing Organization */
+    post: operations["PublicApiService_UpdateUserName"];
+  };
+  "/public/v1/submit/update_user_phone_number": {
+    /** Update a User's phone number in an existing Organization */
+    post: operations["PublicApiService_UpdateUserPhoneNumber"];
   };
   "/public/v1/submit/update_user_tag": {
     /** Update human-readable name or associated users. Note that this activity is atomic: all of the updates will succeed at once, or all of them will fail. */
@@ -593,7 +609,11 @@ export type definitions = {
     | "ACTIVITY_TYPE_VERIFY_OTP"
     | "ACTIVITY_TYPE_OTP_LOGIN"
     | "ACTIVITY_TYPE_STAMP_LOGIN"
-    | "ACTIVITY_TYPE_OAUTH_LOGIN";
+    | "ACTIVITY_TYPE_OAUTH_LOGIN"
+    | "ACTIVITY_TYPE_UPDATE_USER_NAME"
+    | "ACTIVITY_TYPE_UPDATE_USER_EMAIL"
+    | "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"
+    | "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1680,6 +1700,73 @@ export type definitions = {
     | "FEATURE_NAME_WEBHOOK"
     | "FEATURE_NAME_SMS_AUTH"
     | "FEATURE_NAME_OTP_EMAIL_AUTH";
+  /** @enum {string} */
+  v1FiatOnRampBlockchainNetwork:
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BITCOIN"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_ETHEREUM"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_SOLANA"
+    | "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BASE";
+  /** @enum {string} */
+  v1FiatOnRampCryptoCurrency:
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_BTC"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_ETH"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_SOL"
+    | "FIAT_ON_RAMP_CRYPTO_CURRENCY_USDC";
+  /** @enum {string} */
+  v1FiatOnRampCurrency:
+    | "FIAT_ON_RAMP_CURRENCY_AUD"
+    | "FIAT_ON_RAMP_CURRENCY_BGN"
+    | "FIAT_ON_RAMP_CURRENCY_BRL"
+    | "FIAT_ON_RAMP_CURRENCY_CAD"
+    | "FIAT_ON_RAMP_CURRENCY_CHF"
+    | "FIAT_ON_RAMP_CURRENCY_COP"
+    | "FIAT_ON_RAMP_CURRENCY_CZK"
+    | "FIAT_ON_RAMP_CURRENCY_DKK"
+    | "FIAT_ON_RAMP_CURRENCY_DOP"
+    | "FIAT_ON_RAMP_CURRENCY_EGP"
+    | "FIAT_ON_RAMP_CURRENCY_EUR"
+    | "FIAT_ON_RAMP_CURRENCY_GBP"
+    | "FIAT_ON_RAMP_CURRENCY_HKD"
+    | "FIAT_ON_RAMP_CURRENCY_IDR"
+    | "FIAT_ON_RAMP_CURRENCY_ILS"
+    | "FIAT_ON_RAMP_CURRENCY_JOD"
+    | "FIAT_ON_RAMP_CURRENCY_KES"
+    | "FIAT_ON_RAMP_CURRENCY_KWD"
+    | "FIAT_ON_RAMP_CURRENCY_LKR"
+    | "FIAT_ON_RAMP_CURRENCY_MXN"
+    | "FIAT_ON_RAMP_CURRENCY_NGN"
+    | "FIAT_ON_RAMP_CURRENCY_NOK"
+    | "FIAT_ON_RAMP_CURRENCY_NZD"
+    | "FIAT_ON_RAMP_CURRENCY_OMR"
+    | "FIAT_ON_RAMP_CURRENCY_PEN"
+    | "FIAT_ON_RAMP_CURRENCY_PLN"
+    | "FIAT_ON_RAMP_CURRENCY_RON"
+    | "FIAT_ON_RAMP_CURRENCY_SEK"
+    | "FIAT_ON_RAMP_CURRENCY_THB"
+    | "FIAT_ON_RAMP_CURRENCY_TRY"
+    | "FIAT_ON_RAMP_CURRENCY_TWD"
+    | "FIAT_ON_RAMP_CURRENCY_USD"
+    | "FIAT_ON_RAMP_CURRENCY_VND"
+    | "FIAT_ON_RAMP_CURRENCY_ZAR";
+  /** @enum {string} */
+  v1FiatOnRampPaymentMethod:
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_CREDIT_DEBIT_CARD"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_APPLE_PAY"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_BANK_TRANSFER"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GBP_OPEN_BANKING_PAYMENT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_GOOGLE_PAY"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_SEPA_BANK_TRANSFER"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_PIX_INSTANT_PAYMENT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_PAYPAL"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_VENMO"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_MOONPAY_BALANCE"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_CRYPTO_ACCOUNT"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_FIAT_WALLET"
+    | "FIAT_ON_RAMP_PAYMENT_METHOD_ACH_BANK_ACCOUNT";
+  /** @enum {string} */
+  v1FiatOnRampProvider:
+    | "FIAT_ON_RAMP_PROVIDER_COINBASE"
+    | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
   v1GetActivitiesRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -1977,6 +2064,41 @@ export type definitions = {
     /** @description A list of account addresses. */
     addresses: string[];
   };
+  v1InitFiatOnRampIntent: {
+    /** @description Enum to specifiy which on-ramp provider to use */
+    onrampProvider: definitions["v1FiatOnRampProvider"];
+    /** @description Destination wallet address for the buy transaction. */
+    walletAddress: string;
+    /** @description Blockchain network to be used for the transaction, e.g., bitcoin, ethereum. Maps to MoonPay's network or Coinbase's defaultNetwork. */
+    network: definitions["v1FiatOnRampBlockchainNetwork"];
+    /** @description Code for the cryptocurrency to be purchased, e.g., btc, eth. Maps to MoonPay's currencyCode or Coinbase's defaultAsset. */
+    cryptoCurrencyCode: definitions["v1FiatOnRampCryptoCurrency"];
+    /** @description Code for the fiat currency to be used in the transaction, e.g., USD, EUR. */
+    fiatCurrencyCode?: definitions["v1FiatOnRampCurrency"];
+    /** @description Specifies a preset fiat amount for the transaction, e.g., '100'. Must be greater than '20'. If not provided, the user will be prompted to enter an amount. */
+    fiatCurrencyAmount?: string;
+    /** @description Pre-selected payment method, e.g., CREDIT_DEBIT_CARD, APPLE_PAY. Validated against the chosen provider. */
+    paymentMethod?: definitions["v1FiatOnRampPaymentMethod"];
+    /** @description ISO 3166-1 two-digit country code for Coinbase representing the purchasing user’s country of residence, e.g., US, GB. */
+    countryCode?: string;
+    /** @description ISO 3166-2 two-digit country subdivision code for Coinbase representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if country_code=US. */
+    countrySubdivisionCode?: string;
+  };
+  v1InitFiatOnRampRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1InitFiatOnRampIntent"];
+  };
+  v1InitFiatOnRampResult: {
+    /** @description Unique URL for a given fiat on-ramp flow. */
+    onRampUrl: string;
+    /** @description Unique identifier used to retrieve transaction statuses for a given fiat on-ramp flow. */
+    onRampTransactionId: string;
+  };
   v1InitImportPrivateKeyIntent: {
     /** @description The ID of the User importing a Private Key. */
     userId: string;
@@ -2223,6 +2345,10 @@ export type definitions = {
     otpLoginIntent?: definitions["v1OtpLoginIntent"];
     stampLoginIntent?: definitions["v1StampLoginIntent"];
     oauthLoginIntent?: definitions["v1OauthLoginIntent"];
+    updateUserNameIntent?: definitions["v1UpdateUserNameIntent"];
+    updateUserEmailIntent?: definitions["v1UpdateUserEmailIntent"];
+    updateUserPhoneNumberIntent?: definitions["v1UpdateUserPhoneNumberIntent"];
+    initFiatOnRampIntent?: definitions["v1InitFiatOnRampIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -2453,7 +2579,8 @@ export type definitions = {
   /** @enum {string} */
   v1PayloadEncoding:
     | "PAYLOAD_ENCODING_HEXADECIMAL"
-    | "PAYLOAD_ENCODING_TEXT_UTF8";
+    | "PAYLOAD_ENCODING_TEXT_UTF8"
+    | "PAYLOAD_ENCODING_EIP712";
   v1Policy: {
     /** @description Unique identifier for a given Policy. */
     policyId: string;
@@ -2637,6 +2764,10 @@ export type definitions = {
     otpLoginResult?: definitions["v1OtpLoginResult"];
     stampLoginResult?: definitions["v1StampLoginResult"];
     oauthLoginResult?: definitions["v1OauthLoginResult"];
+    updateUserNameResult?: definitions["v1UpdateUserNameResult"];
+    updateUserEmailResult?: definitions["v1UpdateUserEmailResult"];
+    updateUserPhoneNumberResult?: definitions["v1UpdateUserPhoneNumberResult"];
+    initFiatOnRampResult?: definitions["v1InitFiatOnRampResult"];
   };
   v1RootUserParams: {
     /** @description Human-readable name for a User. */
@@ -2941,6 +3072,27 @@ export type definitions = {
     parameters: definitions["v1UpdateRootQuorumIntent"];
   };
   v1UpdateRootQuorumResult: { [key: string]: unknown };
+  v1UpdateUserEmailIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description The user's email address. Setting this to an empty string will remove the user's email. */
+    userEmail: string;
+    /** @description Signed JWT containing a unique id, expiry, verification type, contact */
+    verificationToken?: string;
+  };
+  v1UpdateUserEmailRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_EMAIL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserEmailIntent"];
+  };
+  v1UpdateUserEmailResult: {
+    /** @description Unique identifier of the User whose email was updated. */
+    userId: string;
+  };
   v1UpdateUserIntent: {
     /** @description Unique identifier for a given User. */
     userId: string;
@@ -2952,6 +3104,46 @@ export type definitions = {
     userTagIds?: string[];
     /** @description The user's phone number in E.164 format e.g. +13214567890 */
     userPhoneNumber?: string;
+  };
+  v1UpdateUserNameIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Human-readable name for a User. */
+    userName: string;
+  };
+  v1UpdateUserNameRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_NAME";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserNameIntent"];
+  };
+  v1UpdateUserNameResult: {
+    /** @description Unique identifier of the User whose name was updated. */
+    userId: string;
+  };
+  v1UpdateUserPhoneNumberIntent: {
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number. */
+    userPhoneNumber: string;
+    /** @description Signed JWT containing a unique id, expiry, verification type, contact */
+    verificationToken?: string;
+  };
+  v1UpdateUserPhoneNumberRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateUserPhoneNumberIntent"];
+  };
+  v1UpdateUserPhoneNumberResult: {
+    /** @description Unique identifier of the User whose phone number was updated. */
+    userId: string;
   };
   v1UpdateUserRequest: {
     /** @enum {string} */
@@ -4247,6 +4439,24 @@ export type operations = {
       };
     };
   };
+  /** Initiate a fiat on ramp flow */
+  PublicApiService_InitFiatOnRamp: {
+    parameters: {
+      body: {
+        body: definitions["v1InitFiatOnRampRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Initializes a new private key import */
   PublicApiService_InitImportPrivateKey: {
     parameters: {
@@ -4612,6 +4822,60 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1UpdateUserRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's email in an existing Organization */
+  PublicApiService_UpdateUserEmail: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserEmailRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's name in an existing Organization */
+  PublicApiService_UpdateUserName: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserNameRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Update a User's phone number in an existing Organization */
+  PublicApiService_UpdateUserPhoneNumber: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateUserPhoneNumberRequest"];
       };
     };
     responses: {


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
