### PR TITLE
Named with-breeze properly in package.json

### DIFF
--- a/examples/with-breeze/package.json
+++ b/examples/with-breeze/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@turnkey/with-sdk-js",
+  "name": "@turnkey/with-breeze",
   "version": "0.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary & Motivation

Builds for /examples was prev failing
