### PR TITLE
fix: `@turnkey/crypto` uses `@turnkey/encoding` in actual runtime, despite being a devDependency

### DIFF
--- a/.changeset/bitter-groups-stop.md
+++ b/.changeset/bitter-groups-stop.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": patch
+---
+
+Move `@turnkey/encoding` from devDependencies to dependencies of `@turnkey/crypto`

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -45,12 +45,12 @@
     "@noble/ciphers": "1.3.0",
     "@noble/curves": "1.9.0",
     "@noble/hashes": "1.8.0",
+    "@turnkey/encoding": "workspace:*",
     "bs58check": "4.0.0",
     "bs58": "6.0.0"
   },
   "devDependencies": {
     "jest": "29.7.0",
-    "@turnkey/encoding": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1882,6 +1882,9 @@ importers:
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
+      '@turnkey/encoding':
+        specifier: workspace:*
+        version: link:../encoding
       bs58:
         specifier: 6.0.0
         version: 6.0.0
@@ -1892,9 +1895,6 @@ importers:
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../api-key-stamper
-      '@turnkey/encoding':
-        specifier: workspace:*
-        version: link:../encoding
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http


### PR DESCRIPTION
## Summary & Motivation

`@turnkey/crypto` utilizes `@turnkey/encoding` both in [`crypto.ts`](https://github.com/tkhq/sdk/blob/4e8e9c75e40a0bdf529852ed1a9c07a2bf9af12e/packages/crypto/src/crypto.ts#L8-L12) and [`turnkey.ts`](https://github.com/tkhq/sdk/blob/4e8e9c75e40a0bdf529852ed1a9c07a2bf9af12e/packages/crypto/src/turnkey.ts#L5-L9), which are production code, yet `@turnkey/encoding` is listed as `devDependency`.

As a result, if you use `@turnkey/crypto` (also transitively, e.g. via `@turnkey/wallet-stamper`) in an environment without hoisting or devDependencies installed (`pnpm install --prod`), you'll encounter the following error:

```bash
Error: Cannot find module '@turnkey/encoding'
```

A repository reproducing the issue can be found here: https://github.com/kwaszczuk/turnkey-crypto-encoding-repro

## How I Tested These Changes

I was able to fix the issue locally using the following PNPM [override](https://github.com/kwaszczuk/turnkey-crypto-encoding-repro):

```
overrides:
  '@turnkey/crypto@2.4.3':
    dependencies:
      '@turnkey/encoding': 0.5.0
```

This confirms that the root cause is an incorrect categorization of the `@turnkey/encoding` dependency.

## Did you add a changeset?

Yes