### PR TITLE
fixed export and handleAddOauth for sessionless stamping

### DIFF
--- a/examples/with-sdk-js/src/app/page.tsx
+++ b/examples/with-sdk-js/src/app/page.tsx
@@ -1904,23 +1904,13 @@ export default function AuthPage() {
           <button
             onClick={async () => {
               try {
-                console.log(
-                  "Fetching wallets for organizationId and userId",
-                  organizationId,
-                  userId,
-                );
-                await turnkey.refreshWallets({
-                  organizationId: organizationId,
-                  userId: userId,
-                  stampWith: StamperType.Passkey,
-                });
-                await turnkey.refreshUser({
-                  organizationId: organizationId,
-                  userId: userId,
-                  stampWith: StamperType.Passkey,
-                });
+                await turnkey.loginWithPasskey();
+                await turnkey.refreshWallets();
+                await turnkey.refreshUser();
               } catch (e) {
                 console.error(e);
+              } finally {
+                await turnkey.clearSession();
               }
             }}
             style={{

--- a/packages/react-wallet-kit/src/components/export/Export.tsx
+++ b/packages/react-wallet-kit/src/components/export/Export.tsx
@@ -33,6 +33,8 @@ export function ExportComponent(params: {
   keyFormat?: KeyFormat | undefined;
   stampWith?: StamperType | undefined;
   organizationId?: string;
+  onSuccess: () => void;
+  onError: (error: any) => void;
 }) {
   const {
     exportType,
@@ -41,6 +43,8 @@ export function ExportComponent(params: {
     stampWith,
     target,
     organizationId,
+    onSuccess,
+    onError,
   } = params;
   const { config } = useTurnkey();
 
@@ -92,10 +96,12 @@ export function ExportComponent(params: {
         });
         setExportIframeClient(newExportIframeClient);
       } catch (error) {
-        throw new TurnkeyError(
-          `Error initializing IframeStamper`,
-          TurnkeyErrorCodes.INITIALIZE_IFRAME_ERROR,
-          error,
+        onError(
+          new TurnkeyError(
+            `Error initializing IframeStamper`,
+            TurnkeyErrorCodes.INITIALIZE_IFRAME_ERROR,
+            error,
+          ),
         );
       }
     };
@@ -159,6 +165,7 @@ export function ExportComponent(params: {
           stampWith={stampWith}
           setExportIframeVisible={setExportIframeVisible}
           organizationId={organizationId}
+          onError={onError}
         />
       )}
       <div
@@ -209,7 +216,10 @@ export function ExportComponent(params: {
         <div className="mt-4">
           <ActionButton
             name="export-done"
-            onClick={closeModal}
+            onClick={() => {
+              closeModal();
+              onSuccess();
+            }}
             spinnerClassName="text-primary-text-light dark:text-primary-text-dark"
             className="text-primary-text-light dark:text-primary-text-dark bg-primary-light dark:bg-primary-dark"
           >

--- a/packages/react-wallet-kit/src/components/export/ExportWarning.tsx
+++ b/packages/react-wallet-kit/src/components/export/ExportWarning.tsx
@@ -28,6 +28,7 @@ export function ExportWarning(props: {
   setExportIframeVisible?: (visible: boolean) => void;
   stampWith?: StamperType | undefined;
   organizationId?: string | undefined;
+  onError: (error: any) => void;
 }) {
   const {
     target,
@@ -36,6 +37,7 @@ export function ExportWarning(props: {
     exportType,
     keyFormat,
     stampWith,
+    onError,
   } = props;
 
   const [isLoading, setIsLoading] = useState(false);
@@ -99,9 +101,11 @@ export function ExportWarning(props: {
                   organizationId,
                 });
                 if (!exportBundle) {
-                  throw new TurnkeyError(
-                    "Failed to retrieve export bundle",
-                    TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
+                  onError(
+                    new TurnkeyError(
+                      "Failed to retrieve export bundle",
+                      TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
+                    ),
                   );
                 }
                 await exportIframeClient?.injectWalletExportBundle(
@@ -118,9 +122,11 @@ export function ExportWarning(props: {
                   organizationId,
                 });
                 if (!exportBundle) {
-                  throw new TurnkeyError(
-                    "Failed to retrieve export bundle",
-                    TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
+                  onError(
+                    new TurnkeyError(
+                      "Failed to retrieve export bundle",
+                      TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
+                    ),
                   );
                 }
                 await exportIframeClient?.injectKeyExportBundle(
@@ -138,9 +144,11 @@ export function ExportWarning(props: {
                   organizationId,
                 });
                 if (!exportBundle) {
-                  throw new TurnkeyError(
-                    "Failed to retrieve export bundle",
-                    TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
+                  onError(
+                    new TurnkeyError(
+                      "Failed to retrieve export bundle",
+                      TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
+                    ),
                   );
                 }
                 await exportIframeClient?.injectKeyExportBundle(
@@ -159,10 +167,12 @@ export function ExportWarning(props: {
               props.setExportIframeVisible(true);
             }
           } catch (error) {
-            throw new TurnkeyError(
-              `Error exporting wallet`,
-              TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
-              error,
+            onError(
+              new TurnkeyError(
+                `Error exporting wallet`,
+                TurnkeyErrorCodes.EXPORT_WALLET_ERROR,
+                error,
+              ),
             );
           } finally {
             setIsLoading(false);


### PR DESCRIPTION
## Summary & Motivation
- Made handleExport methods & handleAddOauth fully async

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
