### PR TITLE
samuelsramko contrib

### DIFF
--- a/.changeset/sdk-rn-context-initialized.md
+++ b/.changeset/sdk-rn-context-initialized.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react-native": patch
+---
+
+Added callback function for notifying connected apps, that context initialization has finished.

--- a/.changeset/sdk-rn-context-initialized.md
+++ b/.changeset/sdk-rn-context-initialized.md
@@ -2,4 +2,4 @@
 "@turnkey/sdk-react-native": patch
 ---
 
-Added callback function for notifying connected apps, that context initialization has finished.
+Added `onInitialized`. A callback function that runs when context initialization is complete, useful for notifying connected apps.

--- a/packages/sdk-react-native/README.md
+++ b/packages/sdk-react-native/README.md
@@ -93,6 +93,12 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
   const turnkeyConfig = {
     apiBaseUrl: "https://api.turnkey.com",
     organizationId: "<your organization id>",
+    onInitialized: () => {
+      console.log("Context initialized");
+    },
+    onSessionEmpty: () => {
+      console.log("No active session on app launch");
+    },
     onSessionCreated: (session) => {
       console.log("Session Created", session);
     },
@@ -196,6 +202,8 @@ This SDK supports **multiple sessions**, allowing you to create and switch betwe
 - **Switching Sessions**: Use `setSelectedSession({ sessionKey })` to switch between stored sessions. The client, user, and session information will automatically update.
 - **Session Expiry Management**: Each session has an expiry time, and expired sessions will be automatically cleared.
 - **Callbacks for Session Events**:
+  - `onInitialized`: Called once context initialization is complete.
+  - `onSessionEmpty`: Called when there is no active session on app launch.
   - `onSessionCreated`: Called when a session is created.
   - `onSessionSelected`: Called when a session is selected.
   - `onSessionExpired`: Called when a session expires.

--- a/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
+++ b/packages/sdk-react-native/src/contexts/TurnkeyContext.tsx
@@ -122,6 +122,7 @@ export interface TurnkeyConfig {
   onSessionExpired?: (session: Session) => void;
   onSessionCleared?: (session: Session) => void;
   onSessionEmpty?: () => void;
+  onInitialized?: () => void;
   onSessionExpiryWarning?: (session: Session) => void;
 }
 
@@ -194,7 +195,7 @@ export const TurnkeyProvider: FC<{
     };
 
     initializeSessions();
-
+    config.onInitialized?.();
     return () => {
       clearTimeouts();
     };


### PR DESCRIPTION
## Summary & Motivation

Author: @samuelsramko 

Many applications rely on an initialized context to automatically perform operations based on the active or inactive session. I added a simple callback, which is called once the `useEffect` inside the `TurnkeyContext` has finished.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
