### PR TITLE
update viem implementation to use PAYLOAD_ENCODING_EIP7702_AUTHORIZATION

### DIFF
--- a/.changeset/six-drinks-pay.md
+++ b/.changeset/six-drinks-pay.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/viem": minor
+---
+
+Support `signAuthorization` with bespoke, policy-engine compatible payload encoding type. This means you can now target an `address`, `nonce`, or `chainId` within policies. For more information, see https://docs.turnkey.com/concepts/policies/examples.

--- a/.changeset/six-drinks-pay.md
+++ b/.changeset/six-drinks-pay.md
@@ -2,4 +2,4 @@
 "@turnkey/viem": minor
 ---
 
-Support `signAuthorization` with bespoke, policy-engine compatible payload encoding type. This means you can now target an `address`, `nonce`, or `chainId` within policies. For more information, see https://docs.turnkey.com/concepts/policies/examples.
+Support `signAuthorization` with bespoke, policy-engine compatible payload encoding type. This means you can now target an `address`, `nonce`, or `chainId` within policies. For more information, see an example in our docs [here](https://docs.turnkey.com/policies/examples/ethereum#allow-signing-of-eip-7702-authorizations).

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -22,7 +22,6 @@ import type {
   TransactionSerializable,
   TypedData,
 } from "viem";
-import { hashAuthorization } from "viem/utils";
 import { secp256k1 } from "@noble/curves/secp256k1";
 
 import {
@@ -360,18 +359,16 @@ export async function signAuthorization(
     });
   }
 
-  const hashedAuthorization = hashAuthorization({
-    address,
-    chainId,
-    nonce,
-  });
-
   const signature = await signMessageWithErrorWrapping(
     client,
-    hashedAuthorization,
+    JSON.stringify({
+      address,
+      chainId,
+      nonce,
+    }),
     organizationId,
     signWith,
-    "PAYLOAD_ENCODING_HEXADECIMAL",
+    "PAYLOAD_ENCODING_EIP7702_AUTHORIZATION",
     to,
   );
 


### PR DESCRIPTION
## Summary & Motivation
$title

## How I Tested These Changes
locally

## Did you add a changeset?
yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
