### PR TITLE
Omit optional email parameter if not set

### DIFF
--- a/.changeset/green-banks-flow.md
+++ b/.changeset/green-banks-flow.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/sdk-server": minor
+---
+
+Omit optional email parameter if not set

--- a/packages/sdk-server/src/actions.ts
+++ b/packages/sdk-server/src/actions.ts
@@ -255,8 +255,8 @@ export async function createSuborg(
       rootQuorumThreshold: 1,
       rootUsers: [
         {
-          userName: request.email ?? "",
-          userEmail: request.email ?? "",
+          userName: request.email ?? `suborg-user-${String(Date.now())}`,
+          ...(request.email ? { userEmail: request.email } : {}),
           ...(request.phoneNumber
             ? { userPhoneNumber: request.phoneNumber }
             : {}),


### PR DESCRIPTION
## Summary & Motivation
The email parameter was being sent as "" if it was not set with the createSubOrg function. This failed email validation, so now if it is not sent, email is omitted from the request.
## How I Tested These Changes
local
## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
