### PR TITLE
configure .npmrc.ci and remove viem specific .npmrc

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -288,8 +288,12 @@ jobs:
 
       - name: Set up NPM .npmrc config for NPM registry
         run: |
-          cp .npmrc.ci .npmrc || echo "No .npmrc.ci found, creating new .npmrc"
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          if [ -f .npmrc.ci ]; then
+            cat .npmrc.ci > .npmrc
+          else
+            echo "No .npmrc.ci found, creating new .npmrc"
+          fi
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -271,9 +271,9 @@ jobs:
       - name: Confirm environment variables
         run: |
           if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
-            echo "NODE_AUTH_TOKEN is set"
+            echo "NPM_TOKEN is set"
           else
-            echo "NODE_AUTH_TOKEN is not set"
+            echo "NPM_TOKEN is not set"
             exit 1
           fi
           if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
@@ -283,14 +283,15 @@ jobs:
             exit 1
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up NPM .npmrc config for NPM registry
         run: |
+          cp .npmrc.ci .npmrc || echo "No .npmrc.ci found, creating new .npmrc"
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Debug npm config
         run: |
@@ -306,7 +307,7 @@ jobs:
           echo "npm publish dry run summary:"
           cat publish-summary.json || echo "No NPM dry run summary generated"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish packages to NPM
         run: |
@@ -316,14 +317,14 @@ jobs:
           cat publish-summary.json || echo "No NPM publish summary generated"
           rm .npmrc
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         continue-on-error: true
 
       - name: Set up NPM config for GitHub Packages
         run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GitHub Packages (dry run)
         run: |

--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Set up NPM config for GitHub Packages
         run: |
-          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 enable-pre-post-scripts=true
-use-node-version=18.0.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts=true
+use-node-version=18.0.0

--- a/.npmrc.ci
+++ b/.npmrc.ci
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/examples/with-viem/.npmrc
+++ b/examples/with-viem/.npmrc
@@ -1,1 +1,0 @@
-use-node-version=18.0.0

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -53,6 +53,6 @@
     "@turnkey/webauthn-stamper": "workspace:*"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   }
 }

--- a/packages/viem/.npmrc
+++ b/packages/viem/.npmrc
@@ -1,1 +1,0 @@
-use-node-version=18.0.0


### PR DESCRIPTION
## Summary & Motivation

- remove `@turnkey/viem` specific `.npmrc`
- configure `.npmrc.ci` for use in GitHub Actions

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
