### PR TITLE
fix (viem): signAuthorization duplicate 0x prefix

### DIFF
--- a/.changeset/wide-chairs-sneeze.md
+++ b/.changeset/wide-chairs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/viem": patch
+---
+
+Fix object returned by signAuthorization to not include duplicate 0x prefixes.

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -390,8 +390,8 @@ export async function signAuthorization(
       address,
       chainId,
       nonce,
-      r: `0x${(signature as TSignature).r}`,
-      s: `0x${(signature as TSignature).s}`,
+      r: `${(signature as TSignature).r}`,
+      s: `${(signature as TSignature).s}`,
       v: BigInt((signature as TSignature).v),
       yParity: Number((signature as TSignature).v),
     } as SignAuthorizationReturnType;


### PR DESCRIPTION
## Summary & Motivation'

The signature components returned in `signAuthorization` include duplicate `0x` prefixes, which causes signature issues when the authorization is submitted as part of a transaction or userOp. This may have been recently introduced in #995.

## How I Tested These Changes

```typescript
const rawAuthorization = await turnkeyAccount.signAuthorization({
    address: authorizationTarget,
    chainId: base.id,
    nonce,
})
console.log("Raw authorization:", rawAuthorization)
```

before the changes:
```
Raw authorization: {
  address: "0xe6Cae83BdE06E4c305530e199D7217f42808555B",
  chainId: 8453,
  nonce: 1,
  r: "0x0xba1ef576...", // trimmed
  s: "0x0x23e66cb...", // trimmed
  v: 1n,
  yParity: 1,
}
```

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
