### PR TITLE
connectedSigner: add populateTransaction step before signing tx

### DIFF
--- a/examples/with-ethers/src/index.ts
+++ b/examples/with-ethers/src/index.ts
@@ -122,9 +122,12 @@ async function main() {
     type: 2,
   };
 
+  const populatedTx =
+    await connectedSigner.populateTransaction(transactionRequest);
+
   let signedTx;
   try {
-    signedTx = await connectedSigner.signTransaction(transactionRequest);
+    signedTx = await connectedSigner.signTransaction(populatedTx);
   } catch (error: any) {
     signedTx = await handleActivityError(error).then(
       async (activity?: TActivity) => {
@@ -164,7 +167,7 @@ async function main() {
   // 3. Make a simple send tx (which calls `signTransaction` under the hood)
   let sentTx;
   try {
-    sentTx = await connectedSigner.sendTransaction(transactionRequest);
+    sentTx = await connectedSigner.sendTransaction(populatedTx);
   } catch (error: any) {
     sentTx = await handleActivityError(error).then(
       async (activity?: TActivity) => {


### PR DESCRIPTION
## Summary & Motivation
Currently when running the demo the below error is returned, due to the fact that the transaction object is not fully populated: https://github.com/tkhq/sdk/blob/b755f006f90ff19b94d9d26bb89c16855f115a57/examples/with-ethers/src/index.ts#L119

```
TurnkeyActivityError: Failed to sign: Turnkey error 3: failed to pre-parse Ethereum transaction (Details: [])
    at TurnkeySigner._signTransactionWithErrorWrapping 
```


## How I Tested These Changes
The ethers signer has a populateTransaction method for sending to the network by populating any missing tx properties.
https://docs.ethers.org/v6/api/providers/#Signer-populateTransaction

Signing the fully populated tx works.  



