### PR TITLE
include `0x` in transaction signatures for Ethereum embedded wallets

### DIFF
--- a/.changeset/neat-paws-attend.md
+++ b/.changeset/neat-paws-attend.md
@@ -2,5 +2,4 @@
 "@turnkey/core": patch
 ---
 
-- Fixed `signTransaction` responses for Ethereum embedded wallets to include the `0x` prefix on returned signatures
-- Fixed an issue in `signAndSendTransaction` where Ethereum embedded wallet transactions failed during broadcast due to missing `0x` prefixes
+Fixed an issue in `signAndSendTransaction` where Ethereum embedded wallet transactions failed during broadcast due to missing `0x` prefixes

--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -2407,6 +2407,9 @@ export class TurnkeyClient {
    *   - Delegates signing to the Turnkey API, which returns the signed transaction.
    *   - Supports all Turnkey-supported transaction types (e.g., Ethereum, Solana, Tron).
    *   - Optionally allows stamping with a specific stamper (`StamperType.Passkey`, `StamperType.ApiKey`, or `StamperType.Wallet`).
+   *   - Note: For embedded Ethereum wallets, the returned signature doesn’t include the `0x` prefix. You should add `0x` before
+   *     broadcasting if it’s missing. It’s a good idea to check whether the signature already starts with `0x` before adding it,
+   *     since we plan to include the prefix by default in a future breaking change.
    *
    * @param params.walletAccount - wallet account to use for signing.
    * @param params.unsignedTransaction - unsigned transaction data as a serialized
@@ -2462,9 +2465,9 @@ export class TurnkeyClient {
           stampWith,
         );
 
-        return transactionType === "TRANSACTION_TYPE_ETHEREUM"
-          ? `0x${signTransaction.signedTransaction}`
-          : signTransaction.signedTransaction;
+        // TODO (breaking change): eventually we should append a `0x` prefix for ethereum signatures here
+        // then we should remove the note in the comment header
+        return signTransaction.signedTransaction;
       },
       {
         errorMessage: "Failed to sign transaction",


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
