### PR TITLE
include newer versions of react-native-keychain

### DIFF
--- a/.changeset/short-corners-fry.md
+++ b/.changeset/short-corners-fry.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-react-native": patch
+---
+
+Expand peer dependency range to include newer versions of `react-native-keychain`

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -59,7 +59,7 @@
     "@types/react": ">=16.8.0 <20",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-native": "^0.76.5",
-    "react-native-keychain": "^8.1.0",
+    "react-native-keychain": "^8.1.0 || ^9.2.2 || ^10.0.0",
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-passkey": "^3.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3373,7 +3373,7 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0(react-native@0.76.5(@babel/core@7.26.9)(@babel/preset-env@7.20.2(@babel/core@7.26.9))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))
       react-native-keychain:
-        specifier: ^8.1.0
+        specifier: ^8.1.0 || ^9.2.2 || ^10.0.0
         version: 8.1.0
       react-native-passkey:
         specifier: ^3.3.0


### PR DESCRIPTION
## Summary & Motivation

context: https://turnkeycrypto.slack.com/archives/C08B38241DX/p1760616015542619

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
