### PR TITLE
Fix server action fallback leading to dupe suborgs

### DIFF
--- a/.changeset/few-teachers-boil.md
+++ b/.changeset/few-teachers-boil.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-server": patch
+---
+
+Patch fix for server actions leading to unwanted suborg creation when query requests time out

--- a/packages/sdk-server/src/actions.ts
+++ b/packages/sdk-server/src/actions.ts
@@ -223,8 +223,8 @@ export async function getSuborgs(
     filterValue: request.filterValue,
   });
 
-  if (!response?.organizationIds) {
-    throw new Error("Expected a non-null response with organizationIds.");
+  if (!response || !response?.organizationIds) {
+    throw new Error("Expected a non-null response.");
   }
 
   return { organizationIds: response.organizationIds };
@@ -239,8 +239,8 @@ export async function getVerifiedSuborgs(
     filterValue: request.filterValue,
   });
 
-  if (!response?.organizationIds) {
-    throw new Error("Expected a non-null response with organizationIds.");
+  if (!response || !response?.organizationIds) {
+    throw new Error("Expected a non-null response.");
   }
 
   return { organizationIds: response.organizationIds };

--- a/packages/sdk-server/src/actions.ts
+++ b/packages/sdk-server/src/actions.ts
@@ -216,42 +216,34 @@ export async function getUsers(
 
 export async function getSuborgs(
   request: GetSuborgsRequest,
-): Promise<GetSuborgsResponse | undefined> {
-  try {
-    const response = await turnkeyClient.apiClient().getSubOrgIds({
-      organizationId: turnkeyClient.config.defaultOrganizationId,
-      filterType: request.filterType,
-      filterValue: request.filterValue,
-    });
+): Promise<GetSuborgsResponse> {
+  const response = await turnkeyClient.apiClient().getSubOrgIds({
+    organizationId: turnkeyClient.config.defaultOrganizationId,
+    filterType: request.filterType,
+    filterValue: request.filterValue,
+  });
 
-    if (!response || !response.organizationIds) {
-      throw new Error("Expected a non-null response with organizationIds.");
-    }
-    return { organizationIds: response.organizationIds };
-  } catch (error) {
-    console.error(error);
-    return undefined;
+  if (!response?.organizationIds) {
+    throw new Error("Expected a non-null response with organizationIds.");
   }
+
+  return { organizationIds: response.organizationIds };
 }
 
 export async function getVerifiedSuborgs(
   request: GetSuborgsRequest,
-): Promise<GetSuborgsResponse | undefined> {
-  try {
-    const response = await turnkeyClient.apiClient().getVerifiedSubOrgIds({
-      organizationId: turnkeyClient.config.defaultOrganizationId,
-      filterType: request.filterType,
-      filterValue: request.filterValue,
-    });
+): Promise<GetSuborgsResponse> {
+  const response = await turnkeyClient.apiClient().getVerifiedSubOrgIds({
+    organizationId: turnkeyClient.config.defaultOrganizationId,
+    filterType: request.filterType,
+    filterValue: request.filterValue,
+  });
 
-    if (!response || !response.organizationIds) {
-      throw new Error("Expected a non-null response with organizationIds.");
-    }
-    return { organizationIds: response.organizationIds };
-  } catch (error) {
-    console.error(error);
-    return undefined;
+  if (!response?.organizationIds) {
+    throw new Error("Expected a non-null response with organizationIds.");
   }
+
+  return { organizationIds: response.organizationIds };
 }
 
 export async function createSuborg(
@@ -305,70 +297,61 @@ export async function createSuborg(
 
 export async function getOrCreateSuborg(
   request: GetOrCreateSuborgRequest,
-): Promise<GetOrCreateSuborgResponse | undefined> {
-  try {
-    // First try to get existing suborgs
-    let suborgResponse: GetSuborgsResponse | undefined;
+): Promise<GetOrCreateSuborgResponse> {
+  // First try to get existing suborgs
+  let suborgResponse: GetSuborgsResponse;
 
-    if (
-      request.filterType === FilterType.Email ||
-      request.filterType === FilterType.PhoneNumber
-    ) {
-      suborgResponse = await getVerifiedSuborgs({
-        filterType: request.filterType,
-        filterValue: request.filterValue,
-      });
-    } else {
-      suborgResponse = await getSuborgs({
-        // For OIDC
-        filterType: request.filterType,
-        filterValue: request.filterValue,
-      });
-    }
-
-    // If we found existing suborgs, return the first one
-    if (
-      suborgResponse &&
-      suborgResponse?.organizationIds &&
-      suborgResponse?.organizationIds?.length > 0
-    ) {
-      return {
-        subOrganizationIds: suborgResponse.organizationIds!,
-      };
-    }
-    // No existing suborg found - create a new one
-    const createPayload: CreateSuborgRequest = {
-      ...(request.additionalData?.email && {
-        email: request.additionalData.email,
-      }),
-      ...(request.additionalData?.phoneNumber && {
-        phoneNumber: request.additionalData.phoneNumber,
-      }),
-      ...(request.additionalData?.passkey && {
-        passkey: request.additionalData.passkey,
-      }),
-      ...(request.additionalData?.oauthProviders && {
-        oauthProviders: request.additionalData.oauthProviders,
-      }),
-      ...(request.additionalData?.customAccounts && {
-        customAccounts: request.additionalData.customAccounts,
-      }),
-      ...(request.additionalData?.wallet && {
-        wallet: request.additionalData.wallet,
-      }),
-    };
-
-    const creationResponse = await createSuborg(createPayload);
-
-    if (!creationResponse?.subOrganizationId) {
-      throw new Error("Suborg creation failed");
-    }
-
-    return {
-      subOrganizationIds: [creationResponse.subOrganizationId],
-    };
-  } catch (error) {
-    console.error("Error in getOrCreateSuborg:", error);
-    return undefined;
+  if (
+    request.filterType === FilterType.Email ||
+    request.filterType === FilterType.PhoneNumber
+  ) {
+    suborgResponse = await getVerifiedSuborgs({
+      filterType: request.filterType,
+      filterValue: request.filterValue,
+    });
+  } else {
+    suborgResponse = await getSuborgs({
+      filterType: request.filterType,
+      filterValue: request.filterValue,
+    });
   }
+
+  // If we found existing suborgs, return the first one
+  if (suborgResponse.organizationIds.length > 0) {
+    return {
+      subOrganizationIds: suborgResponse.organizationIds,
+    };
+  }
+
+  // No existing suborg found - create a new one
+  const createPayload: CreateSuborgRequest = {
+    ...(request.additionalData?.email && {
+      email: request.additionalData.email,
+    }),
+    ...(request.additionalData?.phoneNumber && {
+      phoneNumber: request.additionalData.phoneNumber,
+    }),
+    ...(request.additionalData?.passkey && {
+      passkey: request.additionalData.passkey,
+    }),
+    ...(request.additionalData?.oauthProviders && {
+      oauthProviders: request.additionalData.oauthProviders,
+    }),
+    ...(request.additionalData?.customAccounts && {
+      customAccounts: request.additionalData.customAccounts,
+    }),
+    ...(request.additionalData?.wallet && {
+      wallet: request.additionalData.wallet,
+    }),
+  };
+
+  const creationResponse = await createSuborg(createPayload);
+
+  if (!creationResponse?.subOrganizationId) {
+    throw new Error("Suborg creation failed");
+  }
+
+  return {
+    subOrganizationIds: [creationResponse.subOrganizationId],
+  };
 }


### PR DESCRIPTION
Duplicate suborgs were sometimes being created from our getOrCreateSuborg helper function

## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
