### PR TITLE
adding polyfill to credential upload script.

### DIFF
--- a/examples/with-x/credential-upload.tsx
+++ b/examples/with-x/credential-upload.tsx
@@ -1,3 +1,9 @@
+import { webcrypto as nodeCrypto } from "node:crypto";
+if (!globalThis.crypto) {
+  // @ts-ignore
+  globalThis.crypto = nodeCrypto as unknown as Crypto;
+}
+
 import { encryptOauth2ClientSecret } from "@turnkey/crypto";
 import { Turnkey } from "@turnkey/sdk-server";
 import dotenv from "dotenv";


### PR DESCRIPTION
## Summary & Motivation
This PR adds a polyfill to the top of `credentials-upload.tsx` script to ensure the `crypto` API is present at runtime regardless of Node.js runtime.

## How I Tested These Changes

- [x] Ran script locally