### PR TITLE
Added test cases for import util functions

### DIFF
--- a/examples/with-sdk-js/src/app/page.tsx
+++ b/examples/with-sdk-js/src/app/page.tsx
@@ -68,8 +68,6 @@ export default function AuthPage() {
     createWallet,
     logout,
     setActiveSession,
-    addPasskey,
-    removeUserEmail,
     createWalletAccounts,
     signTransaction,
     signAndSendTransaction,
@@ -1129,7 +1127,13 @@ export default function AuthPage() {
         <button
           onClick={async () => {
             await createWalletAccounts({
-              accounts: ["ADDRESS_FORMAT_SOLANA", "ADDRESS_FORMAT_ETHEREUM"],
+              accounts: [
+                "ADDRESS_FORMAT_SOLANA",
+                "ADDRESS_FORMAT_ETHEREUM",
+                "ADDRESS_FORMAT_ETHEREUM",
+                "ADDRESS_FORMAT_ETHEREUM",
+                "ADDRESS_FORMAT_ETHEREUM",
+              ],
               walletId: wallets[0]?.walletId!,
               organizationId: session?.organizationId!,
             });

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,6 +6,7 @@ const config = {
   testMatch: ["**/__tests__/**/*-(spec|test).[jt]s?(x)"],
   testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/node_modules/"],
   testTimeout: 30 * 1000, // For slow CI machines
+  setupFiles: ["<rootDir>/src/__polyfills__/jest.setup.webcrypto.ts"],
 };
 
 module.exports = config;

--- a/packages/core/src/__polyfills__/jest.setup.webcrypto.ts
+++ b/packages/core/src/__polyfills__/jest.setup.webcrypto.ts
@@ -1,0 +1,148 @@
+// jest.setup.webcrypto.ts
+// Minimal WebCrypto polyfill for tests
+// Only implements the bits our tests actually use
+// THIS IS ONLY MEANT FOR OUR TEST CASES
+
+import { TextEncoder } from "util";
+
+// A tiny CryptoKey class so `instanceof CryptoKey` works
+class FakeCryptoKey {
+  public readonly type: "public" | "private";
+  public readonly extractable: boolean;
+  public readonly algorithm: { name: string; namedCurve: string };
+  public readonly usages: KeyUsage[];
+  // internal “pair id” to link pub/priv keys for verify()
+  public readonly __pairId: string;
+
+  constructor(opts: {
+    type: "public" | "private";
+    extractable: boolean;
+    algorithm: any;
+    usages: KeyUsage[];
+    pairId: string;
+  }) {
+    this.type = opts.type;
+    this.extractable = opts.extractable;
+    this.algorithm = opts.algorithm;
+    this.usages = opts.usages;
+    this.__pairId = opts.pairId;
+  }
+}
+
+// Expose globally so `instanceof CryptoKey` passes
+globalThis.CryptoKey = FakeCryptoKey as any;
+
+// A simple RNG using Node crypto if present, else Math.random fallback
+function fillRandom(buf: Uint8Array) {
+  try {
+    // Node's legacy crypto (not webcrypto)
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nodeCrypto = require("crypto");
+    nodeCrypto.randomFillSync(buf);
+  } catch {
+    for (let i = 0; i < buf.length; i++) buf[i] = (Math.random() * 256) | 0;
+  }
+  return buf;
+}
+
+// Deterministic “signature”: we don’t do real ECDSA—just return pairId + msg
+function fakeSign(pairId: string, data: ArrayBuffer): ArrayBuffer {
+  const msg = new Uint8Array(data);
+  const pid = new TextEncoder().encode(pairId);
+  const out = new Uint8Array(pid.length + msg.length);
+  out.set(pid, 0);
+  out.set(msg, pid.length);
+  return out.buffer;
+}
+
+// “Verify” by checking that signature starts with the public key’s pairId bytes
+function fakeVerify(
+  pairId: string,
+  sig: ArrayBuffer,
+  data: ArrayBuffer,
+): boolean {
+  const pid = new TextEncoder().encode(pairId);
+  const s = new Uint8Array(sig);
+  if (s.length < pid.length) return false;
+  for (let i = 0; i < pid.length; i++) if (s[i] !== pid[i]) return false;
+  // also check the tail equals the data bytes (keeps tests honest)
+  const msg = new Uint8Array(data);
+  if (s.length !== pid.length + msg.length) return false;
+  for (let i = 0; i < msg.length; i++)
+    if (s[pid.length + i] !== msg[i]) return false;
+  return true;
+}
+
+// Minimal exportKey('raw') → 65 bytes starting 0x04 (uncompressed P-256)
+function fakeExportRawPublicKey(): ArrayBuffer {
+  const u = new Uint8Array(65);
+  u[0] = 0x04;
+  for (let i = 1; i < 65; i++) u[i] = 0xaa; // fill with 0xaa
+  return u.buffer;
+}
+
+// Build a tiny subtle with the methods our tests hit
+const subtle = {
+  async generateKey(
+    algorithm: { name: string; namedCurve: string },
+    extractable: boolean,
+    usages: KeyUsage[],
+  ): Promise<CryptoKeyPair> {
+    const pairId = Math.random().toString(36).slice(2);
+
+    const priv = new FakeCryptoKey({
+      type: "private",
+      extractable, // code expects false in the happy path
+      algorithm: { name: algorithm.name, namedCurve: algorithm.namedCurve },
+      usages, // e.g. ["sign"]
+      pairId,
+    });
+    const pub = new FakeCryptoKey({
+      type: "public",
+      extractable: true, // typical
+      algorithm: { name: algorithm.name, namedCurve: algorithm.namedCurve },
+      usages, // e.g. ["verify"]
+      pairId,
+    });
+    return { privateKey: priv, publicKey: pub };
+  },
+
+  //@ts-ignore - ignore type errors for testing
+  async exportKey(format: "raw", key: CryptoKey): Promise<ArrayBuffer> {
+    if (format !== "raw") throw new Error("Only 'raw' supported in tests");
+    // Always return a valid uncompressed point so our test can trip this check when needed
+    return fakeExportRawPublicKey();
+  },
+
+  async sign(
+    //@ts-ignore - ignore type errors for testing
+    algorithm: { name: string; hash: string },
+    key: CryptoKey,
+    data: BufferSource,
+  ): Promise<ArrayBuffer> {
+    const k = key as any as FakeCryptoKey;
+    return fakeSign(k.__pairId, data as ArrayBuffer);
+  },
+
+  async verify(
+    //@ts-ignore - ignore type errors for testing
+    algorithm: { name: string; hash: string },
+    key: CryptoKey,
+    signature: BufferSource,
+    data: BufferSource,
+  ): Promise<boolean> {
+    const k = key as any as FakeCryptoKey;
+    return fakeVerify(
+      k.__pairId,
+      signature as ArrayBuffer,
+      data as ArrayBuffer,
+    );
+  },
+};
+
+// Attach global `crypto` with subtle + getRandomValues
+globalThis.crypto = globalThis.crypto || {};
+// @ts-expect-error test polyfill
+globalThis.crypto.subtle = subtle;
+// @ts-expect-error test polyfill
+globalThis.crypto.getRandomValues = (arr: Uint8Array) => fillRandom(arr);

--- a/packages/core/src/__tests__/utils-test.ts
+++ b/packages/core/src/__tests__/utils-test.ts
@@ -1,15 +1,3 @@
-import { v1AddressFormat, v1WalletAccount } from "@turnkey/sdk-types";
-import {
-  isWeb,
-  isReactNative,
-  addressFormatConfig,
-  getHashFunction,
-  getEncodingType,
-  getEncodedMessage,
-  isWalletAccountArray,
-  createWalletAccountFromAddressFormat,
-  generateWalletAccountsFromAddressFormat,
-} from "../utils";
 import {
   describe,
   expect,
@@ -18,6 +6,74 @@ import {
   afterEach,
   it,
 } from "@jest/globals";
+import {
+  TurnkeyError,
+  TurnkeyErrorCodes,
+  type v1AddressFormat,
+  type v1User,
+  type v1WalletAccount,
+} from "@turnkey/sdk-types";
+import {
+  isWeb,
+  isReactNative,
+  getHashFunction,
+  getEncodingType,
+  getEncodedMessage,
+  isWalletAccountArray,
+  createWalletAccountFromAddressFormat,
+  generateWalletAccountsFromAddressFormat,
+  getPublicKeyFromStampHeader,
+  isEthereumProvider,
+  isSolanaProvider,
+  getCurveTypeFromProvider,
+  getSignatureSchemeFromProvider,
+  findWalletProviderFromAddress,
+  addressFromPublicKey,
+  getAuthenticatorAddresses,
+  withTurnkeyErrorHandling,
+  assertValidP256ECDSAKeyPair,
+  isValidPasskeyName,
+} from "../utils";
+import * as utils from "../utils";
+import { stringToBase64urlString } from "@turnkey/encoding";
+import {
+  Chain,
+  EvmChainInfo,
+  SolanaChainInfo,
+  WalletInterfaceType,
+  WalletProvider,
+} from "../__types__/base";
+
+// mock the bs58 library
+jest.mock("bs58", () => ({
+  encode: jest.fn(() => "base58-encoded"),
+}));
+import bs58 from "bs58";
+
+// For deterministic ETH behavior, mock the heavy crypto/EC parts.
+
+// Mock keccak256 to return a predictable value
+jest.mock("ethers", () => ({
+  keccak256: jest.fn(
+    () => "11".repeat(12) + "1234567890abcdef1234567890abcdef12345678",
+  ),
+}));
+import { keccak256 } from "ethers";
+
+// Mock uncompressRawPublicKey
+jest.mock("@turnkey/crypto", () => {
+  const { uint8ArrayFromHexString } = jest.requireActual(
+    "@turnkey/encoding",
+  ) as typeof import("@turnkey/encoding");
+
+  return {
+    uncompressRawPublicKey: jest.fn(() =>
+      uint8ArrayFromHexString("04" + "aa".repeat(64)),
+    ),
+  };
+});
+import { uncompressRawPublicKey } from "@turnkey/crypto";
+import { TurnkeyRequestError } from "@turnkey/http";
 
 describe("platform detection", () => {
   const g = globalThis as any;
@@ -223,8 +279,8 @@ describe("wallet account helpers (with real config)", () => {
         addresses: [ETH, COSMOS],
       });
       expect(accounts).toHaveLength(2);
-      expect(accounts[0].addressFormat).toBe(ETH);
-      expect(accounts[1].addressFormat).toBe(COSMOS);
+      expect(accounts[0]!.addressFormat).toBe(ETH);
+      expect(accounts[1]!.addressFormat).toBe(COSMOS);
     });
 
     it("increments index for duplicates", () => {
@@ -232,9 +288,9 @@ describe("wallet account helpers (with real config)", () => {
         addresses: [ETH, ETH, ETH],
       });
       expect(accounts.map((a) => a.path)).toEqual([
-        "m/44'/60'/0'/0",
-        "m/44'/60'/0'/1",
-        "m/44'/60'/0'/2",
+        "m/44'/60'/0'/0/0",
+        "m/44'/60'/1'/0/0",
+        "m/44'/60'/2'/0/0",
       ]);
     });
 
@@ -243,7 +299,7 @@ describe("wallet account helpers (with real config)", () => {
         {
           addressFormat: ETH,
           curve: "CURVE_SECP256K1",
-          path: "m/44'/60'/0'/5",
+          path: "m/44'/60'/5'/0/0",
           pathFormat: "PATH_FORMAT_BIP32",
         },
       ] as v1WalletAccount[];
@@ -252,9 +308,709 @@ describe("wallet account helpers (with real config)", () => {
         existingWalletAccounts: existing,
       });
       expect(accounts.map((a) => a.path)).toEqual([
-        "m/44'/60'/0'/6",
-        "m/44'/60'/0'/7",
+        "m/44'/60'/6'/0/0",
+        "m/44'/60'/7'/0/0",
       ]);
     });
+  });
+});
+
+const makeStamp = (
+  overrides?: Partial<{ publicKey: string; scheme: string; signature: string }>,
+) => {
+  const base = {
+    publicKey: "abcdef012345",
+    scheme: "SCHEME",
+    signature: "deadbeef",
+  };
+  return { ...base, ...overrides };
+};
+
+describe("getPublicKeyFromStampHeader", () => {
+  it("extracts publicKey from a valid base64url-encoded JSON stamp", () => {
+    const header = stringToBase64urlString(
+      JSON.stringify(makeStamp({ publicKey: "0123abcd" })),
+    );
+    expect(getPublicKeyFromStampHeader(header)).toBe("0123abcd");
+  });
+
+  it("throws a descriptive error for invalid base64/JSON", () => {
+    expect(() => getPublicKeyFromStampHeader("%%%not-base64%%%")).toThrow(
+      /Failed to extract public key from stamp header:/,
+    );
+
+    const looksB64Url = stringToBase64urlString("not-json"); // valid base64url string, not JSON after decode
+    expect(() => getPublicKeyFromStampHeader(looksB64Url)).toThrow(
+      /Failed to extract public key from stamp header:/,
+    );
+  });
+});
+
+const evmProvider = (
+  addresses: string[] = [],
+): WalletProvider & { chainInfo: EvmChainInfo } => ({
+  chainInfo: { namespace: Chain.Ethereum } as EvmChainInfo,
+  connectedAddresses: addresses,
+  interfaceType: WalletInterfaceType.Ethereum,
+  info: { name: "TestProvider" },
+  provider: {} as any,
+});
+
+const solProvider = (
+  addresses: string[] = [],
+): WalletProvider & { chainInfo: SolanaChainInfo } => ({
+  chainInfo: { namespace: Chain.Solana } as SolanaChainInfo,
+  connectedAddresses: addresses,
+  interfaceType: WalletInterfaceType.Solana,
+  info: { name: "TestProvider" },
+  provider: {} as any,
+});
+
+describe("provider type guards", () => {
+  it("isEthereumProvider true for Ethereum, false for Solana", () => {
+    expect(isEthereumProvider(evmProvider())).toBe(true);
+    expect(isEthereumProvider(solProvider())).toBe(false);
+  });
+
+  it("isSolanaProvider true for Solana, false for Ethereum", () => {
+    expect(isSolanaProvider(solProvider())).toBe(true);
+    expect(isSolanaProvider(evmProvider())).toBe(false);
+  });
+});
+
+describe("getCurveTypeFromProvider", () => {
+  it("returns SECP256K1 for Ethereum", () => {
+    expect(getCurveTypeFromProvider(evmProvider())).toBe(
+      "API_KEY_CURVE_SECP256K1",
+    );
+  });
+
+  it("returns ED25519 for Solana", () => {
+    expect(getCurveTypeFromProvider(solProvider())).toBe(
+      "API_KEY_CURVE_ED25519",
+    );
+  });
+
+  it("throws for unsupported namespaces", () => {
+    const weird = {
+      chainInfo: { namespace: "Other" },
+      connectedAddresses: [],
+    } as unknown as WalletProvider;
+    expect(() => getCurveTypeFromProvider(weird)).toThrow(
+      /Unsupported provider namespace: Other/,
+    );
+  });
+});
+
+describe("getSignatureSchemeFromProvider", () => {
+  it("returns EIP-191 scheme for Ethereum", () => {
+    expect(getSignatureSchemeFromProvider(evmProvider())).toBe(
+      "SIGNATURE_SCHEME_TK_API_SECP256K1_EIP191",
+    );
+  });
+
+  it("returns ED25519 scheme for Solana", () => {
+    expect(getSignatureSchemeFromProvider(solProvider())).toBe(
+      "SIGNATURE_SCHEME_TK_API_ED25519",
+    );
+  });
+
+  it("throws for unsupported namespaces", () => {
+    const weird = {
+      chainInfo: { namespace: "Other" },
+      connectedAddresses: [],
+    } as unknown as WalletProvider;
+    expect(() => getSignatureSchemeFromProvider(weird)).toThrow(
+      /Unsupported provider namespace: Other/,
+    );
+  });
+});
+
+describe("findWalletProviderFromAddress", () => {
+  it("returns the first provider that contains the address", () => {
+    const A = evmProvider(["0x1", "0x2"]);
+    const B = solProvider(["solA"]);
+    const C = evmProvider(["0x3"]);
+
+    expect(findWalletProviderFromAddress("solA", [A, B, C])).toBe(B);
+    expect(findWalletProviderFromAddress("0x3", [A, B, C])).toBe(C);
+  });
+
+  it("returns undefined if no provider contains the address", () => {
+    const A = evmProvider(["0x1"]);
+    const B = solProvider(["solA"]);
+    expect(findWalletProviderFromAddress("nope", [A, B])).toBeUndefined();
+  });
+});
+
+describe("addressFromPublicKey", () => {
+  it("Ethereum: strips 0x04 after uncompress, keccak, last 20 bytes", () => {
+    const addr = addressFromPublicKey(Chain.Ethereum, "03deadbeef"); // input value irrelevant due to mocks
+    expect(addr).toBe("0x1234567890abcdef1234567890abcdef12345678");
+    expect(uncompressRawPublicKey).toHaveBeenCalled();
+    expect(keccak256).toHaveBeenCalled();
+  });
+
+  it("Solana: base58 encodes the raw bytes of the hex public key", () => {
+    const out = addressFromPublicKey(Chain.Solana, "a1b2c3");
+    expect(out).toBe("base58-encoded");
+    expect(bs58.encode).toHaveBeenCalled();
+  });
+
+  it("throws for unsupported chain", () => {
+    expect(() =>
+      addressFromPublicKey("Other" as unknown as Chain, "abcd"),
+    ).toThrow(/Unsupported chain:/);
+  });
+});
+
+describe("getAuthenticatorAddresses", () => {
+  it("routes SECP256K1 -> ethereum and ED25519 -> solana", () => {
+    // ✅ Valid hex inputs so we don't need to mock addressFromPublicKey itself
+    const secpCompressed = "02" + "ab".repeat(32); // 33 bytes, starts with 02/03
+    const ed25519 = "cd".repeat(32); // 32 bytes
+
+    const user: v1User = {
+      id: "user-1",
+      email: "x@y.z",
+      apiKeys: [
+        {
+          id: "k1",
+          credential: {
+            type: "CREDENTIAL_TYPE_API_KEY_SECP256K1",
+            publicKey: secpCompressed,
+          },
+        } as any,
+        {
+          id: "k2",
+          credential: {
+            type: "CREDENTIAL_TYPE_API_KEY_ED25519",
+            publicKey: ed25519,
+          },
+        } as any,
+      ],
+    } as any;
+
+    const out = getAuthenticatorAddresses(user);
+
+    // ETH: last 20 bytes of mocked keccak
+    expect(out.ethereum).toEqual([
+      "0x1234567890abcdef1234567890abcdef12345678",
+    ]);
+    // SOL: mocked base58 output
+    expect(out.solana).toEqual(["base58-encoded"]);
+  });
+
+  it("returns empty arrays when no apiKeys", () => {
+    const user: v1User = { id: "u", email: "e", apiKeys: [] } as any;
+    expect(getAuthenticatorAddresses(user)).toEqual({
+      ethereum: [],
+      solana: [],
+    });
+  });
+});
+
+/* ------- Error Handling ------- */
+
+describe("withTurnkeyErrorHandling", () => {
+  const DEFAULT_MSG = "Default wrapped message";
+  const DEFAULT_CODE = TurnkeyErrorCodes.INVALID_REQUEST;
+
+  const ok =
+    <T>(v: T) =>
+    async () =>
+      v;
+  const failWith = (err: unknown) => async () => {
+    throw err;
+  };
+
+  it("returns value on success and calls finallyFn (but not catchFn)", async () => {
+    const result = 42;
+
+    const catchFn = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const finallyFn = jest
+      .fn<() => Promise<void>>()
+      .mockResolvedValue(undefined);
+
+    const out = await withTurnkeyErrorHandling(
+      ok(result),
+      { errorMessage: DEFAULT_MSG, errorCode: DEFAULT_CODE, catchFn },
+      { finallyFn },
+    );
+
+    expect(out).toBe(result);
+    expect(catchFn).not.toHaveBeenCalled();
+    expect(finallyFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls catchFn on error and always calls finallyFn", async () => {
+    const catchFn = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const finallyFn = jest
+      .fn<() => Promise<void>>()
+      .mockResolvedValue(undefined);
+
+    await expect(
+      withTurnkeyErrorHandling(
+        failWith(new Error("boom")),
+        { errorMessage: DEFAULT_MSG, errorCode: DEFAULT_CODE, catchFn },
+        { finallyFn },
+      ),
+    ).rejects.toBeInstanceOf(TurnkeyError);
+
+    expect(catchFn).toHaveBeenCalledTimes(1);
+    expect(finallyFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes original error in cause when thrown via message-map (throwMatchingMessage path)", async () => {
+    const original = new Error("db: ECONNREFUSED 127.0.0.1:5432");
+
+    await expect(
+      withTurnkeyErrorHandling(
+        async () => {
+          throw original;
+        },
+        {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+          customMessageByMessages: {
+            ECONNREFUSED: {
+              message: "Database unavailable",
+              code: TurnkeyErrorCodes.INVALID_REQUEST,
+            },
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      // Ensure we don't hide the underlying error
+      cause: original,
+    });
+  });
+
+  it("includes original error in cause when wrapping a generic Error (no message-map hit)", async () => {
+    const original = new Error("S3 putObject timeout");
+
+    await expect(
+      withTurnkeyErrorHandling(
+        async () => {
+          throw original;
+        },
+        {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+        },
+      ),
+    ).rejects.toMatchObject({
+      cause: original,
+    });
+  });
+
+  describe("when thrown error is TurnkeyError", () => {
+    it("uses customMessageByCodes when the code matches (takes priority over message map)", async () => {
+      const original = new TurnkeyError("original message", DEFAULT_CODE);
+
+      await expect(
+        withTurnkeyErrorHandling(failWith(original), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+          customMessageByCodes: {
+            [DEFAULT_CODE]: {
+              message: "override via code",
+              code: DEFAULT_CODE,
+            },
+          },
+          customMessageByMessages: {
+            original: { message: "message-map-hit", code: DEFAULT_CODE },
+          },
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: "override via code",
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+
+    it("uses customMessageByMessages when message substring matches and no code override", async () => {
+      const original = new TurnkeyError(
+        "something specific happened",
+        DEFAULT_CODE,
+      );
+
+      await expect(
+        withTurnkeyErrorHandling(failWith(original), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+          // no customMessageByCodes hit
+          customMessageByMessages: {
+            specific: { message: "mapped by message", code: DEFAULT_CODE },
+          },
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: "mapped by message",
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+
+    it("rethrows the original TurnkeyError when no custom mapping matches", async () => {
+      const original = new TurnkeyError("no matches here", DEFAULT_CODE);
+
+      try {
+        await withTurnkeyErrorHandling(failWith(original), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+        });
+        throw new Error("should not reach");
+      } catch (e) {
+        // It should be the *same* instance rethrown
+        expect(e).toBe(original);
+      }
+    });
+  });
+
+  describe("when thrown error is TurnkeyRequestError", () => {
+    it("maps by message when customMessageByMessages matches", async () => {
+      const reqErr = new TurnkeyRequestError({
+        message: "token expired",
+        code: 1,
+        details: null,
+      });
+
+      await expect(
+        withTurnkeyErrorHandling(failWith(reqErr), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+          customMessageByMessages: {
+            expired: {
+              message: "Session expired, please re-auth",
+              code: DEFAULT_CODE,
+            },
+          },
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: "Session expired, please re-auth",
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+
+    it("wraps into TurnkeyError with default message/code when no mapping", async () => {
+      const reqErr = new TurnkeyRequestError({
+        message: "some request issue",
+        code: 1,
+        details: null,
+      });
+
+      await expect(
+        withTurnkeyErrorHandling(failWith(reqErr), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: DEFAULT_MSG,
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+  });
+
+  describe("when thrown error is a generic Error", () => {
+    it("maps by message when customMessageByMessages matches", async () => {
+      const err = new Error("db connection refused");
+
+      await expect(
+        withTurnkeyErrorHandling(failWith(err), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+          customMessageByMessages: {
+            "connection refused": {
+              message: "Database unavailable",
+              code: DEFAULT_CODE,
+            },
+          },
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: "Database unavailable",
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+
+    it("wraps into TurnkeyError with default message/code when no mapping", async () => {
+      const err = new Error("unrecognized error");
+
+      await expect(
+        withTurnkeyErrorHandling(failWith(err), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: DEFAULT_MSG,
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+  });
+
+  describe("when a non-Error value is thrown", () => {
+    it("maps by message when customMessageByMessages matches", async () => {
+      await expect(
+        withTurnkeyErrorHandling(failWith("timeout while fetching"), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+          customMessageByMessages: {
+            timeout: { message: "Network timeout", code: DEFAULT_CODE },
+          },
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: "Network timeout",
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+
+    it("wraps into TurnkeyError(String(error), default code) when no mapping", async () => {
+      await expect(
+        withTurnkeyErrorHandling(failWith(404), {
+          errorMessage: DEFAULT_MSG,
+          errorCode: DEFAULT_CODE,
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          // In this branch impl uses String(error) (not DEFAULT_MSG)
+          message: "404",
+          code: DEFAULT_CODE,
+        }),
+      );
+    });
+  });
+});
+
+describe("assertValidP256ECDSAKeyPair", () => {
+  // Helper to generate a P-256 ECDSA keypair with control over extractability/usages
+  const genECDSA = (opts?: {
+    extractable?: boolean;
+    usages?: KeyUsage[];
+    namedCurve?: "P-256" | "P-384";
+  }) => {
+    const {
+      extractable = false,
+      usages = ["sign", "verify"],
+      namedCurve = "P-256",
+    } = opts || {};
+    return crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve },
+      extractable,
+      usages,
+    ) as Promise<CryptoKeyPair>;
+  };
+
+  it("passes for a valid, non-extractable P-256 ECDSA pair", async () => {
+    const pair = await genECDSA();
+    await expect(assertValidP256ECDSAKeyPair(pair)).resolves.toBeUndefined();
+  });
+
+  it("throws if privateKey is extractable", async () => {
+    const pair = await genECDSA({ extractable: true });
+    await expect(assertValidP256ECDSAKeyPair(pair)).rejects.toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "Provided privateKey must be non-extractable",
+        ),
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+
+  it("throws if privateKey.type is not 'private'", async () => {
+    const pair = await genECDSA();
+    const badPair: CryptoKeyPair = {
+      privateKey: pair.publicKey as unknown as CryptoKey,
+      publicKey: pair.publicKey,
+    };
+    await expect(assertValidP256ECDSAKeyPair(badPair)).rejects.toEqual(
+      expect.objectContaining({
+        message: "privateKey.type must be 'private'.",
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+
+  it("throws if publicKey.type is not 'public'", async () => {
+    const pair = await genECDSA();
+    const badPair: CryptoKeyPair = {
+      privateKey: pair.privateKey,
+      publicKey: pair.privateKey as unknown as CryptoKey,
+    };
+    await expect(assertValidP256ECDSAKeyPair(badPair)).rejects.toEqual(
+      expect.objectContaining({
+        message: "publicKey.type must be 'public'.",
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+
+  it("throws if privateKey lacks 'sign' usage", async () => {
+    // Generate ECDH keys to force missing 'sign' usage
+    const ecdhPair = (await crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      false,
+      ["deriveKey"],
+    )) as CryptoKeyPair;
+
+    await expect(assertValidP256ECDSAKeyPair(ecdhPair)).rejects.toEqual(
+      expect.objectContaining({
+        message: "privateKey must have 'sign' in keyUsages.",
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+
+  it("throws if publicKey lacks 'verify' usage", async () => {
+    const pair = await genECDSA();
+    Object.defineProperty(pair.publicKey, "usages", {
+      value: [],
+      configurable: true,
+    });
+
+    await expect(assertValidP256ECDSAKeyPair(pair)).rejects.toEqual(
+      expect.objectContaining({
+        message: "publicKey must have 'verify' in keyUsages.",
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+
+  it("throws if algorithm is not ECDSA (name mismatch)", async () => {
+    const ecdhPair = (await crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      false,
+      ["deriveKey"],
+    )) as CryptoKeyPair;
+
+    // Patch usages so we reach the algorithm check
+    Object.defineProperty(ecdhPair.privateKey, "usages", {
+      value: ["sign"],
+      configurable: true,
+    });
+    Object.defineProperty(ecdhPair.publicKey, "usages", {
+      value: ["verify"],
+      configurable: true,
+    });
+
+    await expect(assertValidP256ECDSAKeyPair(ecdhPair)).rejects.toEqual(
+      expect.objectContaining({
+        message: "Keys must be ECDSA keys.",
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+
+  it("throws if curve is not P-256 (e.g., ECDSA P-384)", async () => {
+    const pair = await genECDSA({ namedCurve: "P-384" });
+    await expect(assertValidP256ECDSAKeyPair(pair)).rejects.toEqual(
+      expect.objectContaining({
+        message: "Keys must be on the P-256 curve.",
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+
+  it("throws if exported public key is not uncompressed (65 bytes starting with 0x04)", async () => {
+    const pair = await genECDSA();
+
+    const exportSpy = jest
+      .spyOn(crypto.subtle, "exportKey")
+      .mockResolvedValue(new Uint8Array(64).buffer);
+
+    await expect(assertValidP256ECDSAKeyPair(pair)).rejects.toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "Public key must be an uncompressed P-256 point (65 bytes, leading 0x04)",
+        ),
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+
+    exportSpy.mockRestore();
+  });
+
+  it("throws if the pair doesn't match (verify fails)", async () => {
+    const a = await genECDSA();
+    const b = await genECDSA();
+    const mixed: CryptoKeyPair = {
+      privateKey: a.privateKey,
+      publicKey: b.publicKey,
+    };
+
+    await expect(assertValidP256ECDSAKeyPair(mixed)).rejects.toEqual(
+      expect.objectContaining({
+        message: "publicKey does not match privateKey (verify failed).",
+        code: TurnkeyErrorCodes.INVALID_REQUEST,
+      }),
+    );
+  });
+});
+
+describe("isValidPasskeyName", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("web: accepts allowed characters and any length >= 1", () => {
+    // Default behavior (assume web): isReactNative() => false
+    jest.spyOn(utils, "isReactNative").mockReturnValue(false);
+
+    expect(isValidPasskeyName("A-Z a_z 0-9 -_:/.")).toBe("A-Z a_z 0-9 -_:/.");
+    // Long name is accepted on web because regex uses `+` (no 64 cap)
+    const long = "a".repeat(200);
+    expect(isValidPasskeyName(long)).toBe(long);
+  });
+
+  it("web: rejects empty or invalid characters (e.g., emoji)", () => {
+    jest.spyOn(utils, "isReactNative").mockReturnValue(false);
+    expect(() => isValidPasskeyName("")).toThrow(TurnkeyError);
+    expect(() => isValidPasskeyName("ok🙂")).toThrow(
+      /Passkey name must be 1-64 characters and only contain/i,
+    );
+  });
+
+  it("react-native: enforces 1–64 length and same allowed charset", () => {
+    // simulate React Native environment
+    const originalNav = (global as any).navigator;
+    (global as any).navigator = { product: "ReactNative" };
+
+    try {
+      expect(isValidPasskeyName("Name_01-/:.")).toBe("Name_01-/:.");
+
+      const max = "x".repeat(64);
+      expect(isValidPasskeyName(max)).toBe(max);
+
+      const over = "x".repeat(65);
+      expect(() => isValidPasskeyName(over)).toThrow(
+        /Passkey name must be 1-64 characters/i,
+      );
+    } finally {
+      // restore original navigator
+      (global as any).navigator = originalNav;
+    }
+  });
+
+  it("react-native: rejects invalid characters", () => {
+    const originalNav = (global as any).navigator;
+    (global as any).navigator = { product: "ReactNative" };
+
+    try {
+      expect(() => isValidPasskeyName("bad*char")).toThrow(TurnkeyError);
+    } finally {
+      // restore original navigator
+      (global as any).navigator = originalNav;
+    }
   });
 });

--- a/packages/core/src/__types__/base.ts
+++ b/packages/core/src/__types__/base.ts
@@ -279,7 +279,7 @@ export type CreateSubOrgParams = {
   /** array of authenticators to create. */
   authenticators?: {
     /** name of the authenticator. */
-    authenticatorName: string;
+    authenticatorName?: string;
     /** challenge for the authenticator. */
     challenge: string;
     /** attestation for the authenticator. */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -584,7 +584,7 @@ export function isWalletAccountArray(
 export function createWalletAccountFromAddressFormat(
   addressFormat: v1AddressFormat,
 ): v1WalletAccountParams {
-  const walletAccount = addressFormatConfig[addressFormat].defaultAccounts;
+  const walletAccount = addressFormatConfig[addressFormat]?.defaultAccounts;
   if (!walletAccount) {
     throw new Error(`Unsupported address format: ${addressFormat}`);
   }
@@ -629,6 +629,7 @@ export function generateWalletAccountsFromAddressFormat(params: {
 
     if (maxIndexMap.has(key)) {
       nextIndex = maxIndexMap.get(key)! + 1;
+      maxIndexMap.set(key, nextIndex);
     } else if (pathMap.has(account.path)) {
       nextIndex = pathMap.get(account.path)!;
     }
@@ -657,7 +658,7 @@ export function buildSignUpBody(params: {
     authenticators =
       createSubOrgParams?.authenticators?.map((authenticator) => ({
         authenticatorName:
-          authenticator.authenticatorName || `${websiteName}-${Date.now()}`,
+          authenticator?.authenticatorName || `${websiteName}-${Date.now()}`,
         challenge: authenticator.challenge,
         attestation: authenticator.attestation,
       })) || [];


### PR DESCRIPTION
## Summary & Motivation
- Started work on test case coverage for the new sdk (puppeteer and more signing cases on the way)

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
