### PR TITLE
release shenanigans

### DIFF
--- a/.changeset/tidy-flies-check.md
+++ b/.changeset/tidy-flies-check.md
@@ -1,7 +1,6 @@
 ---
 "@turnkey/sdk-browser": minor
 "@turnkey/sdk-server": minor
-"@turnkey/sdk-types": minor
 "@turnkey/core": minor
 "@turnkey/http": minor
 ---

--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -289,7 +289,10 @@ jobs:
       - name: Publish packages to NPM
         run: |
           echo "Publishing packages to NPM..."
-          pnpm publish -r --no-git-checks --report-summary || echo "Publish failed, checking logs..."
+          pnpm publish -r --no-git-checks --report-summary || {
+            echo "❌ Publish failed. Check logs above.";
+            exit 1;
+          }"
           echo "npm publish summary:"
           cat publish-summary.json || echo "No NPM publish summary generated"
 

--- a/packages/sdk-types/CHANGELOG.md
+++ b/packages/sdk-types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/sdk-types
 
+## 0.7.0
+
+### Minor Changes
+
+- [#1058](https://github.com/tkhq/sdk/pull/1058) [`9fbd5c4`](https://github.com/tkhq/sdk/commit/9fbd5c459782dc3721dd0935d0a4458babce258b) Author [@moeodeh3](https://github.com/moeodeh3) - Update per mono release `v2025.10.10-hotfix.2`
+
 ## 0.6.3
 
 ### Patch Changes

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-types",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary & Motivation

`@turnkey/sdk-types` independently published by itself, we need to avoid it publishing again

also updated the CI so that the publish step now correctly shows as **failed** if any package fails to publish

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
