### PR TITLE
bs58check

### DIFF
--- a/.changeset/shaggy-buses-dress.md
+++ b/.changeset/shaggy-buses-dress.md
@@ -1,0 +1,7 @@
+---
+"@turnkey/sdk-browser": patch
+---
+
+Updated dependencies
+
+- bs58check@4.0.0

--- a/.changeset/tender-icons-tie.md
+++ b/.changeset/tender-icons-tie.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": patch
+---
+
+Fixed `decryptCredentialBundle` not working in React Native by adding a shim to handle `bs58check`'s ESM-only export.

--- a/packages/crypto/src/bs58check.ts
+++ b/packages/crypto/src/bs58check.ts
@@ -1,0 +1,34 @@
+// This is a temporary shim for bs58check@4.0.0
+//
+// See: https://github.com/bitcoinjs/bs58check/issues/47
+//
+// bs58check v4.0.0 uses ESM with only a default export, which causes compatibility
+// issues with Metro (React Native). When importing the package using
+// `import bs58check from 'bs58check'`, Metro applies multiple levels of wrapping,
+// resulting in a structure like `{ default: { default: { encode, decode, ... } } }`.
+//
+// This shim unwraps the exports until it reaches the object that contains `.decode`,
+// `.encode`, and `.decodeUnsafe`, allowing consistent usage across platforms.
+//
+// We can remove this shim once bs58check publishes a version that properly re-exports
+// named methods from its ESM build
+
+import * as raw from "bs58check";
+
+type Bs58Check = {
+  encode(buf: Uint8Array): string;
+  decode(str: string): Uint8Array;
+  decodeUnsafe(str: string): Uint8Array | undefined;
+};
+
+function unwrap(obj: any): any {
+  let cur = obj;
+  while (cur && !cur.decode && cur.default) {
+    cur = cur.default;
+  }
+  return cur;
+}
+
+const bs58check = unwrap(raw) as Bs58Check;
+
+export default bs58check;

--- a/packages/crypto/src/bs58check.ts
+++ b/packages/crypto/src/bs58check.ts
@@ -16,7 +16,7 @@
 import * as raw from "bs58check";
 
 type Bs58Check = {
-  encode(buf: Uint8Array): string;
+  encode(payload: Uint8Array | number[]): string;
   decode(str: string): Uint8Array;
   decodeUnsafe(str: string): Uint8Array | undefined;
 };

--- a/packages/crypto/src/bs58check.ts
+++ b/packages/crypto/src/bs58check.ts
@@ -23,7 +23,11 @@ type Bs58Check = {
 
 function unwrap(obj: any): any {
   let cur = obj;
-  while (cur && !cur.decode && cur.default) {
+  while (
+    cur &&
+    !(cur.encode && cur.decode && cur.decodeUnsafe) &&
+    cur.default
+  ) {
     cur = cur.default;
   }
   return cur;

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 // Turnkey-specific cryptographic utilities
-import bs58check from "bs58check";
+import bs58check from "./bs58check";
 import bs58 from "bs58";
 import {
   uint8ArrayToHexString,

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -55,7 +55,7 @@
     "@turnkey/webauthn-stamper": "workspace:*",
     "@turnkey/indexed-db-stamper": "workspace:*",
     "@turnkey/sdk-types": "workspace:*",
-    "bs58check": "3.0.1",
+    "bs58check": "^4.0.0",
     "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",
     "hpke-js": "^1.2.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2012,8 +2012,8 @@ importers:
         specifier: workspace:*
         version: link:../webauthn-stamper
       bs58check:
-        specifier: 3.0.1
-        version: 3.0.1
+        specifier: ^4.0.0
+        version: 4.0.0
       buffer:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary & Motivation

- upgrades bs58check to 4.0.0 in our entire codebase because of a security vulnerability reported
- fixes decryptCredentialBundle not working in react-native

why did this happen? Basically the latest version of bs58check introduced ESM/CJS export conditions using the exports field in package.json, which React Native Metro doesn’t resolve correctly.

## How I Tested These Changes

- Called `decryptCredentialBundle` in the `react-native-demo-wallet` referencing the CI build and it worked 
- For web relying on unit tests

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
