### PR TITLE
Expose keyFormat in extractKeyEncryptedBundle for our iframeClient

### DIFF
--- a/.changeset/old-windows-juggle.md
+++ b/.changeset/old-windows-juggle.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-browser": patch
+---
+
+Surface keyFormat for extractKeyEncryptedBundle in iframe client abstraction

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "pnpm": {
     "auditConfig": {
       "ignoreCves": [
-        "CVE-2025-3194"
+        "CVE-2025-3194",
+        "CVE-2025-7783"
       ]
     },
     "overrides": {

--- a/packages/sdk-browser/src/__clients__/browser-clients.ts
+++ b/packages/sdk-browser/src/__clients__/browser-clients.ts
@@ -786,8 +786,12 @@ export class TurnkeyIframeClient extends TurnkeyBrowserClient {
     return await (this.stamper as IframeStamper).extractWalletEncryptedBundle();
   };
 
-  extractKeyEncryptedBundle = async (): Promise<string> => {
-    return await (this.stamper as IframeStamper).extractKeyEncryptedBundle();
+  extractKeyEncryptedBundle = async (
+    keyFormat?: KeyFormat | undefined,
+  ): Promise<string> => {
+    return await (this.stamper as IframeStamper).extractKeyEncryptedBundle(
+      keyFormat,
+    );
   };
 
   getEmbeddedPublicKey = async (): Promise<string | null> => {


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
