### PR TITLE
moe/allow-override-oauth2-client-secret

### DIFF
--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -503,15 +503,20 @@ export const encryptToEnclave = async (
  * when enabling authentication with an OAuth 2.0 provider
  *
  * @param client_secret The client secret issued by the OAuth 2.0 provider
+ * @param dangerouslyOverrideTlsFetcherPublicKey *(optional)* Hex-encoded
+ *              uncompressed P-256 public key to encrypt to (use only in
+ *              tests/dev environment).  Defaults to the production TLS Fetcher key.
  * @returns {Promise<string>} A hex encoded borsh serialized envelope with the encrypted client
  *                            secret meant to be passed to the CreateOauth2Credential Activity
  */
 export const encryptOauth2ClientSecret = async (
   client_secret: string,
+  dangerouslyOverrideTlsFetcherPublicKey?: string,
 ): Promise<string> => {
   return uint8ArrayToHexString(
     await encryptToEnclave(
-      PRODUCTION_TLS_FETCHER_ENCRYPT_PUBLIC_KEY,
+      dangerouslyOverrideTlsFetcherPublicKey ??
+        PRODUCTION_TLS_FETCHER_ENCRYPT_PUBLIC_KEY,
       client_secret,
     ),
   );


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
