### PR TITLE
add turnkey/encoding as a dependency to turnkey/crtypo to fix transit…

### DIFF
--- a/.changeset/spotty-vans-hide.md
+++ b/.changeset/spotty-vans-hide.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": minor
+---
+
+Add `@turnkey/encoding` as a package dependency instead of a devDependency to `@turnkey/crypto`. This resolves an issue with transitive dependencies when devDependencies are not included in the artifact.

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -45,12 +45,12 @@
     "@noble/ciphers": "1.3.0",
     "@noble/curves": "1.9.0",
     "@noble/hashes": "1.8.0",
+    "@turnkey/encoding": "workspace:*",
     "bs58check": "4.0.0",
     "bs58": "6.0.0"
   },
   "devDependencies": {
     "jest": "29.7.0",
-    "@turnkey/encoding": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@turnkey/api-key-stamper": "workspace:*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1882,6 +1882,9 @@ importers:
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
+      '@turnkey/encoding':
+        specifier: workspace:*
+        version: link:../encoding
       bs58:
         specifier: 6.0.0
         version: 6.0.0
@@ -1892,9 +1895,6 @@ importers:
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../api-key-stamper
-      '@turnkey/encoding':
-        specifier: workspace:*
-        version: link:../encoding
       '@turnkey/http':
         specifier: workspace:*
         version: link:../http


### PR DESCRIPTION
…ive dependency issue

## Summary & Motivation

## How I Tested These Changes
- locally
```
packages/crypto build$ rollup -c
│ src/index.ts → dist...
│ created dist in 555ms
│ src/index.ts → dist...
│ created dist in 306ms
└─ Done in 1.1s
```

## Did you add a changeset?

- added minor version change to `@turnkey/crypto`
