### PR TITLE
clean up changelogs for release

### DIFF
--- a/.changeset/major-pans-brush.md
+++ b/.changeset/major-pans-brush.md
@@ -2,27 +2,8 @@
 "@turnkey/sdk-browser": minor
 "@turnkey/sdk-server": minor
 "@turnkey/sdk-types": minor
-"with-x": minor
 "@turnkey/core": minor
 "@turnkey/http": minor
-"@turnkey/delegated-access": patch
-"@turnkey/api-key-stamper": patch
-"@turnkey/cosmjs": patch
-"@turnkey/crypto": patch
-"@turnkey/eip-1193-provider": patch
-"@turnkey/encoding": patch
-"@turnkey/ethers": patch
-"@turnkey/iframe-stamper": patch
-"@turnkey/indexed-db-stamper": patch
-"@turnkey/react-native-passkey-stamper": patch
-"@turnkey/react-wallet-kit": patch
-"@turnkey/sdk-react": patch
-"@turnkey/sdk-react-native": patch
-"@turnkey/solana": patch
-"@turnkey/telegram-cloud-storage-stamper": patch
-"@turnkey/viem": patch
-"@turnkey/wallet-stamper": patch
-"@turnkey/webauthn-stamper": patch
 ---
 
-OAuth2Authenticate now supports returning the encrypted bearer token via the optional `bearerTokenTargetPublicKey` request parameter.
+OAuth2Authenticate now supports returning the encrypted bearer token via the optional `bearerTokenTargetPublicKey` request parameter (mono release v2025.9.5)


### PR DESCRIPTION
## Summary & Motivation

cleaning up changelog from [PR 977](https://github.com/tkhq/sdk/pull/977)

packages with changes:
- `@turnkey/sdk-browser`: minor
- `@turnkey/sdk-server`: minor
- `@turnkey/sdk-types`: minor
- `@turnkey/core`: minor
- `@turnkey/http`: minor

all of these came from the mono sync with `v2025.9.5`

**Note**: other packages that list any of these as dependencies will automatically be patched

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
