### PR TITLE
add `publicKey` field to `onOauthSuccess` callback

### DIFF
--- a/.changeset/small-lamps-battle.md
+++ b/.changeset/small-lamps-battle.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Added missing `publicKey` field to the `onOauthSuccess` callback in OAuth handler functions

--- a/packages/react-wallet-kit/src/providers/client/Provider.tsx
+++ b/packages/react-wallet-kit/src/providers/client/Provider.tsx
@@ -3057,6 +3057,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                         const oidcToken = resp.oidcToken;
                         if (params?.onOauthSuccess) {
                           params.onOauthSuccess({
+                            publicKey,
                             oidcToken,
                             providerName: "discord",
                             ...(sessionKey && { sessionKey }),
@@ -3251,6 +3252,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                         const oidcToken = resp.oidcToken;
                         if (params?.onOauthSuccess) {
                           params.onOauthSuccess({
+                            publicKey,
                             oidcToken,
                             providerName: "twitter",
                             ...(sessionKey && { sessionKey }),
@@ -3417,6 +3419,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
 
                     if (params?.onOauthSuccess) {
                       params.onOauthSuccess({
+                        publicKey,
                         oidcToken: idToken,
                         providerName: "google",
                         ...(sessionKey && { sessionKey }),
@@ -3577,6 +3580,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
 
                     if (params?.onOauthSuccess) {
                       params.onOauthSuccess({
+                        publicKey,
                         oidcToken: idToken,
                         providerName: "apple",
                         ...(sessionKey && { sessionKey }),
@@ -3765,6 +3769,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
 
                         if (params?.onOauthSuccess) {
                           params.onOauthSuccess({
+                            publicKey,
                             oidcToken: tokenData.id_token,
                             providerName: "facebook",
                             ...(sessionKey && { sessionKey }),

--- a/packages/react-wallet-kit/src/types/method-types.ts
+++ b/packages/react-wallet-kit/src/types/method-types.ts
@@ -34,35 +34,55 @@ export type HandleDiscordOauthParams = {
   clientId?: string;
   additionalState?: Record<string, string>;
   openInPage?: boolean;
-  onOauthSuccess?: (params: { oidcToken: string; providerName: string }) => any;
+  onOauthSuccess?: (params: {
+    publicKey: string;
+    oidcToken: string;
+    providerName: string;
+  }) => any;
 };
 
 export type HandleXOauthParams = {
   clientId?: string;
   additionalState?: Record<string, string>;
   openInPage?: boolean;
-  onOauthSuccess?: (params: { oidcToken: string; providerName: string }) => any;
+  onOauthSuccess?: (params: {
+    publicKey: string;
+    oidcToken: string;
+    providerName: string;
+  }) => any;
 };
 
 export type HandleGoogleOauthParams = {
   clientId?: string;
   additionalState?: Record<string, string>;
   openInPage?: boolean;
-  onOauthSuccess?: (params: { oidcToken: string; providerName: string }) => any;
+  onOauthSuccess?: (params: {
+    publicKey: string;
+    oidcToken: string;
+    providerName: string;
+  }) => any;
 };
 
 export type HandleAppleOauthParams = {
   clientId?: string;
   additionalState?: Record<string, string>;
   openInPage?: boolean;
-  onOauthSuccess?: (params: { oidcToken: string; providerName: string }) => any;
+  onOauthSuccess?: (params: {
+    publicKey: string;
+    oidcToken: string;
+    providerName: string;
+  }) => any;
 };
 
 export type HandleFacebookOauthParams = {
   clientId?: string;
   additionalState?: Record<string, string>;
   openInPage?: boolean;
-  onOauthSuccess?: (params: { oidcToken: string; providerName: string }) => any;
+  onOauthSuccess?: (params: {
+    publicKey: string;
+    oidcToken: string;
+    providerName: string;
+  }) => any;
 };
 
 export type HandleExportWalletParams = {


### PR DESCRIPTION
## Summary & Motivation

Context: https://clubturnkey.slack.com/archives/C068436FFSN/p1759428512837959?thread_ts=1759354896.329689&cid=C068436FFSN

**Note:** This is technically a breaking change, but since the function was previously unusable, it’s being released as a patch - this _should_ guarantee no existing users will be affected

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
