### PR TITLE
Updated sdk-react's Auth component to pass customAccounts param to all auth methods

### DIFF
--- a/packages/sdk-react/src/components/auth/Auth.tsx
+++ b/packages/sdk-react/src/components/auth/Auth.tsx
@@ -407,6 +407,7 @@ const Auth: React.FC<AuthProps> = ({
             publicKey,
             type,
           },
+          ...(customAccounts && { customAccounts }),
         },
       });
 
@@ -791,6 +792,7 @@ const Auth: React.FC<AuthProps> = ({
                     onValidateSuccess={onAuthSuccess}
                     onResendCode={handleResendCode}
                     numBoxes={otpConfig?.otpLength ?? 6}
+                    {...(customAccounts && { customAccounts })}
                   />
                 )}
 

--- a/packages/sdk-react/src/components/auth/OtpVerification.tsx
+++ b/packages/sdk-react/src/components/auth/OtpVerification.tsx
@@ -10,6 +10,7 @@ import { CircularProgress } from "@mui/material";
 import { OtpType, FilterType } from "./constants";
 import { server } from "@turnkey/sdk-server";
 import { useTurnkey } from "../../hooks/use-turnkey";
+import type { WalletAccount } from "@turnkey/sdk-browser";
 
 const resendTimerMs = 15000;
 interface OtpVerificationProps {
@@ -24,6 +25,7 @@ interface OtpVerificationProps {
     type: FilterType.Email | FilterType.PhoneNumber,
     value: string,
   ) => Promise<void>;
+  customAccounts?: WalletAccount[]; // Optional custom accounts data
 }
 
 const OtpVerification: React.FC<OtpVerificationProps> = ({
@@ -35,6 +37,7 @@ const OtpVerification: React.FC<OtpVerificationProps> = ({
   onValidateSuccess,
   onResendCode,
   numBoxes,
+  customAccounts = undefined,
 }) => {
   const { indexedDbClient } = useTurnkey();
 
@@ -67,6 +70,7 @@ const OtpVerification: React.FC<OtpVerificationProps> = ({
           ...(type === OtpType.Email
             ? { email: contact }
             : { phoneNumber: contact }),
+          ...(customAccounts && { customAccounts }),
         },
       });
 


### PR DESCRIPTION
## Summary & Motivation
- `customAccounts` were not being passed into the OtpVerification component that handled the `getOrCreateSuborg` call, or the wallet signup `getOrCreateSuborg` call.
- Added them to both allowing devs to specify the wallet accounts they want added to their wallet on suborg creation time

## How I Tested These Changes
- Locally

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
