### PR TITLE
Update codegen to allow for activities with numbers in the name

### DIFF
--- a/packages/sdk-browser/scripts/codegen.js
+++ b/packages/sdk-browser/scripts/codegen.js
@@ -87,7 +87,8 @@ function extractLatestVersions(definitions) {
   const latestVersions = {};
 
   // Regex to separate the version prefix, base activity details, and (optional) activity version
-  const keyVersionRegex = /^(v\d+)([A-Z][a-z]+(?:[A-Z][a-z]+)*)(V\d+)?$/;
+  // prettier-ignore
+  const keyVersionRegex = /^(?<prefix>v\d+)(?<name>[A-Z][a-z0-9]*(?:[A-Z][a-z0-9]*)*)(?<suffix>V\d+)?$/;
 
   Object.keys(definitions).forEach((key) => {
     const match = key.match(keyVersionRegex);

--- a/packages/sdk-server/scripts/codegen.js
+++ b/packages/sdk-server/scripts/codegen.js
@@ -87,7 +87,8 @@ function extractLatestVersions(definitions) {
   const latestVersions = {};
 
   // Regex to separate the version prefix, base activity details, and (optional) activity version
-  const keyVersionRegex = /^(v\d+)([A-Z][a-z]+(?:[A-Z][a-z]+)*)(V\d+)?$/;
+  // prettier-ignore
+  const keyVersionRegex = /^(?<prefix>v\d+)(?<name>[A-Z][a-z0-9]*(?:[A-Z][a-z0-9]*)*)(?<suffix>V\d+)?$/;
 
   Object.keys(definitions).forEach((key) => {
     const match = key.match(keyVersionRegex);


### PR DESCRIPTION
## Summary & Motivation
Code gen was failing for the SDK's for new activities with numbers in the name. This regex update allows for that
## How I Tested These Changes
local with code gen
## Did you add a changeset?
no - not user facing
If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
