### PR TITLE
fix trusted publishing flow

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -292,7 +292,6 @@ jobs:
           pnpm publish -r --no-git-checks --report-summary || echo "Publish failed, checking logs..."
           echo "npm publish summary:"
           cat publish-summary.json || echo "No NPM publish summary generated"
-        continue-on-error: true
 
       - name: Set up NPM config for GitHub Packages
         run: |
@@ -317,4 +316,3 @@ jobs:
           rm .npmrc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,19 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "dist/index.d.ts",
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com/"
+  },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tkhq/sdk.git",
+    "directory": "packages/core"
+  },
   "files": [
     "dist",
     "README.md"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -18,6 +18,10 @@
     "name": "Turnkey",
     "url": "https://turnkey.com/"
   },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tkhq/sdk.git",

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -40,7 +40,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tkhq/sdk.git",
-    "directory": "eip-1193-provider"
+    "directory": "packages/eip-1193-provider"
   },
   "files": [
     "dist/",

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -18,6 +18,10 @@
     "name": "Turnkey",
     "url": "https://turnkey.com/"
   },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tkhq/sdk.git",

--- a/packages/gas-station/package.json
+++ b/packages/gas-station/package.json
@@ -12,6 +12,19 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com/"
+  },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tkhq/sdk.git",
+    "directory": "packages/gas-station"
+  },
   "files": [
     "dist"
   ],

--- a/packages/react-native-wallet-kit/package.json
+++ b/packages/react-native-wallet-kit/package.json
@@ -12,6 +12,19 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com/"
+  },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tkhq/sdk.git",
+    "directory": "packages/react-native-wallet-kit"
+  },
   "files": [
     "dist",
     "README.md"

--- a/packages/react-wallet-kit/package.json
+++ b/packages/react-wallet-kit/package.json
@@ -13,6 +13,19 @@
     },
     "./styles.css": "./dist/styles.css"
   },
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com/"
+  },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tkhq/sdk.git",
+    "directory": "packages/react-wallet-kit"
+  },
   "files": [
     "dist",
     "README.md"


### PR DESCRIPTION
## Summary & Motivation

Linear-[2593](https://linear.app/turnkey/issue/ENG-2593/unblock-future-sdk-releases)

What is this doing?
- fix CI publish flow failures
         - we recently migrated to Trusted Publishing (see [PR #1029](https://github.com/tkhq/sdk/pull/1029)), but missing `repository` URLs caused the publish step to fail
- Possibly controversial ⚠️ : stop ignoring errors in the publish step. The workflow now fails if any package fails to publish


## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
