### PR TITLE
x402 faremeter solana example

### DIFF
--- a/examples/with-x402-faremeter/.env.local.example
+++ b/examples/with-x402-faremeter/.env.local.example
@@ -1,0 +1,15 @@
+# Turnkey API credentials (required)
+# Get these from https://app.turnkey.com
+TURNKEY_API_BASE_URL="https://api.turnkey.com"
+TURNKEY_API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
+TURNKEY_API_PRIVATE_KEY="<Turnkey API Private Key>"
+TURNKEY_ORGANIZATION_ID="<Turnkey Organization ID>"
+
+# Solana RPC endpoint (optional, defaults to devnet)
+SOLANA_RPC_URL="https://api.devnet.solana.com"
+
+# Faremeter facilitator URL (optional, defaults to public facilitator)
+# FAREMETER_FACILITATOR_URL=
+
+# x402-enabled paywall URL for testing (optional)
+# TEST_PAYWALL_URL=

--- a/examples/with-x402-faremeter/.env.local.example
+++ b/examples/with-x402-faremeter/.env.local.example
@@ -1,9 +1,9 @@
 # Turnkey API credentials (required)
 # Get these from https://app.turnkey.com
-TURNKEY_API_BASE_URL="https://api.turnkey.com"
-TURNKEY_API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
-TURNKEY_API_PRIVATE_KEY="<Turnkey API Private Key>"
-TURNKEY_ORGANIZATION_ID="<Turnkey Organization ID>"
+API_BASE_URL="https://api.turnkey.com"
+API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
+API_PRIVATE_KEY="<Turnkey API Private Key>"
+ORGANIZATION_ID="<Turnkey Organization ID>"
 
 # Solana RPC endpoint (optional, defaults to devnet)
 SOLANA_RPC_URL="https://api.devnet.solana.com"

--- a/examples/with-x402-faremeter/.env.local.example
+++ b/examples/with-x402-faremeter/.env.local.example
@@ -1,15 +1,17 @@
 # Turnkey API credentials (required)
 # Get these from https://app.turnkey.com
-API_BASE_URL="https://api.turnkey.com"
 API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 API_PRIVATE_KEY="<Turnkey API Private Key>"
 ORGANIZATION_ID="<Turnkey Organization ID>"
 
+# Turnkey API base URL (optional, defaults to https://api.turnkey.com)
+BASE_URL="https://api.turnkey.com"
+
 # Solana RPC endpoint (optional, defaults to devnet)
 SOLANA_RPC_URL="https://api.devnet.solana.com"
 
-# Faremeter facilitator URL (optional, defaults to public facilitator)
-# FAREMETER_FACILITATOR_URL=
+# Override auto-detected Solana network (optional: "devnet" or "mainnet-beta")
+# SOLANA_NETWORK=
 
 # x402-enabled paywall URL for testing (optional)
 # TEST_PAYWALL_URL=

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -2,7 +2,6 @@
 
 Build a headless Solana agent that automatically pays x402-protected endpoints with a Turnkey wallet and [Faremeter](https://github.com/faremeter/faremeter).
 
-This README is optimized for fast setup and easy debugging.
 
 ## Why This Example
 
@@ -11,12 +10,11 @@ This README is optimized for fast setup and easy debugging.
 - **Gasless on Echo**: server pays SOL fees; your agent pays in USDC.
 - **Practical**: includes balance checks, network/asset compatibility checks, and useful errors.
 
-## Quickstart (5 Minutes)
+## Quickstart
 
 From repo root:
 
 ```bash
-corepack enable
 pnpm install -r
 pnpm run build-all
 cd examples/with-x402-faremeter
@@ -150,7 +148,7 @@ This keeps Faremeter's `wrap()` orchestration while adding Echo-compatible gasle
 - Check wallet USDC balance and network alignment (`SOLANA_RPC_URL` vs paywall endpoint).
 
 **`No compatible Solana payment requirements found`**
-- Requirement network/asset does not match your configured RPC network or expected mint.
+- Required network/asset does not match your configured RPC network or expected mint.
 
 **`bigint: Failed to load bindings`**
 - Rebuild native binding:

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -1,6 +1,6 @@
-# Example: `with-x402-solana`
+# Example: `with-x402-faremeter`
 
-This example demonstrates how AI agents can use Turnkey wallets for autonomous payments via the [x402 protocol](https://github.com/coinbase/x402) using [Faremeter](https://github.com/faremeter/faremeter).
+This example demonstrates how AI agents can use Turnkey wallets for autonomous payments on Solana via the [x402 protocol](https://github.com/coinbase/x402) using [Faremeter](https://github.com/faremeter/faremeter).
 
 ## Overview
 
@@ -55,7 +55,7 @@ cd sdk/
 corepack enable
 pnpm install -r
 pnpm run build-all
-cd examples/with-x402-solana/
+cd examples/with-x402-faremeter/
 ```
 
 ### 2. Configure Environment
@@ -68,15 +68,15 @@ cp .env.local.example .env.local
 
 Now open `.env.local` and add the missing values:
 
-- `TURNKEY_API_PUBLIC_KEY`
-- `TURNKEY_API_PRIVATE_KEY`
-- `TURNKEY_ORGANIZATION_ID`
+- `API_PUBLIC_KEY`
+- `API_PRIVATE_KEY`
+- `ORGANIZATION_ID`
 
 You can optionally configure:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `TURNKEY_API_BASE_URL` | Turnkey API URL | `https://api.turnkey.com` |
+| `BASE_URL` | Turnkey API URL | `https://api.turnkey.com` |
 | `SOLANA_RPC_URL` | Solana RPC endpoint | `https://api.devnet.solana.com` |
 | `FAREMETER_FACILITATOR_URL` | Faremeter facilitator URL | Public facilitator |
 | `TEST_PAYWALL_URL` | x402-enabled endpoint to test against | _(none)_ |
@@ -136,7 +136,7 @@ import { wrapFetch } from "@faremeter/fetch";
 
 const turnkey = new Turnkey({ /* API key config */ });
 const signer = new TurnkeySigner({
-  organizationId: process.env.TURNKEY_ORGANIZATION_ID,
+  organizationId: process.env.ORGANIZATION_ID,
   client: turnkey.apiClient(),
 });
 

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -4,7 +4,11 @@ This example demonstrates how AI agents can use Turnkey wallets for autonomous p
 
 ## Overview
 
-Unlike browser-based examples that require user interaction, this example shows **headless agent signing**:
+This example shows **headless agent signing** with **gasless USDC payments**:
+
+- **Gasless**: The server pays SOL transaction fees; the agent only needs USDC
+- **Automatic**: Faremeter handles the 402 payment flow transparently
+- **Headless**: No browser or user interaction required
 
 1. Agent authenticates with Turnkey using API keys (no browser/WebAuthn)
 2. Agent creates or retrieves a Solana wallet
@@ -78,8 +82,15 @@ You can optionally configure:
 |----------|-------------|---------|
 | `BASE_URL` | Turnkey API URL | `https://api.turnkey.com` |
 | `SOLANA_RPC_URL` | Solana RPC endpoint | `https://api.devnet.solana.com` |
-| `FAREMETER_FACILITATOR_URL` | Faremeter facilitator URL | Public facilitator |
 | `TEST_PAYWALL_URL` | x402-enabled endpoint to test against | _(none)_ |
+
+**Recommended test endpoint:**
+
+```bash
+TEST_PAYWALL_URL=https://x402.payai.network/api/solana-devnet/paid-content
+```
+
+This is the [x402 Echo Server](https://x402.payai.network/) — a free test environment that simulates payments on devnet. Tokens are automatically refunded.
 
 ### 3. Run the Demo
 
@@ -93,9 +104,9 @@ pnpm start
 🤖 Initializing Turnkey Agent...
 
 ✅ Turnkey client initialized
-Using existing Solana wallet: ABC123...
-✅ Agent wallet: ABC123...
-💰 Balance: 1 SOL
+✅ Agent wallet: DJr1iJ...
+💰 SOL Balance: 5 SOL
+💵 USDC Balance: 20.00 USDC
 
 ✅ Faremeter x402 client ready
 
@@ -104,20 +115,43 @@ Using existing Solana wallet: ABC123...
 
 ──────────────────────────────────────────────────
 Agent Summary:
-  Wallet Address: ABC123...
-  Balance: 1 SOL
+  Wallet Address: DJr1iJ...
+  SOL Balance: 5 SOL
+  USDC Balance: 20.00 USDC
   Network: devnet
-  x402 Client: ready
+  Faremeter Client: ready
 ──────────────────────────────────────────────────
 
 ✅ Agent ready for x402 payments!
 ```
 
-**With `TEST_PAYWALL_URL`**, the demo also fetches the paywalled resource, automatically pays via Faremeter if a 402 is returned, and displays the content along with the amount spent.
+**With `TEST_PAYWALL_URL`**, the demo fetches the paywalled resource, automatically pays via Faremeter when a 402 is returned, and displays the content along with USDC spent:
+
+```
+📡 Fetching paywalled resource: https://x402.payai.network/api/solana-devnet/paid-content
+
+✅ Content received!
+──────────────────────────────────────────────────
+{"message":"Payment verified! Here is your protected content..."}
+──────────────────────────────────────────────────
+
+💰 Final SOL balance: 5 SOL
+💵 Final USDC balance: 19.99 USDC
+📊 SOL spent: 0 SOL
+📊 USDC spent: 0.010000 USDC
+```
 
 ### 4. Fund Your Agent Wallet
 
-On Solana devnet, request free SOL:
+The agent needs **USDC** to make payments (SOL fees are covered by the server in gasless mode).
+
+**Get devnet USDC:**
+
+1. Visit the [Circle Faucet](https://faucet.circle.com/)
+2. Select "Solana Devnet"
+3. Enter your wallet address
+
+**Get devnet SOL** (optional, for non-gasless servers):
 
 ```bash
 solana airdrop 1 <WALLET_ADDRESS> --url devnet
@@ -127,12 +161,13 @@ Or use the [Solana Faucet](https://faucet.solana.com/).
 
 ## Core Code
 
-The key integration is wrapping `fetch` with Faremeter and a Turnkey signer:
+The key integration is wrapping `fetch` with Faremeter and a custom gasless payment handler:
 
 ```typescript
 import { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeySigner } from "@turnkey/solana";
-import { wrapFetch } from "@faremeter/fetch";
+import { wrap as wrapFetch } from "@faremeter/fetch";
+import type { PaymentHandler } from "@faremeter/types/client";
 
 const turnkey = new Turnkey({ /* API key config */ });
 const signer = new TurnkeySigner({
@@ -142,17 +177,34 @@ const signer = new TurnkeySigner({
 
 const address = await getOrCreateSolanaWallet(turnkey.apiClient());
 
+// Create a gasless payment handler that uses the server's fee payer
+const gaslessHandler: PaymentHandler = async (_ctx, accepts) => {
+  // Find requirements with a fee payer (gasless)
+  const req = accepts.find((r) => r.extra?.feePayer);
+  if (!req) return [];
+
+  return [{
+    requirements: req,
+    exec: async () => {
+      // Build transaction with server's fee payer
+      // Sign with Turnkey
+      const signedTx = await signer.signTransaction(tx, address);
+      return { payload: { transaction: base64Encode(signedTx) } };
+    },
+  }];
+};
+
 // Wrap fetch so 402 responses are automatically handled
 const x402Fetch = wrapFetch(fetch, {
-  paymentSigner: async (transaction) => {
-    return await signer.signTransaction(transaction, address);
-  },
-  network: "solana:devnet",
+  handlers: [gaslessHandler],
+  retryCount: 3,
 });
 
 // Use x402Fetch like normal fetch — payments happen transparently
-const response = await x402Fetch("https://paywall.example.com/resource");
+const response = await x402Fetch("https://x402.payai.network/api/solana-devnet/paid-content");
 ```
+
+See [`src/index.ts`](./src/index.ts) for the complete implementation including v1/v2 protocol normalization.
 
 ## Security Considerations
 
@@ -167,7 +219,6 @@ When deploying agents with payment capabilities:
 ## Related Examples
 
 - [`with-solana`](../with-solana/) — Interactive Solana signing demo
-- [`with-x402`](../with-x402/) — Browser-based x402 payments with Turnkey embedded wallets
 
 ## Resources
 
@@ -175,4 +226,6 @@ When deploying agents with payment capabilities:
 - [Faremeter GitHub](https://github.com/faremeter/faremeter)
 - [Faremeter Documentation](https://docs.corbits.dev/faremeter/overview)
 - [x402 Protocol](https://github.com/coinbase/x402)
-- [Solana Faucet](https://faucet.solana.com/)
+- [x402 Echo Server](https://x402.payai.network/) — Free test environment
+- [Circle Faucet](https://faucet.circle.com/) — Get devnet USDC
+- [Solana Faucet](https://faucet.solana.com/) — Get devnet SOL

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -2,7 +2,6 @@
 
 Build a headless Solana agent that automatically pays x402-protected endpoints, using Turnkey for authentication, wallet management, and signing, plus [Faremeter](https://github.com/faremeter/faremeter) for x402 orchestration.
 
-
 ## Why This Example
 
 - **Headless**: API key auth only (no browser/WebAuthn flow).
@@ -13,12 +12,12 @@ Build a headless Solana agent that automatically pays x402-protected endpoints, 
 
 ## Where Turnkey Is Used
 
-| Capability | How Turnkey is used in this example |
-|----------|-------------|
-| API authentication | `@turnkey/sdk-server` authenticates with `API_PUBLIC_KEY` / `API_PRIVATE_KEY` |
-| Wallet lifecycle | The example gets or creates a Solana wallet in your Turnkey organization |
+| Capability          | How Turnkey is used in this example                                               |
+| ------------------- | --------------------------------------------------------------------------------- |
+| API authentication  | `@turnkey/sdk-server` authenticates with `API_PUBLIC_KEY` / `API_PRIVATE_KEY`     |
+| Wallet lifecycle    | The example gets or creates a Solana wallet in your Turnkey organization          |
 | Transaction signing | `@turnkey/solana` signs Solana payment transactions without exposing private keys |
-| Security controls | You can apply Turnkey policies to constrain what this agent can sign/spend |
+| Security controls   | You can apply Turnkey policies to constrain what this agent can sign/spend        |
 
 Note: In this Echo flow, transaction fees are sponsored by the x402 server's fee payer. Turnkey is the secure signer for the payer wallet.
 
@@ -63,14 +62,14 @@ You should see:
 
 ## Environment Variables
 
-| Variable | Required | Description | Default |
-|----------|----------|-------------|---------|
-| `API_PUBLIC_KEY` | Yes | Turnkey API public key | - |
-| `API_PRIVATE_KEY` | Yes | Turnkey API private key | - |
-| `ORGANIZATION_ID` | Yes | Turnkey organization ID | - |
-| `TEST_PAYWALL_URL` | No | x402 endpoint to test | - |
-| `SOLANA_RPC_URL` | No | Solana RPC endpoint | `https://api.devnet.solana.com` |
-| `BASE_URL` | No | Turnkey API base URL | `https://api.turnkey.com` |
+| Variable           | Required | Description             | Default                         |
+| ------------------ | -------- | ----------------------- | ------------------------------- |
+| `API_PUBLIC_KEY`   | Yes      | Turnkey API public key  | -                               |
+| `API_PRIVATE_KEY`  | Yes      | Turnkey API private key | -                               |
+| `ORGANIZATION_ID`  | Yes      | Turnkey organization ID | -                               |
+| `TEST_PAYWALL_URL` | No       | x402 endpoint to test   | -                               |
+| `SOLANA_RPC_URL`   | No       | Solana RPC endpoint     | `https://api.devnet.solana.com` |
+| `BASE_URL`         | No       | Turnkey API base URL    | `https://api.turnkey.com`       |
 
 Recommended test endpoint:
 
@@ -149,10 +148,15 @@ const turnkeyWallet = {
 
 const expectedRequirementNetworks = getExpectedRequirementNetworks(network);
 
-const gaslessHandler = createGaslessPaymentHandler(turnkeyWallet, usdcMint, connection, {
-  expectedNetworks: expectedRequirementNetworks,
-  configuredNetworkLabel: network,
-});
+const gaslessHandler = createGaslessPaymentHandler(
+  turnkeyWallet,
+  usdcMint,
+  connection,
+  {
+    expectedNetworks: expectedRequirementNetworks,
+    configuredNetworkLabel: network,
+  },
+);
 
 const normalizingFetch = createV2NormalizingFetch(fetch);
 const adaptiveFetch = createAdaptivePaymentFetch(fetch);
@@ -172,18 +176,23 @@ This keeps Faremeter's `wrap()` orchestration while using Turnkey for key custod
 ## Troubleshooting
 
 **`Missing required environment variables`**
+
 - Ensure `API_PUBLIC_KEY`, `API_PRIVATE_KEY`, and `ORGANIZATION_ID` are set in `.env.local`.
 
 **`fetch failed` / `ENOTFOUND api.turnkey.com`**
+
 - Check internet/DNS and verify `BASE_URL`.
 
 **`Payment failed (402)`**
+
 - Check wallet USDC balance and network alignment (`SOLANA_RPC_URL` vs paywall endpoint).
 
 **`No compatible Solana payment requirements found`**
+
 - Required network/asset does not match your configured RPC network or expected mint.
 
 **`bigint: Failed to load bindings`**
+
 - Rebuild native binding:
   - `pnpm --filter @turnkey/example-with-x402-faremeter rebuild bigint-buffer`
 

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -1,0 +1,178 @@
+# Example: `with-x402-solana`
+
+This example demonstrates how AI agents can use Turnkey wallets for autonomous payments via the [x402 protocol](https://github.com/coinbase/x402) using [Faremeter](https://github.com/faremeter/faremeter).
+
+## Overview
+
+Unlike browser-based examples that require user interaction, this example shows **headless agent signing**:
+
+1. Agent authenticates with Turnkey using API keys (no browser/WebAuthn)
+2. Agent creates or retrieves a Solana wallet
+3. Agent wraps `fetch` with Faremeter's `@faremeter/fetch` to handle x402 payment flows
+4. When a paywalled resource returns HTTP 402, Faremeter automatically negotiates payment via the agent's Turnkey-managed wallet
+5. The signed payment is submitted and the original request is retried with proof of payment
+
+## How It Works
+
+```
+┌─────────────┐         ┌─────────────┐         ┌─────────────┐
+│   AI Agent  │         │   Turnkey   │         │  x402       │
+│             │         │   API       │         │  Resource   │
+└──────┬──────┘         └──────┬──────┘         └──────┬──────┘
+       │                       │                       │
+       │  1. Init with API keys│                       │
+       │──────────────────────>│                       │
+       │                       │                       │
+       │  2. Get/Create wallet │                       │
+       │──────────────────────>│                       │
+       │<──────────────────────│                       │
+       │      Solana address   │                       │
+       │                       │                       │
+       │  3. Request resource  │                       │
+       │───────────────────────────────────────────────>
+       │<───────────────────────────────────────────────
+       │      402 Payment Required                     │
+       │                       │                       │
+       │  4. Sign payment tx   │                       │
+       │──────────────────────>│                       │
+       │<──────────────────────│                       │
+       │      Signed tx        │                       │
+       │                       │                       │
+       │  5. Retry with payment│                       │
+       │───────────────────────────────────────────────>
+       │<───────────────────────────────────────────────
+       │      200 OK + content │                       │
+       │                       │                       │
+```
+
+## Getting Started
+
+### 1. Clone and Install
+
+```bash
+git clone https://github.com/tkhq/sdk
+cd sdk/
+corepack enable
+pnpm install -r
+pnpm run build-all
+cd examples/with-x402-solana/
+```
+
+### 2. Configure Environment
+
+Copy the template and fill in your Turnkey credentials:
+
+```bash
+cp .env.local.example .env.local
+```
+
+Now open `.env.local` and add the missing values:
+
+- `TURNKEY_API_PUBLIC_KEY`
+- `TURNKEY_API_PRIVATE_KEY`
+- `TURNKEY_ORGANIZATION_ID`
+
+You can optionally configure:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TURNKEY_API_BASE_URL` | Turnkey API URL | `https://api.turnkey.com` |
+| `SOLANA_RPC_URL` | Solana RPC endpoint | `https://api.devnet.solana.com` |
+| `FAREMETER_FACILITATOR_URL` | Faremeter facilitator URL | Public facilitator |
+| `TEST_PAYWALL_URL` | x402-enabled endpoint to test against | _(none)_ |
+
+### 3. Run the Demo
+
+```bash
+pnpm start
+```
+
+**Without `TEST_PAYWALL_URL`**, the demo initializes the agent and reports readiness:
+
+```
+🤖 Initializing Turnkey Agent...
+
+✅ Turnkey client initialized
+Using existing Solana wallet: ABC123...
+✅ Agent wallet: ABC123...
+💰 Balance: 1 SOL
+
+✅ Faremeter x402 client ready
+
+ℹ️  No TEST_PAYWALL_URL configured.
+   Set this env var to test the x402 payment flow.
+
+──────────────────────────────────────────────────
+Agent Summary:
+  Wallet Address: ABC123...
+  Balance: 1 SOL
+  Network: devnet
+  x402 Client: ready
+──────────────────────────────────────────────────
+
+✅ Agent ready for x402 payments!
+```
+
+**With `TEST_PAYWALL_URL`**, the demo also fetches the paywalled resource, automatically pays via Faremeter if a 402 is returned, and displays the content along with the amount spent.
+
+### 4. Fund Your Agent Wallet
+
+On Solana devnet, request free SOL:
+
+```bash
+solana airdrop 1 <WALLET_ADDRESS> --url devnet
+```
+
+Or use the [Solana Faucet](https://faucet.solana.com/).
+
+## Core Code
+
+The key integration is wrapping `fetch` with Faremeter and a Turnkey signer:
+
+```typescript
+import { Turnkey } from "@turnkey/sdk-server";
+import { TurnkeySigner } from "@turnkey/solana";
+import { wrapFetch } from "@faremeter/fetch";
+
+const turnkey = new Turnkey({ /* API key config */ });
+const signer = new TurnkeySigner({
+  organizationId: process.env.TURNKEY_ORGANIZATION_ID,
+  client: turnkey.apiClient(),
+});
+
+const address = await getOrCreateSolanaWallet(turnkey.apiClient());
+
+// Wrap fetch so 402 responses are automatically handled
+const x402Fetch = wrapFetch(fetch, {
+  paymentSigner: async (transaction) => {
+    return await signer.signTransaction(transaction, address);
+  },
+  network: "solana:devnet",
+});
+
+// Use x402Fetch like normal fetch — payments happen transparently
+const response = await x402Fetch("https://paywall.example.com/resource");
+```
+
+## Security Considerations
+
+When deploying agents with payment capabilities:
+
+1. **Never commit API keys** — Use environment variables or secrets management
+2. **Use sub-organizations** — Isolate agent wallets from your main organization
+3. **Set spending limits** — Use [Turnkey policies](https://docs.turnkey.com/concepts/policies) to cap transaction amounts
+4. **Monitor activity** — Track agent spending via the Turnkey dashboard
+5. **Rotate keys regularly** — Update API keys periodically
+
+## Related Examples
+
+- [`with-solana`](../with-solana/) — Interactive Solana signing demo
+- [`with-x402`](../with-x402/) — Browser-based x402 payments with Turnkey embedded wallets
+
+## Resources
+
+- [Turnkey Documentation](https://docs.turnkey.com/)
+- [Faremeter GitHub](https://github.com/faremeter/faremeter)
+- [Faremeter Documentation](https://docs.corbits.dev/faremeter/overview)
+- [x402 Protocol](https://github.com/coinbase/x402)
+- [Solana Faucet](https://faucet.solana.com/)

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -100,7 +100,7 @@ solana airdrop 1 <WALLET_ADDRESS> --url devnet
 1. Initialize Turnkey API client + `TurnkeySigner`
 2. Get or create a Solana wallet
 3. Check SOL and USDC balances
-4. Wrap `fetch` with Faremeter and a gasless payment handler
+4. Wrap `fetch` with Faremeter's payment handler (protocol normalization, x402 v2 headers, and CAIP-2 network identifiers are handled by Faremeter automatically)
 5. Make request:
    - if `200`: return content
    - if `402`: build/sign payment payload and retry automatically

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -127,13 +127,14 @@ The `createX402Client` factory in `src/x402-client.ts` handles all the setup:
 ```typescript
 import { createX402Client } from "./x402-client.js";
 
-const { x402Fetch, walletAddress, getBalances, network } = await createX402Client({
-  apiPublicKey: process.env.API_PUBLIC_KEY!,
-  apiPrivateKey: process.env.API_PRIVATE_KEY!,
-  organizationId: process.env.ORGANIZATION_ID!,
-  rpcUrl: process.env.SOLANA_RPC_URL,    // optional
-  baseUrl: process.env.BASE_URL,          // optional
-});
+const { x402Fetch, walletAddress, getBalances, network } =
+  await createX402Client({
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    organizationId: process.env.ORGANIZATION_ID!,
+    rpcUrl: process.env.SOLANA_RPC_URL, // optional
+    baseUrl: process.env.BASE_URL, // optional
+  });
 
 // Use x402Fetch exactly like regular fetch - payments are automatic
 const response = await x402Fetch("https://paid-api.example.com/data");
@@ -151,7 +152,9 @@ The `x402Fetch` function works like standard `fetch()`, making it easy to expose
 import OpenAI from "openai";
 import { createX402Client } from "./x402-client.js";
 
-const { x402Fetch } = await createX402Client({ /* ... */ });
+const { x402Fetch } = await createX402Client({
+  /* ... */
+});
 const openai = new OpenAI();
 
 const tools: OpenAI.ChatCompletionTool[] = [
@@ -159,7 +162,8 @@ const tools: OpenAI.ChatCompletionTool[] = [
     type: "function",
     function: {
       name: "fetch_paid_resource",
-      description: "Fetch data from a URL. Automatically pays if the endpoint requires payment (HTTP 402).",
+      description:
+        "Fetch data from a URL. Automatically pays if the endpoint requires payment (HTTP 402).",
       parameters: {
         type: "object",
         properties: {
@@ -171,7 +175,10 @@ const tools: OpenAI.ChatCompletionTool[] = [
   },
 ];
 
-async function handleToolCall(name: string, args: { url: string }): Promise<string> {
+async function handleToolCall(
+  name: string,
+  args: { url: string },
+): Promise<string> {
   if (name === "fetch_paid_resource") {
     const response = await x402Fetch(args.url);
     return response.text();
@@ -182,7 +189,12 @@ async function handleToolCall(name: string, args: { url: string }): Promise<stri
 // In your chat loop:
 const response = await openai.chat.completions.create({
   model: "gpt-4",
-  messages: [{ role: "user", content: "Get the premium data from https://api.example.com/premium" }],
+  messages: [
+    {
+      role: "user",
+      content: "Get the premium data from https://api.example.com/premium",
+    },
+  ],
   tools,
 });
 
@@ -203,13 +215,16 @@ if (response.choices[0].message.tool_calls) {
 import Anthropic from "@anthropic-ai/sdk";
 import { createX402Client } from "./x402-client.js";
 
-const { x402Fetch } = await createX402Client({ /* ... */ });
+const { x402Fetch } = await createX402Client({
+  /* ... */
+});
 const anthropic = new Anthropic();
 
 const tools: Anthropic.Tool[] = [
   {
     name: "fetch_paid_resource",
-    description: "Fetch data from a URL. Automatically pays if the endpoint requires payment (HTTP 402).",
+    description:
+      "Fetch data from a URL. Automatically pays if the endpoint requires payment (HTTP 402).",
     input_schema: {
       type: "object",
       properties: {
@@ -220,7 +235,10 @@ const tools: Anthropic.Tool[] = [
   },
 ];
 
-async function handleToolUse(name: string, input: { url: string }): Promise<string> {
+async function handleToolUse(
+  name: string,
+  input: { url: string },
+): Promise<string> {
   if (name === "fetch_paid_resource") {
     const response = await x402Fetch(input.url);
     return response.text();
@@ -233,12 +251,20 @@ const response = await anthropic.messages.create({
   model: "claude-sonnet-4-20250514",
   max_tokens: 1024,
   tools,
-  messages: [{ role: "user", content: "Get the premium data from https://api.example.com/premium" }],
+  messages: [
+    {
+      role: "user",
+      content: "Get the premium data from https://api.example.com/premium",
+    },
+  ],
 });
 
 for (const block of response.content) {
   if (block.type === "tool_use") {
-    const result = await handleToolUse(block.name, block.input as { url: string });
+    const result = await handleToolUse(
+      block.name,
+      block.input as { url: string },
+    );
     // Continue conversation with tool result...
   }
 }
@@ -280,12 +306,12 @@ const paidFetchTool: AgentTool = {
 // 3. Wire into your agent loop
 async function agentLoop(task: string) {
   const tools = [paidFetchTool];
-  
+
   while (true) {
     const action = await yourLLM.decide(task, tools);
-    
+
     if (action.type === "tool_call") {
-      const tool = tools.find(t => t.name === action.tool);
+      const tool = tools.find((t) => t.name === action.tool);
       const result = await tool!.execute(action.params);
       // Feed result back to LLM...
     } else if (action.type === "done") {

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -2,6 +2,13 @@
 
 Build a headless Solana agent that automatically pays x402-protected endpoints, using Turnkey for authentication, wallet management, and signing, plus [Faremeter](https://github.com/faremeter/faremeter) for x402 orchestration.
 
+This example walks through the following:
+
+- Creation (or reuse) of a Turnkey wallet with a Solana account
+- Wrapping `fetch` with Faremeter so HTTP 402 responses are paid automatically
+- Signing the payment transaction with `@turnkey/solana`
+- Fetching an x402-protected resource end-to-end on Solana devnet
+
 ## Why This Example
 
 - **Headless**: API key auth only (no browser/WebAuthn flow).
@@ -21,44 +28,82 @@ Build a headless Solana agent that automatically pays x402-protected endpoints, 
 
 Note: In this Echo flow, transaction fees are sponsored by the x402 server's fee payer. Turnkey is the secure signer for the payer wallet.
 
-## Quickstart
+## Getting started
 
-From repo root:
+### 1/ Cloning the example
 
-```bash
-pnpm install -r
-pnpm run build-all
-cd examples/with-x402-faremeter
-cp .env.local.example .env.local
-```
-
-Add values to `.env.local`:
+Make sure you have `Node.js` installed locally; we recommend Node v18+.
 
 ```bash
-API_PUBLIC_KEY=...
-API_PRIVATE_KEY=...
-ORGANIZATION_ID=...
-TEST_PAYWALL_URL=https://x402.payai.network/api/solana-devnet/paid-content
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/with-x402-faremeter/
 ```
 
-Run:
+### 2/ Setting up Turnkey
+
+Follow the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide to create your Turnkey organization and API key pair. You should end up with:
+
+- A public/private API key pair
+- An organization ID
+
+Copy the env template and fill in the required values:
 
 ```bash
-pnpm start
+$ cp .env.local.example .env.local
 ```
 
-You should see:
+Open `.env.local` and set:
 
-- `✅ Faremeter x402 client ready`
-- `✅ Content received!`
+- `API_PUBLIC_KEY`
+- `API_PRIVATE_KEY`
+- `ORGANIZATION_ID`
 
-## Prerequisites
+The other variables (`BASE_URL`, `SOLANA_RPC_URL`, `SOLANA_NETWORK`, `TEST_PAYWALL_URL`) are optional — see the [Environment Variables](#environment-variables) table below. Your private key should be securely managed and **_never_** be committed to git.
 
-- Node.js 18+
-- `pnpm`
-- Turnkey API key pair + organization ID
-- Devnet USDC for testing (from [Circle Faucet](https://faucet.circle.com/))
-- Optional devnet SOL (for non-gasless endpoints)
+The script will create a new Solana wallet in your Turnkey organization on first run, or reuse an existing Solana account if one is already present.
+
+### 3/ Funding the wallet
+
+For the x402 Echo endpoint, the agent mainly needs **USDC** — fees are sponsored by the server. To test against an Echo endpoint:
+
+1. Run the script once (step 4/) to generate the wallet and print its address.
+2. Get devnet USDC from the [Circle Faucet](https://faucet.circle.com/) — select **Solana Devnet** and paste your wallet address.
+
+Optional SOL airdrop (only needed for non-gasless endpoints):
+
+```bash
+$ solana airdrop 1 <WALLET_ADDRESS> --url devnet
+```
+
+### 4/ Running the script
+
+```bash
+$ pnpm start
+```
+
+You should see output similar to the following:
+
+```
+🤖 Initializing Turnkey Agent...
+
+Using existing Solana wallet: DJr1iJiUPNyWDGZagiQRnNAy4RHL5cLz4vDkJDvEJNNb
+✅ Turnkey client initialized
+✅ Agent wallet: DJr1iJiUPNyWDGZagiQRnNAy4RHL5cLz4vDkJDvEJNNb
+💰 SOL Balance: 5 SOL
+💵 USDC Balance: 20.00 USDC
+
+✅ Faremeter x402 client ready
+
+📡 Fetching paywalled resource: https://x402.payai.network/api/solana-devnet/paid-content
+
+✅ Content received!
+```
+
+On Echo, USDC can be refunded quickly, so net spend may show as `0.000000`.
 
 ## Environment Variables
 
@@ -80,22 +125,6 @@ TEST_PAYWALL_URL=https://x402.payai.network/api/solana-devnet/paid-content
 
 This is the [x402 Echo Server](https://x402.payai.network/), a free devnet test environment.
 
-## Funding the Wallet
-
-For Echo, the agent mainly needs **USDC**.
-
-Get devnet USDC:
-
-1. Go to [Circle Faucet](https://faucet.circle.com/)
-2. Select **Solana Devnet**
-3. Paste your wallet address
-
-Optional SOL airdrop:
-
-```bash
-solana airdrop 1 <WALLET_ADDRESS> --url devnet
-```
-
 ## How It Works
 
 1. Initialize Turnkey API client + `TurnkeySigner`
@@ -105,21 +134,6 @@ solana airdrop 1 <WALLET_ADDRESS> --url devnet
 5. Make request:
    - if `200`: return content
    - if `402`: build/sign payment payload and retry automatically
-
-## Example Success Output
-
-```text
-✅ Faremeter x402 client ready
-📡 Fetching paywalled resource: https://x402.payai.network/api/solana-devnet/paid-content
-✅ Content received!
-{"success":true,"transaction":"...","network":"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1","payer":"...","premiumContent":"...","refundTransaction":"..."}
-💰 Final SOL balance: ...
-💵 Final USDC balance: ...
-📊 SOL spent: ...
-📊 USDC spent: ...
-```
-
-On Echo, USDC can be refunded quickly, so net spend may show as `0.000000`.
 
 ## Core Integration
 

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -69,6 +69,7 @@ You should see:
 | `ORGANIZATION_ID`  | Yes      | Turnkey organization ID | -                               |
 | `TEST_PAYWALL_URL` | No       | x402 endpoint to test   | -                               |
 | `SOLANA_RPC_URL`   | No       | Solana RPC endpoint     | `https://api.devnet.solana.com` |
+| `SOLANA_NETWORK`   | No       | Override detected network (`devnet` or `mainnet-beta`); auto-detected via genesis hash when unset | -                               |
 | `BASE_URL`         | No       | Turnkey API base URL    | `https://api.turnkey.com`       |
 
 Recommended test endpoint:

--- a/examples/with-x402-faremeter/README.md
+++ b/examples/with-x402-faremeter/README.md
@@ -107,15 +107,15 @@ On Echo, USDC can be refunded quickly, so net spend may show as `0.000000`.
 
 ## Environment Variables
 
-| Variable           | Required | Description             | Default                         |
-| ------------------ | -------- | ----------------------- | ------------------------------- |
-| `API_PUBLIC_KEY`   | Yes      | Turnkey API public key  | -                               |
-| `API_PRIVATE_KEY`  | Yes      | Turnkey API private key | -                               |
-| `ORGANIZATION_ID`  | Yes      | Turnkey organization ID | -                               |
-| `TEST_PAYWALL_URL` | No       | x402 endpoint to test   | -                               |
-| `SOLANA_RPC_URL`   | No       | Solana RPC endpoint     | `https://api.devnet.solana.com` |
+| Variable           | Required | Description                                                                                       | Default                         |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `API_PUBLIC_KEY`   | Yes      | Turnkey API public key                                                                            | -                               |
+| `API_PRIVATE_KEY`  | Yes      | Turnkey API private key                                                                           | -                               |
+| `ORGANIZATION_ID`  | Yes      | Turnkey organization ID                                                                           | -                               |
+| `TEST_PAYWALL_URL` | No       | x402 endpoint to test                                                                             | -                               |
+| `SOLANA_RPC_URL`   | No       | Solana RPC endpoint                                                                               | `https://api.devnet.solana.com` |
 | `SOLANA_NETWORK`   | No       | Override detected network (`devnet` or `mainnet-beta`); auto-detected via genesis hash when unset | -                               |
-| `BASE_URL`         | No       | Turnkey API base URL    | `https://api.turnkey.com`       |
+| `BASE_URL`         | No       | Turnkey API base URL                                                                              | `https://api.turnkey.com`       |
 
 Recommended test endpoint:
 

--- a/examples/with-x402-faremeter/package.json
+++ b/examples/with-x402-faremeter/package.json
@@ -10,14 +10,11 @@
   },
   "dependencies": {
     "@faremeter/fetch": "^0.16.0",
-    "@faremeter/info": "^0.16.0",
-    "@faremeter/payment-solana": "^0.16.0",
     "@faremeter/types": "^0.16.0",
     "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.8",
     "@turnkey/sdk-server": "workspace:*",
     "@turnkey/solana": "workspace:*",
     "dotenv": "^16.0.3"
-  },
-  "devDependencies": {}
+  }
 }

--- a/examples/with-x402-faremeter/package.json
+++ b/examples/with-x402-faremeter/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "@turnkey/example-with-x402-solana",
+  "name": "@turnkey/example-with-x402-faremeter",
   "version": "0.1.0",
   "private": true,
-  "description": "Demo: AI agents paying for resources with Turnkey wallets via x402",
   "scripts": {
     "start": "pnpm tsx src/index.ts",
-    "clean": "rm -rf ./dist ./.cache",
+    "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -15,9 +14,5 @@
     "@turnkey/solana": "workspace:*",
     "dotenv": "^16.0.3"
   },
-  "devDependencies": {
-    "@types/node": "^20.3.1",
-    "tsx": "^4.7.0",
-    "typescript": "^5.4.3"
-  }
+  "devDependencies": {}
 }

--- a/examples/with-x402-faremeter/package.json
+++ b/examples/with-x402-faremeter/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@turnkey/example-with-x402-solana",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Demo: AI agents paying for resources with Turnkey wallets via x402",
+  "scripts": {
+    "start": "pnpm tsx src/index.ts",
+    "clean": "rm -rf ./dist ./.cache",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@faremeter/fetch": "^0.14.0",
+    "@solana/web3.js": "^1.95.8",
+    "@turnkey/sdk-server": "workspace:*",
+    "@turnkey/solana": "workspace:*",
+    "dotenv": "^16.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.3.1",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.3"
+  }
+}

--- a/examples/with-x402-faremeter/package.json
+++ b/examples/with-x402-faremeter/package.json
@@ -2,13 +2,18 @@
   "name": "@turnkey/example-with-x402-faremeter",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "start": "pnpm tsx src/index.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@faremeter/fetch": "^0.14.0",
+    "@faremeter/fetch": "^0.16.0",
+    "@faremeter/info": "^0.16.0",
+    "@faremeter/payment-solana": "^0.16.0",
+    "@faremeter/types": "^0.16.0",
+    "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.8",
     "@turnkey/sdk-server": "workspace:*",
     "@turnkey/solana": "workspace:*",

--- a/examples/with-x402-faremeter/package.json
+++ b/examples/with-x402-faremeter/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "pnpm tsx src/index.ts",
+    "start": "tsx src/index.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },
@@ -16,5 +16,8 @@
     "@turnkey/sdk-server": "workspace:*",
     "@turnkey/solana": "workspace:*",
     "dotenv": "^16.0.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
   }
 }

--- a/examples/with-x402-faremeter/package.json
+++ b/examples/with-x402-faremeter/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@faremeter/fetch": "^0.16.0",
+    "@faremeter/payment-solana": "^0.16.0",
     "@faremeter/types": "^0.16.0",
     "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.8",

--- a/examples/with-x402-faremeter/package.json
+++ b/examples/with-x402-faremeter/package.json
@@ -9,9 +9,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@faremeter/fetch": "^0.16.0",
-    "@faremeter/payment-solana": "^0.16.0",
-    "@faremeter/types": "^0.16.0",
+    "@faremeter/fetch": "^0.17.0",
+    "@faremeter/payment-solana": "^0.17.0",
+    "@faremeter/types": "^0.17.0",
     "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.8",
     "@turnkey/sdk-server": "workspace:*",

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -1,10 +1,304 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
-import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import {
+  Connection,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  VersionedTransaction,
+  TransactionMessage,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddress,
+  getAccount,
+  createTransferCheckedInstruction,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import { ComputeBudgetProgram } from "@solana/web3.js";
 import { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeySigner } from "@turnkey/solana";
-import { wrapFetch } from "@faremeter/fetch";
+import { wrap as wrapFetch } from "@faremeter/fetch";
+import type { PaymentHandler, PaymentExecer } from "@faremeter/types/client";
 import { getOrCreateSolanaWallet } from "./utils";
+
+// USDC has 6 decimal places
+const USDC_DECIMALS = 6;
+
+/**
+ * Wallet interface for signing transactions.
+ */
+interface GaslessWallet {
+  publicKey: PublicKey;
+  signTransaction: (tx: VersionedTransaction) => Promise<VersionedTransaction>;
+}
+
+/**
+ * Create a gasless payment handler for x402 servers that provide their own fee payer.
+ *
+ * Unlike faremeter's standard `exact` handler which makes the client pay transaction fees,
+ * this handler builds transactions using the server's fee payer (from `extra.feePayer`).
+ * The client only signs for the USDC transfer; the server/facilitator adds the fee payer signature.
+ *
+ * This enables gasless payments where:
+ * - Server pays SOL transaction fees
+ * - Client only needs USDC for the actual payment
+ */
+function createGaslessPaymentHandler(
+  wallet: GaslessWallet,
+  usdcMint: PublicKey,
+  connection: Connection,
+): PaymentHandler {
+  return async (_ctx, accepts) => {
+    const execers: PaymentExecer[] = [];
+
+    for (const req of accepts) {
+      // Check if this is a Solana requirement with a fee payer
+      const extra = req.extra as Record<string, unknown> | undefined;
+      const feePayer = extra?.feePayer as string | undefined;
+
+      if (!feePayer) {
+        // No fee payer provided - skip this requirement
+        continue;
+      }
+
+      // Check network compatibility (support both canonical and CAIP-2 formats)
+      const network = req.network.toLowerCase();
+      const isSolana = network.includes("solana") || network.startsWith("solana:");
+
+      if (!isSolana) {
+        continue;
+      }
+
+      // Check asset matches our USDC mint
+      if (req.asset.toLowerCase() !== usdcMint.toBase58().toLowerCase()) {
+        continue;
+      }
+
+      execers.push({
+        requirements: req,
+        exec: async () => {
+          const feePayerPubkey = new PublicKey(feePayer);
+          const payToPubkey = new PublicKey(req.payTo);
+          const amount = BigInt(req.maxAmountRequired);
+
+          // Get or derive token accounts
+          // payTo is a wallet address - we need to derive the ATA for the USDC mint
+          const sourceAta = await getAssociatedTokenAddress(usdcMint, wallet.publicKey);
+          const destAta = await getAssociatedTokenAddress(usdcMint, payToPubkey);
+
+          // The x402 protocol requires exactly 3 instructions in this order:
+          // 1. setComputeUnitLimit
+          // 2. setComputeUnitPrice
+          // 3. createTransferCheckedInstruction
+          const computeUnitLimitIx = ComputeBudgetProgram.setComputeUnitLimit({
+            units: 50000,
+          });
+
+          const computeUnitPriceIx = ComputeBudgetProgram.setComputeUnitPrice({
+            microLamports: 1,
+          });
+
+          const transferIx = createTransferCheckedInstruction(
+            sourceAta,
+            usdcMint,
+            destAta,
+            wallet.publicKey, // owner/authority is our wallet
+            amount,
+            USDC_DECIMALS, // decimals
+            [],
+            TOKEN_PROGRAM_ID,
+          );
+
+          // Get recent blockhash (or use one from extra if provided)
+          const extraBlockhash = extra?.recentBlockhash as string | undefined;
+          const { blockhash } = extraBlockhash
+            ? { blockhash: extraBlockhash }
+            : await connection.getLatestBlockhash("confirmed");
+
+          // Build transaction with SERVER's fee payer (not our wallet)
+          // Instructions must be in exact order: computeUnitLimit, computeUnitPrice, transfer
+          const message = new TransactionMessage({
+            payerKey: feePayerPubkey, // Server pays fees
+            recentBlockhash: blockhash,
+            instructions: [computeUnitLimitIx, computeUnitPriceIx, transferIx],
+          }).compileToV0Message();
+
+          const tx = new VersionedTransaction(message);
+
+          // Partially sign with our wallet only (server will add fee payer signature)
+          const signedTx = await wallet.signTransaction(tx);
+
+          // Serialize the partially-signed transaction
+          const serialized = Buffer.from(signedTx.serialize()).toString("base64");
+
+          return {
+            payload: {
+              transaction: serialized,
+            },
+          };
+        },
+      });
+    }
+
+    return execers;
+  };
+}
+
+// Store the original server requirements for building v2 payload
+let serverRequirements: Record<string, unknown> | null = null;
+
+/**
+ * Normalize an x402 v2 payment requirement to v1 format.
+ *
+ * The x402 Echo server returns v2 format with:
+ *   - `amount` instead of `maxAmountRequired`
+ *   - `description`, `mimeType`, `resource` nested inside `extra`
+ *   - CAIP-2 network IDs like `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`
+ *
+ * Faremeter expects v1 format with these fields at top-level and
+ * canonical network names like `solana-devnet`.
+ */
+function normalizeRequirement(req: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...req };
+
+  // Store the original server requirements for building v2 response payload
+  serverRequirements = { ...req };
+
+  // amount → maxAmountRequired
+  if (normalized.amount && !normalized.maxAmountRequired) {
+    normalized.maxAmountRequired = normalized.amount;
+  }
+
+  // CAIP-2 network → canonical network name
+  if (typeof normalized.network === "string" && normalized.network.startsWith("solana:")) {
+    const genesisHash = normalized.network.split(":")[1];
+    const networkMap: Record<string, string> = {
+      "EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "solana-devnet",
+      "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": "solana-mainnet-beta",
+    };
+    // Keep the original network in extra for the payment header
+    normalized.originalNetwork = normalized.network;
+    normalized.network = networkMap[genesisHash] ?? normalized.network;
+  }
+
+  // Promote extra fields to top-level (v2 → v1)
+  const extra = normalized.extra as Record<string, unknown> | undefined;
+  if (extra) {
+    if (!normalized.description && extra.description) {
+      normalized.description = extra.description;
+    }
+    if (normalized.mimeType === undefined && extra.mimeType !== undefined) {
+      normalized.mimeType = extra.mimeType || "application/octet-stream";
+    }
+    if (!normalized.resource && extra.resource) {
+      normalized.resource = extra.resource;
+    }
+  }
+
+  // Ensure required string fields have defaults
+  if (!normalized.description) normalized.description = "";
+  if (!normalized.mimeType) normalized.mimeType = "application/octet-stream";
+  if (!normalized.resource) normalized.resource = "";
+
+  return normalized;
+}
+
+// Track the original network format from the server's 402 response
+let serverNetworkFormat: string | null = null;
+
+// Map canonical network names to CAIP-2 format (for v2 servers)
+const canonicalToCAIP2: Record<string, string> = {
+  "solana-devnet": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+  "solana-mainnet-beta": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+};
+
+/**
+ * Create a fetch wrapper that normalizes v2 402 responses to v1 format.
+ * Also tracks the server's original network format for the payment response.
+ */
+function createV2NormalizingFetch(baseFetch: typeof fetch): typeof fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const response = await baseFetch(input, init);
+
+    if (response.status !== 402) {
+      return response;
+    }
+
+    const body = await response.json();
+
+    // Store the server's original network format
+    if (body.accepts?.[0]?.network) {
+      serverNetworkFormat = body.accepts[0].network;
+    }
+
+    // Normalize accepts array for faremeter
+    if (body.accepts && Array.isArray(body.accepts)) {
+      body.accepts = body.accepts.map(normalizeRequirement);
+    }
+
+    return new Response(JSON.stringify(body), {
+      status: 402,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}
+
+/**
+ * Create a fetch wrapper that adapts payment headers for different server types.
+ * - v1 servers (x402test, faremeter): Use X-PAYMENT with canonical network
+ * - v2 servers (Echo): Use PAYMENT-SIGNATURE with CAIP-2 network and `accepted` field
+ */
+function createAdaptivePaymentFetch(baseFetch: typeof fetch): typeof fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const headers = new Headers(init?.headers);
+    
+    const xPayment = headers.get("X-PAYMENT");
+    if (xPayment && serverNetworkFormat) {
+      try {
+        const payloadJson = atob(xPayment);
+        const payload = JSON.parse(payloadJson);
+
+        // Check if server uses CAIP-2 format (v2 protocol)
+        const isV2Server = serverNetworkFormat.includes(":");
+
+        if (isV2Server) {
+          // Convert canonical network back to CAIP-2 for v2 servers
+          const caip2Network = canonicalToCAIP2[payload.network] || payload.network;
+          
+          // Build v2 compliant payload with `accepted` field
+          // The accepted field should mirror the server's requirement (for matching)
+          const v2Payload = {
+            x402Version: 2,
+            scheme: payload.scheme || "exact",
+            network: caip2Network,
+            accepted: serverRequirements ? {
+              scheme: (serverRequirements.scheme as string) || "exact",
+              network: serverNetworkFormat,
+              amount: serverRequirements.amount || serverRequirements.maxAmountRequired,
+              asset: serverRequirements.asset,
+              payTo: serverRequirements.payTo,
+              maxTimeoutSeconds: serverRequirements.maxTimeoutSeconds || 60,
+              // Include extra if server provided it (e.g., feePayer)
+              ...(serverRequirements.extra ? { extra: serverRequirements.extra } : {}),
+            } : undefined,
+            payload: payload.payload,
+            extensions: {},
+          };
+
+          // v2 servers use PAYMENT-SIGNATURE header
+          const fixedPayment = btoa(JSON.stringify(v2Payload));
+          headers.set("X-PAYMENT", fixedPayment);
+          headers.set("PAYMENT-SIGNATURE", fixedPayment);
+        }
+        // For v1 servers, leave the payment as-is (canonical network, X-PAYMENT only)
+      } catch {
+        // If decoding fails, leave headers unchanged
+      }
+    }
+
+    return baseFetch(input, { ...init, headers });
+  };
+}
 
 // Load environment variables from `.env.local`
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
@@ -19,6 +313,18 @@ dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
  *
  * The agent can autonomously pay for resources using the Faremeter x402 protocol.
  * See: https://github.com/faremeter/faremeter
+ *
+ * COMPATIBLE TEST SERVERS:
+ *
+ * 1. x402 Echo Server (recommended for devnet testing):
+ *    - Set TEST_PAYWALL_URL=https://x402.payai.network/api/solana-devnet/paid-content
+ *    - Uses gasless transactions (server pays SOL fees, you pay USDC)
+ *    - Requires devnet USDC: https://faucet.circle.com/
+ *
+ * 2. Helius via Corbits (mainnet, requires real USDC):
+ *    - Set TEST_PAYWALL_URL=https://helius.api.corbits.dev
+ *    - Switch network to mainnet-beta
+ *    - Costs ~$0.01 USDC per request
  */
 async function main() {
   console.log("🤖 Initializing Turnkey Agent...\n");
@@ -56,38 +362,83 @@ async function main() {
   const solanaAddress = await getOrCreateSolanaWallet(turnkey.apiClient());
   console.log(`✅ Agent wallet: ${solanaAddress}`);
 
-  // 4. Check wallet balance
+  // 4. Check wallet balances (SOL and USDC)
   const rpcUrl =
     process.env.SOLANA_RPC_URL || "https://api.devnet.solana.com";
   const connection = new Connection(rpcUrl, "confirmed");
-  const balance = await connection.getBalance(new PublicKey(solanaAddress));
+  const walletPubkey = new PublicKey(solanaAddress);
+  const balance = await connection.getBalance(walletPubkey);
 
-  console.log(`💰 Balance: ${balance / LAMPORTS_PER_SOL} SOL\n`);
+  // Determine network and USDC mint
+  const network = rpcUrl.includes("devnet") ? "devnet" : "mainnet-beta";
+  const usdcMint =
+    network === "devnet"
+      ? new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU") // USDC devnet
+      : new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"); // USDC mainnet
+
+  // Check USDC balance
+  let usdcBalance = 0;
+  try {
+    const usdcAta = await getAssociatedTokenAddress(usdcMint, walletPubkey);
+    const tokenAccount = await getAccount(connection, usdcAta);
+    usdcBalance = Number(tokenAccount.amount) / Math.pow(10, USDC_DECIMALS);
+  } catch {
+    // Token account doesn't exist yet - balance is 0
+  }
+
+  console.log(`💰 SOL Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
+  console.log(`💵 USDC Balance: ${usdcBalance.toFixed(2)} USDC\n`);
 
   if (balance < 0.01 * LAMPORTS_PER_SOL) {
-    console.log("⚠️  Low balance! Request an airdrop on devnet:");
+    console.log("⚠️  Low SOL balance! Request an airdrop on devnet:");
     console.log(`   solana airdrop 1 ${solanaAddress} --url devnet`);
     console.log(`   Or use: https://faucet.solana.com/\n`);
   }
 
-  // 5. Create a Faremeter-wrapped fetch that handles x402 payment flows.
-  //
-  // When a request returns HTTP 402, Faremeter will:
-  //   a) Parse the payment requirements from the response
-  //   b) Build a Solana payment transaction
-  //   c) Call our signer to sign it via Turnkey
-  //   d) Submit payment proof and retry the original request
-  const x402Fetch = wrapFetch(fetch, {
-    paymentSigner: async (transaction) => {
-      return await signer.signTransaction(transaction, solanaAddress);
+  if (usdcBalance < 0.01) {
+    console.log("⚠️  Low USDC balance! Get test USDC on devnet:");
+    console.log(`   Visit: https://faucet.circle.com/ (select Solana Devnet)\n`);
+  }
+
+  // 5. Create a Turnkey wallet adapter for signing transactions
+  const turnkeyWallet: GaslessWallet = {
+    publicKey: walletPubkey,
+    signTransaction: async (tx: VersionedTransaction) => {
+      const signedTx = await signer.signTransaction(tx, solanaAddress);
+      return signedTx as VersionedTransaction;
     },
-    network: "solana:devnet",
-    facilitatorUrl: process.env.FAREMETER_FACILITATOR_URL,
+  };
+
+  // 6. Create the gasless payment handler
+  //
+  // This handler builds transactions using the server's fee payer (from extra.feePayer),
+  // allowing gasless payments where the server covers SOL transaction fees.
+  // The handler:
+  //   a) Parses payment requirements from the 402 response
+  //   b) Builds a USDC transfer with the server's fee payer
+  //   c) Partially signs with Turnkey (server adds fee payer signature)
+  //   d) Returns the transaction for faremeter to send in X-PAYMENT header
+  const gaslessHandler = createGaslessPaymentHandler(turnkeyWallet, usdcMint, connection);
+
+  // Create fetch wrappers for protocol compatibility:
+  // - normalizingFetch: Converts v2 402 responses to v1 format for faremeter
+  // - adaptiveFetch: Adjusts payment headers based on server's protocol version
+  const normalizingFetch = createV2NormalizingFetch(fetch);
+  const adaptiveFetch = createAdaptivePaymentFetch(fetch);
+
+  const x402Fetch = wrapFetch(adaptiveFetch, {
+    handlers: [gaslessHandler],
+    // Use normalizing fetch for initial request to handle v2 servers
+    phase1Fetch: normalizingFetch,
+    // Retry up to 3 times if payment fails
+    retryCount: 3,
+    // Return the 402 response instead of throwing if payment fails
+    returnPaymentFailure: true,
   });
 
   console.log("✅ Faremeter x402 client ready\n");
 
-  // 6. Attempt to fetch a paywalled resource
+  // 7. Attempt to fetch a paywalled resource
   const testUrl = process.env.TEST_PAYWALL_URL;
 
   if (testUrl) {
@@ -96,7 +447,8 @@ async function main() {
     try {
       // x402Fetch handles the full payment lifecycle automatically:
       // - If the server returns 200, the response is passed through as-is
-      // - If the server returns 402, Faremeter negotiates payment and retries
+      // - If the server returns 402, faremeter builds a payment transaction,
+      //   signs it via Turnkey, and retries with the X-PAYMENT header
       const response = await x402Fetch(testUrl);
 
       if (response.ok) {
@@ -107,23 +459,50 @@ async function main() {
           content.substring(0, 500) + (content.length > 500 ? "..." : ""),
         );
         console.log("─".repeat(50));
+      } else if (response.status === 402) {
+        // Payment failed - log the server's response for debugging
+        const body = await response.text();
+        console.log(`❌ Payment failed (402). Server response:`);
+        try {
+          const parsed = JSON.parse(body);
+          console.log(JSON.stringify(parsed, null, 2));
+
+          console.log("\n💡 Possible issues:");
+          console.log("   - Insufficient USDC balance in wallet");
+          console.log("   - Network mismatch (devnet vs mainnet)");
+          console.log("   - Transaction verification failed on server");
+          if (parsed.error) {
+            console.log(`   - Server error: ${parsed.error}`);
+          }
+        } catch {
+          console.log(body);
+        }
       } else {
         console.log(
           `❌ Request failed: ${response.status} ${response.statusText}`,
         );
+        const body = await response.text();
+        console.log(body);
       }
     } catch (error) {
       console.error("❌ Payment flow error:", error);
     }
 
     // Final balance check to show what was spent
-    const finalBalance = await connection.getBalance(
-      new PublicKey(solanaAddress),
-    );
-    console.log(`\n💰 Final balance: ${finalBalance / LAMPORTS_PER_SOL} SOL`);
-    console.log(
-      `📊 Spent: ${(balance - finalBalance) / LAMPORTS_PER_SOL} SOL`,
-    );
+    const finalSolBalance = await connection.getBalance(walletPubkey);
+    let finalUsdcBalance = 0;
+    try {
+      const usdcAta = await getAssociatedTokenAddress(usdcMint, walletPubkey);
+      const tokenAccount = await getAccount(connection, usdcAta);
+      finalUsdcBalance = Number(tokenAccount.amount) / Math.pow(10, USDC_DECIMALS);
+    } catch {
+      // Token account doesn't exist
+    }
+
+    console.log(`\n💰 Final SOL balance: ${finalSolBalance / LAMPORTS_PER_SOL} SOL`);
+    console.log(`💵 Final USDC balance: ${finalUsdcBalance.toFixed(2)} USDC`);
+    console.log(`📊 SOL spent: ${(balance - finalSolBalance) / LAMPORTS_PER_SOL} SOL`);
+    console.log(`📊 USDC spent: ${(usdcBalance - finalUsdcBalance).toFixed(6)} USDC`);
   } else {
     console.log("ℹ️  No TEST_PAYWALL_URL configured.");
     console.log("   Set this env var to test the x402 payment flow.\n");
@@ -132,11 +511,10 @@ async function main() {
     console.log("─".repeat(50));
     console.log("Agent Summary:");
     console.log(`  Wallet Address: ${solanaAddress}`);
-    console.log(`  Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
-    console.log(
-      `  Network: ${rpcUrl.includes("devnet") ? "devnet" : "mainnet"}`,
-    );
-    console.log(`  x402 Client: ready`);
+    console.log(`  SOL Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
+    console.log(`  USDC Balance: ${usdcBalance.toFixed(2)} USDC`);
+    console.log(`  Network: ${network}`);
+    console.log(`  Faremeter Client: ready`);
     console.log("─".repeat(50));
     console.log("\n✅ Agent ready for x402 payments!");
   }

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -18,7 +18,7 @@ import { Turnkey } from "@turnkey/sdk-server";
 import { TurnkeySigner } from "@turnkey/solana";
 import { wrap as wrapFetch } from "@faremeter/fetch";
 import type { PaymentHandler, PaymentExecer } from "@faremeter/types/client";
-import { getOrCreateSolanaWallet } from "./utils";
+import { getOrCreateSolanaWallet } from "./utils.js";
 
 // USDC has 6 decimal places
 const USDC_DECIMALS = 6;

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -1,452 +1,32 @@
-import * as dotenv from "dotenv";
-import * as path from "path";
-import {
-  Connection,
-  LAMPORTS_PER_SOL,
-  PublicKey,
-  VersionedTransaction,
-  TransactionMessage,
-} from "@solana/web3.js";
-import {
-  getAssociatedTokenAddress,
-  getAccount,
-  createTransferCheckedInstruction,
-  TOKEN_PROGRAM_ID,
-} from "@solana/spl-token";
-import { ComputeBudgetProgram } from "@solana/web3.js";
-import { Turnkey } from "@turnkey/sdk-server";
-import { TurnkeySigner } from "@turnkey/solana";
-import { wrap as wrapFetch } from "@faremeter/fetch";
-import type { PaymentHandler, PaymentExecer } from "@faremeter/types/client";
-import { getOrCreateSolanaWallet } from "./utils.js";
-
-// USDC has 6 decimal places
-const USDC_DECIMALS = 6;
-const SOLANA_DEVNET_CAIP2 = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
-const SOLANA_MAINNET_CAIP2 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
-
-function getExpectedRequirementNetworks(
-  network: "devnet" | "mainnet-beta",
-): Set<string> {
-  if (network === "devnet") {
-    return new Set(["solana-devnet", SOLANA_DEVNET_CAIP2.toLowerCase()]);
-  }
-
-  // Support both common v1 names plus CAIP-2 for mainnet requirements.
-  return new Set([
-    "solana-mainnet-beta",
-    "solana",
-    SOLANA_MAINNET_CAIP2.toLowerCase(),
-  ]);
-}
-
-/**
- * Wallet interface for signing transactions.
- */
-interface GaslessWallet {
-  publicKey: PublicKey;
-  signTransaction: (tx: VersionedTransaction) => Promise<VersionedTransaction>;
-}
-
-interface PaymentContext {
-  accepted: {
-    scheme: string;
-    network: string;
-    amount: string;
-    asset: string;
-    payTo: string;
-    maxTimeoutSeconds: number;
-    extra?: Record<string, unknown>;
-  };
-}
-
-// Track per-payment context by transaction payload to avoid cross-request state leaks.
-const pendingPaymentContexts = new Map<string, PaymentContext>();
-
-/**
- * Create a gasless payment handler for x402 servers that provide their own fee payer.
- *
- * Unlike faremeter's standard `exact` handler which makes the client pay transaction fees,
- * this handler builds transactions using the server's fee payer (from `extra.feePayer`).
- * The client only signs for the USDC transfer; the server/facilitator adds the fee payer signature.
- *
- * This enables gasless payments where:
- * - Server pays SOL transaction fees
- * - Client only needs USDC for the actual payment
- */
-function createGaslessPaymentHandler(
-  wallet: GaslessWallet,
-  usdcMint: PublicKey,
-  connection: Connection,
-  options: {
-    expectedNetworks: ReadonlySet<string>;
-    configuredNetworkLabel: string;
-  },
-): PaymentHandler {
-  return async (_ctx, accepts) => {
-    const execers: PaymentExecer[] = [];
-    const incompatibilityReasons: string[] = [];
-    let sawSolanaRequirement = false;
-
-    for (const req of accepts) {
-      // Check network compatibility (support both canonical and CAIP-2 formats)
-      const requirementNetwork = req.network.toLowerCase();
-      const isSolana =
-        requirementNetwork.includes("solana") ||
-        requirementNetwork.startsWith("solana:");
-
-      if (!isSolana) {
-        continue;
-      }
-      sawSolanaRequirement = true;
-
-      // Fail fast on RPC/payment-network mismatches to avoid confusing settlement errors.
-      if (!options.expectedNetworks.has(requirementNetwork)) {
-        incompatibilityReasons.push(
-          `network '${req.network}' does not match configured RPC network '${options.configuredNetworkLabel}'`,
-        );
-        continue;
-      }
-
-      // Check if this is a Solana requirement with a fee payer
-      const extra = req.extra as Record<string, unknown> | undefined;
-      const feePayer = extra?.feePayer as string | undefined;
-      if (!feePayer) {
-        incompatibilityReasons.push(
-          `requirement for network '${req.network}' is missing extra.feePayer`,
-        );
-        continue;
-      }
-
-      // Check asset matches our USDC mint
-      if (req.asset.toLowerCase() !== usdcMint.toBase58().toLowerCase()) {
-        incompatibilityReasons.push(
-          `asset mismatch for network '${req.network}': got ${req.asset}, expected ${usdcMint.toBase58()}`,
-        );
-        continue;
-      }
-
-      execers.push({
-        requirements: req,
-        exec: async () => {
-          const feePayerPubkey = new PublicKey(feePayer);
-          const payToPubkey = new PublicKey(req.payTo);
-          const amount = BigInt(req.maxAmountRequired);
-
-          // Get or derive token accounts
-          // payTo is a wallet address - we need to derive the ATA for the USDC mint
-          const sourceAta = await getAssociatedTokenAddress(
-            usdcMint,
-            wallet.publicKey,
-          );
-          const destAta = await getAssociatedTokenAddress(
-            usdcMint,
-            payToPubkey,
-          );
-
-          // The x402 protocol requires exactly 3 instructions in this order:
-          // 1. setComputeUnitLimit
-          // 2. setComputeUnitPrice
-          // 3. createTransferCheckedInstruction
-          const computeUnitLimitIx = ComputeBudgetProgram.setComputeUnitLimit({
-            units: 50000,
-          });
-
-          const computeUnitPriceIx = ComputeBudgetProgram.setComputeUnitPrice({
-            microLamports: 1,
-          });
-
-          const transferIx = createTransferCheckedInstruction(
-            sourceAta,
-            usdcMint,
-            destAta,
-            wallet.publicKey, // owner/authority is our wallet
-            amount,
-            USDC_DECIMALS, // decimals
-            [],
-            TOKEN_PROGRAM_ID,
-          );
-
-          // Get recent blockhash (or use one from extra if provided)
-          const extraBlockhash = extra?.recentBlockhash as string | undefined;
-          const { blockhash } = extraBlockhash
-            ? { blockhash: extraBlockhash }
-            : await connection.getLatestBlockhash("confirmed");
-
-          // Build transaction with SERVER's fee payer (not our wallet)
-          // Instructions must be in exact order: computeUnitLimit, computeUnitPrice, transfer
-          const message = new TransactionMessage({
-            payerKey: feePayerPubkey, // Server pays fees
-            recentBlockhash: blockhash,
-            instructions: [computeUnitLimitIx, computeUnitPriceIx, transferIx],
-          }).compileToV0Message();
-
-          const tx = new VersionedTransaction(message);
-
-          // Partially sign with our wallet only (server will add fee payer signature)
-          const signedTx = await wallet.signTransaction(tx);
-
-          // Serialize the partially-signed transaction
-          const serialized = Buffer.from(signedTx.serialize()).toString(
-            "base64",
-          );
-
-          // Preserve per-payment requirement context for v2 header adaptation.
-          const originalNetwork =
-            typeof (req as Record<string, unknown>).originalNetwork === "string"
-              ? ((req as Record<string, unknown>).originalNetwork as string)
-              : req.network;
-          if (originalNetwork.includes(":")) {
-            pendingPaymentContexts.set(serialized, {
-              accepted: {
-                scheme: req.scheme,
-                network: originalNetwork,
-                amount: req.maxAmountRequired,
-                asset: req.asset,
-                payTo: req.payTo,
-                maxTimeoutSeconds: req.maxTimeoutSeconds,
-                ...(req.extra
-                  ? { extra: req.extra as Record<string, unknown> }
-                  : {}),
-              },
-            });
-          }
-
-          return {
-            payload: {
-              transaction: serialized,
-            },
-          };
-        },
-      });
-    }
-
-    if (
-      execers.length === 0 &&
-      sawSolanaRequirement &&
-      incompatibilityReasons.length > 0
-    ) {
-      const hint = `Expected one of: ${Array.from(options.expectedNetworks).join(", ")}`;
-      throw new Error(
-        `No compatible Solana payment requirements found. ${hint}. Reasons: ${incompatibilityReasons.join("; ")}`,
-      );
-    }
-
-    return execers;
-  };
-}
-
-/**
- * Normalize an x402 v2 payment requirement to v1 format.
- *
- * The x402 Echo server returns v2 format with:
- *   - `amount` instead of `maxAmountRequired`
- *   - `description`, `mimeType`, `resource` nested inside `extra`
- *   - CAIP-2 network IDs like `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`
- *
- * Faremeter expects v1 format with these fields at top-level and
- * canonical network names like `solana-devnet`.
- */
-function normalizeRequirement(
-  req: Record<string, unknown>,
-): Record<string, unknown> {
-  const normalized = { ...req };
-
-  // amount → maxAmountRequired
-  if (normalized.amount && !normalized.maxAmountRequired) {
-    normalized.maxAmountRequired = normalized.amount;
-  }
-
-  // CAIP-2 network → canonical network name
-  if (
-    typeof normalized.network === "string" &&
-    normalized.network.startsWith("solana:")
-  ) {
-    const genesisHash = normalized.network.split(":")[1];
-    const networkMap: Record<string, string> = {
-      [SOLANA_DEVNET_CAIP2.split(":")[1]]: "solana-devnet",
-      [SOLANA_MAINNET_CAIP2.split(":")[1]]: "solana-mainnet-beta",
-    };
-    // Keep the original network in extra for the payment header
-    normalized.originalNetwork = normalized.network;
-    normalized.network = networkMap[genesisHash] ?? normalized.network;
-  }
-
-  // Promote extra fields to top-level (v2 → v1)
-  const extra = normalized.extra as Record<string, unknown> | undefined;
-  if (extra) {
-    if (!normalized.description && extra.description) {
-      normalized.description = extra.description;
-    }
-    if (normalized.mimeType === undefined && extra.mimeType !== undefined) {
-      normalized.mimeType = extra.mimeType || "application/octet-stream";
-    }
-    if (!normalized.resource && extra.resource) {
-      normalized.resource = extra.resource;
-    }
-  }
-
-  // Ensure required string fields have defaults
-  if (!normalized.description) normalized.description = "";
-  if (!normalized.mimeType) normalized.mimeType = "application/octet-stream";
-  if (!normalized.resource) normalized.resource = "";
-
-  return normalized;
-}
-
-/**
- * Create a fetch wrapper that normalizes v2 402 responses to v1 format.
- */
-function createV2NormalizingFetch(baseFetch: typeof fetch): typeof fetch {
-  return async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const response = await baseFetch(input, init);
-
-    if (response.status !== 402) {
-      return response;
-    }
-
-    const bodyText = await response.text();
-    const headers = new Headers(response.headers);
-    const contentType = headers.get("content-type")?.toLowerCase() ?? "";
-    const isJsonResponse =
-      contentType.includes("application/json") ||
-      contentType.includes("+json") ||
-      bodyText.trim().startsWith("{") ||
-      bodyText.trim().startsWith("[");
-
-    // If this 402 is not JSON, preserve it exactly as-is for upstream handling.
-    if (!isJsonResponse) {
-      return new Response(bodyText, {
-        status: 402,
-        statusText: response.statusText,
-        headers,
-      });
-    }
-
-    let body: unknown;
-    try {
-      body = JSON.parse(bodyText);
-    } catch {
-      // Malformed JSON in 402 response: keep original body so caller can inspect it.
-      return new Response(bodyText, {
-        status: 402,
-        statusText: response.statusText,
-        headers,
-      });
-    }
-
-    if (!body || typeof body !== "object") {
-      return new Response(bodyText, {
-        status: 402,
-        statusText: response.statusText,
-        headers,
-      });
-    }
-
-    const normalizedBody = body as Record<string, unknown>;
-
-    // Normalize accepts array for faremeter
-    if (Array.isArray(normalizedBody.accepts)) {
-      normalizedBody.accepts = normalizedBody.accepts.map((accept) => {
-        if (!accept || typeof accept !== "object") {
-          return accept;
-        }
-        return normalizeRequirement(accept as Record<string, unknown>);
-      });
-    }
-
-    return new Response(JSON.stringify(normalizedBody), {
-      status: 402,
-      statusText: response.statusText,
-      headers,
-    });
-  };
-}
-
-/**
- * Create a fetch wrapper that adapts payment headers for different server types.
- * - v1 servers (x402test, faremeter): Use X-PAYMENT with canonical network
- * - v2 servers (Echo): Use PAYMENT-SIGNATURE with CAIP-2 network and `accepted` field
- */
-function createAdaptivePaymentFetch(baseFetch: typeof fetch): typeof fetch {
-  return async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const headers = new Headers(init?.headers);
-
-    const xPayment = headers.get("X-PAYMENT");
-    if (xPayment) {
-      try {
-        const payloadJson = atob(xPayment);
-        const payload = JSON.parse(payloadJson) as Record<string, unknown>;
-        const tx = (payload.payload as Record<string, unknown> | undefined)
-          ?.transaction;
-
-        if (typeof tx === "string") {
-          const context = pendingPaymentContexts.get(tx);
-          if (context) {
-            const v2Payload = {
-              x402Version: 2,
-              scheme: context.accepted.scheme,
-              network: context.accepted.network,
-              accepted: context.accepted,
-              payload: payload.payload,
-              extensions: {},
-            };
-
-            // v2 servers use PAYMENT-SIGNATURE header
-            const fixedPayment = btoa(JSON.stringify(v2Payload));
-            headers.set("X-PAYMENT", fixedPayment);
-            headers.set("PAYMENT-SIGNATURE", fixedPayment);
-            pendingPaymentContexts.delete(tx);
-          }
-        }
-        // For v1 servers, leave the payment as-is (canonical network, X-PAYMENT only)
-      } catch {
-        // If decoding fails, leave headers unchanged
-      }
-    }
-
-    return baseFetch(input, { ...init, headers });
-  };
-}
-
-// Load environment variables from `.env.local`
-dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
-
 /**
  * Agentic Wallet Payments Demo
  *
- * This example demonstrates how AI agents can use Turnkey wallets to:
- * 1. Authenticate with API keys (no browser/WebAuthn needed)
- * 2. Create or retrieve a Solana wallet
- * 3. Automatically pay for x402-protected resources using Faremeter
+ * This example shows how an AI agent can automatically pay for x402-protected
+ * resources using Turnkey for secure wallet management.
  *
- * The agent can autonomously pay for resources using the Faremeter x402 protocol.
- * See: https://github.com/faremeter/faremeter
- *
- * COMPATIBLE TEST SERVERS:
- *
- * 1. x402 Echo Server (recommended for devnet testing):
- *    - Set TEST_PAYWALL_URL=https://x402.payai.network/api/solana-devnet/paid-content
- *    - Uses gasless transactions (server pays SOL fees, you pay USDC)
- *    - Requires devnet USDC: https://faucet.circle.com/
- *
- * 2. Helius via Corbits (mainnet, requires real USDC):
- *    - Set TEST_PAYWALL_URL=https://helius.api.corbits.dev
- *    - Switch network to mainnet-beta
- *    - Costs ~$0.01 USDC per request
+ * The key insight: once you have `x402Fetch`, you use it exactly like regular
+ * `fetch()`. Payments happen automatically when a server returns HTTP 402.
  */
+
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { createX402Client } from "./x402-client.js";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+// ============================================================================
+// AGENT DEMO
+// ============================================================================
+
 async function main() {
   console.log("🤖 Initializing Turnkey Agent...\n");
 
-  const organizationId = process.env.ORGANIZATION_ID!;
-  const apiPublicKey = process.env.API_PUBLIC_KEY!;
-  const apiPrivateKey = process.env.API_PRIVATE_KEY!;
+  // -------------------------------------------------------------------------
+  // STEP 1: Validate configuration
+  // -------------------------------------------------------------------------
+  const apiPublicKey = process.env.API_PUBLIC_KEY;
+  const apiPrivateKey = process.env.API_PRIVATE_KEY;
+  const organizationId = process.env.ORGANIZATION_ID;
 
   if (!apiPublicKey || !apiPrivateKey || !organizationId) {
     console.error("❌ Missing required environment variables.");
@@ -457,194 +37,113 @@ async function main() {
     process.exit(1);
   }
 
-  // 1. Initialize Turnkey client with API keys (headless auth)
-  const turnkey = new Turnkey({
-    apiBaseUrl: process.env.BASE_URL || "https://api.turnkey.com",
-    apiPublicKey,
-    apiPrivateKey,
-    defaultOrganizationId: organizationId,
-  });
+  // -------------------------------------------------------------------------
+  // STEP 2: Create the x402 payment client
+  //
+  // This is all the setup you need. The client handles:
+  // - Turnkey authentication
+  // - Wallet creation/retrieval
+  // - Transaction signing
+  // - Payment protocol negotiation
+  // -------------------------------------------------------------------------
+  const { x402Fetch, walletAddress, getBalances, network } =
+    await createX402Client({
+      apiPublicKey,
+      apiPrivateKey,
+      organizationId,
+      rpcUrl: process.env.SOLANA_RPC_URL,
+      baseUrl: process.env.BASE_URL,
+    });
 
   console.log("✅ Turnkey client initialized");
+  console.log(`✅ Agent wallet: ${walletAddress}`);
 
-  // 2. Create Solana signer (used by Faremeter to sign payment transactions)
-  const signer = new TurnkeySigner({
-    organizationId,
-    client: turnkey.apiClient(),
-  });
+  // Check balances
+  const { sol, usdc } = await getBalances();
+  console.log(`💰 SOL Balance: ${sol} SOL`);
+  console.log(`💵 USDC Balance: ${usdc.toFixed(2)} USDC\n`);
 
-  // 3. Get or create a Solana wallet
-  const solanaAddress = await getOrCreateSolanaWallet(turnkey.apiClient());
-  console.log(`✅ Agent wallet: ${solanaAddress}`);
-
-  // 4. Check wallet balances (SOL and USDC)
-  const rpcUrl = process.env.SOLANA_RPC_URL || "https://api.devnet.solana.com";
-  const connection = new Connection(rpcUrl, "confirmed");
-  const walletPubkey = new PublicKey(solanaAddress);
-  const balance = await connection.getBalance(walletPubkey);
-
-  // Determine network and USDC mint
-  const network = rpcUrl.includes("devnet") ? "devnet" : "mainnet-beta";
-  const expectedRequirementNetworks = getExpectedRequirementNetworks(network);
-  const usdcMint =
-    network === "devnet"
-      ? new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU") // USDC devnet
-      : new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"); // USDC mainnet
-
-  // Check USDC balance
-  let usdcBalance = 0;
-  try {
-    const usdcAta = await getAssociatedTokenAddress(usdcMint, walletPubkey);
-    const tokenAccount = await getAccount(connection, usdcAta);
-    usdcBalance = Number(tokenAccount.amount) / Math.pow(10, USDC_DECIMALS);
-  } catch {
-    // Token account doesn't exist yet - balance is 0
-  }
-
-  console.log(`💰 SOL Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
-  console.log(`💵 USDC Balance: ${usdcBalance.toFixed(2)} USDC\n`);
-
-  if (balance < 0.01 * LAMPORTS_PER_SOL) {
+  if (sol < 0.01) {
     console.log("⚠️  Low SOL balance! Request an airdrop on devnet:");
-    console.log(`   solana airdrop 1 ${solanaAddress} --url devnet`);
-    console.log(`   Or use: https://faucet.solana.com/\n`);
+    console.log(`   solana airdrop 1 ${walletAddress} --url devnet\n`);
   }
 
-  if (usdcBalance < 0.01) {
+  if (usdc < 0.01) {
     console.log("⚠️  Low USDC balance! Get test USDC on devnet:");
-    console.log(
-      `   Visit: https://faucet.circle.com/ (select Solana Devnet)\n`,
-    );
+    console.log("   Visit: https://faucet.circle.com/ (select Solana Devnet)\n");
   }
-
-  // 5. Create a Turnkey wallet adapter for signing transactions
-  const turnkeyWallet: GaslessWallet = {
-    publicKey: walletPubkey,
-    signTransaction: async (tx: VersionedTransaction) => {
-      const signedTx = await signer.signTransaction(tx, solanaAddress);
-      return signedTx as VersionedTransaction;
-    },
-  };
-
-  // 6. Create the gasless payment handler
-  //
-  // This handler builds transactions using the server's fee payer (from extra.feePayer),
-  // allowing gasless payments where the server covers SOL transaction fees.
-  // The handler:
-  //   a) Parses payment requirements from the 402 response
-  //   b) Builds a USDC transfer with the server's fee payer
-  //   c) Partially signs with Turnkey (server adds fee payer signature)
-  //   d) Returns the transaction for faremeter to send in X-PAYMENT header
-  const gaslessHandler = createGaslessPaymentHandler(
-    turnkeyWallet,
-    usdcMint,
-    connection,
-    {
-      expectedNetworks: expectedRequirementNetworks,
-      configuredNetworkLabel: network,
-    },
-  );
-
-  // Create fetch wrappers for protocol compatibility:
-  // - normalizingFetch: Converts v2 402 responses to v1 format for faremeter
-  // - adaptiveFetch: Adjusts payment headers based on server's protocol version
-  const normalizingFetch = createV2NormalizingFetch(fetch);
-  const adaptiveFetch = createAdaptivePaymentFetch(fetch);
-
-  const x402Fetch = wrapFetch(adaptiveFetch, {
-    handlers: [gaslessHandler],
-    // Use normalizing fetch for initial request to handle v2 servers
-    phase1Fetch: normalizingFetch,
-    // Retry up to 3 times if payment fails
-    retryCount: 3,
-    // Return the 402 response instead of throwing if payment fails
-    returnPaymentFailure: true,
-  });
 
   console.log("✅ Faremeter x402 client ready\n");
 
-  // 7. Attempt to fetch a paywalled resource
+  // -------------------------------------------------------------------------
+  // STEP 3: Use x402Fetch in your agent
+  //
+  // THIS IS THE AGENT INTEGRATION POINT
+  //
+  // In a real agent, you would expose x402Fetch as a tool that the LLM can
+  // call. For example:
+  //
+  //   const tools = [{
+  //     name: "fetch_paid_resource",
+  //     description: "Fetch data from a URL, automatically paying if required",
+  //     execute: (url) => x402Fetch(url).then(r => r.text())
+  //   }];
+  //
+  // The agent doesn't need to know about payments - they just happen.
+  // -------------------------------------------------------------------------
   const testUrl = process.env.TEST_PAYWALL_URL;
 
   if (testUrl) {
     console.log(`📡 Fetching paywalled resource: ${testUrl}\n`);
 
+    const initialBalances = { sol, usdc };
+
     try {
-      // x402Fetch handles the full payment lifecycle automatically:
-      // - If the server returns 200, the response is passed through as-is
-      // - If the server returns 402, faremeter builds a payment transaction,
-      //   signs it via Turnkey, and retries with the X-PAYMENT header
+      // This is it! Use x402Fetch exactly like regular fetch.
+      // If the server returns 402, payment is handled automatically.
       const response = await x402Fetch(testUrl);
 
       if (response.ok) {
         const content = await response.text();
         console.log("✅ Content received!");
         console.log("─".repeat(50));
-        console.log(
-          content.substring(0, 500) + (content.length > 500 ? "..." : ""),
-        );
+        console.log(content.substring(0, 500) + (content.length > 500 ? "..." : ""));
         console.log("─".repeat(50));
       } else if (response.status === 402) {
-        // Payment failed - log the server's response for debugging
         const body = await response.text();
-        console.log(`❌ Payment failed (402). Server response:`);
+        console.log("❌ Payment failed (402). Server response:");
         try {
-          const parsed = JSON.parse(body);
-          console.log(JSON.stringify(parsed, null, 2));
-
-          console.log("\n💡 Possible issues:");
-          console.log("   - Insufficient USDC balance in wallet");
-          console.log("   - Network mismatch (devnet vs mainnet)");
-          console.log("   - Transaction verification failed on server");
-          if (parsed.error) {
-            console.log(`   - Server error: ${parsed.error}`);
-          }
+          console.log(JSON.stringify(JSON.parse(body), null, 2));
         } catch {
           console.log(body);
         }
+        console.log("\n💡 Possible issues:");
+        console.log("   - Insufficient USDC balance in wallet");
+        console.log("   - Network mismatch (devnet vs mainnet)");
+        console.log("   - Transaction verification failed on server");
       } else {
-        console.log(
-          `❌ Request failed: ${response.status} ${response.statusText}`,
-        );
-        const body = await response.text();
-        console.log(body);
+        console.log(`❌ Request failed: ${response.status} ${response.statusText}`);
+        console.log(await response.text());
       }
     } catch (error) {
       console.error("❌ Payment flow error:", error);
     }
 
-    // Final balance check to show what was spent
-    const finalSolBalance = await connection.getBalance(walletPubkey);
-    let finalUsdcBalance = 0;
-    try {
-      const usdcAta = await getAssociatedTokenAddress(usdcMint, walletPubkey);
-      const tokenAccount = await getAccount(connection, usdcAta);
-      finalUsdcBalance =
-        Number(tokenAccount.amount) / Math.pow(10, USDC_DECIMALS);
-    } catch {
-      // Token account doesn't exist
-    }
-
-    console.log(
-      `\n💰 Final SOL balance: ${finalSolBalance / LAMPORTS_PER_SOL} SOL`,
-    );
-    console.log(`💵 Final USDC balance: ${finalUsdcBalance.toFixed(2)} USDC`);
-    console.log(
-      `📊 SOL spent: ${(balance - finalSolBalance) / LAMPORTS_PER_SOL} SOL`,
-    );
-    console.log(
-      `📊 USDC spent: ${(usdcBalance - finalUsdcBalance).toFixed(6)} USDC`,
-    );
+    // Show what was spent
+    const finalBalances = await getBalances();
+    console.log(`\n💰 Final SOL balance: ${finalBalances.sol} SOL`);
+    console.log(`💵 Final USDC balance: ${finalBalances.usdc.toFixed(2)} USDC`);
+    console.log(`📊 SOL spent: ${(initialBalances.sol - finalBalances.sol).toFixed(6)} SOL`);
+    console.log(`📊 USDC spent: ${(initialBalances.usdc - finalBalances.usdc).toFixed(6)} USDC`);
   } else {
     console.log("ℹ️  No TEST_PAYWALL_URL configured.");
     console.log("   Set this env var to test the x402 payment flow.\n");
 
-    // Summary
     console.log("─".repeat(50));
     console.log("Agent Summary:");
-    console.log(`  Wallet Address: ${solanaAddress}`);
-    console.log(`  SOL Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
-    console.log(`  USDC Balance: ${usdcBalance.toFixed(2)} USDC`);
+    console.log(`  Wallet Address: ${walletAddress}`);
+    console.log(`  SOL Balance: ${sol} SOL`);
+    console.log(`  USDC Balance: ${usdc.toFixed(2)} USDC`);
     console.log(`  Network: ${network}`);
     console.log(`  Faremeter Client: ready`);
     console.log("─".repeat(50));

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -23,24 +23,22 @@ dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 async function main() {
   console.log("🤖 Initializing Turnkey Agent...\n");
 
-  // Validate required environment variables
-  const apiPublicKey = process.env.TURNKEY_API_PUBLIC_KEY;
-  const apiPrivateKey = process.env.TURNKEY_API_PRIVATE_KEY;
-  const organizationId = process.env.TURNKEY_ORGANIZATION_ID;
+  const organizationId = process.env.ORGANIZATION_ID!;
+  const apiPublicKey = process.env.API_PUBLIC_KEY!;
+  const apiPrivateKey = process.env.API_PRIVATE_KEY!;
 
   if (!apiPublicKey || !apiPrivateKey || !organizationId) {
     console.error("❌ Missing required environment variables.");
     console.error("Please set the following in your .env.local file:");
-    console.error("  - TURNKEY_API_PUBLIC_KEY");
-    console.error("  - TURNKEY_API_PRIVATE_KEY");
-    console.error("  - TURNKEY_ORGANIZATION_ID");
+    console.error("  - API_PUBLIC_KEY");
+    console.error("  - API_PRIVATE_KEY");
+    console.error("  - ORGANIZATION_ID");
     process.exit(1);
   }
 
   // 1. Initialize Turnkey client with API keys (headless auth)
   const turnkey = new Turnkey({
-    apiBaseUrl:
-      process.env.TURNKEY_API_BASE_URL || "https://api.turnkey.com",
+    apiBaseUrl: process.env.BASE_URL || "https://api.turnkey.com",
     apiPublicKey,
     apiPrivateKey,
     defaultOrganizationId: organizationId,
@@ -106,12 +104,12 @@ async function main() {
         console.log("✅ Content received!");
         console.log("─".repeat(50));
         console.log(
-          content.substring(0, 500) + (content.length > 500 ? "..." : "")
+          content.substring(0, 500) + (content.length > 500 ? "..." : ""),
         );
         console.log("─".repeat(50));
       } else {
         console.log(
-          `❌ Request failed: ${response.status} ${response.statusText}`
+          `❌ Request failed: ${response.status} ${response.statusText}`,
         );
       }
     } catch (error) {
@@ -120,11 +118,11 @@ async function main() {
 
     // Final balance check to show what was spent
     const finalBalance = await connection.getBalance(
-      new PublicKey(solanaAddress)
+      new PublicKey(solanaAddress),
     );
     console.log(`\n💰 Final balance: ${finalBalance / LAMPORTS_PER_SOL} SOL`);
     console.log(
-      `📊 Spent: ${(balance - finalBalance) / LAMPORTS_PER_SOL} SOL`
+      `📊 Spent: ${(balance - finalBalance) / LAMPORTS_PER_SOL} SOL`,
     );
   } else {
     console.log("ℹ️  No TEST_PAYWALL_URL configured.");
@@ -136,15 +134,17 @@ async function main() {
     console.log(`  Wallet Address: ${solanaAddress}`);
     console.log(`  Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
     console.log(
-      `  Network: ${rpcUrl.includes("devnet") ? "devnet" : "mainnet"}`
+      `  Network: ${rpcUrl.includes("devnet") ? "devnet" : "mainnet"}`,
     );
     console.log(`  x402 Client: ready`);
     console.log("─".repeat(50));
     console.log("\n✅ Agent ready for x402 payments!");
   }
+
+  process.exit(0);
 }
 
 main().catch((error) => {
-  console.error("❌ Error:", error);
+  console.error(error);
   process.exit(1);
 });

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -1,0 +1,150 @@
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import { Turnkey } from "@turnkey/sdk-server";
+import { TurnkeySigner } from "@turnkey/solana";
+import { wrapFetch } from "@faremeter/fetch";
+import { getOrCreateSolanaWallet } from "./utils";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+/**
+ * Agentic Wallet Payments Demo
+ *
+ * This example demonstrates how AI agents can use Turnkey wallets to:
+ * 1. Authenticate with API keys (no browser/WebAuthn needed)
+ * 2. Create or retrieve a Solana wallet
+ * 3. Automatically pay for x402-protected resources using Faremeter
+ *
+ * The agent can autonomously pay for resources using the Faremeter x402 protocol.
+ * See: https://github.com/faremeter/faremeter
+ */
+async function main() {
+  console.log("🤖 Initializing Turnkey Agent...\n");
+
+  // Validate required environment variables
+  const apiPublicKey = process.env.TURNKEY_API_PUBLIC_KEY;
+  const apiPrivateKey = process.env.TURNKEY_API_PRIVATE_KEY;
+  const organizationId = process.env.TURNKEY_ORGANIZATION_ID;
+
+  if (!apiPublicKey || !apiPrivateKey || !organizationId) {
+    console.error("❌ Missing required environment variables.");
+    console.error("Please set the following in your .env.local file:");
+    console.error("  - TURNKEY_API_PUBLIC_KEY");
+    console.error("  - TURNKEY_API_PRIVATE_KEY");
+    console.error("  - TURNKEY_ORGANIZATION_ID");
+    process.exit(1);
+  }
+
+  // 1. Initialize Turnkey client with API keys (headless auth)
+  const turnkey = new Turnkey({
+    apiBaseUrl:
+      process.env.TURNKEY_API_BASE_URL || "https://api.turnkey.com",
+    apiPublicKey,
+    apiPrivateKey,
+    defaultOrganizationId: organizationId,
+  });
+
+  console.log("✅ Turnkey client initialized");
+
+  // 2. Create Solana signer (used by Faremeter to sign payment transactions)
+  const signer = new TurnkeySigner({
+    organizationId,
+    client: turnkey.apiClient(),
+  });
+
+  // 3. Get or create a Solana wallet
+  const solanaAddress = await getOrCreateSolanaWallet(turnkey.apiClient());
+  console.log(`✅ Agent wallet: ${solanaAddress}`);
+
+  // 4. Check wallet balance
+  const rpcUrl =
+    process.env.SOLANA_RPC_URL || "https://api.devnet.solana.com";
+  const connection = new Connection(rpcUrl, "confirmed");
+  const balance = await connection.getBalance(new PublicKey(solanaAddress));
+
+  console.log(`💰 Balance: ${balance / LAMPORTS_PER_SOL} SOL\n`);
+
+  if (balance < 0.01 * LAMPORTS_PER_SOL) {
+    console.log("⚠️  Low balance! Request an airdrop on devnet:");
+    console.log(`   solana airdrop 1 ${solanaAddress} --url devnet`);
+    console.log(`   Or use: https://faucet.solana.com/\n`);
+  }
+
+  // 5. Create a Faremeter-wrapped fetch that handles x402 payment flows.
+  //
+  // When a request returns HTTP 402, Faremeter will:
+  //   a) Parse the payment requirements from the response
+  //   b) Build a Solana payment transaction
+  //   c) Call our signer to sign it via Turnkey
+  //   d) Submit payment proof and retry the original request
+  const x402Fetch = wrapFetch(fetch, {
+    paymentSigner: async (transaction) => {
+      return await signer.signTransaction(transaction, solanaAddress);
+    },
+    network: "solana:devnet",
+    facilitatorUrl: process.env.FAREMETER_FACILITATOR_URL,
+  });
+
+  console.log("✅ Faremeter x402 client ready\n");
+
+  // 6. Attempt to fetch a paywalled resource
+  const testUrl = process.env.TEST_PAYWALL_URL;
+
+  if (testUrl) {
+    console.log(`📡 Fetching paywalled resource: ${testUrl}\n`);
+
+    try {
+      // x402Fetch handles the full payment lifecycle automatically:
+      // - If the server returns 200, the response is passed through as-is
+      // - If the server returns 402, Faremeter negotiates payment and retries
+      const response = await x402Fetch(testUrl);
+
+      if (response.ok) {
+        const content = await response.text();
+        console.log("✅ Content received!");
+        console.log("─".repeat(50));
+        console.log(
+          content.substring(0, 500) + (content.length > 500 ? "..." : "")
+        );
+        console.log("─".repeat(50));
+      } else {
+        console.log(
+          `❌ Request failed: ${response.status} ${response.statusText}`
+        );
+      }
+    } catch (error) {
+      console.error("❌ Payment flow error:", error);
+    }
+
+    // Final balance check to show what was spent
+    const finalBalance = await connection.getBalance(
+      new PublicKey(solanaAddress)
+    );
+    console.log(`\n💰 Final balance: ${finalBalance / LAMPORTS_PER_SOL} SOL`);
+    console.log(
+      `📊 Spent: ${(balance - finalBalance) / LAMPORTS_PER_SOL} SOL`
+    );
+  } else {
+    console.log("ℹ️  No TEST_PAYWALL_URL configured.");
+    console.log("   Set this env var to test the x402 payment flow.\n");
+
+    // Summary
+    console.log("─".repeat(50));
+    console.log("Agent Summary:");
+    console.log(`  Wallet Address: ${solanaAddress}`);
+    console.log(`  Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
+    console.log(
+      `  Network: ${rpcUrl.includes("devnet") ? "devnet" : "mainnet"}`
+    );
+    console.log(`  x402 Client: ready`);
+    console.log("─".repeat(50));
+    console.log("\n✅ Agent ready for x402 payments!");
+  }
+}
+
+main().catch((error) => {
+  console.error("❌ Error:", error);
+  process.exit(1);
+});

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -70,7 +70,9 @@ async function main() {
 
   if (usdc < 0.01) {
     console.log("⚠️  Low USDC balance! Get test USDC on devnet:");
-    console.log("   Visit: https://faucet.circle.com/ (select Solana Devnet)\n");
+    console.log(
+      "   Visit: https://faucet.circle.com/ (select Solana Devnet)\n",
+    );
   }
 
   console.log("✅ Faremeter x402 client ready\n");
@@ -107,7 +109,9 @@ async function main() {
         const content = await response.text();
         console.log("✅ Content received!");
         console.log("─".repeat(50));
-        console.log(content.substring(0, 500) + (content.length > 500 ? "..." : ""));
+        console.log(
+          content.substring(0, 500) + (content.length > 500 ? "..." : ""),
+        );
         console.log("─".repeat(50));
       } else if (response.status === 402) {
         const body = await response.text();
@@ -122,7 +126,9 @@ async function main() {
         console.log("   - Network mismatch (devnet vs mainnet)");
         console.log("   - Transaction verification failed on server");
       } else {
-        console.log(`❌ Request failed: ${response.status} ${response.statusText}`);
+        console.log(
+          `❌ Request failed: ${response.status} ${response.statusText}`,
+        );
         console.log(await response.text());
       }
     } catch (error) {
@@ -133,8 +139,12 @@ async function main() {
     const finalBalances = await getBalances();
     console.log(`\n💰 Final SOL balance: ${finalBalances.sol} SOL`);
     console.log(`💵 Final USDC balance: ${finalBalances.usdc.toFixed(2)} USDC`);
-    console.log(`📊 SOL spent: ${(initialBalances.sol - finalBalances.sol).toFixed(6)} SOL`);
-    console.log(`📊 USDC spent: ${(initialBalances.usdc - finalBalances.usdc).toFixed(6)} USDC`);
+    console.log(
+      `📊 SOL spent: ${(initialBalances.sol - finalBalances.sol).toFixed(6)} SOL`,
+    );
+    console.log(
+      `📊 USDC spent: ${(initialBalances.usdc - finalBalances.usdc).toFixed(6)} USDC`,
+    );
   } else {
     console.log("ℹ️  No TEST_PAYWALL_URL configured.");
     console.log("   Set this env var to test the x402 payment flow.\n");

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -163,8 +163,6 @@ async function main() {
     console.log("─".repeat(50));
     console.log("\n✅ Agent ready for x402 payments!");
   }
-
-  process.exit(0);
 }
 
 main().catch((error) => {

--- a/examples/with-x402-faremeter/src/index.ts
+++ b/examples/with-x402-faremeter/src/index.ts
@@ -53,6 +53,10 @@ async function main() {
       organizationId,
       rpcUrl: process.env.SOLANA_RPC_URL,
       baseUrl: process.env.BASE_URL,
+      network: process.env.SOLANA_NETWORK as
+        | "devnet"
+        | "mainnet-beta"
+        | undefined,
     });
 
   console.log("✅ Turnkey client initialized");

--- a/examples/with-x402-faremeter/src/utils.ts
+++ b/examples/with-x402-faremeter/src/utils.ts
@@ -12,7 +12,7 @@ import * as crypto from "crypto";
  * Otherwise, it creates a new wallet with a Solana account.
  */
 export async function getOrCreateSolanaWallet(
-  client: TurnkeyApiClient
+  client: TurnkeyApiClient,
 ): Promise<string> {
   // Check for existing wallets with Solana accounts
   const existingAddress = await findExistingSolanaWallet(client);
@@ -32,7 +32,7 @@ export async function getOrCreateSolanaWallet(
  * when the real issue is a transient network/auth failure.
  */
 async function findExistingSolanaWallet(
-  client: TurnkeyApiClient
+  client: TurnkeyApiClient,
 ): Promise<string | null> {
   const { wallets } = await client.getWallets();
 
@@ -48,7 +48,7 @@ async function findExistingSolanaWallet(
 
     const solanaAccount = accounts?.find(
       (account: { addressFormat: string; address: string }) =>
-        account.addressFormat === "ADDRESS_FORMAT_SOLANA"
+        account.addressFormat === "ADDRESS_FORMAT_SOLANA",
     );
 
     if (solanaAccount) {
@@ -65,7 +65,7 @@ async function findExistingSolanaWallet(
  * This follows the same pattern as examples/with-solana.
  */
 async function createNewSolanaWallet(
-  client: TurnkeyApiClient
+  client: TurnkeyApiClient,
 ): Promise<string> {
   console.log("Creating a new Solana wallet...\n");
 
@@ -102,7 +102,7 @@ async function createNewSolanaWallet(
         `- Wallet ID: ${walletId}`,
         `- Solana address: ${address}`,
         "",
-      ].join("\n")
+      ].join("\n"),
     );
 
     return address;

--- a/examples/with-x402-faremeter/src/utils.ts
+++ b/examples/with-x402-faremeter/src/utils.ts
@@ -1,0 +1,119 @@
+import {
+  type TurnkeyApiClient,
+  TurnkeyActivityError,
+} from "@turnkey/sdk-server";
+import * as crypto from "crypto";
+
+/**
+ * Get an existing Solana wallet or create a new one.
+ *
+ * This function first checks for existing wallets in the organization.
+ * If a wallet with a Solana account exists, it returns that address.
+ * Otherwise, it creates a new wallet with a Solana account.
+ */
+export async function getOrCreateSolanaWallet(
+  client: TurnkeyApiClient
+): Promise<string> {
+  // Check for existing wallets with Solana accounts
+  const existingAddress = await findExistingSolanaWallet(client);
+  if (existingAddress) {
+    console.log(`Using existing Solana wallet: ${existingAddress}`);
+    return existingAddress;
+  }
+
+  // Create a new wallet
+  return await createNewSolanaWallet(client);
+}
+
+/**
+ * Find an existing Solana wallet in the organization.
+ *
+ * Throws on API errors to avoid silently creating duplicate wallets
+ * when the real issue is a transient network/auth failure.
+ */
+async function findExistingSolanaWallet(
+  client: TurnkeyApiClient
+): Promise<string | null> {
+  const { wallets } = await client.getWallets();
+
+  if (!wallets || wallets.length === 0) {
+    return null;
+  }
+
+  // Look for a wallet with a Solana account
+  for (const wallet of wallets) {
+    const { accounts } = await client.getWalletAccounts({
+      walletId: wallet.walletId,
+    });
+
+    const solanaAccount = accounts?.find(
+      (account: { addressFormat: string; address: string }) =>
+        account.addressFormat === "ADDRESS_FORMAT_SOLANA"
+    );
+
+    if (solanaAccount) {
+      return solanaAccount.address;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Create a new Solana wallet in the Turnkey organization.
+ *
+ * This follows the same pattern as examples/with-solana.
+ */
+async function createNewSolanaWallet(
+  client: TurnkeyApiClient
+): Promise<string> {
+  console.log("Creating a new Solana wallet...\n");
+
+  const walletName = `Agent Wallet ${crypto.randomBytes(2).toString("hex")}`;
+
+  try {
+    const response = await client.createWallet({
+      walletName,
+      accounts: [
+        {
+          pathFormat: "PATH_FORMAT_BIP32",
+          // Solana BIP44 path: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+          path: "m/44'/501'/0'/0'",
+          curve: "CURVE_ED25519",
+          addressFormat: "ADDRESS_FORMAT_SOLANA",
+        },
+      ],
+    });
+
+    const walletId = response.walletId;
+    if (!walletId) {
+      throw new Error("Response doesn't contain a valid wallet ID");
+    }
+
+    const address = response.addresses[0];
+    if (!address) {
+      throw new Error("Response doesn't contain a valid address");
+    }
+
+    console.log(
+      [
+        `New Solana wallet created!`,
+        `- Name: ${walletName}`,
+        `- Wallet ID: ${walletId}`,
+        `- Solana address: ${address}`,
+        "",
+      ].join("\n")
+    );
+
+    return address;
+  } catch (error) {
+    if (error instanceof TurnkeyActivityError) {
+      throw error;
+    }
+
+    throw new TurnkeyActivityError({
+      message: `Failed to create a new Solana wallet: ${(error as Error).message}`,
+      cause: error as Error,
+    });
+  }
+}

--- a/examples/with-x402-faremeter/src/utils.ts
+++ b/examples/with-x402-faremeter/src/utils.ts
@@ -1,5 +1,6 @@
 import {
   type TurnkeyApiClient,
+  type TurnkeyApiTypes,
   TurnkeyActivityError,
 } from "@turnkey/sdk-server";
 import * as crypto from "crypto";
@@ -47,7 +48,7 @@ async function findExistingSolanaWallet(
     });
 
     const solanaAccount = accounts?.find(
-      (account: { addressFormat: string; address: string }) =>
+      (account: TurnkeyApiTypes["v1WalletAccount"]) =>
         account.addressFormat === "ADDRESS_FORMAT_SOLANA",
     );
 

--- a/examples/with-x402-faremeter/src/x402-client.ts
+++ b/examples/with-x402-faremeter/src/x402-client.ts
@@ -1,0 +1,485 @@
+import {
+  Connection,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  VersionedTransaction,
+  TransactionMessage,
+  ComputeBudgetProgram,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddress,
+  getAccount,
+  createTransferCheckedInstruction,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import { Turnkey } from "@turnkey/sdk-server";
+import { TurnkeySigner } from "@turnkey/solana";
+import { wrap as wrapFetch } from "@faremeter/fetch";
+import type { PaymentHandler, PaymentExecer } from "@faremeter/types/client";
+import { getOrCreateSolanaWallet } from "./utils.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const USDC_DECIMALS = 6;
+const SOLANA_DEVNET_CAIP2 = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
+const SOLANA_MAINNET_CAIP2 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+
+const USDC_MINTS = {
+  devnet: new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+  "mainnet-beta": new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+};
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface X402ClientConfig {
+  apiPublicKey: string;
+  apiPrivateKey: string;
+  organizationId: string;
+  rpcUrl?: string;
+  baseUrl?: string;
+}
+
+export interface X402Client {
+  /** Payment-enabled fetch - use this like regular fetch, payments are automatic */
+  x402Fetch: typeof fetch;
+  /** The Solana wallet address used for payments */
+  walletAddress: string;
+  /** Get current SOL and USDC balances */
+  getBalances: () => Promise<{ sol: number; usdc: number }>;
+  /** The detected network (devnet or mainnet-beta) */
+  network: "devnet" | "mainnet-beta";
+}
+
+interface GaslessWallet {
+  publicKey: PublicKey;
+  signTransaction: (tx: VersionedTransaction) => Promise<VersionedTransaction>;
+}
+
+interface PaymentContext {
+  accepted: {
+    scheme: string;
+    network: string;
+    amount: string;
+    asset: string;
+    payTo: string;
+    maxTimeoutSeconds: number;
+    extra?: Record<string, unknown>;
+  };
+}
+
+// ============================================================================
+// MAIN FACTORY FUNCTION
+// ============================================================================
+
+/**
+ * Create an x402 payment client.
+ *
+ * This sets up all the infrastructure needed for an agent to make
+ * automatic payments to x402-protected endpoints.
+ *
+ * @example
+ * ```typescript
+ * const { x402Fetch, walletAddress, getBalances } = await createX402Client({
+ *   apiPublicKey: process.env.API_PUBLIC_KEY!,
+ *   apiPrivateKey: process.env.API_PRIVATE_KEY!,
+ *   organizationId: process.env.ORGANIZATION_ID!,
+ * });
+ *
+ * // Use x402Fetch like regular fetch - payments are automatic
+ * const response = await x402Fetch("https://paid-api.example.com/data");
+ * ```
+ */
+export async function createX402Client(
+  config: X402ClientConfig,
+): Promise<X402Client> {
+  const { apiPublicKey, apiPrivateKey, organizationId } = config;
+  const rpcUrl = config.rpcUrl ?? "https://api.devnet.solana.com";
+  const baseUrl = config.baseUrl ?? "https://api.turnkey.com";
+
+  // Initialize Turnkey client
+  const turnkey = new Turnkey({
+    apiBaseUrl: baseUrl,
+    apiPublicKey,
+    apiPrivateKey,
+    defaultOrganizationId: organizationId,
+  });
+
+  // Create Solana signer
+  const signer = new TurnkeySigner({
+    organizationId,
+    client: turnkey.apiClient(),
+  });
+
+  // Get or create wallet
+  const walletAddress = await getOrCreateSolanaWallet(turnkey.apiClient());
+  const walletPubkey = new PublicKey(walletAddress);
+
+  // Set up connection and detect network
+  const connection = new Connection(rpcUrl, "confirmed");
+  const network = rpcUrl.includes("devnet") ? "devnet" : "mainnet-beta";
+  const usdcMint = USDC_MINTS[network];
+  const expectedNetworks = getExpectedRequirementNetworks(network);
+
+  // Create wallet adapter for signing
+  const wallet: GaslessWallet = {
+    publicKey: walletPubkey,
+    signTransaction: async (tx: VersionedTransaction) => {
+      const signedTx = await signer.signTransaction(tx, walletAddress);
+      return signedTx as VersionedTransaction;
+    },
+  };
+
+  // Track per-payment context (module-private state)
+  const pendingPaymentContexts = new Map<string, PaymentContext>();
+
+  // Create the payment handler
+  const gaslessHandler = createGaslessPaymentHandler(
+    wallet,
+    usdcMint,
+    connection,
+    expectedNetworks,
+    network,
+    pendingPaymentContexts,
+  );
+
+  // Create fetch wrappers for protocol compatibility
+  const normalizingFetch = createV2NormalizingFetch(fetch);
+  const adaptiveFetch = createAdaptivePaymentFetch(fetch, pendingPaymentContexts);
+
+  // Create the payment-enabled fetch
+  const x402Fetch = wrapFetch(adaptiveFetch, {
+    handlers: [gaslessHandler],
+    phase1Fetch: normalizingFetch,
+    retryCount: 3,
+    returnPaymentFailure: true,
+  });
+
+  // Balance helper
+  const getBalances = async (): Promise<{ sol: number; usdc: number }> => {
+    const solBalance = await connection.getBalance(walletPubkey);
+    let usdcBalance = 0;
+    try {
+      const usdcAta = await getAssociatedTokenAddress(usdcMint, walletPubkey);
+      const tokenAccount = await getAccount(connection, usdcAta);
+      usdcBalance = Number(tokenAccount.amount) / Math.pow(10, USDC_DECIMALS);
+    } catch {
+      // Token account doesn't exist yet
+    }
+    return {
+      sol: solBalance / LAMPORTS_PER_SOL,
+      usdc: usdcBalance,
+    };
+  };
+
+  return {
+    x402Fetch,
+    walletAddress,
+    getBalances,
+    network,
+  };
+}
+
+// ============================================================================
+// INTERNAL: Protocol helpers (not exported)
+// ============================================================================
+
+function getExpectedRequirementNetworks(
+  network: "devnet" | "mainnet-beta",
+): Set<string> {
+  if (network === "devnet") {
+    return new Set(["solana-devnet", SOLANA_DEVNET_CAIP2.toLowerCase()]);
+  }
+  return new Set([
+    "solana-mainnet-beta",
+    "solana",
+    SOLANA_MAINNET_CAIP2.toLowerCase(),
+  ]);
+}
+
+function createGaslessPaymentHandler(
+  wallet: GaslessWallet,
+  usdcMint: PublicKey,
+  connection: Connection,
+  expectedNetworks: ReadonlySet<string>,
+  configuredNetworkLabel: string,
+  pendingPaymentContexts: Map<string, PaymentContext>,
+): PaymentHandler {
+  return async (_ctx, accepts) => {
+    const execers: PaymentExecer[] = [];
+    const incompatibilityReasons: string[] = [];
+    let sawSolanaRequirement = false;
+
+    for (const req of accepts) {
+      const requirementNetwork = req.network.toLowerCase();
+      const isSolana =
+        requirementNetwork.includes("solana") ||
+        requirementNetwork.startsWith("solana:");
+
+      if (!isSolana) continue;
+      sawSolanaRequirement = true;
+
+      if (!expectedNetworks.has(requirementNetwork)) {
+        incompatibilityReasons.push(
+          `network '${req.network}' does not match configured RPC network '${configuredNetworkLabel}'`,
+        );
+        continue;
+      }
+
+      const extra = req.extra as Record<string, unknown> | undefined;
+      const feePayer = extra?.feePayer as string | undefined;
+      if (!feePayer) {
+        incompatibilityReasons.push(
+          `requirement for network '${req.network}' is missing extra.feePayer`,
+        );
+        continue;
+      }
+
+      if (req.asset.toLowerCase() !== usdcMint.toBase58().toLowerCase()) {
+        incompatibilityReasons.push(
+          `asset mismatch for network '${req.network}': got ${req.asset}, expected ${usdcMint.toBase58()}`,
+        );
+        continue;
+      }
+
+      execers.push({
+        requirements: req,
+        exec: async () => {
+          const feePayerPubkey = new PublicKey(feePayer);
+          const payToPubkey = new PublicKey(req.payTo);
+          const amount = BigInt(req.maxAmountRequired);
+
+          const sourceAta = await getAssociatedTokenAddress(
+            usdcMint,
+            wallet.publicKey,
+          );
+          const destAta = await getAssociatedTokenAddress(usdcMint, payToPubkey);
+
+          const computeUnitLimitIx = ComputeBudgetProgram.setComputeUnitLimit({
+            units: 50000,
+          });
+          const computeUnitPriceIx = ComputeBudgetProgram.setComputeUnitPrice({
+            microLamports: 1,
+          });
+          const transferIx = createTransferCheckedInstruction(
+            sourceAta,
+            usdcMint,
+            destAta,
+            wallet.publicKey,
+            amount,
+            USDC_DECIMALS,
+            [],
+            TOKEN_PROGRAM_ID,
+          );
+
+          const extraBlockhash = extra?.recentBlockhash as string | undefined;
+          const { blockhash } = extraBlockhash
+            ? { blockhash: extraBlockhash }
+            : await connection.getLatestBlockhash("confirmed");
+
+          const message = new TransactionMessage({
+            payerKey: feePayerPubkey,
+            recentBlockhash: blockhash,
+            instructions: [computeUnitLimitIx, computeUnitPriceIx, transferIx],
+          }).compileToV0Message();
+
+          const tx = new VersionedTransaction(message);
+          const signedTx = await wallet.signTransaction(tx);
+          const serialized = Buffer.from(signedTx.serialize()).toString("base64");
+
+          const originalNetwork =
+            typeof (req as Record<string, unknown>).originalNetwork === "string"
+              ? ((req as Record<string, unknown>).originalNetwork as string)
+              : req.network;
+
+          if (originalNetwork.includes(":")) {
+            pendingPaymentContexts.set(serialized, {
+              accepted: {
+                scheme: req.scheme,
+                network: originalNetwork,
+                amount: req.maxAmountRequired,
+                asset: req.asset,
+                payTo: req.payTo,
+                maxTimeoutSeconds: req.maxTimeoutSeconds,
+                ...(req.extra
+                  ? { extra: req.extra as Record<string, unknown> }
+                  : {}),
+              },
+            });
+          }
+
+          return { payload: { transaction: serialized } };
+        },
+      });
+    }
+
+    if (
+      execers.length === 0 &&
+      sawSolanaRequirement &&
+      incompatibilityReasons.length > 0
+    ) {
+      const hint = `Expected one of: ${Array.from(expectedNetworks).join(", ")}`;
+      throw new Error(
+        `No compatible Solana payment requirements found. ${hint}. Reasons: ${incompatibilityReasons.join("; ")}`,
+      );
+    }
+
+    return execers;
+  };
+}
+
+function normalizeRequirement(
+  req: Record<string, unknown>,
+): Record<string, unknown> {
+  const normalized = { ...req };
+
+  if (normalized.amount && !normalized.maxAmountRequired) {
+    normalized.maxAmountRequired = normalized.amount;
+  }
+
+  if (
+    typeof normalized.network === "string" &&
+    normalized.network.startsWith("solana:")
+  ) {
+    const genesisHash = normalized.network.split(":")[1];
+    const networkMap: Record<string, string> = {
+      [SOLANA_DEVNET_CAIP2.split(":")[1]]: "solana-devnet",
+      [SOLANA_MAINNET_CAIP2.split(":")[1]]: "solana-mainnet-beta",
+    };
+    normalized.originalNetwork = normalized.network;
+    normalized.network = networkMap[genesisHash] ?? normalized.network;
+  }
+
+  const extra = normalized.extra as Record<string, unknown> | undefined;
+  if (extra) {
+    if (!normalized.description && extra.description) {
+      normalized.description = extra.description;
+    }
+    if (normalized.mimeType === undefined && extra.mimeType !== undefined) {
+      normalized.mimeType = extra.mimeType || "application/octet-stream";
+    }
+    if (!normalized.resource && extra.resource) {
+      normalized.resource = extra.resource;
+    }
+  }
+
+  if (!normalized.description) normalized.description = "";
+  if (!normalized.mimeType) normalized.mimeType = "application/octet-stream";
+  if (!normalized.resource) normalized.resource = "";
+
+  return normalized;
+}
+
+function createV2NormalizingFetch(baseFetch: typeof fetch): typeof fetch {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const response = await baseFetch(input, init);
+
+    if (response.status !== 402) {
+      return response;
+    }
+
+    const bodyText = await response.text();
+    const headers = new Headers(response.headers);
+    const contentType = headers.get("content-type")?.toLowerCase() ?? "";
+    const isJsonResponse =
+      contentType.includes("application/json") ||
+      contentType.includes("+json") ||
+      bodyText.trim().startsWith("{") ||
+      bodyText.trim().startsWith("[");
+
+    if (!isJsonResponse) {
+      return new Response(bodyText, {
+        status: 402,
+        statusText: response.statusText,
+        headers,
+      });
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(bodyText);
+    } catch {
+      return new Response(bodyText, {
+        status: 402,
+        statusText: response.statusText,
+        headers,
+      });
+    }
+
+    if (!body || typeof body !== "object") {
+      return new Response(bodyText, {
+        status: 402,
+        statusText: response.statusText,
+        headers,
+      });
+    }
+
+    const normalizedBody = body as Record<string, unknown>;
+
+    if (Array.isArray(normalizedBody.accepts)) {
+      normalizedBody.accepts = normalizedBody.accepts.map((accept) => {
+        if (!accept || typeof accept !== "object") {
+          return accept;
+        }
+        return normalizeRequirement(accept as Record<string, unknown>);
+      });
+    }
+
+    return new Response(JSON.stringify(normalizedBody), {
+      status: 402,
+      statusText: response.statusText,
+      headers,
+    });
+  };
+}
+
+function createAdaptivePaymentFetch(
+  baseFetch: typeof fetch,
+  pendingPaymentContexts: Map<string, PaymentContext>,
+): typeof fetch {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const headers = new Headers(init?.headers);
+
+    const xPayment = headers.get("X-PAYMENT");
+    if (xPayment) {
+      try {
+        const payloadJson = atob(xPayment);
+        const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+        const tx = (payload.payload as Record<string, unknown> | undefined)
+          ?.transaction;
+
+        if (typeof tx === "string") {
+          const context = pendingPaymentContexts.get(tx);
+          if (context) {
+            const v2Payload = {
+              x402Version: 2,
+              scheme: context.accepted.scheme,
+              network: context.accepted.network,
+              accepted: context.accepted,
+              payload: payload.payload,
+              extensions: {},
+            };
+
+            const fixedPayment = btoa(JSON.stringify(v2Payload));
+            headers.set("X-PAYMENT", fixedPayment);
+            headers.set("PAYMENT-SIGNATURE", fixedPayment);
+            pendingPaymentContexts.delete(tx);
+          }
+        }
+      } catch {
+        // If decoding fails, leave headers unchanged
+      }
+    }
+
+    return baseFetch(input, { ...init, headers });
+  };
+}

--- a/examples/with-x402-faremeter/src/x402-client.ts
+++ b/examples/with-x402-faremeter/src/x402-client.ts
@@ -134,11 +134,50 @@ export async function createX402Client(
   // This handles gasless transactions (fee payer in extra.feePayer) automatically.
   const paymentHandler = createPaymentHandler(wallet, usdcMint, connection);
 
+  // Some x402 servers send a PAYMENT-REQUIRED header (v2) but omit the
+  // required `resource` object. This minimal phase1Fetch patches that so
+  // faremeter's v2 validation passes. Once servers fully implement v2,
+  // this can be removed and plain `fetch` used for both.
+  const patchV2Fetch: typeof fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const response = await fetch(input, init);
+    if (response.status !== 402) return response;
+
+    const v2Header = response.headers.get("PAYMENT-REQUIRED");
+    if (!v2Header) return response;
+
+    try {
+      const decoded = JSON.parse(atob(v2Header));
+      if (!decoded.resource) {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        decoded.resource = { url };
+        const headers = new Headers(response.headers);
+        headers.set("PAYMENT-REQUIRED", btoa(JSON.stringify(decoded)));
+        return new Response(response.body, {
+          status: 402,
+          statusText: response.statusText,
+          headers,
+        });
+      }
+    } catch {
+      // If decoding fails, let faremeter handle the error
+    }
+    return response;
+  };
+
   // Create the payment-enabled fetch.
-  // As of faremeter v0.17.0, protocol normalization (lenient 402 responses,
+  // As of faremeter v0.17.0, protocol normalization (lenient v1 responses,
   // CAIP-2 network identifiers) and x402 v2 headers are handled internally.
   const x402Fetch = wrapFetch(fetch, {
     handlers: [paymentHandler],
+    phase1Fetch: patchV2Fetch,
     retryCount: 3,
     returnPaymentFailure: true,
   });

--- a/examples/with-x402-faremeter/src/x402-client.ts
+++ b/examples/with-x402-faremeter/src/x402-client.ts
@@ -16,8 +16,6 @@ import { getOrCreateSolanaWallet } from "./utils.js";
 // ============================================================================
 
 const USDC_DECIMALS = 6;
-const SOLANA_DEVNET_CAIP2 = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
-const SOLANA_MAINNET_CAIP2 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
 
 const USDC_MINTS = {
   devnet: new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
@@ -57,18 +55,9 @@ interface TurnkeyWallet {
   updateTransaction: (
     tx: VersionedTransaction,
   ) => Promise<VersionedTransaction>;
-}
-
-interface PaymentContext {
-  accepted: {
-    scheme: string;
-    network: string;
-    amount: string;
-    asset: string;
-    payTo: string;
-    maxTimeoutSeconds: number;
-    extra?: Record<string, unknown>;
-  };
+  partiallySignTransaction: (
+    tx: VersionedTransaction,
+  ) => Promise<VersionedTransaction>;
 }
 
 // ============================================================================
@@ -124,36 +113,32 @@ export async function createX402Client(
   const usdcMint = USDC_MINTS[network];
 
   // Create Turnkey wallet adapter compatible with faremeter's interface.
-  // The `updateTransaction` hook is called by faremeter to sign the payment transaction.
+  // Both `updateTransaction` and `partiallySignTransaction` delegate to
+  // Turnkey's signer — the distinction is for faremeter's internal flow.
   // See: https://docs.corbits.dev/api/reference/payment-solana/overview
+  const signWithTurnkey = async (
+    tx: VersionedTransaction,
+  ): Promise<VersionedTransaction> => {
+    const signedTx = await signer.signTransaction(tx, walletAddress);
+    return signedTx as VersionedTransaction;
+  };
+
   const wallet: TurnkeyWallet = {
     network,
     publicKey: walletPubkey,
-    updateTransaction: async (tx: VersionedTransaction) => {
-      const signedTx = await signer.signTransaction(tx, walletAddress);
-      return signedTx as VersionedTransaction;
-    },
+    updateTransaction: signWithTurnkey,
+    partiallySignTransaction: signWithTurnkey,
   };
 
   // Create payment handler using faremeter's exact payment implementation.
   // This handles gasless transactions (fee payer in extra.feePayer) automatically.
   const paymentHandler = createPaymentHandler(wallet, usdcMint, connection);
 
-  // Track payment context for v2 header formatting
-  const pendingPaymentContexts = new Map<string, PaymentContext>();
-
-  // Create normalizing fetch to handle servers that don't include all required fields.
-  // This adds missing fields (description, mimeType, resource) and converts
-  // `amount` to `maxAmountRequired` for protocol compatibility.
-  const normalizingFetch = createNormalizingFetch(fetch, pendingPaymentContexts);
-
-  // Create adaptive fetch that adds PAYMENT-SIGNATURE header with v2 format
-  const adaptiveFetch = createAdaptivePaymentFetch(fetch, pendingPaymentContexts);
-
-  // Create the payment-enabled fetch
-  const x402Fetch = wrapFetch(adaptiveFetch, {
+  // Create the payment-enabled fetch.
+  // As of faremeter v0.17.0, protocol normalization (lenient 402 responses,
+  // CAIP-2 network identifiers) and x402 v2 headers are handled internally.
+  const x402Fetch = wrapFetch(fetch, {
     handlers: [paymentHandler],
-    phase1Fetch: normalizingFetch,
     retryCount: 3,
     returnPaymentFailure: true,
   });
@@ -180,213 +165,5 @@ export async function createX402Client(
     walletAddress,
     getBalances,
     network,
-  };
-}
-
-// ============================================================================
-// INTERNAL: Protocol normalization
-// ============================================================================
-
-/**
- * Normalize a payment requirement to include all fields faremeter expects.
- * Some x402 servers omit optional fields or use `amount` instead of `maxAmountRequired`.
- */
-function normalizeRequirement(
-  req: Record<string, unknown>,
-): Record<string, unknown> {
-  const normalized = { ...req };
-
-  // Convert `amount` to `maxAmountRequired` (protocol variation)
-  if (normalized.amount && !normalized.maxAmountRequired) {
-    normalized.maxAmountRequired = normalized.amount;
-  }
-
-  // Convert CAIP-2 network identifiers to faremeter's expected format
-  if (
-    typeof normalized.network === "string" &&
-    normalized.network.startsWith("solana:")
-  ) {
-    const genesisHash = normalized.network.split(":")[1];
-    const networkMap: Record<string, string> = {
-      [SOLANA_DEVNET_CAIP2.split(":")[1]]: "solana-devnet",
-      [SOLANA_MAINNET_CAIP2.split(":")[1]]: "solana-mainnet-beta",
-    };
-    normalized.originalNetwork = normalized.network;
-    normalized.network = networkMap[genesisHash] ?? normalized.network;
-  }
-
-  // Extract fields from `extra` if not present at top level
-  const extra = normalized.extra as Record<string, unknown> | undefined;
-  if (extra) {
-    if (!normalized.description && extra.description) {
-      normalized.description = extra.description;
-    }
-    if (normalized.mimeType === undefined && extra.mimeType !== undefined) {
-      normalized.mimeType = extra.mimeType || "application/octet-stream";
-    }
-    if (!normalized.resource && extra.resource) {
-      normalized.resource = extra.resource;
-    }
-  }
-
-  // Provide defaults for required fields that faremeter validates
-  if (!normalized.description) normalized.description = "";
-  if (!normalized.mimeType) normalized.mimeType = "application/octet-stream";
-  if (!normalized.resource) normalized.resource = "";
-
-  return normalized;
-}
-
-/**
- * Wrap fetch to normalize 402 responses before faremeter parses them.
- * This handles servers that don't include all fields faremeter requires.
- * Also stores original payment context for v2 header formatting.
- */
-function createNormalizingFetch(
-  baseFetch: typeof fetch,
-  pendingPaymentContexts: Map<string, PaymentContext>,
-): typeof fetch {
-  return async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const response = await baseFetch(input, init);
-
-    if (response.status !== 402) {
-      return response;
-    }
-
-    const bodyText = await response.text();
-    const headers = new Headers(response.headers);
-    const contentType = headers.get("content-type")?.toLowerCase() ?? "";
-    const isJsonResponse =
-      contentType.includes("application/json") ||
-      contentType.includes("+json") ||
-      bodyText.trim().startsWith("{") ||
-      bodyText.trim().startsWith("[");
-
-    if (!isJsonResponse) {
-      return new Response(bodyText, {
-        status: 402,
-        statusText: response.statusText,
-        headers,
-      });
-    }
-
-    let body: unknown;
-    try {
-      body = JSON.parse(bodyText);
-    } catch {
-      return new Response(bodyText, {
-        status: 402,
-        statusText: response.statusText,
-        headers,
-      });
-    }
-
-    if (!body || typeof body !== "object") {
-      return new Response(bodyText, {
-        status: 402,
-        statusText: response.statusText,
-        headers,
-      });
-    }
-
-    const normalizedBody = body as Record<string, unknown>;
-
-    if (Array.isArray(normalizedBody.accepts)) {
-      normalizedBody.accepts = normalizedBody.accepts.map((accept) => {
-        if (!accept || typeof accept !== "object") {
-          return accept;
-        }
-        return normalizeRequirement(accept as Record<string, unknown>);
-      });
-    }
-
-    // Store payment context for each requirement (for v2 header formatting later)
-    if (Array.isArray(normalizedBody.accepts)) {
-      for (const accept of normalizedBody.accepts) {
-        if (accept && typeof accept === "object") {
-          const req = accept as Record<string, unknown>;
-          const originalNetwork = req.originalNetwork as string | undefined;
-          if (originalNetwork) {
-            // Key by payTo+amount+asset to match later
-            const key = `${req.payTo}:${req.maxAmountRequired}:${req.asset}`;
-            pendingPaymentContexts.set(key, {
-              accepted: {
-                scheme: (req.scheme as string) || "exact",
-                network: originalNetwork,
-                amount: req.maxAmountRequired as string,
-                asset: req.asset as string,
-                payTo: req.payTo as string,
-                maxTimeoutSeconds: (req.maxTimeoutSeconds as number) || 60,
-                ...(req.extra
-                  ? { extra: req.extra as Record<string, unknown> }
-                  : {}),
-              },
-            });
-          }
-        }
-      }
-    }
-
-    return new Response(JSON.stringify(normalizedBody), {
-      status: 402,
-      statusText: response.statusText,
-      headers,
-    });
-  };
-}
-
-/**
- * Wrap fetch to add PAYMENT-SIGNATURE header with v2 format.
- * This is required by servers expecting x402 v2 protocol.
- */
-function createAdaptivePaymentFetch(
-  baseFetch: typeof fetch,
-  pendingPaymentContexts: Map<string, PaymentContext>,
-): typeof fetch {
-  return async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const headers = new Headers(init?.headers);
-
-    const xPayment = headers.get("X-PAYMENT");
-    if (xPayment) {
-      try {
-        const payloadJson = atob(xPayment);
-        const payload = JSON.parse(payloadJson) as Record<string, unknown>;
-
-        // Find matching context by looking at all stored contexts
-        // and use the first one (since we typically have one payment at a time)
-        const contexts = Array.from(pendingPaymentContexts.entries());
-        if (contexts.length > 0) {
-          const [key, context] = contexts[0];
-
-          const v2Payload = {
-            x402Version: 2,
-            scheme: context.accepted.scheme,
-            network: context.accepted.network,
-            accepted: context.accepted,
-            payload: payload.payload ?? payload,
-            extensions: {},
-          };
-
-          const fixedPayment = btoa(JSON.stringify(v2Payload));
-          headers.set("X-PAYMENT", fixedPayment);
-          headers.set("PAYMENT-SIGNATURE", fixedPayment);
-          pendingPaymentContexts.delete(key);
-        } else {
-          // No stored context, just copy X-PAYMENT to PAYMENT-SIGNATURE
-          headers.set("PAYMENT-SIGNATURE", xPayment);
-        }
-      } catch {
-        // If decoding fails, just copy the header
-        headers.set("PAYMENT-SIGNATURE", xPayment);
-      }
-    }
-
-    return baseFetch(input, { ...init, headers });
   };
 }

--- a/examples/with-x402-faremeter/src/x402-client.ts
+++ b/examples/with-x402-faremeter/src/x402-client.ts
@@ -52,9 +52,6 @@ export interface X402Client {
 interface TurnkeyWallet {
   network: string;
   publicKey: PublicKey;
-  updateTransaction: (
-    tx: VersionedTransaction,
-  ) => Promise<VersionedTransaction>;
   partiallySignTransaction: (
     tx: VersionedTransaction,
   ) => Promise<VersionedTransaction>;
@@ -112,22 +109,16 @@ export async function createX402Client(
   const network = rpcUrl.includes("devnet") ? "devnet" : "mainnet-beta";
   const usdcMint = USDC_MINTS[network];
 
-  // Create Turnkey wallet adapter compatible with faremeter's interface.
-  // Both `updateTransaction` and `partiallySignTransaction` delegate to
-  // Turnkey's signer — the distinction is for faremeter's internal flow.
+  // Faremeter assembles the payment transaction (fee payer from
+  // requirements.extra.feePayer, blockhash, SPL transfer instructions) and
+  // then calls partiallySignTransaction to have the payer wallet add its
+  // signature. Turnkey signs without exposing the private key.
   // See: https://docs.corbits.dev/api/reference/payment-solana/overview
-  const signWithTurnkey = async (
-    tx: VersionedTransaction,
-  ): Promise<VersionedTransaction> => {
-    const signedTx = await signer.signTransaction(tx, walletAddress);
-    return signedTx as VersionedTransaction;
-  };
-
   const wallet: TurnkeyWallet = {
     network,
     publicKey: walletPubkey,
-    updateTransaction: signWithTurnkey,
-    partiallySignTransaction: signWithTurnkey,
+    partiallySignTransaction: async (tx) =>
+      (await signer.signTransaction(tx, walletAddress)) as VersionedTransaction,
   };
 
   // Create payment handler using faremeter's exact payment implementation.

--- a/examples/with-x402-faremeter/src/x402-client.ts
+++ b/examples/with-x402-faremeter/src/x402-client.ts
@@ -22,6 +22,13 @@ const USDC_MINTS = {
   "mainnet-beta": new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
 };
 
+// Genesis hashes are fixed per Solana cluster and are the authoritative
+// way to identify which network an RPC endpoint is serving.
+const GENESIS_HASHES: Record<string, "devnet" | "mainnet-beta"> = {
+  EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG: "devnet",
+  "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d": "mainnet-beta",
+};
+
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -32,6 +39,11 @@ export interface X402ClientConfig {
   organizationId: string;
   rpcUrl?: string;
   baseUrl?: string;
+  /**
+   * Override the detected Solana network. If unset, the network is
+   * detected by calling `getGenesisHash()` on the RPC endpoint.
+   */
+  network?: "devnet" | "mainnet-beta";
 }
 
 export interface X402Client {
@@ -104,9 +116,23 @@ export async function createX402Client(
   const walletAddress = await getOrCreateSolanaWallet(turnkey.apiClient());
   const walletPubkey = new PublicKey(walletAddress);
 
-  // Set up connection and detect network
+  // Set up connection and resolve network via genesis hash (or explicit override)
   const connection = new Connection(rpcUrl, "confirmed");
-  const network = rpcUrl.includes("devnet") ? "devnet" : "mainnet-beta";
+  let network: "devnet" | "mainnet-beta";
+  if (config.network) {
+    network = config.network;
+  } else {
+    const genesisHash = await connection.getGenesisHash();
+    const detected = GENESIS_HASHES[genesisHash];
+    if (!detected) {
+      throw new Error(
+        `Unknown Solana cluster (genesis hash: ${genesisHash}). ` +
+          `Only devnet and mainnet-beta are supported. ` +
+          `Pass an explicit 'network' in X402ClientConfig to override.`,
+      );
+    }
+    network = detected;
+  }
   const usdcMint = USDC_MINTS[network];
 
   // Faremeter assembles the payment transaction (fee payer from

--- a/examples/with-x402-faremeter/src/x402-client.ts
+++ b/examples/with-x402-faremeter/src/x402-client.ts
@@ -155,6 +155,7 @@ export async function createX402Client(
   // required `resource` object. This minimal phase1Fetch patches that so
   // faremeter's v2 validation passes. Once servers fully implement v2,
   // this can be removed and plain `fetch` used for both.
+  let hasWarnedAboutBadV2Header = false;
   const patchV2Fetch: typeof fetch = async (
     input: RequestInfo | URL,
     init?: RequestInit,
@@ -183,8 +184,15 @@ export async function createX402Client(
           headers,
         });
       }
-    } catch {
-      // If decoding fails, let faremeter handle the error
+    } catch (err) {
+      if (!hasWarnedAboutBadV2Header) {
+        hasWarnedAboutBadV2Header = true;
+        console.warn(
+          "x402: failed to decode PAYMENT-REQUIRED header; " +
+            "the server may be sending a malformed v2 response.",
+          err,
+        );
+      }
     }
     return response;
   };

--- a/examples/with-x402-faremeter/tsconfig.json
+++ b/examples/with-x402-faremeter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"]
+}

--- a/examples/with-x402-faremeter/tsconfig.json
+++ b/examples/with-x402-faremeter/tsconfig.json
@@ -10,6 +10,7 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "noEmit": true,
+    "incremental": true,
     "tsBuildInfoFile": "./.cache/.tsbuildinfo"
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"]

--- a/examples/with-x402-faremeter/tsconfig.json
+++ b/examples/with-x402-faremeter/tsconfig.json
@@ -1,6 +1,14 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
     "noEmit": true,
     "tsBuildInfoFile": "./.cache/.tsbuildinfo"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3392,6 +3392,36 @@ importers:
         specifier: ^5
         version: 5.4.3
 
+  examples/with-x402-faremeter:
+    dependencies:
+      '@faremeter/fetch':
+        specifier: ^0.16.0
+        version: 0.16.0
+      '@faremeter/info':
+        specifier: ^0.16.0
+        version: 0.16.0
+      '@faremeter/payment-solana':
+        specifier: ^0.16.0
+        version: 0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@faremeter/types':
+        specifier: ^0.16.0
+        version: 0.16.0
+      '@solana/spl-token':
+        specifier: ^0.4.9
+        version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js':
+        specifier: ^1.95.8
+        version: 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@turnkey/sdk-server':
+        specifier: workspace:*
+        version: link:../../packages/sdk-server
+      '@turnkey/solana':
+        specifier: workspace:*
+        version: link:../../packages/solana
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.0.3
+
   examples/with-yield-xyz:
     dependencies:
       '@turnkey/ethers':
@@ -4276,6 +4306,12 @@ packages:
     resolution: {integrity: sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==}
     engines: {node: '>=15.10.0'}
     deprecated: <1.0.0 is no longer supported please upgrade to the latest version
+
+  '@ark/schema@0.47.0':
+    resolution: {integrity: sha512-s5Hc1TUmRiA+NhewAHZJtl7xuFN0y4vAdv/JrvgCxgf1NKwBAylTvqCnQ8iPYn8kG3qAmHwgPpbJ+C5iHKJsbQ==}
+
+  '@ark/util@0.47.0':
+    resolution: {integrity: sha512-KAOwSSjgZCEYd/3QEIjmq1LRHnVk2fOjypGVfm3V+1C7KrSsV5yRoQjb50b0KTuA1A317G9LXz+UD6g4O1A6NA==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -5899,6 +5935,26 @@ packages:
       '@farcaster/frame-sdk': ^0.0.28
       '@wagmi/core': ^2.14.1
       viem: ^2.21.55
+
+  '@faremeter/fetch@0.16.0':
+    resolution: {integrity: sha512-dcITgX/U1c0hUYhafSgExdLyuv2DM5qyFnhQXLFHrGW1iSgsY8oNBAm4twF6jo/qC7TjZZ2QAt4OtvupwfR07g==}
+
+  '@faremeter/info@0.16.0':
+    resolution: {integrity: sha512-eVg0MjaqfDjSOb6p444EvAuBY0uIqXziVxNxkKAeoq7eON550ukz0cJPdUNEGx3jQfUM6/D4TEHDj3GVv7xlvg==}
+
+  '@faremeter/logs@0.16.0':
+    resolution: {integrity: sha512-1f4XHqGklWtdBd6kdFDEJ9tGLtqIxe3GqclPN4nlO64HLX4nHyzoD+QLEqLqR0008MJj278RyVZ4FwWbCrP6nw==}
+    peerDependencies:
+      '@logtape/logtape': 1.0.4
+    peerDependenciesMeta:
+      '@logtape/logtape':
+        optional: true
+
+  '@faremeter/payment-solana@0.16.0':
+    resolution: {integrity: sha512-ohtystWMIqW52lrOWryJrCjkhOihnkjMCcZJG8P17OBQuYhVnBBZ2yg9BOSMEp/XuLH87+KF+VywF5SSczle1A==}
+
+  '@faremeter/types@0.16.0':
+    resolution: {integrity: sha512-YwUtY5anged4QC7I+kAFOeuYN4+VXEodmZX/b02hGOjbXc4gjCZV5sUXsFEAoCw+Ru8O2vbPcKcPgekas1ELsA==}
 
   '@fivebinaries/coin-selection@3.0.0':
     resolution: {integrity: sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==}
@@ -8101,6 +8157,11 @@ packages:
     peerDependencies:
       '@solana/kit': ^2.1.0
 
+  '@solana-program/memo@0.10.0':
+    resolution: {integrity: sha512-1FvQFenL3lzl5SpxhWV4QJCOLU/nvAOXGXjKjS7dprvG+0u971xoanApN7bM/a4NFZolp6S+lP2xVl6vTVIxbg==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
   '@solana-program/stake@0.2.1':
     resolution: {integrity: sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==}
     peerDependencies:
@@ -8146,6 +8207,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/addresses@5.0.0':
+    resolution: {integrity: sha512-bVk+khc1ZZQHMri25csosM/ikuyPcB/CZidDM/ZMBX0CoJErpHJnmcID5mYOmv4/UHbqo2OANuEaGcFO0Q37sw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/assertions@2.3.0':
     resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
     engines: {node: '>=20.18.0'}
@@ -8154,6 +8221,12 @@ packages:
 
   '@solana/assertions@3.0.3':
     resolution: {integrity: sha512-2qspxdbWp2y62dfCIlqeWQr4g+hE8FYSSwcaP6itwMwGRb8393yDGCJfI/znuzJh6m/XVWhMHIgFgsBwnevCmg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/assertions@5.0.0':
+    resolution: {integrity: sha512-2kIykk90kYciQW6bp+KaE6jRd1Y2CgHPeJxxlc5chQnjhoG6eiD8VXvocs6AvqPTht0p/SoEj9jH5tT4oG/bcg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8183,6 +8256,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/codecs-core@5.0.0':
+    resolution: {integrity: sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs-data-structures@2.0.0-rc.1':
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
@@ -8196,6 +8275,12 @@ packages:
 
   '@solana/codecs-data-structures@3.0.3':
     resolution: {integrity: sha512-R15cLp8riJvToXziW8lP6AMSwsztGhEnwgyGmll32Mo0Yjq+hduW2/fJrA/TJs6tA/OgTzMQjlxgk009EqZHCw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/codecs-data-structures@5.0.0':
+    resolution: {integrity: sha512-y503Pqmv0LHcfcf0vQJGaxDvydQJbyCo8nK3nxn56EhFj5lBQ1NWb3WvTd83epigwuZurW2MhJARrpikfhQglQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8217,6 +8302,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/codecs-numbers@5.0.0':
+    resolution: {integrity: sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs-strings@2.0.0-rc.1':
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
@@ -8232,6 +8323,13 @@ packages:
 
   '@solana/codecs-strings@3.0.3':
     resolution: {integrity: sha512-VHBXnnTVtcQ1j+7Vrz+qSYo38no+jiHRdGnhFspRXEHNJbllzwKqgBE7YN3qoIXH+MKxgJUcwO5KHmdzf8Wn2A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.3.3'
+
+  '@solana/codecs-strings@5.0.0':
+    resolution: {integrity: sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -8274,8 +8372,21 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/errors@5.0.0':
+    resolution: {integrity: sha512-gTuhzO6E+ydfAAzqmqdPcvFyJwAzFKKIrqtnZPpgAuomcPYu+HSo0tuwSM/cTX0djmHt+GoOsf/julph+nvs2w==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/fast-stable-stringify@2.3.0':
     resolution: {integrity: sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/fast-stable-stringify@5.0.0':
+    resolution: {integrity: sha512-sGTbu7a4/olL+8EIOOJ7IZjzqOOpCJcK1UaVJ6015sRgo9vwGf4jg9KtXEYv5LVhLCTYmAb50L4BaIUcBph/Ig==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8286,14 +8397,32 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/functional@5.0.0':
+    resolution: {integrity: sha512-UNBrpfzBL4dKD2iucjNnrkFbnjz5ZYDu2OvrIBAcCSQsxxgHMamUj1n3EDe6kl1us49YG1r05Ho8QLqNrbkVbw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/instructions@2.3.0':
     resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/instructions@5.0.0':
+    resolution: {integrity: sha512-12dbrmwERT1o6NTr/Uvrjj/ZsiteSXoT5Gi+dnjIeRNHWg9H+gEFuFzJvTDVKlNg34CZ71xdvbVdbV0V8gKGvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/keys@2.3.0':
     resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/keys@5.0.0':
+    resolution: {integrity: sha512-kWkR7NslpTttk5i1BhBNCDtVQDkEtgkdsM3Jp9TGPk0GFjBjBwrQStw3vvwLe8itEIvRFGFZU6JHEk8HLS0WLQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8312,6 +8441,12 @@ packages:
 
   '@solana/nominal-types@3.0.3':
     resolution: {integrity: sha512-aZavCiexeUAoMHRQg4s1AHkH3wscbOb70diyfjhwZVgFz1uUsFez7csPp9tNFkNolnadVb2gky7yBk3IImQJ6A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/nominal-types@5.0.0':
+    resolution: {integrity: sha512-Qn7xH4UG2rDAv+wAyheP4jWvX3oQmbZ/woxFZwug7PaRLvyjUswGr38Hil+SjiQyFDo+un1UqWM9N9yusUeeZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8351,8 +8486,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-api@5.0.0':
+    resolution: {integrity: sha512-IJbZZnX2B1ldXPok1NhneXTYq9ZvdJbE5Pryr03pZTlPJaWGqDcZuQ14nwR4s6PoUUgdT+p87QlLZqLb8MusoQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-parsed-types@2.3.0':
     resolution: {integrity: sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc-parsed-types@5.0.0':
+    resolution: {integrity: sha512-fU9uqlOYAaBqgk2qCl+ntenBm7wuSFBRbIO/rVjeBPd/qPCvNZU+qFET+ERLK6wbCTSz0MmdHqPn1V8KCMOvZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8369,6 +8516,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-spec-types@5.0.0':
+    resolution: {integrity: sha512-B0P/ylXVaCG5oSIV+kB88s2qoW996D8iKhc7RyF0C/AyYvklF6kCwv0N9ZVrWp0ibjlQ8St290WbBHJyo7QZkA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-spec@2.3.0':
     resolution: {integrity: sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==}
     engines: {node: '>=20.18.0'}
@@ -8377,6 +8530,12 @@ packages:
 
   '@solana/rpc-spec@3.0.3':
     resolution: {integrity: sha512-MZn5/8BebB6MQ4Gstw6zyfWsFAZYAyLzMK+AUf/rSfT8tPmWiJ/mcxnxqOXvFup/l6D67U8pyGpIoFqwCeZqqA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc-spec@5.0.0':
+    resolution: {integrity: sha512-1LD2SYEQ5bYhiBumznAPzymtxSX4nYLZd6u+FA0bAxNBVzHDvUUQzVSXHAoWROhlGrCyvtALTs9u0DIDlgZHCA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8412,8 +8571,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-transformers@5.0.0':
+    resolution: {integrity: sha512-EMHhSgfF6/T4FfHbLaBP08SIj1ZAjxJr6WPNZMHLV7Cup8UfiB9TNV+bPQkum7JbVQNhUKzkKEEmyYqPfQoV9w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-transport-http@2.3.0':
     resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc-transport-http@5.0.0':
+    resolution: {integrity: sha512-RoIEvWp7yc7rIRzNkOyjLs2UQF0odIEMWj87dbD4Ir4hwTCGo/TSTfQF/8KDV2etdke3Fa1K+W1NkpG2POqWFg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8430,8 +8601,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-types@5.0.0':
+    resolution: {integrity: sha512-JMbhwnV6nX4ezJv/KmaElOR0r/MZTKzKpaz6cv7FopLNuPrYCBrRCZKuM2XQh6gUbt9Mey08/KBOmOGmzTbL/g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc@2.3.0':
     resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc@5.0.0':
+    resolution: {integrity: sha512-Myx/ZBmMHkgh9Di3tLzc+vd30f+6YC1JXr9+YmIHKEeqN/+iTHkDJU2E/hGRLy8vTOBOU7+2466A+dLnSVuGkg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8453,6 +8636,12 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token@0.4.13':
+    resolution: {integrity: sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.5
 
   '@solana/spl-token@0.4.14':
     resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
@@ -8490,8 +8679,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/transaction-messages@5.0.0':
+    resolution: {integrity: sha512-rJLe1wUGW5DovQFV0gjXHXnriPxTBgZ3TvGWnjCu2OIBU8mcQkQVJ7zzVZY2IAYlmJ6OSF9nvzhSt/ncPbkJPg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/transactions@2.3.0':
     resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/transactions@5.0.0':
+    resolution: {integrity: sha512-4TcsqH7JtgRKGGBIRRGz0n+tXu4h5TPPC49kkV0ygIndQaHW7FOZUYTwQ0epq0A5h9KYi+ClNbzF9xiuDbAD5Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -10192,6 +10393,9 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  arktype@2.1.21:
+    resolution: {integrity: sha512-RPsqONfr/hi8nnlzqSn1i3oMAtvFqt8jIVD7tIFoqP+/wu0Jb04f0bQOLBBDILWv+tjBxBqmCeIfO4f9AMYktw==}
+
   array-back@3.1.0:
     resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
     engines: {node: '>=6'}
@@ -11012,6 +11216,10 @@ packages:
 
   commander@14.0.0:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
+
+  commander@14.0.1:
+    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
   commander@2.20.3:
@@ -15986,6 +16194,9 @@ packages:
   undici-types@7.15.0:
     resolution: {integrity: sha512-Xyn5T99wU4kPhLZMm+ElE6M+IoSeG8Se7eG9xoZ82ZgVHJ07wb/IWcDZeXe2GOPkavcJ8ko5oSlXMDRl/QgY9Q==}
 
+  undici-types@7.22.0:
+    resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
+
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
@@ -16739,6 +16950,12 @@ snapshots:
       got: 11.8.6
     transitivePeerDependencies:
       - debug
+
+  '@ark/schema@0.47.0':
+    dependencies:
+      '@ark/util': 0.47.0
+
+  '@ark/util@0.47.0': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -20007,6 +20224,48 @@ snapshots:
       '@farcaster/frame-sdk': 0.0.28(typescript@5.4.3)(zod@4.1.11)
       '@wagmi/core': 2.21.2(@tanstack/query-core@5.90.2)(@types/react@18.2.14)(react@18.2.0)(typescript@5.4.3)(use-sync-external-store@1.5.0(react@18.2.0))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))
       viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+
+  '@faremeter/fetch@0.16.0':
+    dependencies:
+      '@faremeter/types': 0.16.0
+      arktype: 2.1.21
+
+  '@faremeter/info@0.16.0':
+    dependencies:
+      '@faremeter/types': 0.16.0
+      arktype: 2.1.21
+
+  '@faremeter/logs@0.16.0': {}
+
+  '@faremeter/payment-solana@0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@faremeter/info': 0.16.0
+      '@faremeter/logs': 0.16.0
+      '@faremeter/types': 0.16.0
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/memo': 0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/spl-token': 0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      arktype: 2.1.21
+    transitivePeerDependencies:
+      - '@logtape/logtape'
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@faremeter/types@0.16.0':
+    dependencies:
+      arktype: 2.1.21
 
   '@fivebinaries/coin-selection@3.0.0':
     dependencies:
@@ -24363,6 +24622,10 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
+  '@solana-program/memo@0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+
   '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -24426,6 +24689,17 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/addresses@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/assertions': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/assertions@2.3.0(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -24434,6 +24708,11 @@ snapshots:
   '@solana/assertions@3.0.3(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.4.3)
+      typescript: 5.4.3
+
+  '@solana/assertions@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/buffer-layout-utils@0.2.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)':
@@ -24472,6 +24751,11 @@ snapshots:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       typescript: 5.4.3
 
+  '@solana/codecs-core@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+
   '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.4.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.4.3)
@@ -24491,6 +24775,13 @@ snapshots:
       '@solana/codecs-core': 3.0.3(typescript@5.4.3)
       '@solana/codecs-numbers': 3.0.3(typescript@5.4.3)
       '@solana/errors': 3.0.3(typescript@5.4.3)
+      typescript: 5.4.3
+
+  '@solana/codecs-data-structures@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.4.3)':
@@ -24517,6 +24808,12 @@ snapshots:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       typescript: 5.4.3
 
+  '@solana/codecs-numbers@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+
   '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.4.3)
@@ -24538,6 +24835,14 @@ snapshots:
       '@solana/codecs-core': 3.0.3(typescript@5.4.3)
       '@solana/codecs-numbers': 3.0.3(typescript@5.4.3)
       '@solana/errors': 3.0.3(typescript@5.4.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.4.3
+
+  '@solana/codecs-strings@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.4.3
 
@@ -24598,11 +24903,25 @@ snapshots:
       commander: 14.0.0
       typescript: 5.4.3
 
+  '@solana/errors@5.0.0(typescript@5.4.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.1
+      typescript: 5.4.3
+
   '@solana/fast-stable-stringify@2.3.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
+  '@solana/fast-stable-stringify@5.0.0(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
   '@solana/functional@2.3.0(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/functional@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -24612,6 +24931,12 @@ snapshots:
       '@solana/errors': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
 
+  '@solana/instructions@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+
   '@solana/keys@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/assertions': 2.3.0(typescript@5.4.3)
@@ -24619,6 +24944,17 @@ snapshots:
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/errors': 2.3.0(typescript@5.4.3)
       '@solana/nominal-types': 2.3.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/keys@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/assertions': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -24653,6 +24989,10 @@ snapshots:
       typescript: 5.4.3
 
   '@solana/nominal-types@3.0.3(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/nominal-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -24718,7 +25058,28 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-api@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-parsed-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-parsed-types@2.3.0(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/rpc-parsed-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -24727,6 +25088,10 @@ snapshots:
       typescript: 5.4.3
 
   '@solana/rpc-spec-types@3.0.3(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/rpc-spec-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -24740,6 +25105,12 @@ snapshots:
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.4.3)
+      typescript: 5.4.3
+
+  '@solana/rpc-spec@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/rpc-subscriptions-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
@@ -24801,6 +25172,17 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-transformers@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-transport-http@2.3.0(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -24808,6 +25190,14 @@ snapshots:
       '@solana/rpc-spec-types': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
       undici-types: 7.15.0
+
+  '@solana/rpc-transport-http@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+      undici-types: 7.22.0
 
   '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
@@ -24833,6 +25223,18 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-types@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -24844,6 +25246,21 @@ snapshots:
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/rpc-transport-http': 2.3.0(typescript@5.4.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/fast-stable-stringify': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-transport-http': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -24877,6 +25294,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
+
+  '@solana/spl-token@0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -24950,6 +25382,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/transaction-messages@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/instructions': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/transactions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
@@ -24964,6 +25411,24 @@ snapshots:
       '@solana/nominal-types': 2.3.0(typescript@5.4.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/instructions': 5.0.0(typescript@5.4.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -29951,6 +30416,11 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  arktype@2.1.21:
+    dependencies:
+      '@ark/schema': 0.47.0
+      '@ark/util': 0.47.0
+
   array-back@3.1.0: {}
 
   array-back@4.0.2: {}
@@ -31043,6 +31513,8 @@ snapshots:
   commander@13.1.0: {}
 
   commander@14.0.0: {}
+
+  commander@14.0.1: {}
 
   commander@2.20.3: {}
 
@@ -38126,6 +38598,8 @@ snapshots:
   undici-types@7.14.0: {}
 
   undici-types@7.15.0: {}
+
+  undici-types@7.22.0: {}
 
   undici@7.24.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3397,12 +3397,6 @@ importers:
       '@faremeter/fetch':
         specifier: ^0.16.0
         version: 0.16.0
-      '@faremeter/info':
-        specifier: ^0.16.0
-        version: 0.16.0
-      '@faremeter/payment-solana':
-        specifier: ^0.16.0
-        version: 0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@faremeter/types':
         specifier: ^0.16.0
         version: 0.16.0
@@ -5939,20 +5933,6 @@ packages:
   '@faremeter/fetch@0.16.0':
     resolution: {integrity: sha512-dcITgX/U1c0hUYhafSgExdLyuv2DM5qyFnhQXLFHrGW1iSgsY8oNBAm4twF6jo/qC7TjZZ2QAt4OtvupwfR07g==}
 
-  '@faremeter/info@0.16.0':
-    resolution: {integrity: sha512-eVg0MjaqfDjSOb6p444EvAuBY0uIqXziVxNxkKAeoq7eON550ukz0cJPdUNEGx3jQfUM6/D4TEHDj3GVv7xlvg==}
-
-  '@faremeter/logs@0.16.0':
-    resolution: {integrity: sha512-1f4XHqGklWtdBd6kdFDEJ9tGLtqIxe3GqclPN4nlO64HLX4nHyzoD+QLEqLqR0008MJj278RyVZ4FwWbCrP6nw==}
-    peerDependencies:
-      '@logtape/logtape': 1.0.4
-    peerDependenciesMeta:
-      '@logtape/logtape':
-        optional: true
-
-  '@faremeter/payment-solana@0.16.0':
-    resolution: {integrity: sha512-ohtystWMIqW52lrOWryJrCjkhOihnkjMCcZJG8P17OBQuYhVnBBZ2yg9BOSMEp/XuLH87+KF+VywF5SSczle1A==}
-
   '@faremeter/types@0.16.0':
     resolution: {integrity: sha512-YwUtY5anged4QC7I+kAFOeuYN4+VXEodmZX/b02hGOjbXc4gjCZV5sUXsFEAoCw+Ru8O2vbPcKcPgekas1ELsA==}
 
@@ -8157,11 +8137,6 @@ packages:
     peerDependencies:
       '@solana/kit': ^2.1.0
 
-  '@solana-program/memo@0.10.0':
-    resolution: {integrity: sha512-1FvQFenL3lzl5SpxhWV4QJCOLU/nvAOXGXjKjS7dprvG+0u971xoanApN7bM/a4NFZolp6S+lP2xVl6vTVIxbg==}
-    peerDependencies:
-      '@solana/kit': ^5.0
-
   '@solana-program/stake@0.2.1':
     resolution: {integrity: sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==}
     peerDependencies:
@@ -8207,12 +8182,6 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/addresses@5.0.0':
-    resolution: {integrity: sha512-bVk+khc1ZZQHMri25csosM/ikuyPcB/CZidDM/ZMBX0CoJErpHJnmcID5mYOmv4/UHbqo2OANuEaGcFO0Q37sw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/assertions@2.3.0':
     resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
     engines: {node: '>=20.18.0'}
@@ -8221,12 +8190,6 @@ packages:
 
   '@solana/assertions@3.0.3':
     resolution: {integrity: sha512-2qspxdbWp2y62dfCIlqeWQr4g+hE8FYSSwcaP6itwMwGRb8393yDGCJfI/znuzJh6m/XVWhMHIgFgsBwnevCmg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/assertions@5.0.0':
-    resolution: {integrity: sha512-2kIykk90kYciQW6bp+KaE6jRd1Y2CgHPeJxxlc5chQnjhoG6eiD8VXvocs6AvqPTht0p/SoEj9jH5tT4oG/bcg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8256,12 +8219,6 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-core@5.0.0':
-    resolution: {integrity: sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-data-structures@2.0.0-rc.1':
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
@@ -8275,12 +8232,6 @@ packages:
 
   '@solana/codecs-data-structures@3.0.3':
     resolution: {integrity: sha512-R15cLp8riJvToXziW8lP6AMSwsztGhEnwgyGmll32Mo0Yjq+hduW2/fJrA/TJs6tA/OgTzMQjlxgk009EqZHCw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/codecs-data-structures@5.0.0':
-    resolution: {integrity: sha512-y503Pqmv0LHcfcf0vQJGaxDvydQJbyCo8nK3nxn56EhFj5lBQ1NWb3WvTd83epigwuZurW2MhJARrpikfhQglQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8302,12 +8253,6 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-numbers@5.0.0':
-    resolution: {integrity: sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-strings@2.0.0-rc.1':
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
@@ -8323,13 +8268,6 @@ packages:
 
   '@solana/codecs-strings@3.0.3':
     resolution: {integrity: sha512-VHBXnnTVtcQ1j+7Vrz+qSYo38no+jiHRdGnhFspRXEHNJbllzwKqgBE7YN3qoIXH+MKxgJUcwO5KHmdzf8Wn2A==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.3.3'
-
-  '@solana/codecs-strings@5.0.0':
-    resolution: {integrity: sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -8372,21 +8310,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/errors@5.0.0':
-    resolution: {integrity: sha512-gTuhzO6E+ydfAAzqmqdPcvFyJwAzFKKIrqtnZPpgAuomcPYu+HSo0tuwSM/cTX0djmHt+GoOsf/julph+nvs2w==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/fast-stable-stringify@2.3.0':
     resolution: {integrity: sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/fast-stable-stringify@5.0.0':
-    resolution: {integrity: sha512-sGTbu7a4/olL+8EIOOJ7IZjzqOOpCJcK1UaVJ6015sRgo9vwGf4jg9KtXEYv5LVhLCTYmAb50L4BaIUcBph/Ig==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8397,32 +8322,14 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/functional@5.0.0':
-    resolution: {integrity: sha512-UNBrpfzBL4dKD2iucjNnrkFbnjz5ZYDu2OvrIBAcCSQsxxgHMamUj1n3EDe6kl1us49YG1r05Ho8QLqNrbkVbw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/instructions@2.3.0':
     resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/instructions@5.0.0':
-    resolution: {integrity: sha512-12dbrmwERT1o6NTr/Uvrjj/ZsiteSXoT5Gi+dnjIeRNHWg9H+gEFuFzJvTDVKlNg34CZ71xdvbVdbV0V8gKGvg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/keys@2.3.0':
     resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/keys@5.0.0':
-    resolution: {integrity: sha512-kWkR7NslpTttk5i1BhBNCDtVQDkEtgkdsM3Jp9TGPk0GFjBjBwrQStw3vvwLe8itEIvRFGFZU6JHEk8HLS0WLQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8441,12 +8348,6 @@ packages:
 
   '@solana/nominal-types@3.0.3':
     resolution: {integrity: sha512-aZavCiexeUAoMHRQg4s1AHkH3wscbOb70diyfjhwZVgFz1uUsFez7csPp9tNFkNolnadVb2gky7yBk3IImQJ6A==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/nominal-types@5.0.0':
-    resolution: {integrity: sha512-Qn7xH4UG2rDAv+wAyheP4jWvX3oQmbZ/woxFZwug7PaRLvyjUswGr38Hil+SjiQyFDo+un1UqWM9N9yusUeeZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8486,20 +8387,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-api@5.0.0':
-    resolution: {integrity: sha512-IJbZZnX2B1ldXPok1NhneXTYq9ZvdJbE5Pryr03pZTlPJaWGqDcZuQ14nwR4s6PoUUgdT+p87QlLZqLb8MusoQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/rpc-parsed-types@2.3.0':
     resolution: {integrity: sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-parsed-types@5.0.0':
-    resolution: {integrity: sha512-fU9uqlOYAaBqgk2qCl+ntenBm7wuSFBRbIO/rVjeBPd/qPCvNZU+qFET+ERLK6wbCTSz0MmdHqPn1V8KCMOvZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8516,12 +8405,6 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-spec-types@5.0.0':
-    resolution: {integrity: sha512-B0P/ylXVaCG5oSIV+kB88s2qoW996D8iKhc7RyF0C/AyYvklF6kCwv0N9ZVrWp0ibjlQ8St290WbBHJyo7QZkA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/rpc-spec@2.3.0':
     resolution: {integrity: sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==}
     engines: {node: '>=20.18.0'}
@@ -8530,12 +8413,6 @@ packages:
 
   '@solana/rpc-spec@3.0.3':
     resolution: {integrity: sha512-MZn5/8BebB6MQ4Gstw6zyfWsFAZYAyLzMK+AUf/rSfT8tPmWiJ/mcxnxqOXvFup/l6D67U8pyGpIoFqwCeZqqA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-spec@5.0.0':
-    resolution: {integrity: sha512-1LD2SYEQ5bYhiBumznAPzymtxSX4nYLZd6u+FA0bAxNBVzHDvUUQzVSXHAoWROhlGrCyvtALTs9u0DIDlgZHCA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8571,20 +8448,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-transformers@5.0.0':
-    resolution: {integrity: sha512-EMHhSgfF6/T4FfHbLaBP08SIj1ZAjxJr6WPNZMHLV7Cup8UfiB9TNV+bPQkum7JbVQNhUKzkKEEmyYqPfQoV9w==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/rpc-transport-http@2.3.0':
     resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-transport-http@5.0.0':
-    resolution: {integrity: sha512-RoIEvWp7yc7rIRzNkOyjLs2UQF0odIEMWj87dbD4Ir4hwTCGo/TSTfQF/8KDV2etdke3Fa1K+W1NkpG2POqWFg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8601,20 +8466,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/rpc-types@5.0.0':
-    resolution: {integrity: sha512-JMbhwnV6nX4ezJv/KmaElOR0r/MZTKzKpaz6cv7FopLNuPrYCBrRCZKuM2XQh6gUbt9Mey08/KBOmOGmzTbL/g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/rpc@2.3.0':
     resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc@5.0.0':
-    resolution: {integrity: sha512-Myx/ZBmMHkgh9Di3tLzc+vd30f+6YC1JXr9+YmIHKEeqN/+iTHkDJU2E/hGRLy8vTOBOU7+2466A+dLnSVuGkg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8636,12 +8489,6 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.3
-
-  '@solana/spl-token@0.4.13':
-    resolution: {integrity: sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@solana/web3.js': ^1.95.5
 
   '@solana/spl-token@0.4.14':
     resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
@@ -8679,20 +8526,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/transaction-messages@5.0.0':
-    resolution: {integrity: sha512-rJLe1wUGW5DovQFV0gjXHXnriPxTBgZ3TvGWnjCu2OIBU8mcQkQVJ7zzVZY2IAYlmJ6OSF9nvzhSt/ncPbkJPg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/transactions@2.3.0':
     resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/transactions@5.0.0':
-    resolution: {integrity: sha512-4TcsqH7JtgRKGGBIRRGz0n+tXu4h5TPPC49kkV0ygIndQaHW7FOZUYTwQ0epq0A5h9KYi+ClNbzF9xiuDbAD5Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -11216,10 +11051,6 @@ packages:
 
   commander@14.0.0:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
-    engines: {node: '>=20'}
-
-  commander@14.0.1:
-    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
   commander@2.20.3:
@@ -16194,9 +16025,6 @@ packages:
   undici-types@7.15.0:
     resolution: {integrity: sha512-Xyn5T99wU4kPhLZMm+ElE6M+IoSeG8Se7eG9xoZ82ZgVHJ07wb/IWcDZeXe2GOPkavcJ8ko5oSlXMDRl/QgY9Q==}
 
-  undici-types@7.22.0:
-    resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
-
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
@@ -20229,39 +20057,6 @@ snapshots:
     dependencies:
       '@faremeter/types': 0.16.0
       arktype: 2.1.21
-
-  '@faremeter/info@0.16.0':
-    dependencies:
-      '@faremeter/types': 0.16.0
-      arktype: 2.1.21
-
-  '@faremeter/logs@0.16.0': {}
-
-  '@faremeter/payment-solana@0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@faremeter/info': 0.16.0
-      '@faremeter/logs': 0.16.0
-      '@faremeter/types': 0.16.0
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/memo': 0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/rpc-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/spl-token': 0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)
-      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
-      arktype: 2.1.21
-    transitivePeerDependencies:
-      - '@logtape/logtape'
-      - bufferutil
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
-      - ws
 
   '@faremeter/types@0.16.0':
     dependencies:
@@ -24622,10 +24417,6 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/memo@0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-
   '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -24689,17 +24480,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/assertions': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
   '@solana/assertions@2.3.0(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -24708,11 +24488,6 @@ snapshots:
   '@solana/assertions@3.0.3(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.4.3)
-      typescript: 5.4.3
-
-  '@solana/assertions@5.0.0(typescript@5.4.3)':
-    dependencies:
-      '@solana/errors': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/buffer-layout-utils@0.2.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)':
@@ -24751,11 +24526,6 @@ snapshots:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       typescript: 5.4.3
 
-  '@solana/codecs-core@5.0.0(typescript@5.4.3)':
-    dependencies:
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      typescript: 5.4.3
-
   '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.4.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.4.3)
@@ -24775,13 +24545,6 @@ snapshots:
       '@solana/codecs-core': 3.0.3(typescript@5.4.3)
       '@solana/codecs-numbers': 3.0.3(typescript@5.4.3)
       '@solana/errors': 3.0.3(typescript@5.4.3)
-      typescript: 5.4.3
-
-  '@solana/codecs-data-structures@5.0.0(typescript@5.4.3)':
-    dependencies:
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.4.3)':
@@ -24808,12 +24571,6 @@ snapshots:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       typescript: 5.4.3
 
-  '@solana/codecs-numbers@5.0.0(typescript@5.4.3)':
-    dependencies:
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      typescript: 5.4.3
-
   '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.4.3)
@@ -24835,14 +24592,6 @@ snapshots:
       '@solana/codecs-core': 3.0.3(typescript@5.4.3)
       '@solana/codecs-numbers': 3.0.3(typescript@5.4.3)
       '@solana/errors': 3.0.3(typescript@5.4.3)
-      fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.4.3
-
-  '@solana/codecs-strings@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.4.3
 
@@ -24903,25 +24652,11 @@ snapshots:
       commander: 14.0.0
       typescript: 5.4.3
 
-  '@solana/errors@5.0.0(typescript@5.4.3)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.1
-      typescript: 5.4.3
-
   '@solana/fast-stable-stringify@2.3.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
-  '@solana/fast-stable-stringify@5.0.0(typescript@5.4.3)':
-    dependencies:
-      typescript: 5.4.3
-
   '@solana/functional@2.3.0(typescript@5.4.3)':
-    dependencies:
-      typescript: 5.4.3
-
-  '@solana/functional@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -24931,12 +24666,6 @@ snapshots:
       '@solana/errors': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
 
-  '@solana/instructions@5.0.0(typescript@5.4.3)':
-    dependencies:
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      typescript: 5.4.3
-
   '@solana/keys@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/assertions': 2.3.0(typescript@5.4.3)
@@ -24944,17 +24673,6 @@ snapshots:
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/errors': 2.3.0(typescript@5.4.3)
       '@solana/nominal-types': 2.3.0(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/keys@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/assertions': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -24989,10 +24707,6 @@ snapshots:
       typescript: 5.4.3
 
   '@solana/nominal-types@3.0.3(typescript@5.4.3)':
-    dependencies:
-      typescript: 5.4.3
-
-  '@solana/nominal-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -25058,28 +24772,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/rpc-parsed-types': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
   '@solana/rpc-parsed-types@2.3.0(typescript@5.4.3)':
-    dependencies:
-      typescript: 5.4.3
-
-  '@solana/rpc-parsed-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -25088,10 +24781,6 @@ snapshots:
       typescript: 5.4.3
 
   '@solana/rpc-spec-types@3.0.3(typescript@5.4.3)':
-    dependencies:
-      typescript: 5.4.3
-
-  '@solana/rpc-spec-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -25105,12 +24794,6 @@ snapshots:
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.4.3)
-      typescript: 5.4.3
-
-  '@solana/rpc-spec@5.0.0(typescript@5.4.3)':
-    dependencies:
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/rpc-subscriptions-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
@@ -25172,17 +24855,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transformers@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/functional': 5.0.0(typescript@5.4.3)
-      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
   '@solana/rpc-transport-http@2.3.0(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -25190,14 +24862,6 @@ snapshots:
       '@solana/rpc-spec-types': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
       undici-types: 7.15.0
-
-  '@solana/rpc-transport-http@5.0.0(typescript@5.4.3)':
-    dependencies:
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
-      typescript: 5.4.3
-      undici-types: 7.22.0
 
   '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
@@ -25223,18 +24887,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
   '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -25246,21 +24898,6 @@ snapshots:
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/rpc-transport-http': 2.3.0(typescript@5.4.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/fast-stable-stringify': 5.0.0(typescript@5.4.3)
-      '@solana/functional': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/rpc-transport-http': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -25294,21 +24931,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
-
-  '@solana/spl-token@0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
-      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
 
   '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -25382,21 +25004,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-data-structures': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/functional': 5.0.0(typescript@5.4.3)
-      '@solana/instructions': 5.0.0(typescript@5.4.3)
-      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
   '@solana/transactions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
@@ -25411,24 +25018,6 @@ snapshots:
       '@solana/nominal-types': 2.3.0(typescript@5.4.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transactions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
-    dependencies:
-      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-data-structures': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
-      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/errors': 5.0.0(typescript@5.4.3)
-      '@solana/functional': 5.0.0(typescript@5.4.3)
-      '@solana/instructions': 5.0.0(typescript@5.4.3)
-      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
-      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
-      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -31513,8 +31102,6 @@ snapshots:
   commander@13.1.0: {}
 
   commander@14.0.0: {}
-
-  commander@14.0.1: {}
 
   commander@2.20.3: {}
 
@@ -38598,8 +38185,6 @@ snapshots:
   undici-types@7.14.0: {}
 
   undici-types@7.15.0: {}
-
-  undici-types@7.22.0: {}
 
   undici@7.24.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3415,6 +3415,10 @@ importers:
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
   examples/with-yield-xyz:
     dependencies:
@@ -5385,6 +5389,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -5393,6 +5403,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.10':
     resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -5409,6 +5425,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -5417,6 +5439,12 @@ packages:
 
   '@esbuild/android-x64@0.25.10':
     resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -5433,6 +5461,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -5441,6 +5475,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.10':
     resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -5457,6 +5497,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -5465,6 +5511,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.10':
     resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -5481,6 +5533,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -5489,6 +5547,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.10':
     resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -5505,6 +5569,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -5513,6 +5583,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.10':
     resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -5529,6 +5605,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -5537,6 +5619,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.10':
     resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -5553,6 +5641,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -5561,6 +5655,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.10':
     resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -5577,8 +5677,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.10':
     resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -5595,8 +5707,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.10':
     resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -5613,8 +5737,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.10':
     resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -5631,6 +5767,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
@@ -5639,6 +5781,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.10':
     resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -5655,6 +5803,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -5663,6 +5817,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.10':
     resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -11685,6 +11845,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -15841,6 +16006,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
@@ -19360,10 +19530,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.10':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -19372,10 +19548,16 @@ snapshots:
   '@esbuild/android-arm@0.25.10':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -19384,10 +19566,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.10':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -19396,10 +19584,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.10':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -19408,10 +19602,16 @@ snapshots:
   '@esbuild/linux-arm64@0.25.10':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -19420,10 +19620,16 @@ snapshots:
   '@esbuild/linux-ia32@0.25.10':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -19432,10 +19638,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.10':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -19444,10 +19656,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.10':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
   '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -19456,7 +19674,13 @@ snapshots:
   '@esbuild/linux-x64@0.25.10':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-x64@0.18.20':
@@ -19465,7 +19689,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.10':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -19474,7 +19704,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.10':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/sunos-x64@0.18.20':
@@ -19483,10 +19719,16 @@ snapshots:
   '@esbuild/sunos-x64@0.25.10':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-ia32@0.18.20':
@@ -19495,10 +19737,16 @@ snapshots:
   '@esbuild/win32-ia32@0.25.10':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@8.56.0)':
@@ -31910,6 +32158,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.10
       '@esbuild/win32-x64': 0.25.10
 
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -38005,6 +38282,13 @@ snapshots:
   tsx@4.20.6:
     dependencies:
       esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2861,7 +2861,7 @@ importers:
     dependencies:
       '@buildonspark/issuer-sdk':
         specifier: ^0.1.23
-        version: 0.1.23(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 0.1.32(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@buildonspark/spark-sdk':
         specifier: 0.7.5
         version: 0.7.5(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -2886,7 +2886,7 @@ importers:
     devDependencies:
       tsx:
         specifier: ^4.7.0
-        version: 4.20.6
+        version: 4.21.0
       typescript:
         specifier: 5.4.3
         version: 5.4.3
@@ -3397,6 +3397,9 @@ importers:
       '@faremeter/fetch':
         specifier: ^0.16.0
         version: 0.16.0
+      '@faremeter/payment-solana':
+        specifier: ^0.16.0
+        version: 0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@faremeter/types':
         specifier: ^0.16.0
         version: 0.16.0
@@ -5142,8 +5145,23 @@ packages:
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
 
-  '@buildonspark/issuer-sdk@0.1.23':
-    resolution: {integrity: sha512-INArHAU4TMXcvTjoqz2bU9+TiOGU33WudkBLuvgXyT0f1plevqxeWf2JsK/I6euWAwtxrN9TEi7opRQgzbiqjg==}
+  '@buildonspark/issuer-sdk@0.1.32':
+    resolution: {integrity: sha512-jAPL8Kb8Y46nAidkrVX3eSsuGHc54WimlSQcxnyFzl4tWRDKUYCeTkjhRHyt2j+7fSLDX8ISUM/El/FHB2h/Eg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: '>=18.2.0'
+      react-native: '>=0.71.0'
+      react-native-get-random-values: '>=1.11.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-native:
+        optional: true
+      react-native-get-random-values:
+        optional: true
+
+  '@buildonspark/spark-sdk@0.7.14':
+    resolution: {integrity: sha512-R/kJp+MSPQDvV6QfFGEBV9um6hhQNN60vWGA+e5hdh/cMroVL9BAmz7h4cNxXHZM0PhpMW18PeLVg9Qjhh9ipQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: '>=18.2.0'
@@ -6093,6 +6111,20 @@ packages:
   '@faremeter/fetch@0.16.0':
     resolution: {integrity: sha512-dcITgX/U1c0hUYhafSgExdLyuv2DM5qyFnhQXLFHrGW1iSgsY8oNBAm4twF6jo/qC7TjZZ2QAt4OtvupwfR07g==}
 
+  '@faremeter/info@0.16.0':
+    resolution: {integrity: sha512-eVg0MjaqfDjSOb6p444EvAuBY0uIqXziVxNxkKAeoq7eON550ukz0cJPdUNEGx3jQfUM6/D4TEHDj3GVv7xlvg==}
+
+  '@faremeter/logs@0.16.0':
+    resolution: {integrity: sha512-1f4XHqGklWtdBd6kdFDEJ9tGLtqIxe3GqclPN4nlO64HLX4nHyzoD+QLEqLqR0008MJj278RyVZ4FwWbCrP6nw==}
+    peerDependencies:
+      '@logtape/logtape': 1.0.4
+    peerDependenciesMeta:
+      '@logtape/logtape':
+        optional: true
+
+  '@faremeter/payment-solana@0.16.0':
+    resolution: {integrity: sha512-ohtystWMIqW52lrOWryJrCjkhOihnkjMCcZJG8P17OBQuYhVnBBZ2yg9BOSMEp/XuLH87+KF+VywF5SSczle1A==}
+
   '@faremeter/types@0.16.0':
     resolution: {integrity: sha512-YwUtY5anged4QC7I+kAFOeuYN4+VXEodmZX/b02hGOjbXc4gjCZV5sUXsFEAoCw+Ru8O2vbPcKcPgekas1ELsA==}
 
@@ -6688,11 +6720,9 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
-    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
-    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -6702,11 +6732,9 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
-    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
-    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -7105,14 +7133,14 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/context-async-hooks@2.6.1':
-    resolution: {integrity: sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==}
+  '@opentelemetry/context-async-hooks@2.7.0':
+    resolution: {integrity: sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.6.1':
-    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -7129,26 +7157,26 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/resources@2.6.1':
-    resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.6.1':
-    resolution: {integrity: sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==}
+  '@opentelemetry/sdk-trace-base@2.7.0':
+    resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-node@2.6.1':
-    resolution: {integrity: sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==}
+  '@opentelemetry/sdk-trace-node@2.7.0':
+    resolution: {integrity: sha512-RrFHOXw0IYp/OThew6QORdybnnLitUAUMCJKcQNBYS0hDkCYarO2vTkVxfrGxCIqd5XHSMvbCpBd/T8ZMw8oSg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-web@2.6.1':
-    resolution: {integrity: sha512-JQevIjBlWGcKBfuwe7tdxGR/75RERsf1OOIvUzPKq86J8qhzkyjnLTTuPNPLRQF1xxEe65W5aI1Uwl6yWUGPQQ==}
+  '@opentelemetry/sdk-trace-web@2.7.0':
+    resolution: {integrity: sha512-WehQSom/hQO0uDVtYQV5O+UaTQU6UFMevYs0uE33bK/4abEyRHrIZF+3DGMmTaz08jQkCfaa0xTOpR873WKn1g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -8297,6 +8325,11 @@ packages:
     peerDependencies:
       '@solana/kit': ^2.1.0
 
+  '@solana-program/memo@0.10.0':
+    resolution: {integrity: sha512-1FvQFenL3lzl5SpxhWV4QJCOLU/nvAOXGXjKjS7dprvG+0u971xoanApN7bM/a4NFZolp6S+lP2xVl6vTVIxbg==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
   '@solana-program/stake@0.2.1':
     resolution: {integrity: sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==}
     peerDependencies:
@@ -8342,6 +8375,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/addresses@5.0.0':
+    resolution: {integrity: sha512-bVk+khc1ZZQHMri25csosM/ikuyPcB/CZidDM/ZMBX0CoJErpHJnmcID5mYOmv4/UHbqo2OANuEaGcFO0Q37sw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/assertions@2.3.0':
     resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
     engines: {node: '>=20.18.0'}
@@ -8350,6 +8389,12 @@ packages:
 
   '@solana/assertions@3.0.3':
     resolution: {integrity: sha512-2qspxdbWp2y62dfCIlqeWQr4g+hE8FYSSwcaP6itwMwGRb8393yDGCJfI/znuzJh6m/XVWhMHIgFgsBwnevCmg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/assertions@5.0.0':
+    resolution: {integrity: sha512-2kIykk90kYciQW6bp+KaE6jRd1Y2CgHPeJxxlc5chQnjhoG6eiD8VXvocs6AvqPTht0p/SoEj9jH5tT4oG/bcg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8379,6 +8424,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/codecs-core@5.0.0':
+    resolution: {integrity: sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs-data-structures@2.0.0-rc.1':
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
@@ -8392,6 +8443,12 @@ packages:
 
   '@solana/codecs-data-structures@3.0.3':
     resolution: {integrity: sha512-R15cLp8riJvToXziW8lP6AMSwsztGhEnwgyGmll32Mo0Yjq+hduW2/fJrA/TJs6tA/OgTzMQjlxgk009EqZHCw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/codecs-data-structures@5.0.0':
+    resolution: {integrity: sha512-y503Pqmv0LHcfcf0vQJGaxDvydQJbyCo8nK3nxn56EhFj5lBQ1NWb3WvTd83epigwuZurW2MhJARrpikfhQglQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8413,6 +8470,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/codecs-numbers@5.0.0':
+    resolution: {integrity: sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs-strings@2.0.0-rc.1':
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
@@ -8428,6 +8491,13 @@ packages:
 
   '@solana/codecs-strings@3.0.3':
     resolution: {integrity: sha512-VHBXnnTVtcQ1j+7Vrz+qSYo38no+jiHRdGnhFspRXEHNJbllzwKqgBE7YN3qoIXH+MKxgJUcwO5KHmdzf8Wn2A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.3.3'
+
+  '@solana/codecs-strings@5.0.0':
+    resolution: {integrity: sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -8470,8 +8540,21 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/errors@5.0.0':
+    resolution: {integrity: sha512-gTuhzO6E+ydfAAzqmqdPcvFyJwAzFKKIrqtnZPpgAuomcPYu+HSo0tuwSM/cTX0djmHt+GoOsf/julph+nvs2w==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/fast-stable-stringify@2.3.0':
     resolution: {integrity: sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/fast-stable-stringify@5.0.0':
+    resolution: {integrity: sha512-sGTbu7a4/olL+8EIOOJ7IZjzqOOpCJcK1UaVJ6015sRgo9vwGf4jg9KtXEYv5LVhLCTYmAb50L4BaIUcBph/Ig==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8482,14 +8565,32 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/functional@5.0.0':
+    resolution: {integrity: sha512-UNBrpfzBL4dKD2iucjNnrkFbnjz5ZYDu2OvrIBAcCSQsxxgHMamUj1n3EDe6kl1us49YG1r05Ho8QLqNrbkVbw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/instructions@2.3.0':
     resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/instructions@5.0.0':
+    resolution: {integrity: sha512-12dbrmwERT1o6NTr/Uvrjj/ZsiteSXoT5Gi+dnjIeRNHWg9H+gEFuFzJvTDVKlNg34CZ71xdvbVdbV0V8gKGvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/keys@2.3.0':
     resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/keys@5.0.0':
+    resolution: {integrity: sha512-kWkR7NslpTttk5i1BhBNCDtVQDkEtgkdsM3Jp9TGPk0GFjBjBwrQStw3vvwLe8itEIvRFGFZU6JHEk8HLS0WLQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8508,6 +8609,12 @@ packages:
 
   '@solana/nominal-types@3.0.3':
     resolution: {integrity: sha512-aZavCiexeUAoMHRQg4s1AHkH3wscbOb70diyfjhwZVgFz1uUsFez7csPp9tNFkNolnadVb2gky7yBk3IImQJ6A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/nominal-types@5.0.0':
+    resolution: {integrity: sha512-Qn7xH4UG2rDAv+wAyheP4jWvX3oQmbZ/woxFZwug7PaRLvyjUswGr38Hil+SjiQyFDo+un1UqWM9N9yusUeeZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8547,8 +8654,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-api@5.0.0':
+    resolution: {integrity: sha512-IJbZZnX2B1ldXPok1NhneXTYq9ZvdJbE5Pryr03pZTlPJaWGqDcZuQ14nwR4s6PoUUgdT+p87QlLZqLb8MusoQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-parsed-types@2.3.0':
     resolution: {integrity: sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc-parsed-types@5.0.0':
+    resolution: {integrity: sha512-fU9uqlOYAaBqgk2qCl+ntenBm7wuSFBRbIO/rVjeBPd/qPCvNZU+qFET+ERLK6wbCTSz0MmdHqPn1V8KCMOvZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8565,6 +8684,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-spec-types@5.0.0':
+    resolution: {integrity: sha512-B0P/ylXVaCG5oSIV+kB88s2qoW996D8iKhc7RyF0C/AyYvklF6kCwv0N9ZVrWp0ibjlQ8St290WbBHJyo7QZkA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-spec@2.3.0':
     resolution: {integrity: sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==}
     engines: {node: '>=20.18.0'}
@@ -8573,6 +8698,12 @@ packages:
 
   '@solana/rpc-spec@3.0.3':
     resolution: {integrity: sha512-MZn5/8BebB6MQ4Gstw6zyfWsFAZYAyLzMK+AUf/rSfT8tPmWiJ/mcxnxqOXvFup/l6D67U8pyGpIoFqwCeZqqA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc-spec@5.0.0':
+    resolution: {integrity: sha512-1LD2SYEQ5bYhiBumznAPzymtxSX4nYLZd6u+FA0bAxNBVzHDvUUQzVSXHAoWROhlGrCyvtALTs9u0DIDlgZHCA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8608,8 +8739,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-transformers@5.0.0':
+    resolution: {integrity: sha512-EMHhSgfF6/T4FfHbLaBP08SIj1ZAjxJr6WPNZMHLV7Cup8UfiB9TNV+bPQkum7JbVQNhUKzkKEEmyYqPfQoV9w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-transport-http@2.3.0':
     resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc-transport-http@5.0.0':
+    resolution: {integrity: sha512-RoIEvWp7yc7rIRzNkOyjLs2UQF0odIEMWj87dbD4Ir4hwTCGo/TSTfQF/8KDV2etdke3Fa1K+W1NkpG2POqWFg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8626,8 +8769,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/rpc-types@5.0.0':
+    resolution: {integrity: sha512-JMbhwnV6nX4ezJv/KmaElOR0r/MZTKzKpaz6cv7FopLNuPrYCBrRCZKuM2XQh6gUbt9Mey08/KBOmOGmzTbL/g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc@2.3.0':
     resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/rpc@5.0.0':
+    resolution: {integrity: sha512-Myx/ZBmMHkgh9Di3tLzc+vd30f+6YC1JXr9+YmIHKEeqN/+iTHkDJU2E/hGRLy8vTOBOU7+2466A+dLnSVuGkg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -8649,6 +8804,12 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token@0.4.13':
+    resolution: {integrity: sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.5
 
   '@solana/spl-token@0.4.14':
     resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
@@ -8686,8 +8847,20 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/transaction-messages@5.0.0':
+    resolution: {integrity: sha512-rJLe1wUGW5DovQFV0gjXHXnriPxTBgZ3TvGWnjCu2OIBU8mcQkQVJ7zzVZY2IAYlmJ6OSF9nvzhSt/ncPbkJPg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/transactions@2.3.0':
     resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/transactions@5.0.0':
+    resolution: {integrity: sha512-4TcsqH7JtgRKGGBIRRGz0n+tXu4h5TPPC49kkV0ygIndQaHW7FOZUYTwQ0epq0A5h9KYi+ClNbzF9xiuDbAD5Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -10261,6 +10434,9 @@ packages:
   abort-controller-x@0.4.3:
     resolution: {integrity: sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==}
 
+  abort-controller-x@0.5.0:
+    resolution: {integrity: sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -10638,8 +10814,8 @@ packages:
       bare-abort-controller:
         optional: true
 
-  bare-fetch@2.8.0:
-    resolution: {integrity: sha512-xCBF6oKwzZmq+M6FGcAHv8Fn3XEXHeauLr6dfmr5IG07PFhabg1+r9eeVaIybPAqx8syF9M9+4r23QuDvh3Uvg==}
+  bare-fetch@2.8.2:
+    resolution: {integrity: sha512-N0gZH8iuuC36Ygd4Kjfeo90aOKZ19cycbuZWVpm9W+f5v2ks/2qvgVIKp9hRDZSo5imqO097ynJcn4w24F8c/A==}
     peerDependencies:
       bare-abort-controller: '*'
       bare-buffer: '*'
@@ -10655,8 +10831,8 @@ packages:
   bare-http-parser@1.1.3:
     resolution: {integrity: sha512-+dhVvQi6brHq14L/XHNRQ+TLuVE76VjRmMt61wVEtS+Od8xUslfMHWJN/ZjIIt3RtTG6vPuA+x9cOh7KrkBJsA==}
 
-  bare-http1@4.5.5:
-    resolution: {integrity: sha512-ADITiRo0huP76JGMbv6Arsh9KehHqjEBoYcmjvAo67IY78+/9mV2MeKLLCkiJSFxA85T/m8cTaE44OwJQCcwdw==}
+  bare-http1@4.5.6:
+    resolution: {integrity: sha512-31OAwMkSU+z1VuUOCk65hx3aWQgzCfH/zQ6LGxbJtmiy2Czsw0+uvOBM9YkqaL6zUSTSYG2pLbL0v/TjME3Buw==}
     peerDependencies:
       bare-buffer: '*'
       bare-url: '*'
@@ -10698,8 +10874,8 @@ packages:
   bare-semver@1.0.1:
     resolution: {integrity: sha512-UtggzHLiTrmFOC/ogQ+Hy7VfoKoIwrP1UFcYtTxoCUdLtsIErT8+SWtOC2DH/snT9h+xDrcBEPcwKei1mzemgg==}
 
-  bare-stream@2.12.0:
-    resolution: {integrity: sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==}
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
     peerDependencies:
       bare-abort-controller: '*'
       bare-buffer: '*'
@@ -10716,19 +10892,22 @@ packages:
     resolution: {integrity: sha512-rjpqNQ2cOCkNo3NeYA/W4GTK3DRkl8sDHO3uos+AEswUjLC8XXMQF8WrJCSjlIowCbS6NUVxKE92X5RGXjyefg==}
     engines: {bare: '>=1.16.0'}
 
-  bare-tls@2.2.1:
-    resolution: {integrity: sha512-hZ+ZqwrUO4dyH7/6WYkYWjgAFNJKjzwEYJiDaMnMs+eRleBDjQ3CvNZawpkw0Ar9jnM9NZK6+f6GqjkZ2FLGmQ==}
+  bare-tls@2.2.3:
+    resolution: {integrity: sha512-dPYBGEXtgLceRFMfGaF2/rqR86/xMxMyrM9ootO/gaRKL/z2uNHJs7aP7IOBtnJF8eUCt5qwMzbKfrKgDIxPLg==}
     engines: {bare: '>=1.7.0'}
 
   bare-type@1.1.0:
     resolution: {integrity: sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==}
     engines: {bare: '>=1.2.0'}
 
+  bare-url@2.2.2:
+    resolution: {integrity: sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==}
+
   bare-url@2.4.0:
     resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
-  bare-zlib@1.3.1:
-    resolution: {integrity: sha512-VP93GFzhrTdWh9mXNocn7XsP/nF5JQluiiSsbTvsQ4yIYlhEHRMF9lQmZZDXwzK9PNYaVGUV1bdQuqp0Mj7MHw==}
+  bare-zlib@1.3.3:
+    resolution: {integrity: sha512-rXNczo+SQg6cn20olmh/mUiGeJK9maipFH/zI/QwYgwhEmOns1R7fl1GV5apNO+aAp4x2d4uUa7HLhO4mhOnBQ==}
 
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
@@ -11211,6 +11390,10 @@ packages:
 
   commander@14.0.0:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
+
+  commander@14.0.1:
+    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
   commander@2.20.3:
@@ -13837,20 +14020,20 @@ packages:
       sass:
         optional: true
 
-  nice-grpc-client-middleware-retry@3.1.13:
-    resolution: {integrity: sha512-Q9I/wm5lYkDTveKFirrTHBkBY137yavXZ4xQDXTPIycUp7aLXD8xPTHFhqtAFWUw05aS91uffZZRgdv3HS0y/g==}
+  nice-grpc-client-middleware-retry@3.1.14:
+    resolution: {integrity: sha512-n/E3n73R6N59Ef7YJ34NvCOQs45ZK4JhlKQn1uV5HuM2PktUoG2KKhoAaxn+7zdtV9dwstPLSv5IT/XxMle0og==}
 
-  nice-grpc-common@2.0.2:
-    resolution: {integrity: sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==}
+  nice-grpc-common@2.0.3:
+    resolution: {integrity: sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==}
 
-  nice-grpc-opentelemetry@0.1.20:
-    resolution: {integrity: sha512-dRH6lmm8OgqY21WRo9BP6cHHqIhbG5UT/INFne0qIDSlSseYc6s1+qNTE3Up0z/4zY50V8tVTOH30yyhkwNXTw==}
+  nice-grpc-opentelemetry@0.1.21:
+    resolution: {integrity: sha512-hH3yZoTIbC0M1SyXlF9aXxQGOmGEgg8XhV85L/i8oU4KZMF4cw1lQME8ow+ABO5lDCksI60p+ECFv3aW6lH5Xw==}
 
-  nice-grpc-web@3.3.9:
-    resolution: {integrity: sha512-CiCQLdLTux9D4try8XlHW9tHIP/uLB+aciNKErDNLUM6kzhPFaVh8q+oTkoVGOjxOacEzlOwQRRjwQETAx5lVw==}
+  nice-grpc-web@3.3.10:
+    resolution: {integrity: sha512-8XyCtbs7uL0mWQEjpkjZy57bnLbtheRbIWgj8p98XPbjFqXOBkTLu+ebj5H4fUu/yxqt+6ULPPDHT/icUsyieA==}
 
-  nice-grpc@2.1.14:
-    resolution: {integrity: sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww==}
+  nice-grpc@2.1.15:
+    resolution: {integrity: sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw==}
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
@@ -16144,6 +16327,10 @@ packages:
   ua-is-frozen@0.1.2:
     resolution: {integrity: sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==}
 
+  ua-parser-js@2.0.5:
+    resolution: {integrity: sha512-sZErtx3rhpvZQanWW5umau4o/snfoLqRcQwQIZ54377WtRzIecnIKvjpkd5JwPcSUMglGnbIgcsQBGAbdi3S9Q==}
+    hasBin: true
+
   ua-parser-js@2.0.9:
     resolution: {integrity: sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==}
     hasBin: true
@@ -16194,6 +16381,9 @@ packages:
 
   undici-types@7.15.0:
     resolution: {integrity: sha512-Xyn5T99wU4kPhLZMm+ElE6M+IoSeG8Se7eG9xoZ82ZgVHJ07wb/IWcDZeXe2GOPkavcJ8ko5oSlXMDRl/QgY9Q==}
+
+  undici-types@7.22.0:
+    resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
@@ -18898,12 +19088,60 @@ snapshots:
 
   '@bufbuild/protobuf@2.11.0': {}
 
-  '@buildonspark/issuer-sdk@0.1.23(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@buildonspark/issuer-sdk@0.1.32(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@buildonspark/spark-sdk': 0.7.5(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@buildonspark/spark-sdk': 0.7.14(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@noble/curves': 1.9.7
       '@scure/btc-signer': 1.8.1
       buffer: 6.0.3
+    optionalDependencies:
+      react: 19.2.4
+      react-native: 0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bare-events
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+      - ws
+
+  '@buildonspark/spark-sdk@0.7.14(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@lightsparkdev/core': 1.5.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.14.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.7.0(@opentelemetry/api@1.9.1)
+      '@scure/base': 1.2.6
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      '@scure/btc-signer': 1.8.1
+      abort-controller-x: 0.4.3
+      abortcontroller-polyfill: 1.7.8
+      async-mutex: 0.5.0
+      bare-crypto: 1.13.4(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-fetch: 2.8.2(bare-buffer@3.6.0)(bare-events@2.8.2)
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      js-base64: 3.7.8
+      light-bolt11-decoder: 3.2.0
+      nice-grpc: 2.1.15
+      nice-grpc-client-middleware-retry: 3.1.14
+      nice-grpc-common: 2.0.3
+      nice-grpc-opentelemetry: 0.1.21
+      nice-grpc-web: 3.3.10(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ts-proto: 2.8.3
+      ua-parser-js: 2.0.9
+      uuidv7: 1.2.1
     optionalDependencies:
       react: 19.2.4
       react-native: 0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10)
@@ -18924,13 +19162,13 @@ snapshots:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-undici': 0.14.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-web': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.7.0(@opentelemetry/api@1.9.1)
       '@scure/base': 1.2.6
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
@@ -18939,16 +19177,16 @@ snapshots:
       abortcontroller-polyfill: 1.7.8
       async-mutex: 0.5.0
       bare-crypto: 1.13.4(bare-buffer@3.6.0)(bare-events@2.8.2)
-      bare-fetch: 2.8.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-fetch: 2.8.2(bare-buffer@3.6.0)(bare-events@2.8.2)
       buffer: 6.0.3
       eventemitter3: 5.0.1
       js-base64: 3.7.8
       light-bolt11-decoder: 3.2.0
-      nice-grpc: 2.1.14
-      nice-grpc-client-middleware-retry: 3.1.13
-      nice-grpc-common: 2.0.2
-      nice-grpc-opentelemetry: 0.1.20
-      nice-grpc-web: 3.3.9(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      nice-grpc: 2.1.15
+      nice-grpc-client-middleware-retry: 3.1.14
+      nice-grpc-common: 2.0.3
+      nice-grpc-opentelemetry: 0.1.21
+      nice-grpc-web: 3.3.10(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ts-proto: 2.8.3
       ua-parser-js: 2.0.9
       uuidv7: 1.2.1
@@ -20305,6 +20543,39 @@ snapshots:
     dependencies:
       '@faremeter/types': 0.16.0
       arktype: 2.1.21
+
+  '@faremeter/info@0.16.0':
+    dependencies:
+      '@faremeter/types': 0.16.0
+      arktype: 2.1.21
+
+  '@faremeter/logs@0.16.0': {}
+
+  '@faremeter/payment-solana@0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@faremeter/info': 0.16.0
+      '@faremeter/logs': 0.16.0
+      '@faremeter/types': 0.16.0
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/memo': 0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/spl-token': 0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      arktype: 2.1.21
+    transitivePeerDependencies:
+      - '@logtape/logtape'
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
 
   '@faremeter/types@0.16.0':
     dependencies:
@@ -21817,11 +22088,11 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -21829,7 +22100,7 @@ snapshots:
   '@opentelemetry/instrumentation-undici@0.14.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
@@ -21843,31 +22114,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-node@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-trace-web@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-web@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
 
@@ -24665,6 +24936,10 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
+  '@solana-program/memo@0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+
   '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -24728,6 +25003,17 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/addresses@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/assertions': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/assertions@2.3.0(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -24736,6 +25022,11 @@ snapshots:
   '@solana/assertions@3.0.3(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.4.3)
+      typescript: 5.4.3
+
+  '@solana/assertions@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/buffer-layout-utils@0.2.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)':
@@ -24774,6 +25065,11 @@ snapshots:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       typescript: 5.4.3
 
+  '@solana/codecs-core@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+
   '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.4.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.4.3)
@@ -24793,6 +25089,13 @@ snapshots:
       '@solana/codecs-core': 3.0.3(typescript@5.4.3)
       '@solana/codecs-numbers': 3.0.3(typescript@5.4.3)
       '@solana/errors': 3.0.3(typescript@5.4.3)
+      typescript: 5.4.3
+
+  '@solana/codecs-data-structures@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.4.3)':
@@ -24819,6 +25122,12 @@ snapshots:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       typescript: 5.4.3
 
+  '@solana/codecs-numbers@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+
   '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.4.3)
@@ -24840,6 +25149,14 @@ snapshots:
       '@solana/codecs-core': 3.0.3(typescript@5.4.3)
       '@solana/codecs-numbers': 3.0.3(typescript@5.4.3)
       '@solana/errors': 3.0.3(typescript@5.4.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.4.3
+
+  '@solana/codecs-strings@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.4.3
 
@@ -24900,11 +25217,25 @@ snapshots:
       commander: 14.0.0
       typescript: 5.4.3
 
+  '@solana/errors@5.0.0(typescript@5.4.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.1
+      typescript: 5.4.3
+
   '@solana/fast-stable-stringify@2.3.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
+  '@solana/fast-stable-stringify@5.0.0(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
   '@solana/functional@2.3.0(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/functional@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -24914,6 +25245,12 @@ snapshots:
       '@solana/errors': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
 
+  '@solana/instructions@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+
   '@solana/keys@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/assertions': 2.3.0(typescript@5.4.3)
@@ -24921,6 +25258,17 @@ snapshots:
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/errors': 2.3.0(typescript@5.4.3)
       '@solana/nominal-types': 2.3.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/keys@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/assertions': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -24955,6 +25303,10 @@ snapshots:
       typescript: 5.4.3
 
   '@solana/nominal-types@3.0.3(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/nominal-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -25020,7 +25372,28 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-api@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-parsed-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-parsed-types@2.3.0(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/rpc-parsed-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -25029,6 +25402,10 @@ snapshots:
       typescript: 5.4.3
 
   '@solana/rpc-spec-types@3.0.3(typescript@5.4.3)':
+    dependencies:
+      typescript: 5.4.3
+
+  '@solana/rpc-spec-types@5.0.0(typescript@5.4.3)':
     dependencies:
       typescript: 5.4.3
 
@@ -25042,6 +25419,12 @@ snapshots:
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.4.3)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.4.3)
+      typescript: 5.4.3
+
+  '@solana/rpc-spec@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
       typescript: 5.4.3
 
   '@solana/rpc-subscriptions-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
@@ -25103,6 +25486,17 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-transformers@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-transport-http@2.3.0(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -25110,6 +25504,14 @@ snapshots:
       '@solana/rpc-spec-types': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
       undici-types: 7.15.0
+
+  '@solana/rpc-transport-http@5.0.0(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+      undici-types: 7.22.0
 
   '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
@@ -25135,6 +25537,18 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-types@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.4.3)
@@ -25146,6 +25560,21 @@ snapshots:
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/rpc-transport-http': 2.3.0(typescript@5.4.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/fast-stable-stringify': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-spec': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/rpc-transport-http': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -25179,6 +25608,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
+
+  '@solana/spl-token@0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -25252,6 +25696,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/transaction-messages@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/instructions': 5.0.0(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/transactions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
@@ -25266,6 +25725,24 @@ snapshots:
       '@solana/nominal-types': 2.3.0(typescript@5.4.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/codecs-core': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-data-structures': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-numbers': 5.0.0(typescript@5.4.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/errors': 5.0.0(typescript@5.4.3)
+      '@solana/functional': 5.0.0(typescript@5.4.3)
+      '@solana/instructions': 5.0.0(typescript@5.4.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/nominal-types': 5.0.0(typescript@5.4.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -26361,7 +26838,7 @@ snapshots:
   '@trezor/env-utils@1.4.2(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
-      ua-parser-js: 2.0.9
+      ua-parser-js: 2.0.5
     optionalDependencies:
       react-native: 0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)
 
@@ -30128,6 +30605,8 @@ snapshots:
 
   abort-controller-x@0.4.3: {}
 
+  abort-controller-x@0.5.0: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -30643,17 +31122,17 @@ snapshots:
 
   balanced-match@4.0.3: {}
 
-  bare-addon-resolve@1.9.4(bare-url@2.4.0):
+  bare-addon-resolve@1.9.4(bare-url@2.2.2):
     dependencies:
-      bare-module-resolve: 1.11.1(bare-url@2.4.0)
+      bare-module-resolve: 1.11.1(bare-url@2.2.2)
       bare-semver: 1.0.1
     optionalDependencies:
-      bare-url: 2.4.0
+      bare-url: 2.2.2
     optional: true
 
   bare-ansi-escapes@2.2.3(bare-buffer@3.6.0)(bare-events@2.8.2):
     dependencies:
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
     optionalDependencies:
       bare-buffer: 3.6.0
     transitivePeerDependencies:
@@ -30675,7 +31154,7 @@ snapshots:
   bare-crypto@1.13.4(bare-buffer@3.6.0)(bare-events@2.8.2):
     dependencies:
       bare-assert: 1.2.0(bare-buffer@3.6.0)(bare-events@2.8.2)
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
     optionalDependencies:
       bare-buffer: 3.6.0
     transitivePeerDependencies:
@@ -30687,14 +31166,14 @@ snapshots:
 
   bare-events@2.8.2: {}
 
-  bare-fetch@2.8.0(bare-buffer@3.6.0)(bare-events@2.8.2):
+  bare-fetch@2.8.2(bare-buffer@3.6.0)(bare-events@2.8.2):
     dependencies:
       bare-form-data: 1.2.1(bare-events@2.8.2)
-      bare-http1: 4.5.5(bare-buffer@3.6.0)(bare-url@2.4.0)
+      bare-http1: 4.5.6(bare-buffer@3.6.0)(bare-url@2.4.0)
       bare-https: 2.1.3(bare-buffer@3.6.0)(bare-events@2.8.2)(bare-url@2.4.0)
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
       bare-url: 2.4.0
-      bare-zlib: 1.3.1(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-zlib: 1.3.3(bare-buffer@3.6.0)(bare-events@2.8.2)
     optionalDependencies:
       bare-buffer: 3.6.0
     transitivePeerDependencies:
@@ -30704,7 +31183,7 @@ snapshots:
   bare-form-data@1.2.1(bare-events@2.8.2):
     dependencies:
       bare-buffer: 3.6.0
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-events
@@ -30712,11 +31191,11 @@ snapshots:
 
   bare-http-parser@1.1.3: {}
 
-  bare-http1@4.5.5(bare-buffer@3.6.0)(bare-url@2.4.0):
+  bare-http1@4.5.6(bare-buffer@3.6.0)(bare-url@2.4.0):
     dependencies:
       bare-events: 2.8.2
       bare-http-parser: 1.1.3
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
       bare-tcp: 2.2.7(bare-buffer@3.6.0)
     optionalDependencies:
       bare-buffer: 3.6.0
@@ -30727,9 +31206,9 @@ snapshots:
 
   bare-https@2.1.3(bare-buffer@3.6.0)(bare-events@2.8.2)(bare-url@2.4.0):
     dependencies:
-      bare-http1: 4.5.5(bare-buffer@3.6.0)(bare-url@2.4.0)
+      bare-http1: 4.5.6(bare-buffer@3.6.0)(bare-url@2.4.0)
       bare-tcp: 2.2.7(bare-buffer@3.6.0)
-      bare-tls: 2.2.1(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-tls: 2.2.3(bare-buffer@3.6.0)(bare-events@2.8.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -30747,18 +31226,18 @@ snapshots:
       - bare-events
       - react-native-b4a
 
-  bare-module-resolve@1.11.1(bare-url@2.4.0):
+  bare-module-resolve@1.11.1(bare-url@2.2.2):
     dependencies:
       bare-semver: 1.0.1
     optionalDependencies:
-      bare-url: 2.4.0
+      bare-url: 2.2.2
     optional: true
 
   bare-net@2.3.1(bare-buffer@3.6.0):
     dependencies:
       bare-events: 2.8.2
       bare-pipe: 4.1.5(bare-buffer@3.6.0)
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
       bare-tcp: 2.2.7(bare-buffer@3.6.0)
     transitivePeerDependencies:
       - bare-abort-controller
@@ -30774,7 +31253,7 @@ snapshots:
   bare-pipe@4.1.5(bare-buffer@3.6.0):
     dependencies:
       bare-events: 2.8.2
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -30783,7 +31262,7 @@ snapshots:
   bare-semver@1.0.1:
     optional: true
 
-  bare-stream@2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2):
+  bare-stream@2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2):
     dependencies:
       streamx: 2.25.0
       teex: 1.0.1
@@ -30797,16 +31276,16 @@ snapshots:
     dependencies:
       bare-dns: 2.1.4
       bare-events: 2.8.2
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
 
-  bare-tls@2.2.1(bare-buffer@3.6.0)(bare-events@2.8.2):
+  bare-tls@2.2.3(bare-buffer@3.6.0)(bare-events@2.8.2):
     dependencies:
       bare-net: 2.3.1(bare-buffer@3.6.0)
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -30815,13 +31294,18 @@ snapshots:
 
   bare-type@1.1.0: {}
 
+  bare-url@2.2.2:
+    dependencies:
+      bare-path: 3.0.0
+    optional: true
+
   bare-url@2.4.0:
     dependencies:
       bare-path: 3.0.0
 
-  bare-zlib@1.3.1(bare-buffer@3.6.0)(bare-events@2.8.2):
+  bare-zlib@1.3.3(bare-buffer@3.6.0)(bare-events@2.8.2):
     dependencies:
-      bare-stream: 2.12.0(bare-buffer@3.6.0)(bare-events@2.8.2)
+      bare-stream: 2.13.0(bare-buffer@3.6.0)(bare-events@2.8.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -31350,6 +31834,8 @@ snapshots:
   commander@13.1.0: {}
 
   commander@14.0.0: {}
+
+  commander@14.0.1: {}
 
   commander@2.20.3: {}
 
@@ -35218,37 +35704,37 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nice-grpc-client-middleware-retry@3.1.13:
+  nice-grpc-client-middleware-retry@3.1.14:
     dependencies:
-      abort-controller-x: 0.4.3
-      nice-grpc-common: 2.0.2
+      abort-controller-x: 0.5.0
+      nice-grpc-common: 2.0.3
 
-  nice-grpc-common@2.0.2:
+  nice-grpc-common@2.0.3:
     dependencies:
       ts-error: 1.0.6
 
-  nice-grpc-opentelemetry@0.1.20:
+  nice-grpc-opentelemetry@0.1.21:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
-      abort-controller-x: 0.4.3
+      abort-controller-x: 0.5.0
       ipaddr.js: 2.3.0
-      nice-grpc-common: 2.0.2
+      nice-grpc-common: 2.0.3
 
-  nice-grpc-web@3.3.9(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  nice-grpc-web@3.3.10(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
-      abort-controller-x: 0.4.3
+      abort-controller-x: 0.5.0
       isomorphic-ws: 5.0.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       js-base64: 3.7.8
-      nice-grpc-common: 2.0.2
+      nice-grpc-common: 2.0.3
     transitivePeerDependencies:
       - ws
 
-  nice-grpc@2.1.14:
+  nice-grpc@2.1.15:
     dependencies:
       '@grpc/grpc-js': 1.14.3
-      abort-controller-x: 0.4.3
-      nice-grpc-common: 2.0.2
+      abort-controller-x: 0.5.0
+      nice-grpc-common: 2.0.3
 
   no-case@3.0.4:
     dependencies:
@@ -37103,8 +37589,8 @@ snapshots:
 
   require-addon@1.1.0:
     dependencies:
-      bare-addon-resolve: 1.9.4(bare-url@2.4.0)
-      bare-url: 2.4.0
+      bare-addon-resolve: 1.9.4(bare-url@2.2.2)
+      bare-url: 2.2.2
     optional: true
 
   require-directory@2.1.1: {}
@@ -38426,6 +38912,13 @@ snapshots:
 
   ua-is-frozen@0.1.2: {}
 
+  ua-parser-js@2.0.5:
+    dependencies:
+      detect-europe-js: 0.1.2
+      is-standalone-pwa: 0.1.1
+      ua-is-frozen: 0.1.2
+      undici: 7.24.4
+
   ua-parser-js@2.0.9:
     dependencies:
       detect-europe-js: 0.1.2
@@ -38469,6 +38962,8 @@ snapshots:
   undici-types@7.14.0: {}
 
   undici-types@7.15.0: {}
+
+  undici-types@7.22.0: {}
 
   undici@7.24.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3395,14 +3395,14 @@ importers:
   examples/with-x402-faremeter:
     dependencies:
       '@faremeter/fetch':
-        specifier: ^0.16.0
-        version: 0.16.0
+        specifier: ^0.17.0
+        version: 0.17.1
       '@faremeter/payment-solana':
-        specifier: ^0.16.0
-        version: 0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: ^0.17.0
+        version: 0.17.1(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@faremeter/types':
-        specifier: ^0.16.0
-        version: 0.16.0
+        specifier: ^0.17.0
+        version: 0.17.1
       '@solana/spl-token':
         specifier: ^0.4.9
         version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)
@@ -4306,7 +4306,7 @@ packages:
   '@aptos-labs/aptos-client@0.1.1':
     resolution: {integrity: sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==}
     engines: {node: '>=15.10.0'}
-    deprecated: <1.0.0 is no longer supported please upgrade to the latest version
+    deprecated: This version is deprecated.  Please upgrade to version 2.1.0 or later.
 
   '@ark/schema@0.47.0':
     resolution: {integrity: sha512-s5Hc1TUmRiA+NhewAHZJtl7xuFN0y4vAdv/JrvgCxgf1NKwBAylTvqCnQ8iPYn8kG3qAmHwgPpbJ+C5iHKJsbQ==}
@@ -6108,25 +6108,25 @@ packages:
       '@wagmi/core': ^2.14.1
       viem: ^2.21.55
 
-  '@faremeter/fetch@0.16.0':
-    resolution: {integrity: sha512-dcITgX/U1c0hUYhafSgExdLyuv2DM5qyFnhQXLFHrGW1iSgsY8oNBAm4twF6jo/qC7TjZZ2QAt4OtvupwfR07g==}
+  '@faremeter/fetch@0.17.1':
+    resolution: {integrity: sha512-c9JnfunBOH+YDiP9qzusJWWJZg+7RHhctRgkVrQlOml7C0CZJeYwowjkxBQ0IsDTYO3UMBPtMo1lv2lUJKCBDg==}
 
-  '@faremeter/info@0.16.0':
-    resolution: {integrity: sha512-eVg0MjaqfDjSOb6p444EvAuBY0uIqXziVxNxkKAeoq7eON550ukz0cJPdUNEGx3jQfUM6/D4TEHDj3GVv7xlvg==}
+  '@faremeter/info@0.17.1':
+    resolution: {integrity: sha512-Zyv8nvl/wSfsQxtoiR4VrrsGNMuZLf3UbmjqJzqfBGa03R5o9WOjR2QsQw0Srmwj3X/2gRFRdwyMnKXFjQ1RVw==}
 
-  '@faremeter/logs@0.16.0':
-    resolution: {integrity: sha512-1f4XHqGklWtdBd6kdFDEJ9tGLtqIxe3GqclPN4nlO64HLX4nHyzoD+QLEqLqR0008MJj278RyVZ4FwWbCrP6nw==}
+  '@faremeter/logs@0.17.1':
+    resolution: {integrity: sha512-URbANx1IisTw9pGHGswPKOnLAU0FUgnfMYwgMmjkLsqHqYebeAPOnVVGu3SDGgyNudNz0iiLnIfG6sXfZvM0YQ==}
     peerDependencies:
       '@logtape/logtape': 1.0.4
     peerDependenciesMeta:
       '@logtape/logtape':
         optional: true
 
-  '@faremeter/payment-solana@0.16.0':
-    resolution: {integrity: sha512-ohtystWMIqW52lrOWryJrCjkhOihnkjMCcZJG8P17OBQuYhVnBBZ2yg9BOSMEp/XuLH87+KF+VywF5SSczle1A==}
+  '@faremeter/payment-solana@0.17.1':
+    resolution: {integrity: sha512-jZEiExJ9Q6x5DnIs9doWp5KgMDwQKxUcM4vY4AenDRx+qFiZFd6rMiVhlCUcYkFwhcN4RTKqp7QO8d6kfSCNFg==}
 
-  '@faremeter/types@0.16.0':
-    resolution: {integrity: sha512-YwUtY5anged4QC7I+kAFOeuYN4+VXEodmZX/b02hGOjbXc4gjCZV5sUXsFEAoCw+Ru8O2vbPcKcPgekas1ELsA==}
+  '@faremeter/types@0.17.1':
+    resolution: {integrity: sha512-riq7Kmg6QmIynwrJ9SH50Z6qI0HUU6kcJHE4t2j/jIvric3he5iGkiej5Ou0IEKC7nKYC7tlwlmGrri41dwnug==}
 
   '@fivebinaries/coin-selection@3.0.0':
     resolution: {integrity: sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==}
@@ -16379,9 +16379,6 @@ packages:
   undici-types@7.14.0:
     resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
 
-  undici-types@7.15.0:
-    resolution: {integrity: sha512-Xyn5T99wU4kPhLZMm+ElE6M+IoSeG8Se7eG9xoZ82ZgVHJ07wb/IWcDZeXe2GOPkavcJ8ko5oSlXMDRl/QgY9Q==}
-
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
@@ -20539,23 +20536,24 @@ snapshots:
       '@wagmi/core': 2.21.2(@tanstack/query-core@5.90.2)(@types/react@18.2.14)(react@18.2.0)(typescript@5.4.3)(use-sync-external-store@1.5.0(react@18.2.0))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))
       viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
 
-  '@faremeter/fetch@0.16.0':
+  '@faremeter/fetch@0.17.1':
     dependencies:
-      '@faremeter/types': 0.16.0
+      '@faremeter/info': 0.17.1
+      '@faremeter/types': 0.17.1
       arktype: 2.1.21
 
-  '@faremeter/info@0.16.0':
+  '@faremeter/info@0.17.1':
     dependencies:
-      '@faremeter/types': 0.16.0
+      '@faremeter/types': 0.17.1
       arktype: 2.1.21
 
-  '@faremeter/logs@0.16.0': {}
+  '@faremeter/logs@0.17.1': {}
 
-  '@faremeter/payment-solana@0.16.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@faremeter/payment-solana@0.17.1(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@faremeter/info': 0.16.0
-      '@faremeter/logs': 0.16.0
-      '@faremeter/types': 0.16.0
+      '@faremeter/info': 0.17.1
+      '@faremeter/logs': 0.17.1
+      '@faremeter/types': 0.17.1
       '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/memo': 0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
@@ -20577,7 +20575,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@faremeter/types@0.16.0':
+  '@faremeter/types@0.17.1':
     dependencies:
       arktype: 2.1.21
 
@@ -25503,7 +25501,7 @@ snapshots:
       '@solana/rpc-spec': 2.3.0(typescript@5.4.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
-      undici-types: 7.15.0
+      undici-types: 7.22.0
 
   '@solana/rpc-transport-http@5.0.0(typescript@5.4.3)':
     dependencies:
@@ -38960,8 +38958,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.14.0: {}
-
-  undici-types@7.15.0: {}
 
   undici-types@7.22.0: {}
 


### PR DESCRIPTION
This PR adds a new `example/with-x402-faremeter` flow for headless Solana x402 payments using Turnkey + Faremeter.

**What Changed**

 - Added a complete `with-x402-faremeter` example with:
    - Turnkey API-key auth (headless)
    - Solana wallet create/reuse logic
    - SOL + USDC balance checks
    - Paywalled fetch flow via `@faremeter/fetch` + `@faremeter/payment-solana/exact`
  - Uses Faremeter v0.17.0 for native x402 v2 protocol support, lenient v1
    response parsing, and CAIP-2 network identifier handling
  - Includes a minimal `patchV2Fetch` workaround for servers (e.g. Echo)
    that send a PAYMENT-REQUIRED header without the required `resource` object

    
<img width="897" height="411" alt="Screenshot 2026-02-19 at 9 05 41 AM" src="https://github.com/user-attachments/assets/060d570a-3a2d-42bf-9033-2ded69e5a8d4" />


**Test Plan**
- - `pnpm --filter @turnkey/example-with-x402-faremeter typecheck`
  - `pnpm start` in `examples/with-x402-faremeter` with:
    - `TEST_PAYWALL_URL=https://x402.payai.network/api/solana-devnet/paid-content`
  - Verified successful paid fetch flow (✅ Content received!) and final balance reporting.

**Note**
Echo server uses gasless settlement semantics (server covers SOL fee);
  Faremeter's exact payment handler supports this path directly via `extra.feePayer`.