### PR TITLE
Readme: Corrected IOTA denominator and IOTA spelling

### DIFF
--- a/examples/with-iota/README.md
+++ b/examples/with-iota/README.md
@@ -2,7 +2,7 @@
 
 This is a simple example that walks through the following:
 
-- Construction of a iota transaction sending the funds out on mainnet
+- Construction of an IOTA transaction sending the funds out on mainnet
 
 ## Getting started
 
@@ -43,7 +43,7 @@ Now open `.env.local` and add the missing environment variables:
 
 ### 3/ Running the script
 
-Note that this example is currently set up with iota mainnet. You will need a balance to run this example
+Note that this example is currently set up with IOTA mainnet. You will need a balance to run this example.
 
 ```bash
 $ pnpm start
@@ -54,7 +54,7 @@ You should see output similar to the following:
 ```
 ? Recipient address: (<recipient_iota_address>)
 
-Sending 1000 MIOTA (0.000001 IOTA) to <recipient_iota_address>
+Sending 1000000 Nanos (1 IOTA) to <recipient_iota_address>
 
 Transaction Hash: <iota_transaction_hash>
 ```


### PR DESCRIPTION
- Removed mention of "MIOTA"
- Input the correct smallest denominator "Nano" for the example call
- I corrected the iota to correct the uppercase spelling in normal text. Please try always to use "IOTA" in normal text.

## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
