### PR TITLE
Update .env variable names in README - examples/with-indexed-db

### DIFF
--- a/examples/import-in-node/README.md
+++ b/examples/import-in-node/README.md
@@ -38,6 +38,7 @@ Now open `.env.local` and add the missing environment variables:
 
 - `API_PUBLIC_KEY`
 - `API_PRIVATE_KEY`
+- `USER_ID`
 - `BASE_URL`
 - `ORGANIZATION_ID`
 

--- a/examples/import-in-node/src/index.ts
+++ b/examples/import-in-node/src/index.ts
@@ -101,7 +101,7 @@ async function main() {
             : ["ADDRESS_FORMAT_ETHEREUM"],
       });
     console.log(
-      `Successfully imported wallet with id: ${privateKeyImportResult.privateKeyId}`,
+      `Successfully imported private key with id: ${privateKeyImportResult.privateKeyId}`,
     );
   }
 }

--- a/examples/with-indexed-db/.env.local.example
+++ b/examples/with-indexed-db/.env.local.example
@@ -2,3 +2,4 @@ TURNKEY_API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 TURNKEY_API_PRIVATE_KEY="<Turnkey API Private Key>"
 NEXT_PUBLIC_BASE_URL="https://api.turnkey.com"
 NEXT_PUBLIC_ORGANIZATION_ID="<Turnkey organization ID>"
+NEXT_PUBLIC_RPID=localhost

--- a/examples/with-indexed-db/README.md
+++ b/examples/with-indexed-db/README.md
@@ -50,6 +50,7 @@ TURNKEY_API_PUBLIC_KEY=<your-api-public-key>
 TURNKEY_API_PRIVATE_KEY=<your-api-private-key> # DO NOT commit this
 NEXT_PUBLIC_BASE_URL=https://api.turnkey.com
 NEXT_PUBLIC_ORGANIZATION_ID=<your-org-id>
+NEXT_PUBLIC_RPID=localhost
 ```
 
 > **Note:** Your private key is used only in development and must be handled securely. Do not expose it in production builds.


### PR DESCRIPTION
updated examples/with-indexed-db variable names in README to:
TURNKEY_API_PUBLIC_KEY
TURNKEY_API_PRIVATE_KEY
