### PR TITLE
add createInvitations examples

### DIFF
--- a/examples/kitchen-sink/src/http/createInvitations.ts
+++ b/examples/kitchen-sink/src/http/createInvitations.ts
@@ -19,35 +19,35 @@ async function main() {
     }),
   );
 
-   const receiverUserName = "<Invitation receiver user name>"
-   const receiverUserEmail = "<Invitation receiver email>"
-   const receiverUserTags: string[] = []// A list of tags assigned to the Invitation recipient. This field, if not needed, should be an empty array in your request body.,
-   const accessType=  "ACCESS_TYPE_WEB" 
-   const senderUserId =  "<Sender user ID>"
+  const receiverUserName = "<Invitation receiver user name>";
+  const receiverUserEmail = "<Invitation receiver email>";
+  const receiverUserTags: string[] = []; // A list of tags assigned to the Invitation recipient. This field, if not needed, should be an empty array in your request body.,
+  const accessType = "ACCESS_TYPE_WEB";
+  const senderUserId = "<Sender user ID>";
 
-   const { activity } = await turnkeyClient.createInvitations({
-     type: "ACTIVITY_TYPE_CREATE_INVITATIONS",
-     timestampMs: String(Date.now()),
-     organizationId: process.env.ORGANIZATION_ID!,
-     parameters: {
-        invitations: [
-            {
-            receiverUserName,
-            receiverUserEmail,
-            receiverUserTags,
-            accessType,
-            senderUserId
-            }
-         ]
-        }
-    })
-  
-    const invitationId = refineNonNull(
-      activity.result.createInvitationsResult?.invitationIds,
+  const { activity } = await turnkeyClient.createInvitations({
+    type: "ACTIVITY_TYPE_CREATE_INVITATIONS",
+    timestampMs: String(Date.now()),
+    organizationId: process.env.ORGANIZATION_ID!,
+    parameters: {
+      invitations: [
+        {
+          receiverUserName,
+          receiverUserEmail,
+          receiverUserTags,
+          accessType,
+          senderUserId,
+        },
+      ],
+    },
+  });
+
+  const invitationId = refineNonNull(
+    activity.result.createInvitationsResult?.invitationIds,
   );
 
-    // Success!
-    console.log(`Invitation with ID ${invitationId} sent succesfully`);
+  // Success!
+  console.log(`Invitation with ID ${invitationId} sent succesfully`);
 }
 
 main().catch((error) => {

--- a/examples/kitchen-sink/src/http/with-poller/createInvitations.ts
+++ b/examples/kitchen-sink/src/http/with-poller/createInvitations.ts
@@ -19,35 +19,35 @@ async function main() {
     }),
   );
 
-   const receiverUserName = "<Invitation receiver user name>"
-   const receiverUserEmail = "<Invitation receiver email>"
-   const receiverUserTags: string[] = []// A list of tags assigned to the Invitation recipient. This field, if not needed, should be an empty array in your request body.,
-   const accessType=  "ACCESS_TYPE_WEB" 
-   const senderUserId =  "<Sender user ID>"
+  const receiverUserName = "<Invitation receiver user name>";
+  const receiverUserEmail = "<Invitation receiver email>";
+  const receiverUserTags: string[] = []; // A list of tags assigned to the Invitation recipient. This field, if not needed, should be an empty array in your request body.,
+  const accessType = "ACCESS_TYPE_WEB";
+  const senderUserId = "<Sender user ID>";
 
-   const { activity } = await turnkeyClient.createInvitations({
-     type: "ACTIVITY_TYPE_CREATE_INVITATIONS",
-     timestampMs: String(Date.now()),
-     organizationId: process.env.ORGANIZATION_ID!,
-     parameters: {
-        invitations: [
-            {
-            receiverUserName,
-            receiverUserEmail,
-            receiverUserTags,
-            accessType,
-            senderUserId
-            }
-         ]
-        }
-    })
-  
-    const invitationId = refineNonNull(
-      activity.result.createInvitationsResult?.invitationIds,
+  const { activity } = await turnkeyClient.createInvitations({
+    type: "ACTIVITY_TYPE_CREATE_INVITATIONS",
+    timestampMs: String(Date.now()),
+    organizationId: process.env.ORGANIZATION_ID!,
+    parameters: {
+      invitations: [
+        {
+          receiverUserName,
+          receiverUserEmail,
+          receiverUserTags,
+          accessType,
+          senderUserId,
+        },
+      ],
+    },
+  });
+
+  const invitationId = refineNonNull(
+    activity.result.createInvitationsResult?.invitationIds,
   );
 
-    // Success!
-    console.log(`Invitation with ID ${invitationId} sent succesfully`);
+  // Success!
+  console.log(`Invitation with ID ${invitationId} sent succesfully`);
 }
 
 main().catch((error) => {

--- a/examples/kitchen-sink/src/sdk-server/createInvitations.ts
+++ b/examples/kitchen-sink/src/sdk-server/createInvitations.ts
@@ -4,9 +4,7 @@ import * as dotenv from "dotenv";
 // Load environment variables from `.env.local`
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
-import {
-  Turnkey as TurnkeySDKServer
-} from "@turnkey/sdk-server";
+import { Turnkey as TurnkeySDKServer } from "@turnkey/sdk-server";
 
 import { refineNonNull } from "../utils";
 
@@ -19,29 +17,28 @@ async function main() {
     apiPrivateKey: process.env.API_PRIVATE_KEY!,
     defaultOrganizationId: process.env.ORGANIZATION_ID!,
   });
-    
-    const receiverUserName = "<Invitation receiver user name>"
-    const receiverUserEmail = "<Invitation receiver email>"
-    const receiverUserTags: string[] = []// A list of tags assigned to the Invitation recipient. This field, if not needed, should be an empty array in your request body.,
-    const accessType=  "ACCESS_TYPE_WEB" 
-    const senderUserId =  "<Sender user ID>"
 
+  const receiverUserName = "<Invitation receiver user name>";
+  const receiverUserEmail = "<Invitation receiver email>";
+  const receiverUserTags: string[] = []; // A list of tags assigned to the Invitation recipient. This field, if not needed, should be an empty array in your request body.,
+  const accessType = "ACCESS_TYPE_WEB";
+  const senderUserId = "<Sender user ID>";
 
-    const invitation = await turnkeyClient.apiClient().createInvitations({
-      invitations:[{ 
+  const invitation = await turnkeyClient.apiClient().createInvitations({
+    invitations: [
+      {
         receiverUserName,
         receiverUserEmail,
         receiverUserTags,
         accessType,
-        senderUserId
-      }]
-     
-    })
+        senderUserId,
+      },
+    ],
+  });
 
-    const invitationId = refineNonNull(invitation.invitationIds)
-    //success
-    console.log(`Invitation with ID ${invitationId} sent succesfully`)
-
+  const invitationId = refineNonNull(invitation.invitationIds);
+  //success
+  console.log(`Invitation with ID ${invitationId} sent succesfully`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary & Motivation
Added `createInvitations.ts` examples in kitchen-sink (sdk-server, http and http/with-poller), to help users who get locked out of the dashboard to log back in via an alias. 
## How I Tested These Changes
Tested locally.
