### PR TITLE
Added callback function for notifying connected apps, that context initialization has finished.

### DIFF
--- a/.changeset/sdk-rn-context-initialized.md
+++ b/.changeset/sdk-rn-context-initialized.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react-native": patch
+---
+
+Added callback function for notifying connected apps, that context initialization has finished.

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -122,6 +122,7 @@ export interface TurnkeyConfig {
   onSessionExpired?: (session: Session) => void;
   onSessionCleared?: (session: Session) => void;
   onSessionEmpty?: () => void;
+  onInitialized?: () => void;
   onSessionExpiryWarning?: (session: Session) => void;
 }
 
@@ -194,7 +195,7 @@ export const TurnkeyProvider: FC<{
     };
 
     initializeSessions();
-
+    config.onInitialized?.();
     return () => {
       clearTimeouts();
     };


### PR DESCRIPTION
## Summary & Motivation
Many applications rely on an initialized context to automatically perform operations based on the active or inactive session. I added a simple callback, which is called once the useEffect inside the TuernkeyContext has finished.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
