### PR TITLE
Fix the codegen to include the result version

### DIFF
--- a/packages/sdk-browser/scripts/codegen.js
+++ b/packages/sdk-browser/scripts/codegen.js
@@ -88,7 +88,7 @@ function extractLatestVersions(definitions) {
 
   // Regex to separate the version prefix, base activity details, and (optional) activity version
   // prettier-ignore
-  const keyVersionRegex = /^(?<prefix>v\d+)(?<name>[A-Z][a-z0-9]*(?:[A-Z][a-z0-9]*)*)(?<suffix>V\d+)?$/;
+  const keyVersionRegex = /^(v\d+)([A-Za-z0-9]+?)(V\d+)?$/
 
   Object.keys(definitions).forEach((key) => {
     const match = key.match(keyVersionRegex);

--- a/packages/sdk-server/scripts/codegen.js
+++ b/packages/sdk-server/scripts/codegen.js
@@ -88,7 +88,7 @@ function extractLatestVersions(definitions) {
 
   // Regex to separate the version prefix, base activity details, and (optional) activity version
   // prettier-ignore
-  const keyVersionRegex = /^(?<prefix>v\d+)(?<name>[A-Z][a-z0-9]*(?:[A-Z][a-z0-9]*)*)(?<suffix>V\d+)?$/;
+  const keyVersionRegex = /^(v\d+)([A-Za-z0-9]+?)(V\d+)?$/
 
   Object.keys(definitions).forEach((key) => {
     const match = key.match(keyVersionRegex);


### PR DESCRIPTION
## Summary & Motivation
Third in the series of the codegen fix PR's
## How I Tested These Changes
local codegen
## Did you add a changeset?
n/a
If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
