### PR TITLE
replace 0x${string} with Hex and make chainId configurable on signAuthorization

### DIFF
--- a/.changeset/icy-chefs-carry.md
+++ b/.changeset/icy-chefs-carry.md
@@ -1,5 +1,0 @@
----
-"@turnkey/gas-station": patch
----
-
-replace incorrect local dependency with workspace:\*

--- a/.changeset/khaki-moose-agree.md
+++ b/.changeset/khaki-moose-agree.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/gas-station": minor
+---
+
+Replace `0x{string}` using with viem Hex + make chain_id configurable on signAuthorizations

--- a/examples/tk-gas-station/src/transferETHDelegated.ts
+++ b/examples/tk-gas-station/src/transferETHDelegated.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import * as dotenv from "dotenv";
 import { z } from "zod";
 import { parseArgs } from "node:util";
-import { parseEther, createWalletClient, http } from "viem";
+import { parseEther, createWalletClient, http, type Hex } from "viem";
 import { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
 import { createAccount } from "@turnkey/viem";
 import {
@@ -90,13 +90,13 @@ const main = async () => {
   const userAccount = await createAccount({
     client: turnkeyClient.apiClient(),
     organizationId: env.ORGANIZATION_ID,
-    signWith: env.EOA_ADDRESS as `0x${string}`,
+    signWith: env.EOA_ADDRESS as Hex,
   });
 
   const paymasterAccount = await createAccount({
     client: turnkeyClient.apiClient(),
     organizationId: env.ORGANIZATION_ID,
-    signWith: env.PAYMASTER_ADDRESS as `0x${string}`,
+    signWith: env.PAYMASTER_ADDRESS as Hex,
   });
 
   const userWalletClient = createWalletClient({
@@ -161,7 +161,7 @@ const main = async () => {
 
   // Build the execution parameters using the helper
   const executionParams = buildETHTransfer(
-    env.PAYMASTER_ADDRESS as `0x${string}`, // transfer eth to paymaster from EOA
+    env.PAYMASTER_ADDRESS as Hex, // transfer eth to paymaster from EOA
     transferAmount,
   );
 

--- a/examples/tk-gas-station/src/transferUSDCDelegated.ts
+++ b/examples/tk-gas-station/src/transferUSDCDelegated.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import * as dotenv from "dotenv";
 import { z } from "zod";
 import { parseArgs } from "node:util";
-import { parseUnits, createWalletClient, http } from "viem";
+import { parseUnits, createWalletClient, http, type Hex } from "viem";
 import { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
 import { createAccount } from "@turnkey/viem";
 import {
@@ -90,13 +90,13 @@ const main = async () => {
   const userAccount = await createAccount({
     client: turnkeyClient.apiClient(),
     organizationId: env.ORGANIZATION_ID,
-    signWith: env.EOA_ADDRESS as `0x${string}`,
+    signWith: env.EOA_ADDRESS as Hex,
   });
 
   const paymasterAccount = await createAccount({
     client: turnkeyClient.apiClient(),
     organizationId: env.ORGANIZATION_ID,
-    signWith: env.PAYMASTER_ADDRESS as `0x${string}`,
+    signWith: env.PAYMASTER_ADDRESS as Hex,
   });
 
   const userWalletClient = createWalletClient({
@@ -168,7 +168,7 @@ const main = async () => {
   // Build the execution parameters using the helper
   const executionParams = buildTokenTransfer(
     usdcAddress,
-    env.PAYMASTER_ADDRESS as `0x${string}`,
+    env.PAYMASTER_ADDRESS as Hex,
     transferAmount,
   );
 

--- a/packages/gas-station/src/config.ts
+++ b/packages/gas-station/src/config.ts
@@ -1,32 +1,33 @@
-import type { Chain, WalletClient, Account, Transport } from "viem";
+import type { Chain, WalletClient, Account, Transport, Hex } from "viem";
+
 import { base, mainnet, sepolia } from "viem/chains";
 
 // Default contract addresses (deterministically deployed across all chains)
-export const DEFAULT_DELEGATE_CONTRACT: `0x${string}` =
+export const DEFAULT_DELEGATE_CONTRACT: Hex =
   "0xC2a37Ee08cAc3778d9d05FF0a93FD5B553C77E3a";
-export const DEFAULT_EXECUTION_CONTRACT: `0x${string}` =
+export const DEFAULT_EXECUTION_CONTRACT: Hex =
   "0x4ece92b06C7d2d99d87f052E0Fca47Fb180c3348";
 
 // Type definitions
 export interface GasStationConfig {
   walletClient: WalletClient<Transport, Chain, Account>;
-  delegateContract?: `0x${string}`;
-  executionContract?: `0x${string}`;
+  delegateContract?: Hex;
+  executionContract?: Hex;
 }
 
 export interface ChainPreset {
   chain: Chain;
   rpcUrl: string;
-  delegateContract?: `0x${string}`;
-  executionContract?: `0x${string}`;
+  delegateContract?: Hex;
+  executionContract?: Hex;
   tokens?: {
-    USDC?: `0x${string}`;
-    [key: string]: `0x${string}` | undefined;
+    USDC?: Hex;
+    [key: string]: Hex | undefined;
   };
 }
 
 export interface ContractCallParams {
-  contract: `0x${string}`;
+  contract: Hex;
   abi: readonly any[] | any[];
   functionName: string;
   args: any[];
@@ -36,11 +37,11 @@ export interface ContractCallParams {
 export interface ExecutionIntent {
   nonce: bigint;
   deadline: number;
-  outputContract: `0x${string}`;
+  outputContract: Hex;
   ethAmount: bigint; // amount of ETH to transfer in wei
-  callData: `0x${string}`;
-  signature: `0x${string}`;
-  eoaAddress: `0x${string}`;
+  callData: Hex;
+  signature: Hex;
+  eoaAddress: Hex;
 }
 
 // Chain preset configurations

--- a/packages/gas-station/src/gasStationUtils.ts
+++ b/packages/gas-station/src/gasStationUtils.ts
@@ -59,8 +59,8 @@ export const ERC20_ABI = [
  * Maps directly to the gas station contract's execute function
  */
 export interface ExecutionParams {
-  outputContract: `0x${string}`;
-  callData: `0x${string}`;
+  outputContract: Hex;
+  callData: Hex;
   value?: bigint;
 }
 

--- a/packages/gas-station/src/intentBuilder.ts
+++ b/packages/gas-station/src/intentBuilder.ts
@@ -4,6 +4,7 @@ import {
   type Account,
   type Chain,
   type Transport,
+  type Hex,
 } from "viem";
 import type { ContractCallParams, ExecutionIntent } from "./config";
 import { ERC20_ABI } from "./gasStationUtils";
@@ -11,13 +12,13 @@ import { ERC20_ABI } from "./gasStationUtils";
 interface IntentBuilderConfig {
   eoaWalletClient: WalletClient<Transport, Chain, Account>;
   chainId: number;
-  eoaAddress: `0x${string}`;
+  eoaAddress: Hex;
 }
 
 export class IntentBuilder {
   private config: IntentBuilderConfig;
-  private outputContract?: `0x${string}`;
-  private callData: `0x${string}` = "0x";
+  private outputContract?: Hex;
+  private callData: Hex = "0x";
   private ethAmount: bigint = 0n;
   private nonce?: bigint;
   private deadline?: number;
@@ -29,7 +30,7 @@ export class IntentBuilder {
   /**
    * Set the target contract for this intent execution
    */
-  setTarget(contract: `0x${string}`): this {
+  setTarget(contract: Hex): this {
     this.outputContract = contract;
     return this;
   }
@@ -62,7 +63,7 @@ export class IntentBuilder {
   /**
    * Set the call data directly (for pre-encoded function calls)
    */
-  withCallData(callData: `0x${string}`): this {
+  withCallData(callData: Hex): this {
     this.callData = callData;
     return this;
   }
@@ -86,7 +87,7 @@ export class IntentBuilder {
   /**
    * Convenience method for ERC20 transfers
    */
-  transferToken(token: `0x${string}`, to: `0x${string}`, amount: bigint): this {
+  transferToken(token: Hex, to: Hex, amount: bigint): this {
     return this.callContract({
       contract: token,
       abi: ERC20_ABI,
@@ -98,11 +99,7 @@ export class IntentBuilder {
   /**
    * Convenience method for ERC20 approvals
    */
-  approveToken(
-    token: `0x${string}`,
-    spender: `0x${string}`,
-    amount: bigint,
-  ): this {
+  approveToken(token: Hex, spender: Hex, amount: bigint): this {
     return this.callContract({
       contract: token,
       abi: ERC20_ABI,
@@ -114,7 +111,7 @@ export class IntentBuilder {
   /**
    * Convenience method for native ETH transfers
    */
-  transferETH(to: `0x${string}`, amount: bigint): this {
+  transferETH(to: Hex, amount: bigint): this {
     this.outputContract = to;
     this.callData = "0x";
     this.ethAmount = amount;

--- a/packages/gas-station/src/policyUtils.ts
+++ b/packages/gas-station/src/policyUtils.ts
@@ -2,6 +2,7 @@
 
 import type { TurnkeyApiClient } from "@turnkey/sdk-server";
 import { gasStationAbi } from "./abi/gas-station";
+import type { Hex } from "viem";
 
 /**
  * Build a Turnkey policy to restrict what EIP-712 intents an EOA can sign
@@ -89,7 +90,7 @@ export function buildIntentSigningPolicy(config: {
   additionalApprovers?: string[];
   customConsensus?: string;
   restrictions?: {
-    allowedContracts?: `0x${string}`[];
+    allowedContracts?: Hex[];
     disallowEthTransfer?: boolean;
   };
   policyName?: string;
@@ -254,10 +255,10 @@ export function buildPaymasterExecutionPolicy(config: {
   paymasterUserId: string;
   additionalApprovers?: string[];
   customConsensus?: string;
-  executionContractAddress: `0x${string}`;
+  executionContractAddress: Hex;
   restrictions?: {
-    allowedEOAs?: `0x${string}`[];
-    allowedContracts?: `0x${string}`[];
+    allowedEOAs?: Hex[];
+    allowedContracts?: Hex[];
     maxEthAmount?: bigint;
     maxGasPrice?: bigint;
     maxGasLimit?: bigint;
@@ -359,7 +360,7 @@ export async function getSmartContractInterface({
 }: {
   client: TurnkeyApiClient;
   organizationId: string;
-  contractAddress: `0x${string}`;
+  contractAddress: Hex;
 }): Promise<string | undefined> {
   // Query Turnkey for existing interfaces
   const response = await client.getSmartContractInterfaces({
@@ -395,7 +396,7 @@ export async function uploadGasStationInterface({
 }: {
   client: TurnkeyApiClient;
   organizationId: string;
-  contractAddress: `0x${string}`;
+  contractAddress: Hex;
   label?: string;
   chainName?: string;
 }): Promise<string> {
@@ -458,7 +459,7 @@ export async function ensureGasStationInterface({
 }: {
   client: TurnkeyApiClient;
   organizationId: string;
-  contractAddress: `0x${string}`;
+  contractAddress: Hex;
   label?: string;
   chainName?: string;
 }): Promise<string> {


### PR DESCRIPTION
## Summary & Motivation

 Replaced inline 0x${string} type annotations with viem's Hex type throughout the codebase
More maintainable and consistent with viem's conventions

Made chain_id configurable on signAuthorizations

## How I Tested These Changes
Run both examples and ran tests

## Did you add a changeset?
yes