### PR TITLE
Optimize fetch wallets

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -27,6 +27,8 @@ import {
   EvmChainInfo,
   SolanaChainInfo,
   Curve,
+  EmbeddedWallet,
+  WalletSource,
 } from "./__types__/base";
 import { bs58 } from "@turnkey/encoding";
 
@@ -1150,4 +1152,40 @@ export function isValidPasskeyName(name: string): string {
     );
   }
   return name;
+}
+
+export function mapAccountsToWallet(
+  accounts: v1WalletAccount[],
+): EmbeddedWallet[] {
+  // map of walletId to Wallet
+  const walletMap = new Map<string, EmbeddedWallet>();
+
+  // map all wallet accounts to their wallets
+  accounts.forEach(async (account) => {
+    if (walletMap.has(account.walletDetails!.walletId)) {
+      const wallet = walletMap.get(account.walletDetails!.walletId)!;
+      wallet.accounts.push({
+        ...account,
+        source: WalletSource.Embedded,
+      });
+      return;
+    } else {
+      walletMap.set(account.walletDetails!.walletId, {
+        source: WalletSource.Embedded,
+        walletId: account.walletDetails!.walletId,
+        walletName: account.walletDetails!.walletName,
+        createdAt: account.walletDetails!.createdAt,
+        updatedAt: account.walletDetails!.updatedAt,
+        exported: account.walletDetails!.exported,
+        imported: account.walletDetails!.imported,
+        accounts: [
+          {
+            ...account,
+            source: WalletSource.Embedded,
+          },
+        ],
+      });
+    }
+  });
+  return Array.from(walletMap.values());
 }


### PR DESCRIPTION
## Summary & Motivation
- Use the new flag on getWalletAccounts to optimize wallet fetch by mapping wallet accounts to the correct wallet object on the sdk level

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
