### PR TITLE
Updated React Native readme to include inappbrowser fix

### DIFF
--- a/packages/sdk-react-native/README.md
+++ b/packages/sdk-react-native/README.md
@@ -26,6 +26,58 @@ The `@turnkey/sdk-react-native` package simplifies the integration of the Turnke
 
 ---
 
+---
+
+## **⚠️ Android InAppBrowser Bug (Fix Required)**
+
+If you're using `react-native-inappbrowser-reborn` on Android, you may encounter the following **build error**:
+
+```
+Dependency 'androidx.browser:browser:1.9.0-alpha05' requires libraries and applications that
+depend on it to compile against version 36 or later of the Android APIs.
+```
+
+This is a known issue: [GitHub Issue #475](https://github.com/proyecto26/react-native-inappbrowser/issues/475)
+
+### ✅ Fix
+
+#### For plain React Native:
+
+In your `android/build.gradle`, add the following:
+
+```groovy
+buildscript {
+    ext {
+        androidXBrowser = "1.8.0"
+    }
+}
+```
+
+#### For Expo:
+
+Run:
+
+```bash
+npx expo install expo-gradle-ext-vars
+```
+
+Then update your `app.json` (or `app.config.js`) to include:
+
+```json
+{
+  "plugins": [
+    [
+      "expo-gradle-ext-vars",
+      {
+        "androidXBrowser": "1.8.0"
+      }
+    ]
+  ]
+}
+```
+
+---
+
 ## **Usage**
 
 ### **Wrapping Your App with the Provider**


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
