### PR TITLE
added optional wallet/pk name override for import modals

### DIFF
--- a/.changeset/slimy-baths-do.md
+++ b/.changeset/slimy-baths-do.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": minor
+---
+
+Added optional name overide param for handleImportWallet & handleImportPrivateKey. If provided, the input field for wallet name will no longer be shown and the passed in name param will be used instead.

--- a/packages/react-wallet-kit/src/components/import/Import.tsx
+++ b/packages/react-wallet-kit/src/components/import/Import.tsx
@@ -39,6 +39,7 @@ export function ImportComponent(props: {
   onError: (error: TurnkeyError) => void;
   successPageDuration?: number | undefined; // Duration in milliseconds for the success page to show. If 0, it will not show the success page.
   stampWith?: StamperType | undefined;
+  name?: string;
 }) {
   const {
     importType,
@@ -49,6 +50,7 @@ export function ImportComponent(props: {
     defaultWalletAccounts,
     successPageDuration,
     stampWith,
+    name,
   } = props;
 
   const { config, session, importWallet, importPrivateKey, httpClient } =
@@ -61,7 +63,7 @@ export function ImportComponent(props: {
     );
   }
 
-  const [walletName, setWalletName] = useState<string>("");
+  const [walletName, setWalletName] = useState<string>(name || "");
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<TurnkeyError | null>(null);
 
@@ -381,20 +383,22 @@ export function ImportComponent(props: {
         }}
         className={`transition-all ${shaking ? "animate-shake" : ""}`}
       />
-      <Input
-        type="text"
-        data-testid="import-wallet-name-input"
-        placeholder={placeholder}
-        value={walletName}
-        onChange={(e) => setWalletName(e.target.value)}
-        className="placeholder:text-icon-text-light dark:placeholder:text-icon-text-dark w-full my-2 py-3 px-3 rounded-md text-inherit bg-icon-background-light dark:bg-icon-background-dark border border-modal-background-dark/20 dark:border-modal-background-light/20 focus:outline-primary-light focus:dark:outline-primary-dark focus:outline-[1px] focus:outline-offset-0 box-border"
-      />
+      {!name && (
+        <Input
+          type="text"
+          data-testid="import-wallet-name-input"
+          placeholder={placeholder}
+          value={walletName}
+          onChange={(e) => setWalletName(e.target.value)}
+          className="placeholder:text-icon-text-light dark:placeholder:text-icon-text-dark w-full mt-2 py-3 px-3 rounded-md text-inherit bg-icon-background-light dark:bg-icon-background-dark border border-modal-background-dark/20 dark:border-modal-background-light/20 focus:outline-primary-light focus:dark:outline-primary-dark focus:outline-[1px] focus:outline-offset-0 box-border"
+        />
+      )}
       <ActionButton
         name="import-button"
         loading={isLoading}
         spinnerClassName="text-primary-text-light dark:text-primary-text-dark"
         onClick={handleImport}
-        className="bg-primary-light dark:bg-primary-dark text-primary-text-light dark:text-primary-text-dark"
+        className="bg-primary-light mt-2 dark:bg-primary-dark text-primary-text-light dark:text-primary-text-dark"
       >
         Import
       </ActionButton>

--- a/packages/react-wallet-kit/src/providers/client/Provider.tsx
+++ b/packages/react-wallet-kit/src/providers/client/Provider.tsx
@@ -3803,11 +3803,13 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       defaultWalletAccounts?: v1AddressFormat[] | v1WalletAccountParams[];
       successPageDuration?: number | undefined;
       stampWith?: StamperType | undefined;
+      walletName?: string;
     }): Promise<string> => {
       const {
         defaultWalletAccounts,
         successPageDuration = 2000,
         stampWith,
+        walletName,
       } = params || {};
       try {
         return withTurnkeyErrorHandling(
@@ -3829,6 +3831,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                       successPageDuration,
                     })}
                     {...(stampWith !== undefined && { stampWith })}
+                    {...(walletName !== undefined && { name: walletName })}
                   />
                 ),
               }),
@@ -3855,12 +3858,14 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       addressFormats: v1AddressFormat[];
       successPageDuration?: number | undefined;
       stampWith?: StamperType | undefined;
+      keyName?: string;
     }): Promise<string> => {
       const {
         curve,
         addressFormats,
         successPageDuration = 2000,
         stampWith,
+        keyName,
       } = params || {};
       try {
         return withTurnkeyErrorHandling(
@@ -3881,6 +3886,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                       successPageDuration,
                     })}
                     {...(stampWith !== undefined && { stampWith })}
+                    {...(keyName !== undefined && { name: keyName })}
                   />
                 ),
               }),

--- a/packages/react-wallet-kit/src/providers/client/Types.tsx
+++ b/packages/react-wallet-kit/src/providers/client/Types.tsx
@@ -391,6 +391,7 @@ export interface ClientContextType extends TurnkeyClientMethods {
    * @param params.defaultWalletAccounts - array of default wallet accounts (v1AddressFormat[] or v1WalletAccountParams[]) to pre-fill the import form.
    * @param params.successPageDuration - duration (in ms) for the success page after import (default: 0, no success page).
    * @param params.stampWith - parameter to specify the stamper to use for the import (Passkey, ApiKey, or Wallet).
+   * @param params.walletName - name for the imported wallet, if not provided, an input box will be shown for the name.
    *
    * @returns A promise that resolves to the new wallet's ID.
    */
@@ -398,6 +399,7 @@ export interface ClientContextType extends TurnkeyClientMethods {
     defaultWalletAccounts?: v1AddressFormat[] | v1WalletAccountParams[];
     successPageDuration?: number | undefined; // Duration in milliseconds for the success page to show. If 0, it will not show the success page.
     stampWith?: StamperType | undefined;
+    walletName?: string;
   }) => Promise<string>;
 
   /**
@@ -414,6 +416,7 @@ export interface ClientContextType extends TurnkeyClientMethods {
    * @param params.addressFormats - array of address formats (v1AddressFormat[]) that the private key supports (Eg: "ADDRESS_FORMAT_ETHEREUM" for Ethereum, "ADDRESS_FORMAT_SOLANA" for Solana).
    * @param params.successPageDuration - duration (in ms) for the success page after import (default: 0, no success page).
    * @param params.stampWith - parameter to specify the stamper to use for the import (Passkey, ApiKey, or Wallet).
+   * @param params.keyName - name for the imported private key, if not provided, an input box will be shown for the name.
    *
    * @returns A promise that resolves to the new private key's ID.
    */
@@ -422,6 +425,7 @@ export interface ClientContextType extends TurnkeyClientMethods {
     addressFormats: v1AddressFormat[];
     successPageDuration?: number | undefined; // Duration in milliseconds for the success page to show. If 0, it will not show the success page.
     stampWith?: StamperType | undefined;
+    keyName?: string;
   }) => Promise<string>;
 
   /**


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
