### PR TITLE
feat(core): add createHttpClientWithPasskeyCredentials for dynamic credential filtering

### DIFF
--- a/.changeset/brave-keys-filter.md
+++ b/.changeset/brave-keys-filter.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/core": minor
+"@turnkey/react-native-wallet-kit": minor
+---
+
+Add `createHttpClientWithPasskeyCredentials()` method for dynamic passkey credential filtering during signing operations

--- a/packages/core/src/__types__/method-types/shared.ts
+++ b/packages/core/src/__types__/method-types/shared.ts
@@ -30,6 +30,8 @@ export type CreateHttpClientParams = {
   authProxyUrl?: string | undefined;
   authProxyConfigId?: string | undefined;
   defaultStamperType?: StamperType | undefined;
+  /** Optional allowCredentials to filter which passkeys are shown during signing */
+  allowCredentials?: PublicKeyCredentialDescriptor[] | undefined;
 };
 
 export type CreatePasskeyParams = {

--- a/packages/react-native-wallet-kit/src/providers/TurnkeyProvider.tsx
+++ b/packages/react-native-wallet-kit/src/providers/TurnkeyProvider.tsx
@@ -729,6 +729,23 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
     [client],
   );
 
+  const createHttpClientWithPasskeyCredentials = useCallback(
+    async (
+      params: CreateHttpClientParams & {
+        allowCredentials: PublicKeyCredentialDescriptor[];
+      },
+    ): Promise<TurnkeySDKClientBase> => {
+      if (!client) {
+        throw new TurnkeyError(
+          "Client is not initialized.",
+          TurnkeyErrorCodes.CLIENT_NOT_INITIALIZED,
+        );
+      }
+      return client.createHttpClientWithPasskeyCredentials(params);
+    },
+    [client],
+  );
+
   const logout: (params?: LogoutParams) => Promise<void> = useCallback(
     async (params?: { sessionKey?: string }): Promise<void> => {
       if (!client) {
@@ -3325,6 +3342,7 @@ export const TurnkeyProvider: React.FC<TurnkeyProviderProps> = ({
         config: masterConfig,
         httpClient: client?.httpClient,
         createHttpClient,
+        createHttpClientWithPasskeyCredentials,
         createPasskey,
         logout,
         loginWithPasskey,


### PR DESCRIPTION
## Summary & Motivation

Add support for dynamically specifying `allowCredentials` when creating HTTP clients. This enables filtering which passkeys are shown during WebAuthn signing operations on a per-client basis.

**Use case:** When an app stores multiple users locally (each with their own passkey), this feature allows creating HTTP clients that only prompt for a specific user's passkey during signing. This improves UX by avoiding showing irrelevant passkeys in the WebAuthn prompt.
  
**Changes:**
- Add `allowCredentials` to `CreateHttpClientParams` type
- Add async `createHttpClientWithPasskeyCredentials()` method to `TurnkeyClient`
- Expose the new method in `react-native-wallet-kit` TurnkeyProvider

**Example usage:**
```typescript
const client = await createHttpClientWithPasskeyCredentials({
  allowCredentials: [{
    id: credentialIdAsUint8Array,
    type: 'public-key',
  }],
})
```

## How I Tested These Changes

- Verified TypeScript compilation
- Tested in a React Native app with multiple user profiles, confirming only the selected user's passkey appears during signing

## Did you add a changeset?

Yes - `brave-keys-filter.md` with minor version bumps for `@turnkey/core` and `@turnkey/react-native-wallet-kit`.

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
