### PR TITLE
Revert "Merge pull request #784 from tkhq/release/v2025.8.2"

### DIFF
--- a/.changeset/curvy-drinks-reflect.md
+++ b/.changeset/curvy-drinks-reflect.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react": patch
+---
+
+Add `showTitle` toggle in authConfig for the Auth component to control visibility of the "Log in or Sign up" title.

--- a/.changeset/forty-bananas-sniff.md
+++ b/.changeset/forty-bananas-sniff.md
@@ -1,0 +1,7 @@
+---
+"@turnkey/sdk-browser": minor
+"@turnkey/sdk-server": minor
+"@turnkey/http": minor
+---
+
+Release v2025.7.16

--- a/.changeset/lemon-cameras-bathe.md
+++ b/.changeset/lemon-cameras-bathe.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-browser": patch
+---
+
+Add optional `organizationId` parameter to `loginWithPasskey()` and `loginWithWallet()` to allow targeting a specific organization.

--- a/examples/delegated-access/CHANGELOG.md
+++ b/examples/delegated-access/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @turnkey/delegated-access
 
-## 0.0.12
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e)]:
-  - @turnkey/sdk-server@4.3.0
-
 ## 0.0.11
 
 ### Patch Changes

--- a/examples/delegated-access/package.json
+++ b/examples/delegated-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/delegated-access",
-  "version": "0.0.12",
+  "version": "0.0.11",
   "private": true,
   "scripts": {
     "build": "pnpm -w run build-all",

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @turnkey/cosmjs
 
-## 0.7.21
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e), [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833)]:
-  - @turnkey/sdk-browser@5.4.0
-  - @turnkey/sdk-server@4.3.0
-  - @turnkey/http@3.6.0
-
 ## 0.7.20
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.7.21",
+  "version": "0.7.20",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @turnkey/eip-1193-provider
 
-## 3.3.20
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e), [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833)]:
-  - @turnkey/sdk-browser@5.4.0
-  - @turnkey/http@3.6.0
-
 ## 3.3.19
 
 ### Patch Changes

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "3.3.20",
+  "version": "3.3.19",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/src/version.ts
+++ b/packages/eip-1193-provider/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/eip-1193-provider@3.3.20";
+export const VERSION = "@turnkey/eip-1193-provider@3.3.19";

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @turnkey/ethers
 
-## 1.2.4
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e), [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833)]:
-  - @turnkey/sdk-browser@5.4.0
-  - @turnkey/sdk-server@4.3.0
-  - @turnkey/http@3.6.0
-
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "1.2.4",
+  "version": "1.2.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @turnkey/http
 
-## 3.6.0
-
-### Minor Changes
-
-- [#782](https://github.com/tkhq/sdk/pull/782) [`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e) Thanks [@r-n-o](https://github.com/r-n-o)! - Release v2025.7.16
-
 ## 3.5.1
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "3.6.0",
+  "version": "3.5.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@3.6.0";
+export const VERSION = "@turnkey/http@3.5.1";

--- a/packages/react-native-passkey-stamper/CHANGELOG.md
+++ b/packages/react-native-passkey-stamper/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @turnkey/react-native-passkey-stamper
 
-## 1.0.19
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e)]:
-  - @turnkey/http@3.6.0
-
 ## 1.0.18
 
 ### Patch Changes

--- a/packages/react-native-passkey-stamper/package.json
+++ b/packages/react-native-passkey-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-native-passkey-stamper",
-  "version": "1.0.19",
+  "version": "1.0.18",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/CHANGELOG.md
+++ b/packages/sdk-browser/CHANGELOG.md
@@ -1,20 +1,5 @@
 # @turnkey/sdk-browser
 
-## 5.4.0
-
-### Minor Changes
-
-- [#782](https://github.com/tkhq/sdk/pull/782) [`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e) Thanks [@r-n-o](https://github.com/r-n-o)! - Release v2025.7.16
-
-### Patch Changes
-
-- [#783](https://github.com/tkhq/sdk/pull/783) [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833) Author [@moeodeh3](https://github.com/moeodeh3) - Add optional `organizationId` parameter to `loginWithPasskey()` and `loginWithWallet()` to allow targeting a specific organization.
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e)]:
-  - @turnkey/http@3.6.0
-  - @turnkey/crypto@2.4.3
-  - @turnkey/wallet-stamper@1.0.7
-
 ## 5.3.4
 
 ### Patch Changes

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-browser",
-  "version": "5.4.0",
+  "version": "5.3.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/src/__generated__/version.ts
+++ b/packages/sdk-browser/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-browser@5.4.0";
+export const VERSION = "@turnkey/sdk-browser@5.3.4";

--- a/packages/sdk-react-native/CHANGELOG.md
+++ b/packages/sdk-react-native/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @turnkey/sdk-react-native
 
-## 1.3.7
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e)]:
-  - @turnkey/http@3.6.0
-  - @turnkey/crypto@2.4.3
-  - @turnkey/react-native-passkey-stamper@1.0.19
-
 ## 1.3.6
 
 ### Patch Changes

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react-native",
-  "version": "1.3.7",
+  "version": "1.3.6",
   "description": "React Native SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @turnkey/sdk-react
 
-## 5.2.10
-
-### Patch Changes
-
-- [#783](https://github.com/tkhq/sdk/pull/783) [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833) Author [@moeodeh3](https://github.com/moeodeh3) - Add `showTitle` toggle in authConfig for the Auth component to control visibility of the "Log in or Sign up" title.
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e), [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833)]:
-  - @turnkey/sdk-browser@5.4.0
-  - @turnkey/sdk-server@4.3.0
-  - @turnkey/crypto@2.4.3
-  - @turnkey/wallet-stamper@1.0.7
-
 ## 5.2.9
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "5.2.10",
+  "version": "5.2.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/CHANGELOG.md
+++ b/packages/sdk-server/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @turnkey/sdk-server
 
-## 4.3.0
-
-### Minor Changes
-
-- [#782](https://github.com/tkhq/sdk/pull/782) [`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e) Thanks [@r-n-o](https://github.com/r-n-o)! - Release v2025.7.16
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e)]:
-  - @turnkey/http@3.6.0
-  - @turnkey/wallet-stamper@1.0.7
-
 ## 4.2.4
 
 ### Patch Changes

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-server",
-  "version": "4.3.0",
+  "version": "4.2.4",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/src/__generated__/version.ts
+++ b/packages/sdk-server/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-server@4.3.0";
+export const VERSION = "@turnkey/sdk-server@4.2.4";

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @turnkey/solana
 
-## 1.0.37
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e), [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833)]:
-  - @turnkey/sdk-browser@5.4.0
-  - @turnkey/sdk-server@4.3.0
-  - @turnkey/http@3.6.0
-
 ## 1.0.36
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "1.0.37",
+  "version": "1.0.36",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @turnkey/viem
 
-## 0.10.4
-
-### Patch Changes
-
-- Updated dependencies [[`e90a478`](https://github.com/tkhq/sdk/commit/e90a478c9208d858b1144df9b2c2c7ba956c406e), [`edb0900`](https://github.com/tkhq/sdk/commit/edb090013edddb9247790f7f8be6d2ea96223833)]:
-  - @turnkey/sdk-browser@5.4.0
-  - @turnkey/sdk-server@4.3.0
-  - @turnkey/http@3.6.0
-
 ## 0.10.3
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.10.4",
+  "version": "0.10.3",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
This reverts commit 11101197d269cd6bee80fab95b1d4531ddb0d9b7, reversing changes made to 8c9e91bc4e262fba8bdde3522fe5d14733c7b959.

## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
