### PR TITLE
fix invalid changelog format for mintlify

### DIFF
--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ### Minor Changes
 
-- [#632](https://github.com/tkhq/sdk/pull/632) [`a38a6e3`](https://github.com/tkhq/sdk/commit/a38a6e36dc2bf9abdea64bc817d1cad95b8a289a) Author [@amircheikh](https://github.com/amircheikh) - Added optional `socialLinking` boolean to the `authConfig`. If true, this will enable social linking for new Google <-> Gmail users. For more information on social linking, visit [our docs](https://docs.turnkey.com/authentication/social-logins#social-linking).
+- [#632](https://github.com/tkhq/sdk/pull/632) [`a38a6e3`](https://github.com/tkhq/sdk/commit/a38a6e36dc2bf9abdea64bc817d1cad95b8a289a) Author [@amircheikh](https://github.com/amircheikh) - Added optional `socialLinking` boolean to the `authConfig`. If true, this will enable social linking for new Google &lt;-&gt; Gmail users. For more information on social linking, visit [our docs](https://docs.turnkey.com/authentication/social-logins#social-linking).
 
 ### Patch Changes
 


### PR DESCRIPTION
## Summary & Motivation

The changelog file contained the literal string `<->`, which was interpreted as an invalid or malformed HTML tag by Mintlify. This caused a parsing error when syncing changelogs in our docs repo

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
