### PR TITLE
use viem's serialization utils

### DIFF
--- a/.changeset/busy-crabs-camp.md
+++ b/.changeset/busy-crabs-camp.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/viem": patch
+---
+
+Fix: update serialization of typed data to conform to Viem's implementation

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -6,6 +6,7 @@ import {
   hexToBigInt,
   hexToBytes,
   parseTransaction,
+  serializeTypedData,
 } from "viem";
 import {
   SignAuthorizationReturnType,
@@ -16,6 +17,7 @@ import type {
   Hex,
   LocalAccount,
   SerializeTransactionFn,
+  SignTypedDataParameters,
   SignableMessage,
   TransactionSerializable,
   TypedData,
@@ -448,7 +450,7 @@ export async function signTypedData(
 ): Promise<Hex> {
   return (await signMessageWithErrorWrapping(
     client,
-    jsonStringifyWithBigInt(data),
+    serializeTypedData(data as SignTypedDataParameters),
     organizationId,
     signWith,
     "PAYLOAD_ENCODING_EIP712",
@@ -672,11 +674,5 @@ export function isTurnkeyActivityError(error: any) {
     error.walk((e: any) => {
       return e instanceof TurnkeyActivityError;
     })
-  );
-}
-
-export function jsonStringifyWithBigInt(value: unknown) {
-  return JSON.stringify(value, (_, v) =>
-    typeof v === "bigint" ? v.toString() : v,
   );
 }


### PR DESCRIPTION
## Summary & Motivation
$title

this resolves an error where signature verification would fail because the signature verification function (`recoverTypedDataAddress`) would encode typed data differently than our implementation of Viem.

## How I Tested These Changes
locally using examples

## Did you add a changeset?
yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
