### PR TITLE
Fixed broken padding on Safari ios/macos26

### DIFF
--- a/.changeset/bitter-yaks-stare.md
+++ b/.changeset/bitter-yaks-stare.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+- Fixed broken padding on Safari using iOS 26 and MacOS 26

--- a/packages/react-wallet-kit/postcss-important.js
+++ b/packages/react-wallet-kit/postcss-important.js
@@ -1,0 +1,31 @@
+// This script adds !important to all padding/margin declarations except those that use revert-layer
+// This is because (for some reason) Safari on iOS 26 and MacOS 26 now forces 0 padding and margin when using revert-layer. This seems to be a bug/oversight.
+// We fix this by forcing !important on all padding/margin declarations that come from tailwind's.
+
+const postcss = require("postcss");
+
+module.exports = postcss.plugin("postcss-important-padding-margin", () => {
+  return (root) => {
+    root.walkDecls((decl) => {
+      const prop = decl.prop.toLowerCase();
+
+      // Match padding/margin and their shorthands
+      if (
+        prop === "padding" ||
+        prop === "margin" ||
+        prop.startsWith("padding-") ||
+        prop.startsWith("margin-")
+      ) {
+        // Skip if this is a revert-layer reset
+        if (decl.value && decl.value.includes("revert-layer")) {
+          return;
+        }
+
+        // Only add if it doesn't already have !important
+        if (!decl.important) {
+          decl.important = true;
+        }
+      }
+    });
+  };
+});

--- a/packages/react-wallet-kit/postcss.config.js
+++ b/packages/react-wallet-kit/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
     "@tailwindcss/postcss": {},
+    "./postcss-important.js": {},
   },
 };

--- a/packages/react-wallet-kit/rollup.config.mjs
+++ b/packages/react-wallet-kit/rollup.config.mjs
@@ -97,6 +97,7 @@ const getFormatConfig = (format) => {
       }),
       postcss({
         extract: "styles.css",
+        config: true, // Look for postcss.config.js. We run the postcss-important script there.
         minimize: true,
       }),
     ],


### PR DESCRIPTION
## Summary & Motivation

Fixes 0 padding bug when using Safari on MacOS 26 and iOS 26

Bug:
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/989deb59-a946-4ac8-bf53-71f6a060bfac" />

Fixed:
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/bbba869e-3f56-4755-9f4e-f475ab0ba52a" />


## How I Tested These Changes

Tailwind 3 and 4 apps
iOS 26 and 18 phones
Chrome on computer 

## Did you add a changeset?

yes