### PR TITLE
fixed sdk-types codegen for auth proxy

### DIFF
--- a/packages/sdk-types/scripts/codegen.js
+++ b/packages/sdk-types/scripts/codegen.js
@@ -440,7 +440,8 @@ function generateApiTypes(swagger, prefix = "") {
         for (const [prop, schema] of Object.entries(
           requestTypeDef.properties,
         )) {
-          if (prop === "organizationId") continue;
+          // NOTE: Not sure why this was here, seems wrong
+          // if (prop === "organizationId") continue;
           let type = "any";
           if (schema.$ref) {
             type = refToTs(schema.$ref);

--- a/packages/sdk-types/src/__generated__/types.ts
+++ b/packages/sdk-types/src/__generated__/types.ts
@@ -5537,6 +5537,8 @@ export type ProxyTOAuthLoginBody = {
   publicKey: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  /** Unique identifier for a given Organization. If provided, this organization id will be used directly. If omitted, uses the OIDC token to look up the associated organization id. */
+  organizationId?: string;
 };
 
 export type ProxyTOAuthLoginInput = { body: ProxyTOAuthLoginBody };
@@ -5567,6 +5569,8 @@ export type ProxyTOtpLoginBody = {
   publicKey: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  /** Unique identifier for a given Organization. If provided, this organization id will be used directly. If omitted, uses the verification token to look up the verified sub-organization based on the contact and verification type. */
+  organizationId?: string;
   /** Optional signature associated with the public key passed into the verification step. This must be a hex-encoded ECDSA signature over the verification token. Only required if a public key was provided during the verification step. */
   clientSignature?: string;
 };


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
