### PR TITLE
Added setup steps for kitchen sink example

### DIFF
--- a/examples/kitchen-sink/README.md
+++ b/examples/kitchen-sink/README.md
@@ -7,6 +7,41 @@ A playground and example bank for making Turnkey requests in various ways:
 - `src/sdk-server`: create Turnkey requests using `@turnkey/sdk-server`, which abstracts away some of the internals in the above method. This is the preferred way to use Turnkey.
 - 🚧 WIP `src/sdk-browser`: create Turnkey requests using `@turnkey/sdk-browser`, which also abstracts away some of the internals from the `@turnkey/http` approach. Note that `@turnkey/sdk-browser` has an interface identical to `@turnkey/sdk-server`
 
+## Getting started
+
+### 1/ Cloning the example
+
+Make sure you have `Node.js` installed locally; we recommend using Node v18+.
+
+```bash
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/kitchen-sink/
+```
+
+### 2/ Setting up Turnkey
+
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
+
+- A public/private API key pair for Turnkey
+- An organization ID
+
+Once you've gathered these values, add them to a new `.env.local` file. Notice that your private key should be securely managed and **_never_** be committed to git.
+
+```bash
+$ cp .env.local.example .env.local
+```
+
+Now open `.env.local` and add the missing environment variables:
+
+- `API_PUBLIC_KEY`
+- `API_PRIVATE_KEY`
+- `BASE_URL`
+- `ORGANIZATION_ID`
+
 ## Usage
 
 In order to run any of these scripts, from `sdk/examples/kitchen-sink`, you can run `pnpm tsx src/sdk-server/createEthereumWallet.ts` (where `sdk-server` can be replaced by `http`, and `createEthereumWallet.ts` can be replaced by any other script)


### PR DESCRIPTION
I was going through the [kitchen-sink example](https://github.com/tkhq/sdk/tree/main/examples/kitchen-sink) in the SDK and realized it was missing the same Getting Started instructions that other example READMEs have. It tripped me up for a bit because I didn't realize the setup steps I needed to take on the monorepo until I started looking at other examples. I made a change to the README to address this.
