### PR TITLE
Padding and margin is now only important under tk-modal

### DIFF
--- a/.changeset/mighty-items-fry.md
+++ b/.changeset/mighty-items-fry.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Padding and margin styles are now only forced under `.tk-modal`

--- a/packages/react-wallet-kit/postcss-important.js
+++ b/packages/react-wallet-kit/postcss-important.js
@@ -1,31 +1,83 @@
-// This script adds !important to all padding/margin declarations except those that use revert-layer
-// This is because (for some reason) Safari on iOS 26 and MacOS 26 now forces 0 padding and margin when using revert-layer. This seems to be a bug/oversight.
-// We fix this by forcing !important on all padding/margin declarations that come from tailwind's.
+// Clone only spacing rules and scope them under `.tk-modal` with !important.
+// Leaves original Tailwind utilities untouched (so no global side-effects).
+// This is because (for some reason) Safari on iOS 26 and MacOS 26 now forces 0 padding and margin
+// when using revert-layer. This seems to be a bug/oversight.
+// We fix this by forcing !important on all padding/margin declarations that come from tailwind
+// but only scoping it to `.tk-modal`.
+//
+// Options:
+//   prefix: string  — default ":where(.tk-modal)"
+//   strict: boolean — default true; only target Tailwind spacing utilities
 
-const postcss = require("postcss");
+// Matches Tailwind spacing utilities, including variants and negatives:
+// .p-4 .mt-2 .-mt-2 .md\:p-4 .hover\:mt-2 .ps-3 .me-1 .m-[3px] etc.
+const TAILWIND_SPACING_SELECTOR_RE =
+  /(^|[^\\])\.(?:-)?(?:[\w-]+\\:)*!?-?(?:m|p)(?:[trblxyse])?-\[(?:[^\]]+)\]|(^|[^\\])\.(?:-)?(?:[\w-]+\\:)*!?-?(?:m|p)(?:[trblxyse])?-[\w./]+/;
 
-module.exports = postcss.plugin("postcss-important-padding-margin", () => {
-  return (root) => {
-    root.walkDecls((decl) => {
-      const prop = decl.prop.toLowerCase();
+function isSpacingDecl(decl) {
+  const prop = decl.prop.toLowerCase();
+  if (
+    prop === "margin" ||
+    prop === "padding" ||
+    prop.startsWith("margin-") ||
+    prop.startsWith("padding-")
+  ) {
+    if (decl.value && decl.value.includes("revert-layer")) return false; // don't fight resets
+    return true;
+  }
+  return false;
+}
 
-      // Match padding/margin and their shorthands
-      if (
-        prop === "padding" ||
-        prop === "margin" ||
-        prop.startsWith("padding-") ||
-        prop.startsWith("margin-")
-      ) {
-        // Skip if this is a revert-layer reset
-        if (decl.value && decl.value.includes("revert-layer")) {
-          return;
+function prefixSelectors(selector, prefix) {
+  // Prefix each comma-separated selector with the parent scope.
+  return selector
+    .split(",")
+    .map((s) => `${prefix} ${s.trim()}`)
+    .join(", ");
+}
+
+const plugin = (opts = {}) => {
+  const prefix = opts.prefix || ":where(.tk-modal)";
+  const strict = opts.strict !== false; // default true
+
+  return {
+    postcssPlugin: "postcss-tkmodal-spacing-important",
+    Once(root) {
+      root.walkRules((rule) => {
+        // Avoid re-processing already-scoped rules
+        if (rule.selector.includes(".tk-modal")) return;
+        if (rule.selector.includes(":where(.tk-modal)")) return;
+
+        // Only touch Tailwind spacing utilities
+        if (strict) {
+          if (!TAILWIND_SPACING_SELECTOR_RE.test(rule.selector)) return;
         }
 
-        // Only add if it doesn't already have !important
-        if (!decl.important) {
-          decl.important = true;
-        }
-      }
-    });
+        // Check if this rule sets any spacing declarations we care about
+        let hasSpacing = false;
+        rule.walkDecls((decl) => {
+          if (isSpacingDecl(decl)) hasSpacing = true;
+        });
+        if (!hasSpacing) return;
+
+        // Clone the rule and scope it
+        const clone = rule.clone();
+        clone.selector = prefixSelectors(rule.selector, prefix);
+
+        // Add !important only to spacing decls, still skipping revert-layer
+        clone.walkDecls((decl) => {
+          if (isSpacingDecl(decl) && !decl.important) {
+            decl.important = true;
+          }
+        });
+
+        // Emit the override *after* the original so it wins in source order
+        rule.after(clone);
+      });
+    },
   };
-});
+};
+
+plugin.postcss = true;
+
+module.exports = plugin;


### PR DESCRIPTION
## Summary & Motivation


## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
