### PR TITLE
run prod tests before preprod

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -54,43 +54,9 @@ jobs:
             packages/*/dist/**
           retention-days: 1
 
-  test-pre-prod:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      # Install and cache JS toolchain and dependencies (node_modules)
-      - name: Setup JS
-        uses: ./.github/actions/js-setup
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: build-artifacts-${{ github.sha }}
-          path: packages/
-
-      - name: Test (preprod)
-        run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
-        env:
-          API_PUBLIC_KEY: ${{ secrets.PREPROD_API_PUBLIC_KEY }}
-          API_PRIVATE_KEY: ${{ secrets.PREPROD_API_PRIVATE_KEY }}
-          BASE_URL: ${{ secrets.PREPROD_BASE_URL }}
-          ORGANIZATION_ID: ${{ secrets.PREPROD_ORGANIZATION_ID }}
-          PRIVATE_KEY_ID: ${{ secrets.PREPROD_PRIVATE_KEY_ID }}
-          EXPECTED_PRIVATE_KEY_ETH_ADDRESS: ${{ secrets.PREPROD_EXPECTED_PRIVATE_KEY_ETH_ADDRESS }}
-          EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2: ${{ secrets.PREPROD_EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2 }}
-          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS: ${{ secrets.PREPROD_EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS }}
-          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2: ${{ secrets.PREPROD_EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2 }}
-          BANNED_TO_ADDRESS: ${{ secrets.PREPROD_BANNED_TO_ADDRESS }}
-          SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
-          WALLET_ID: ${{ secrets.PREPROD_WALLET_ID }}
-
   test-prod:
     runs-on: ubuntu-latest
-    needs: test-pre-prod
+    needs: build
     steps:
       # https://github.com/actions/checkout
       - name: Checkout
@@ -122,6 +88,39 @@ jobs:
           SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
           WALLET_ID: ${{ secrets.WALLET_ID }}
 
+  test-pre-prod:
+    runs-on: ubuntu-latest
+    needs: test-pre-prod
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: build-artifacts-${{ github.sha }}
+          path: packages/
+
+      - name: Test (preprod)
+        run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
+        env:
+          API_PUBLIC_KEY: ${{ secrets.PREPROD_API_PUBLIC_KEY }}
+          API_PRIVATE_KEY: ${{ secrets.PREPROD_API_PRIVATE_KEY }}
+          BASE_URL: ${{ secrets.PREPROD_BASE_URL }}
+          ORGANIZATION_ID: ${{ secrets.PREPROD_ORGANIZATION_ID }}
+          PRIVATE_KEY_ID: ${{ secrets.PREPROD_PRIVATE_KEY_ID }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS: ${{ secrets.PREPROD_EXPECTED_PRIVATE_KEY_ETH_ADDRESS }}
+          EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2: ${{ secrets.PREPROD_EXPECTED_PRIVATE_KEY_ETH_ADDRESS_2 }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS: ${{ secrets.PREPROD_EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS }}
+          EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2: ${{ secrets.PREPROD_EXPECTED_WALLET_ACCOUNT_ETH_ADDRESS_2 }}
+          BANNED_TO_ADDRESS: ${{ secrets.PREPROD_BANNED_TO_ADDRESS }}
+          SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
+          WALLET_ID: ${{ secrets.PREPROD_WALLET_ID }}
   test-end-to-end:
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary & Motivation

$title

prod is higher signal; its results should be prioritized. if prod succeeds, then we go on to test in preprod as well. preprod provides us marginal signal; if it fails, we should investigate, but otherwise if it fails simply due to flakiness, it can be bypassed.

otherwise, if prod fails, we stop there

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
