### PR TITLE
Removed peculiar/webcrypto

### DIFF
--- a/.changeset/lovely-streets-like.md
+++ b/.changeset/lovely-streets-like.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": patch
+---
+
+- Removed `@peculiar/webcrypto` dependancy. This will fix build errors in environments where `webcrypto` is not defined but will still require a polyfill if you use a function where `webcrypto` is required.

--- a/examples/with-react-native-wallet-kit/package-lock.json
+++ b/examples/with-react-native-wallet-kit/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.17",
-        "@turnkey/react-native-wallet-kit": "https://pkg.csb.dev/tkhq/sdk/commit/5a528d4d/@turnkey/react-native-wallet-kit",
+        "@turnkey/react-native-wallet-kit": "latest",
         "expo": "~54.0.7",
         "expo-constants": "~18.0.8",
         "expo-font": "~14.0.8",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -45,7 +45,6 @@
     "@noble/ciphers": "1.3.0",
     "@noble/curves": "1.9.0",
     "@noble/hashes": "1.8.0",
-    "@peculiar/webcrypto": "1.5.0",
     "@peculiar/x509": "1.12.3",
     "@turnkey/encoding": "workspace:*",
     "@turnkey/sdk-types": "workspace:*",

--- a/packages/crypto/src/proof.ts
+++ b/packages/crypto/src/proof.ts
@@ -17,20 +17,9 @@ export const getCryptoInstance = async () => {
     x509.cryptoProvider.set(cryptoInstance);
 
     return cryptoInstance;
-  }
-
-  try {
-    // Dynamic import to prevent bundling in environments that already have WebCrypto
-    const { Crypto: PeculiarCrypto } = await import("@peculiar/webcrypto");
-    cryptoInstance = new PeculiarCrypto();
-    x509.cryptoProvider.set(cryptoInstance);
-    return cryptoInstance;
-  } catch {
-    // Happens usually on React Native
+  } else {
     throw new Error(
-      "No WebCrypto implementation found. " +
-        "In React Native, please polyfill `global.crypto.subtle` (e.g., with `react-native-webcrypto`) " +
-        "before calling verify().",
+      "Web Crypto API is not available in this environment. You may need to polyfill it.",
     );
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2897,9 +2897,6 @@ importers:
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
-      '@peculiar/webcrypto':
-        specifier: 1.5.0
-        version: 1.5.0
       '@peculiar/x509':
         specifier: 1.12.3
         version: 1.12.3


### PR DESCRIPTION
## Summary & Motivation
Removed @peculiar/webcrypto as a dep for @turnkey/crypto. We used to include it in the `verify` function because tests were running with an older version of node that required a webcrypto polyfill. Now that we use node v20, we don't need this anymore. 

@peculiar/webcrypto was causing an issue with production builds on react-native since it was trying to `import crypto from 'crypto';` which would fail on react-native. Even tho @peculiar/webcrypto was being dynamically imported to avoid this, some expo production builds will bundle this package anyways and fail to build. On react-native, @peculiar/webcrypto required a webcrypto polyfill anyways to work so removing this package does not negatively impact react-native users.

Now, if you try to use the `verify` function on an environment that does not have webcrypto (old node or react-native), you will simply get this error: ` "Web Crypto API is not available in this environment. You may need to polyfill it."`


## How I Tested These Changes
with-react-native-wallet-kit example using codesandbox build
and
react-wallet-kit example for a sanity check.

## Did you add a changeset?
yes