### PR TITLE
WalletConnect handling

### DIFF
--- a/.changeset/floppy-lizards-stay.md
+++ b/.changeset/floppy-lizards-stay.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/core": patch
+---
+
+WalletConnect initialization now has a 5-second timeout. If setup fails, it no longer blocks overall client initialization

--- a/packages/core/src/__wallet__/web/manager.ts
+++ b/packages/core/src/__wallet__/web/manager.ts
@@ -11,6 +11,7 @@ import {
 } from "../../__types__";
 import { WalletConnectClient } from "../wallet-connect/client";
 import { WalletConnectWallet } from "../wallet-connect/base";
+import { withTimeout } from "@utils";
 
 export class WebWalletManager {
   // queue of async initialization functions
@@ -75,7 +76,18 @@ export class WebWalletManager {
 
       // add async init step to the initializer queue
       this.initializers.push(() =>
-        wcUnified.init({ ethereumNamespaces, solanaNamespaces }),
+        withTimeout(
+          wcUnified.init({ ethereumNamespaces, solanaNamespaces }),
+          5000,
+          "WalletConnect wallet",
+        ).catch((err) => {
+          // WalletConnect can be a bit unreliable, so instead of throwing an error
+          // we handle failures silently to avoid blocking the rest of the client
+          // from initializing. If setup fails, we also remove WalletConnect
+          // from the available wallets list
+          console.error("Failed to init WalletConnect wallet:", err);
+          this.removeWalletInterface(WalletInterfaceType.WalletConnect);
+        }),
       );
 
       // register WalletConnect as a wallet interface for each enabled chain
@@ -107,7 +119,16 @@ export class WebWalletManager {
    */
   async init(cfg: TWalletManagerConfig): Promise<void> {
     if (this.wcClient) {
-      await this.wcClient.init(cfg.walletConnect!);
+      try {
+        await this.wcClient.init(cfg.walletConnect!);
+      } catch (error) {
+        // WalletConnect can be a bit unreliable, so instead of throwing an error
+        // we handle failures silently to avoid blocking the rest of the client
+        // from initializing. If setup fails, we also remove WalletConnect
+        // from the available wallets list
+        console.error("Failed to initialize WalletConnect client", error);
+        this.removeWalletInterface(WalletInterfaceType.WalletConnect);
+      }
     }
 
     // we initialize the high-level WalletConnectWallet
@@ -166,4 +187,29 @@ export class WebWalletManager {
     if (!this.chainToInterfaces[chain]) this.chainToInterfaces[chain] = [];
     this.chainToInterfaces[chain]!.push(interfaceType);
   };
+
+  /**
+   * Removes a wallet interface from the manager.
+   *
+   * - Deletes the wallet instance from the wallets map.
+   * - Cleans up references to the wallet interface in chainToInterfaces.
+   * - Removes the chain entry entirely if no interfaces remain.
+   *
+   * @param type - The WalletInterfaceType to remove.
+   */
+  private removeWalletInterface(type: WalletInterfaceType) {
+    delete this.wallets[type];
+
+    for (const chain of Object.keys(this.chainToInterfaces) as Chain[]) {
+      const filtered = (this.chainToInterfaces[chain] ?? []).filter(
+        (interfaceType) => interfaceType !== type,
+      );
+
+      if (filtered.length > 0) {
+        this.chainToInterfaces[chain] = filtered;
+      } else {
+        delete this.chainToInterfaces[chain];
+      }
+    }
+  }
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1204,3 +1204,21 @@ export function mapAccountsToWallet(
   });
   return Array.from(walletMap.values());
 }
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout;
+  const timer = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+
+  return Promise.race([promise, timer]).finally(() =>
+    clearTimeout(timeout!),
+  ) as Promise<T>;
+}

--- a/packages/react-wallet-kit/src/utils/utils.ts
+++ b/packages/react-wallet-kit/src/utils/utils.ts
@@ -77,6 +77,7 @@ export const useDebouncedCallback = <T extends (...args: any[]) => void>(
     [wait],
   ) as T;
 };
+
 export const isValidSession = (session?: Session | undefined): boolean => {
   return session?.expiry !== undefined && session.expiry * 1000 > Date.now();
 };


### PR DESCRIPTION
## Summary & Motivation
- add 5 second timeout for initialization
- if initialization fails, we fail silently and remove WalletConnect as an option

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
