### PR TITLE
EIP-712: Signing Examples

### DIFF
--- a/examples/with-ethers/package.json
+++ b/examples/with-ethers/package.json
@@ -6,6 +6,9 @@
     "start": "tsx src/index.ts",
     "start-advanced": "tsx src/advanced.ts",
     "start-sepolia-legacy": "tsx src/sepoliaLegacyTx.ts",
+    "start-hyperliquid": "tsx src/eip712/hyperliquid.ts",
+    "start-erc2612-permit": "tsx src/eip712/erc2612_permit.ts",
+    "start-erc3009-transfer": "tsx src/eip712/erc3009_transfer.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/with-ethers/src/eip712/erc2612_permit.ts
+++ b/examples/with-ethers/src/eip712/erc2612_permit.ts
@@ -1,0 +1,97 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { TurnkeySigner } from "@turnkey/ethers";
+import { ethers } from "ethers";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import { createNewWallet } from "../createNewWallet";
+import { print, assertEqual } from "../util";
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  // Initialize a Turnkey Signer
+  const turnkeySigner = new TurnkeySigner({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  // Bring your own provider (such as Alchemy or Infura: https://docs.ethers.org/v6/api/providers/)
+  const network = "sepolia";
+  const provider = new ethers.InfuraProvider(network);
+  const connectedSigner = turnkeySigner.connect(provider);
+  const address = await connectedSigner.getAddress();
+
+  print("Address:", address);
+
+  // Sign an EIP-712 Payload for an ERC-2612 Permit
+  const approveAgentPayload = {
+    types: {
+      Permit: [
+        { name: "owner", type: "address" },
+        { name: "spender", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    domain: {
+      name: "USD Coin", // ERC-20 token name
+      version: "1", // Token’s ERC-712 version
+      chainId: 1, // Mainnet chain ID
+      verifyingContract: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    },
+    primaryType: "Permit",
+    message: {
+      owner: "0x1111111111111111111111111111111111111111",
+      spender: "0x2222222222222222222222222222222222222222",
+      value: 10000, // amount to approve
+      nonce: 0, // current permit nonce for owner
+      deadline: 1992689033, // timestamp after which it’s invalid
+    },
+  };
+
+  let signature = await connectedSigner.signTypedData(
+    approveAgentPayload.domain,
+    approveAgentPayload.types,
+    approveAgentPayload.message,
+  );
+
+  let recoveredAddress = ethers.verifyTypedData(
+    approveAgentPayload.domain,
+    approveAgentPayload.types,
+    approveAgentPayload.message,
+    signature,
+  );
+
+  assertEqual(recoveredAddress, address);
+
+  print(
+    "Turnkey-powered signature - Hyperliquid Sign Transaction Payload:",
+    `${signature}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-ethers/src/eip712/erc3009_transfer.ts
+++ b/examples/with-ethers/src/eip712/erc3009_transfer.ts
@@ -1,0 +1,100 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { TurnkeySigner } from "@turnkey/ethers";
+import { ethers } from "ethers";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import { createNewWallet } from "../createNewWallet";
+import { print, assertEqual } from "../util";
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  // Initialize a Turnkey Signer
+  const turnkeySigner = new TurnkeySigner({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  // Bring your own provider (such as Alchemy or Infura: https://docs.ethers.org/v6/api/providers/)
+  const network = "sepolia";
+  const provider = new ethers.InfuraProvider(network);
+  const connectedSigner = turnkeySigner.connect(provider);
+  const address = await connectedSigner.getAddress();
+
+  print("Address:", address);
+
+  // Sign an EIP-712 Payload for a ERC-3009 Transfer
+  const approveAgentPayload = {
+    types: {
+      TransferWithAuthorization: [
+        { name: "from", type: "address" },
+        { name: "to", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "validAfter", type: "uint256" },
+        { name: "validBefore", type: "uint256" },
+        { name: "nonce", type: "bytes32" },
+      ],
+    },
+    domain: {
+      name: "USD Coin", // ERC-20 token name
+      version: "2", // USDC v2 implements EIP-3009 & EIP-2612
+      chainId: 1, // Ethereum Mainnet
+      verifyingContract: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    },
+    primaryType: "TransferWithAuthorization",
+    message: {
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0x2222222222222222222222222222222222222222",
+      value: 5000, // amount of tokens
+      validAfter: 0, // immediately valid
+      validBefore: 1992689033, // expires at this UNIX timestamp
+      nonce:
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    },
+  };
+
+  let signature = await connectedSigner.signTypedData(
+    approveAgentPayload.domain,
+    approveAgentPayload.types,
+    approveAgentPayload.message,
+  );
+
+  let recoveredAddress = ethers.verifyTypedData(
+    approveAgentPayload.domain,
+    approveAgentPayload.types,
+    approveAgentPayload.message,
+    signature,
+  );
+
+  assertEqual(recoveredAddress, address);
+
+  print(
+    "Turnkey-powered signature - Hyperliquid Sign Transaction Payload:",
+    `${signature}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-ethers/src/eip712/hyperliquid.ts
+++ b/examples/with-ethers/src/eip712/hyperliquid.ts
@@ -1,0 +1,97 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { TurnkeySigner } from "@turnkey/ethers";
+import { ethers } from "ethers";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import { createNewWallet } from "../createNewWallet";
+import { print, assertEqual } from "../util";
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  // Initialize a Turnkey Signer
+  const turnkeySigner = new TurnkeySigner({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  // Bring your own provider (such as Alchemy or Infura: https://docs.ethers.org/v6/api/providers/)
+  const network = "sepolia";
+  const provider = new ethers.InfuraProvider(network);
+  const connectedSigner = turnkeySigner.connect(provider);
+  const address = await connectedSigner.getAddress();
+
+  print("Address:", address);
+
+  // Sign an EIP-712 Payload for a Hyperliquid `ApproveAgent` operation
+  const approveAgentPayload = {
+    types: {
+      "HyperliquidTransaction:ApproveAgent": [
+        { name: "hyperliquidChain", type: "string" },
+        { name: "agentAddress", type: "address" },
+        { name: "agentName", type: "string" },
+        { name: "nonce", type: "uint64" },
+      ],
+    },
+    domain: {
+      name: "HyperliquidSignTransaction",
+      version: "1",
+      chainId: 1,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+    },
+    primaryType: "HyperliquidTransaction:ApproveAgent",
+    message: {
+      hyperliquidChain: "Testnet",
+      signatureChainId: "0x1",
+      agentAddress: "0x279f28cbbf5bd83c568ff6b599420b473319c25f",
+      agentName: "Mobile QR",
+      nonce: 1751566432540,
+      type: "approveAgent",
+    },
+  };
+
+  let signature = await connectedSigner.signTypedData(
+    approveAgentPayload.domain,
+    approveAgentPayload.types,
+    approveAgentPayload.message,
+  );
+
+  let recoveredAddress = ethers.verifyTypedData(
+    approveAgentPayload.domain,
+    approveAgentPayload.types,
+    approveAgentPayload.message,
+    signature,
+  );
+
+  assertEqual(recoveredAddress, address);
+
+  print(
+    "Turnkey-powered signature - Hyperliquid Sign Transaction Payload:",
+    `${signature}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-viem/package.json
+++ b/examples/with-viem/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "start-advanced": "tsx src/advanced.ts",
+    "start-hyperliquid": "tsx src/eip712/hyperliquid.ts",
+    "start-erc2612-permit": "tsx src/eip712/erc2612_permit.ts",
+    "start-erc3009-transfer": "tsx src/eip712/erc3009_transfer.ts",
     "start-contracts": "tsx src/contracts.ts",
     "start-legacy": "tsx src/legacy/index.ts",
     "start-1559-sign-raw": "tsx src/eip1559/signRawTransaction.ts",

--- a/examples/with-viem/src/eip712/erc2612_permit.ts
+++ b/examples/with-viem/src/eip712/erc2612_permit.ts
@@ -1,0 +1,100 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+import { createAccount } from "@turnkey/viem";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import {
+  createWalletClient,
+  http,
+  recoverTypedDataAddress,
+  type Account,
+} from "viem";
+import { sepolia } from "viem/chains";
+import { print, assertEqual } from "../util";
+import { createNewWallet } from "../createNewWallet";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  const turnkeyAccount = await createAccount({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  const client = createWalletClient({
+    account: turnkeyAccount as Account,
+    chain: sepolia,
+    transport: http(
+      `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY!}`,
+    ),
+  });
+
+  const address = client.account.address;
+  print("Address:", address);
+
+  // 3. Sign typed data (EIP-712)
+  const domain = {
+    name: "USD Coin", // ERC-20 token name
+    version: "1", // Token’s ERC-712 version
+    chainId: 1, // Mainnet chain ID
+    verifyingContract: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  } as const;
+
+  // The named list of all type definitions
+  const types = {
+    Permit: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "nonce", type: "uint256" },
+      { name: "deadline", type: "uint256" },
+    ],
+  } as const;
+
+  const typedData = {
+    account: turnkeyAccount as Account,
+    domain,
+    types,
+    primaryType: "Permit",
+    message: {
+      owner: "0x1111111111111111111111111111111111111111",
+      spender: "0x2222222222222222222222222222222222222222",
+      value: 10000n, // amount to approve
+      nonce: 0n, // current permit nonce for owner
+      deadline: 1992689033n, // timestamp after which it’s invalid
+    },
+  } as const;
+
+  let signature = await client.signTypedData(typedData);
+  let recoveredAddress = await recoverTypedDataAddress({
+    ...typedData,
+    signature,
+  });
+
+  print("Turnkey-powered signature - typed data (EIP-712):", `${signature}`);
+  assertEqual(address, recoveredAddress);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-viem/src/eip712/erc3009_transfer.ts
+++ b/examples/with-viem/src/eip712/erc3009_transfer.ts
@@ -1,0 +1,103 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+import { createAccount } from "@turnkey/viem";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import {
+  createWalletClient,
+  http,
+  recoverTypedDataAddress,
+  type Account,
+} from "viem";
+import { sepolia } from "viem/chains";
+import { print, assertEqual } from "../util";
+import { createNewWallet } from "../createNewWallet";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  const turnkeyAccount = await createAccount({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  const client = createWalletClient({
+    account: turnkeyAccount as Account,
+    chain: sepolia,
+    transport: http(
+      `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY!}`,
+    ),
+  });
+
+  const address = client.account.address;
+  print("Address:", address);
+
+  // 3. Sign typed data (EIP-712)
+  const domain = {
+    name: "USD Coin", // ERC-20 token name
+    version: "2", // USDC v2 implements EIP-3009 & EIP-2612
+    chainId: 1, // Ethereum Mainnet
+    verifyingContract: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  } as const;
+
+  // The named list of all type definitions
+  const types = {
+    TransferWithAuthorization: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "validAfter", type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce", type: "bytes32" },
+    ],
+  } as const;
+
+  const payload = {
+    account: turnkeyAccount as Account,
+    domain,
+    types,
+    primaryType: "TransferWithAuthorization",
+    message: {
+      from: "0x1111111111111111111111111111111111111111",
+      to: "0x2222222222222222222222222222222222222222",
+      value: 5000n, // amount of tokens
+      validAfter: 0n, // immediately valid
+      validBefore: 1992689033n, // expires at this UNIX timestamp
+      nonce:
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    },
+  } as const;
+
+  let signature = await client.signTypedData(payload);
+  let recoveredAddress = await recoverTypedDataAddress({
+    ...payload,
+    signature,
+  });
+
+  print("Turnkey-powered signature - typed data (EIP-712):", `${signature}`);
+  assertEqual(address, recoveredAddress);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-viem/src/eip712/hyperliquid.ts
+++ b/examples/with-viem/src/eip712/hyperliquid.ts
@@ -1,0 +1,100 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+import { createAccount } from "@turnkey/viem";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import {
+  createWalletClient,
+  http,
+  recoverTypedDataAddress,
+  type Account,
+} from "viem";
+import { sepolia } from "viem/chains";
+import { print, assertEqual } from "../util";
+import { createNewWallet } from "../createNewWallet";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  const turnkeyAccount = await createAccount({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  const client = createWalletClient({
+    account: turnkeyAccount as Account,
+    chain: sepolia,
+    transport: http(
+      `https://sepolia.infura.io/v3/${process.env.INFURA_API_KEY!}`,
+    ),
+  });
+
+  const address = client.account.address;
+  print("Address:", address);
+
+  // 3. Sign typed data (EIP-712)
+  const domain = {
+    name: "HyperliquidSignTransaction",
+    version: "1",
+    chainId: 1,
+    verifyingContract: "0x0000000000000000000000000000000000000000",
+  } as const;
+
+  // The named list of all type definitions
+  const types = {
+    "HyperliquidTransaction:ApproveAgent": [
+      { name: "hyperliquidChain", type: "string" },
+      { name: "agentAddress", type: "address" },
+      { name: "agentName", type: "string" },
+      { name: "nonce", type: "uint64" },
+    ],
+  } as const;
+
+  const payload = {
+    account: turnkeyAccount as Account,
+    domain,
+    types,
+    primaryType: "HyperliquidTransaction:ApproveAgent",
+    message: {
+      hyperliquidChain: "Testnet",
+      signatureChainId: "0x1",
+      agentAddress: "0x279f28cbbf5bd83c568ff6b599420b473319c25f",
+      agentName: "Mobile QR",
+      nonce: 1751566432540n,
+      type: "approveAgent",
+    },
+  } as const;
+
+  let signature = await client.signTypedData(payload);
+  let recoveredAddress = await recoverTypedDataAddress({
+    ...payload,
+    signature,
+  });
+
+  print("Turnkey-powered signature - typed data (EIP-712):", `${signature}`);
+  assertEqual(address, recoveredAddress);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary & Motivation
This PR introduces signing examples for a Hyperliquid `ApproveAgent` EIP-712 payload, an ERC-2612 permit, and an ERC-3009 Transfer. Examples are provided for both our `ethers` and `viem` packages, and are executable via `pnpm`.

## How I Tested These Changes

- [x] local testing against preprod.

## Did you add a changeset?
No: PR does not include SDK changes.
