### PR TITLE
Add signing helpers to @turnkey/agent-auth (Phase 2/3)

### DIFF
--- a/examples/agent-auth/README.md
+++ b/examples/agent-auth/README.md
@@ -37,6 +37,16 @@ Complete walkthrough of the agent auth flow:
 
 Simplest possible usage. Creates an agent session with no wallet accounts and the default signing policy, then cleans up. Good starting point for understanding the API.
 
+### Signing Helpers (`pnpm run signing`)
+
+Demonstrates all three signing helpers:
+
+- `signJwt`: Mint ES256 JWTs for API authentication (MCP servers, internal APIs)
+- `signSshCommit`: Sign git commits with Ed25519 in SSHSIG format (for "Verified" badges)
+- `signMessage`: General-purpose signing returning raw r, s, v components
+
+Shows JWT decoding, SSHSIG armored output, and the complete signing flow without ever exposing private keys.
+
 ### Multi-Agent Swarm (`pnpm run multi-agent`)
 
 Provisions three agents with different capabilities (JWT, git, ETH signing) from the same parent org. Demonstrates:

--- a/examples/agent-auth/package.json
+++ b/examples/agent-auth/package.json
@@ -6,6 +6,7 @@
     "start": "pnpm tsx src/index.ts",
     "minimal": "pnpm tsx src/minimal.ts",
     "multi-agent": "pnpm tsx src/multi-agent.ts",
+    "signing": "pnpm tsx src/signing.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/agent-auth/src/index.ts
+++ b/examples/agent-auth/src/index.ts
@@ -22,6 +22,9 @@ import {
   deleteAgentSession,
   presets,
   policies,
+  signJwt,
+  signSshCommit,
+  signMessage,
 } from "@turnkey/agent-auth";
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });

--- a/examples/agent-auth/src/signing.ts
+++ b/examples/agent-auth/src/signing.ts
@@ -1,0 +1,139 @@
+/**
+ * Signing helpers example for @turnkey/agent-auth
+ *
+ * Demonstrates:
+ * - signJwt: Mint ES256 JWTs for API authentication
+ * - signSshCommit: Sign git commits with Ed25519 (SSHSIG format)
+ * - signMessage: General-purpose message signing
+ *
+ * Usage:
+ *   cp .env.local.example .env.local
+ *   # Fill in your Turnkey credentials
+ *   pnpm run signing
+ */
+
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { Turnkey } from "@turnkey/sdk-server";
+import {
+  createAgentSession,
+  deleteAgentSession,
+  presets,
+  signJwt,
+  signSshCommit,
+  signMessage,
+} from "@turnkey/agent-auth";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  const organizationId = process.env.ORGANIZATION_ID!;
+  const apiBaseUrl = process.env.BASE_URL!;
+
+  const turnkey = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    defaultOrganizationId: organizationId,
+  });
+
+  // 1. Provision an agent with JWT signing (P256) and git signing (Ed25519)
+  console.log("Provisioning agent...");
+  const session = await createAgentSession(
+    turnkey.apiClient(),
+    {
+      organizationId,
+      agentName: `signing-example-${Date.now()}`,
+      expirationSeconds: 600,
+      accounts: [presets.jwtSigning(), presets.gitSigning()],
+    },
+    { apiBaseUrl },
+  );
+  console.log(`  Agent provisioned: ${session.subOrganizationId}\n`);
+
+  // Create the agent's authenticated client
+  const agentTurnkey = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: session.apiKey.publicKey,
+    apiPrivateKey: session.apiKey.privateKey,
+    defaultOrganizationId: session.subOrganizationId,
+  });
+  const agentClient = agentTurnkey.apiClient();
+
+  // 2. signJwt: Mint an ES256 JWT
+  //    Use case: authenticate to MCP servers, internal APIs, Pierre
+  console.log("--- signJwt ---");
+  const jwt = await signJwt(agentClient, {
+    organizationId: session.subOrganizationId,
+    signingKey: session.accounts[0]!.publicKey,
+    payload: {
+      iss: session.subOrganizationId,
+      sub: session.agentUserId,
+      aud: "https://my-api.example.com",
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 300,
+      scope: "read write",
+    },
+  });
+  console.log(`JWT: ${jwt.substring(0, 60)}...`);
+
+  // Decode and display the JWT parts
+  const [headerB64, payloadB64] = jwt.split(".");
+  const header = JSON.parse(
+    atob(headerB64!.replace(/-/g, "+").replace(/_/g, "/")),
+  );
+  const payload = JSON.parse(
+    atob(payloadB64!.replace(/-/g, "+").replace(/_/g, "/")),
+  );
+  console.log(`Header: ${JSON.stringify(header)}`);
+  console.log(`Payload: ${JSON.stringify(payload)}`);
+  console.log(`Expires: ${new Date(payload.exp * 1000).toISOString()}\n`);
+
+  // 3. signSshCommit: Sign a git commit with Ed25519
+  //    Use case: git commit signing with "Verified" badges
+  console.log("--- signSshCommit ---");
+  const fakeCommit = Buffer.from(
+    "tree 4b825dc642cb6eb9a060e54bf899d8e33f4daa0a\n" +
+      "author Agent <agent@example.com> 1700000000 +0000\n" +
+      "committer Agent <agent@example.com> 1700000000 +0000\n\n" +
+      "Initial commit\n",
+  ).toString("hex");
+
+  const sshSig = await signSshCommit(agentClient, {
+    organizationId: session.subOrganizationId,
+    signingKey: session.accounts[1]!.publicKey,
+    commitBuffer: fakeCommit,
+    publicKey: session.accounts[1]!.publicKey,
+  });
+  console.log("SSH Signature:");
+  console.log(sshSig.split("\n").slice(0, 3).join("\n"));
+  console.log("  ...");
+  console.log(sshSig.split("\n").slice(-2).join("\n"));
+
+  // 4. signMessage: General-purpose signing
+  //    Use case: webhook signatures, challenge-response, custom protocols
+  console.log("\n--- signMessage ---");
+  const messageHex =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  const sig = await signMessage(agentClient, {
+    organizationId: session.subOrganizationId,
+    signingKey: session.accounts[0]!.publicKey,
+    message: messageHex,
+  });
+  console.log(`r: ${sig.r.substring(0, 20)}...`);
+  console.log(`s: ${sig.s.substring(0, 20)}...`);
+  console.log(`v: ${sig.v}`);
+
+  // 5. Clean up
+  console.log("\nCleaning up...");
+  await deleteAgentSession(
+    {
+      subOrganizationId: session.subOrganizationId,
+      adminApiKey: session.adminApiKey,
+    },
+    { apiBaseUrl },
+  );
+  console.log("Done.");
+}
+
+main().catch(console.error);

--- a/examples/agent-auth/src/signing.ts
+++ b/examples/agent-auth/src/signing.ts
@@ -61,7 +61,7 @@ async function main() {
   const agentClient = agentTurnkey.apiClient();
 
   // 2. signJwt: Mint an ES256 JWT
-  //    Use case: authenticate to MCP servers, internal APIs, Pierre
+  //    Use case: authenticate to MCP servers, external APIs, service-to-service auth
   console.log("--- signJwt ---");
   const jwt = await signJwt(agentClient, {
     organizationId: session.subOrganizationId,

--- a/packages/agent-auth/jest.config.js
+++ b/packages/agent-auth/jest.config.js
@@ -10,6 +10,7 @@ const config = {
     "^@turnkey/crypto$": "<rootDir>/../crypto/src/index.ts",
     "^@turnkey/sdk-server$": "<rootDir>/../sdk-server/src/index.ts",
     "^@turnkey/api-key-stamper$": "<rootDir>/../api-key-stamper/src/index.ts",
+    "^@turnkey/encoding$": "<rootDir>/../encoding/src/index.ts",
   },
 };
 

--- a/packages/agent-auth/package.json
+++ b/packages/agent-auth/package.json
@@ -25,7 +25,8 @@
     "@turnkey/sdk-server": "workspace:*"
   },
   "dependencies": {
-    "@turnkey/crypto": "workspace:*"
+    "@turnkey/crypto": "workspace:*",
+    "@turnkey/encoding": "workspace:*"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/packages/agent-auth/package.json
+++ b/packages/agent-auth/package.json
@@ -25,6 +25,7 @@
     "@turnkey/sdk-server": "workspace:*"
   },
   "dependencies": {
+    "@noble/hashes": "^1.5.0",
     "@turnkey/crypto": "workspace:*",
     "@turnkey/encoding": "workspace:*"
   },

--- a/packages/agent-auth/scripts/smoke-test.ts
+++ b/packages/agent-auth/scripts/smoke-test.ts
@@ -193,7 +193,7 @@ async function main() {
       );
       check(
         "signSshCommit has end marker",
-        sig.endsWith("-----END SSH SIGNATURE-----"),
+        sig.endsWith("-----END SSH SIGNATURE-----\n"),
       );
     } catch (err: any) {
       check("signSshCommit produces armored signature", false, err.message);

--- a/packages/agent-auth/scripts/smoke-test.ts
+++ b/packages/agent-auth/scripts/smoke-test.ts
@@ -11,7 +11,14 @@
 
 import { Turnkey } from "@turnkey/sdk-server";
 const TurnkeyServerSDK = Turnkey;
-import { createAgentSession, deleteAgentSession, presets } from "../src/index";
+import {
+  createAgentSession,
+  deleteAgentSession,
+  presets,
+  signJwt,
+  signSshCommit,
+  signMessage,
+} from "../src/index";
 
 const API_BASE_URL = process.env.TURNKEY_API_BASE_URL;
 const API_PUBLIC_KEY = process.env.TURNKEY_API_PUBLIC_KEY;
@@ -140,6 +147,79 @@ async function main() {
       check("Ed25519 sign_raw_payload succeeded", true);
     } catch (err: any) {
       check("Ed25519 sign_raw_payload succeeded", false, err.message);
+    }
+  }
+
+  // Step 4c: Test signJwt helper
+  if (session.accounts.length > 0 && session.accounts[0].publicKey) {
+    console.log("\n3c. Testing signJwt helper...");
+    try {
+      const jwt = await signJwt(agentClient, {
+        organizationId: session.subOrganizationId,
+        signingKey: session.accounts[0].publicKey,
+        payload: {
+          iss: session.subOrganizationId,
+          sub: session.agentUserId,
+          aud: "smoke-test",
+          iat: Math.floor(Date.now() / 1000),
+          exp: Math.floor(Date.now() / 1000) + 300,
+        },
+      });
+      const parts = jwt.split(".");
+      check("signJwt produces 3-part JWT", parts.length === 3);
+      // Decode and verify header
+      const header = JSON.parse(
+        atob(parts[0]!.replace(/-/g, "+").replace(/_/g, "/")),
+      );
+      check("signJwt header has ES256", header.alg === "ES256");
+    } catch (err: any) {
+      check("signJwt produces 3-part JWT", false, err.message);
+    }
+  }
+
+  // Step 4d: Test signSshCommit helper
+  if (session.accounts.length > 1 && session.accounts[1].publicKey) {
+    console.log("\n3d. Testing signSshCommit helper...");
+    try {
+      const sig = await signSshCommit(agentClient, {
+        organizationId: session.subOrganizationId,
+        signingKey: session.accounts[1].publicKey,
+        commitBuffer: "48656c6c6f20576f726c64", // "Hello World" hex
+        publicKey: session.accounts[1].publicKey,
+      });
+      check(
+        "signSshCommit produces armored signature",
+        sig.startsWith("-----BEGIN SSH SIGNATURE-----"),
+      );
+      check(
+        "signSshCommit has end marker",
+        sig.endsWith("-----END SSH SIGNATURE-----"),
+      );
+    } catch (err: any) {
+      check("signSshCommit produces armored signature", false, err.message);
+    }
+  }
+
+  // Step 4e: Test signMessage helper
+  if (session.accounts.length > 0 && session.accounts[0].publicKey) {
+    console.log("\n3e. Testing signMessage helper...");
+    try {
+      const sig = await signMessage(agentClient, {
+        organizationId: session.subOrganizationId,
+        signingKey: session.accounts[0].publicKey,
+        message:
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      });
+      check(
+        "signMessage returns r",
+        typeof sig.r === "string" && sig.r.length === 64,
+      );
+      check(
+        "signMessage returns s",
+        typeof sig.s === "string" && sig.s.length === 64,
+      );
+    } catch (err: any) {
+      check("signMessage returns r", false, err.message);
     }
   }
 

--- a/packages/agent-auth/src/__tests__/signing-test.ts
+++ b/packages/agent-auth/src/__tests__/signing-test.ts
@@ -172,7 +172,7 @@ describe("signSshCommit", () => {
   it("produces an armored SSH signature with correct headers", async () => {
     const result = await signSshCommit(mockClient, baseParams);
     expect(result).toMatch(/^-----BEGIN SSH SIGNATURE-----\n/);
-    expect(result).toMatch(/\n-----END SSH SIGNATURE-----$/);
+    expect(result).toMatch(/\n-----END SSH SIGNATURE-----\n$/);
   });
 
   it("uses HASH_FUNCTION_NOT_APPLICABLE for Ed25519", async () => {
@@ -193,7 +193,7 @@ describe("signSshCommit", () => {
     // armored output contains valid base64.
     const result = await signSshCommit(mockClient, baseParams);
     const lines = result.split("\n");
-    const base64Content = lines.slice(1, -1).join("");
+    const base64Content = lines.slice(1, -2).filter(Boolean).join("");
     expect(() => atob(base64Content)).not.toThrow();
   });
 
@@ -210,7 +210,7 @@ describe("signSshCommit", () => {
 
     // Decode the base64 content
     const lines = result.split("\n");
-    const base64Content = lines.slice(1, -1).join("");
+    const base64Content = lines.slice(1, -2).filter(Boolean).join("");
     const binary = Uint8Array.from(atob(base64Content), (c) => c.charCodeAt(0));
 
     // First 6 bytes: "SSHSIG"

--- a/packages/agent-auth/src/__tests__/signing-test.ts
+++ b/packages/agent-auth/src/__tests__/signing-test.ts
@@ -1,0 +1,162 @@
+import { signJwt, signMessage } from "../signing";
+
+const mockClient = {
+  signRawPayload: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Default: return fixed r, s, v (each 64 hex chars = 32 bytes)
+  mockClient.signRawPayload.mockResolvedValue({
+    r: "a".repeat(64),
+    s: "b".repeat(64),
+    v: "00",
+  });
+});
+
+describe("signJwt", () => {
+  const baseParams = {
+    organizationId: "org-123",
+    signingKey: "0xP256Address",
+    payload: { iss: "test-issuer", sub: "test-subject", aud: "test-audience" },
+  };
+
+  it("produces a valid JWT with 3 base64url segments", async () => {
+    const jwt = await signJwt(mockClient, baseParams);
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+
+    // Each part should be valid base64url (no +, /, or = characters)
+    for (const part of parts) {
+      expect(part).not.toMatch(/[+/=]/);
+    }
+  });
+
+  it("defaults header to ES256", async () => {
+    const jwt = await signJwt(mockClient, baseParams);
+    const headerJson = JSON.parse(
+      atob(jwt.split(".")[0]!.replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    expect(headerJson).toEqual({ alg: "ES256", typ: "JWT" });
+  });
+
+  it("passes custom header through", async () => {
+    const jwt = await signJwt(mockClient, {
+      ...baseParams,
+      header: { alg: "ES256", typ: "JWT", kid: "my-key-id" },
+    });
+    const headerJson = JSON.parse(
+      atob(jwt.split(".")[0]!.replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    expect(headerJson.kid).toBe("my-key-id");
+  });
+
+  it("passes payload claims through unchanged (no auto-iat, no auto-exp)", async () => {
+    const jwt = await signJwt(mockClient, baseParams);
+    const payloadJson = JSON.parse(
+      atob(jwt.split(".")[1]!.replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    expect(payloadJson).toEqual({
+      iss: "test-issuer",
+      sub: "test-subject",
+      aud: "test-audience",
+    });
+    // No iat or exp auto-added
+    expect(payloadJson.iat).toBeUndefined();
+    expect(payloadJson.exp).toBeUndefined();
+  });
+
+  it("sends HASH_FUNCTION_NO_OP with pre-hashed digest to Turnkey", async () => {
+    await signJwt(mockClient, baseParams);
+
+    expect(mockClient.signRawPayload).toHaveBeenCalledTimes(1);
+    const args = mockClient.signRawPayload.mock.calls[0]![0];
+    expect(args.hashFunction).toBe("HASH_FUNCTION_NO_OP");
+    expect(args.encoding).toBe("PAYLOAD_ENCODING_HEXADECIMAL");
+    expect(args.signWith).toBe("0xP256Address");
+    expect(args.organizationId).toBe("org-123");
+    // Payload should be 64 hex chars (32 bytes SHA-256 digest)
+    expect(args.payload).toHaveLength(64);
+  });
+
+  it("signature is raw r||s base64url encoded (not DER)", async () => {
+    const jwt = await signJwt(mockClient, baseParams);
+    const sigPart = jwt.split(".")[2]!;
+
+    // Decode base64url to bytes
+    const sigBase64 = sigPart.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = sigBase64 + "=".repeat((4 - (sigBase64.length % 4)) % 4);
+    const sigBytes = Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+
+    // ES256 raw signature is exactly 64 bytes (r: 32 + s: 32)
+    expect(sigBytes.length).toBe(64);
+  });
+
+  it("throws if r or s has unexpected length", async () => {
+    mockClient.signRawPayload.mockResolvedValue({
+      r: "abcd", // too short
+      s: "b".repeat(64),
+      v: "00",
+    });
+
+    await expect(signJwt(mockClient, baseParams)).rejects.toThrow(
+      "Unexpected signature component length",
+    );
+  });
+});
+
+describe("signMessage", () => {
+  const baseParams = {
+    organizationId: "org-123",
+    signingKey: "0xAnyAddress",
+    message: "deadbeef",
+  };
+
+  it("passes params through to signRawPayload with defaults", async () => {
+    const result = await signMessage(mockClient, baseParams);
+
+    expect(mockClient.signRawPayload).toHaveBeenCalledTimes(1);
+    const args = mockClient.signRawPayload.mock.calls[0]![0];
+    expect(args.organizationId).toBe("org-123");
+    expect(args.signWith).toBe("0xAnyAddress");
+    expect(args.payload).toBe("deadbeef");
+    expect(args.encoding).toBe("PAYLOAD_ENCODING_HEXADECIMAL");
+    expect(args.hashFunction).toBe("HASH_FUNCTION_SHA256");
+
+    expect(result).toEqual({
+      r: "a".repeat(64),
+      s: "b".repeat(64),
+      v: "00",
+    });
+  });
+
+  it("respects custom encoding and hashFunction", async () => {
+    await signMessage(mockClient, {
+      ...baseParams,
+      encoding: "PAYLOAD_ENCODING_TEXT_UTF8",
+      hashFunction: "HASH_FUNCTION_NOT_APPLICABLE",
+    });
+
+    const args = mockClient.signRawPayload.mock.calls[0]![0];
+    expect(args.encoding).toBe("PAYLOAD_ENCODING_TEXT_UTF8");
+    expect(args.hashFunction).toBe("HASH_FUNCTION_NOT_APPLICABLE");
+  });
+
+  it("returns raw r, s, v from response", async () => {
+    mockClient.signRawPayload.mockResolvedValue({
+      r: "1111111111111111111111111111111111111111111111111111111111111111",
+      s: "2222222222222222222222222222222222222222222222222222222222222222",
+      v: "1b",
+    });
+
+    const result = await signMessage(mockClient, baseParams);
+    expect(result.r).toBe(
+      "1111111111111111111111111111111111111111111111111111111111111111",
+    );
+    expect(result.s).toBe(
+      "2222222222222222222222222222222222222222222222222222222222222222",
+    );
+    expect(result.v).toBe("1b");
+  });
+});

--- a/packages/agent-auth/src/__tests__/signing-test.ts
+++ b/packages/agent-auth/src/__tests__/signing-test.ts
@@ -1,4 +1,4 @@
-import { signJwt, signMessage } from "../signing";
+import { signJwt, signSshCommit, signMessage } from "../signing";
 
 const mockClient = {
   signRawPayload: jest.fn(),
@@ -158,5 +158,71 @@ describe("signMessage", () => {
       "2222222222222222222222222222222222222222222222222222222222222222",
     );
     expect(result.v).toBe("1b");
+  });
+});
+
+describe("signSshCommit", () => {
+  const baseParams = {
+    organizationId: "org-123",
+    signingKey: "0xEd25519Address",
+    commitBuffer: "48656c6c6f20576f726c64", // "Hello World" in hex
+    publicKey: "a".repeat(64), // 32-byte Ed25519 public key hex
+  };
+
+  it("produces an armored SSH signature with correct headers", async () => {
+    const result = await signSshCommit(mockClient, baseParams);
+    expect(result).toMatch(/^-----BEGIN SSH SIGNATURE-----\n/);
+    expect(result).toMatch(/\n-----END SSH SIGNATURE-----$/);
+  });
+
+  it("uses HASH_FUNCTION_NOT_APPLICABLE for Ed25519", async () => {
+    await signSshCommit(mockClient, baseParams);
+
+    expect(mockClient.signRawPayload).toHaveBeenCalledTimes(1);
+    const args = mockClient.signRawPayload.mock.calls[0]![0];
+    expect(args.hashFunction).toBe("HASH_FUNCTION_NOT_APPLICABLE");
+    expect(args.encoding).toBe("PAYLOAD_ENCODING_HEXADECIMAL");
+    expect(args.signWith).toBe("0xEd25519Address");
+  });
+
+  it("defaults namespace to git", async () => {
+    await signSshCommit(mockClient, baseParams);
+
+    // The payload sent to Turnkey should contain the SSHSIG signed data blob
+    // which includes the namespace. We verify indirectly by checking the
+    // armored output contains valid base64.
+    const result = await signSshCommit(mockClient, baseParams);
+    const lines = result.split("\n");
+    const base64Content = lines.slice(1, -1).join("");
+    expect(() => atob(base64Content)).not.toThrow();
+  });
+
+  it("accepts custom namespace", async () => {
+    const result = await signSshCommit(mockClient, {
+      ...baseParams,
+      namespace: "file",
+    });
+    expect(result).toMatch(/^-----BEGIN SSH SIGNATURE-----\n/);
+  });
+
+  it("contains SSHSIG magic and version in the envelope", async () => {
+    const result = await signSshCommit(mockClient, baseParams);
+
+    // Decode the base64 content
+    const lines = result.split("\n");
+    const base64Content = lines.slice(1, -1).join("");
+    const binary = Uint8Array.from(atob(base64Content), (c) => c.charCodeAt(0));
+
+    // First 6 bytes: "SSHSIG"
+    const magic = new TextDecoder().decode(binary.slice(0, 6));
+    expect(magic).toBe("SSHSIG");
+
+    // Next 4 bytes: version = 1
+    const version = new DataView(
+      binary.buffer,
+      binary.byteOffset + 6,
+      4,
+    ).getUint32(0);
+    expect(version).toBe(1);
   });
 });

--- a/packages/agent-auth/src/__tests__/ssh-wire-test.ts
+++ b/packages/agent-auth/src/__tests__/ssh-wire-test.ts
@@ -1,0 +1,160 @@
+import {
+  sshString,
+  sshUint32,
+  sshStringFromUtf8,
+  sshEd25519PublicKey,
+  buildSshsigSignedData,
+  buildSshsigEnvelope,
+  armorSshSignature,
+} from "../ssh-wire";
+
+describe("sshString", () => {
+  it("encodes data with 4-byte big-endian length prefix", () => {
+    const data = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]); // "Hello"
+    const result = sshString(data);
+    // Length = 5, big-endian: [0, 0, 0, 5]
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(0);
+    expect(result[2]).toBe(0);
+    expect(result[3]).toBe(5);
+    // Data follows
+    expect(result[4]).toBe(0x48);
+    expect(result.length).toBe(9); // 4 + 5
+  });
+
+  it("encodes empty data", () => {
+    const result = sshString(new Uint8Array(0));
+    expect(result.length).toBe(4);
+    expect(result[0]).toBe(0);
+    expect(result[3]).toBe(0);
+  });
+});
+
+describe("sshUint32", () => {
+  it("writes uint32 in big-endian", () => {
+    const result = sshUint32(1);
+    expect(result).toEqual(new Uint8Array([0, 0, 0, 1]));
+  });
+
+  it("writes larger values correctly", () => {
+    const result = sshUint32(256);
+    expect(result).toEqual(new Uint8Array([0, 0, 1, 0]));
+  });
+});
+
+describe("sshStringFromUtf8", () => {
+  it("encodes a UTF-8 string with length prefix", () => {
+    const result = sshStringFromUtf8("git");
+    // Length = 3: [0, 0, 0, 3] + "git" bytes
+    expect(result[3]).toBe(3);
+    expect(result[4]).toBe(0x67); // 'g'
+    expect(result[5]).toBe(0x69); // 'i'
+    expect(result[6]).toBe(0x74); // 't'
+    expect(result.length).toBe(7);
+  });
+
+  it("encodes empty string", () => {
+    const result = sshStringFromUtf8("");
+    expect(result.length).toBe(4);
+    expect(result[3]).toBe(0);
+  });
+});
+
+describe("sshEd25519PublicKey", () => {
+  const validKeyHex = "a".repeat(64); // 32 bytes
+
+  it("produces SSH wire format with ssh-ed25519 type prefix", () => {
+    const result = sshEd25519PublicKey(validKeyHex);
+    // Structure: sshString("ssh-ed25519") + sshString(32-byte-key)
+    // "ssh-ed25519" = 11 bytes, so: [0,0,0,11] + "ssh-ed25519" + [0,0,0,32] + key
+    // Total: 4 + 11 + 4 + 32 = 51 bytes
+    expect(result.length).toBe(51);
+
+    // First 4 bytes: length of "ssh-ed25519" = 11
+    expect(result[3]).toBe(11);
+
+    // Bytes 4-14: "ssh-ed25519"
+    const typeStr = new TextDecoder().decode(result.slice(4, 15));
+    expect(typeStr).toBe("ssh-ed25519");
+  });
+
+  it("throws on invalid key length", () => {
+    expect(() => sshEd25519PublicKey("abcd")).toThrow(
+      "Expected 32-byte Ed25519 public key",
+    );
+  });
+});
+
+describe("buildSshsigSignedData", () => {
+  it("builds the data-to-be-signed blob with SSHSIG magic", () => {
+    const messageHash = new Uint8Array(64).fill(0xff); // 64 bytes (SHA-512)
+    const result = buildSshsigSignedData({
+      namespace: "git",
+      hashAlgorithm: "sha512",
+      messageHash,
+    });
+
+    // Should start with sshString("SSHSIG")
+    // "SSHSIG" = 6 bytes, so first bytes: [0,0,0,6] + "SSHSIG"
+    expect(result[3]).toBe(6);
+    const magic = new TextDecoder().decode(result.slice(4, 10));
+    expect(magic).toBe("SSHSIG");
+
+    // Should contain namespace "git" somewhere after magic
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildSshsigEnvelope", () => {
+  it("builds envelope with correct magic and version", () => {
+    const signature = new Uint8Array(64).fill(0xab);
+    const result = buildSshsigEnvelope({
+      publicKeyHex: "a".repeat(64),
+      namespace: "git",
+      hashAlgorithm: "sha512",
+      signature,
+    });
+
+    // First 6 bytes: "SSHSIG" (no null terminator in the magic for the envelope)
+    const magic = new TextDecoder().decode(result.slice(0, 6));
+    expect(magic).toBe("SSHSIG");
+
+    // Next 4 bytes: version = 1
+    const version = new DataView(
+      result.buffer,
+      result.byteOffset + 6,
+      4,
+    ).getUint32(0);
+    expect(version).toBe(1);
+  });
+
+  it("produces non-empty binary output", () => {
+    const signature = new Uint8Array(64).fill(0xab);
+    const result = buildSshsigEnvelope({
+      publicKeyHex: "a".repeat(64),
+      namespace: "git",
+      hashAlgorithm: "sha512",
+      signature,
+    });
+    expect(result.length).toBeGreaterThan(100); // Magic + version + pubkey + namespace + hash + sig
+  });
+});
+
+describe("armorSshSignature", () => {
+  it("wraps binary in SSH SIGNATURE PEM headers", () => {
+    const binary = new Uint8Array([1, 2, 3, 4, 5]);
+    const result = armorSshSignature(binary);
+    expect(result).toMatch(/^-----BEGIN SSH SIGNATURE-----\n/);
+    expect(result).toMatch(/\n-----END SSH SIGNATURE-----$/);
+  });
+
+  it("contains valid base64 content", () => {
+    const binary = new Uint8Array(100).fill(0x42);
+    const result = armorSshSignature(binary);
+    const lines = result.split("\n");
+    // First and last lines are headers
+    const base64Content = lines.slice(1, -1).join("");
+    // Should be valid base64
+    expect(() => atob(base64Content)).not.toThrow();
+  });
+});

--- a/packages/agent-auth/src/__tests__/ssh-wire-test.ts
+++ b/packages/agent-auth/src/__tests__/ssh-wire-test.ts
@@ -145,7 +145,7 @@ describe("armorSshSignature", () => {
     const binary = new Uint8Array([1, 2, 3, 4, 5]);
     const result = armorSshSignature(binary);
     expect(result).toMatch(/^-----BEGIN SSH SIGNATURE-----\n/);
-    expect(result).toMatch(/\n-----END SSH SIGNATURE-----$/);
+    expect(result).toMatch(/\n-----END SSH SIGNATURE-----\n$/);
   });
 
   it("contains valid base64 content", () => {
@@ -153,7 +153,7 @@ describe("armorSshSignature", () => {
     const result = armorSshSignature(binary);
     const lines = result.split("\n");
     // First and last lines are headers
-    const base64Content = lines.slice(1, -1).join("");
+    const base64Content = lines.slice(1, -2).filter(Boolean).join("");
     // Should be valid base64
     expect(() => atob(base64Content)).not.toThrow();
   });

--- a/packages/agent-auth/src/index.ts
+++ b/packages/agent-auth/src/index.ts
@@ -1,6 +1,6 @@
 export { createAgentSession } from "./create-session";
 export { deleteAgentSession } from "./delete-session";
-export { signJwt, signMessage } from "./signing";
+export { signJwt, signSshCommit, signMessage } from "./signing";
 export * as presets from "./presets";
 export * as policies from "./policies";
 export type {

--- a/packages/agent-auth/src/index.ts
+++ b/packages/agent-auth/src/index.ts
@@ -1,5 +1,6 @@
 export { createAgentSession } from "./create-session";
 export { deleteAgentSession } from "./delete-session";
+export { signJwt, signMessage } from "./signing";
 export * as presets from "./presets";
 export * as policies from "./policies";
 export type {

--- a/packages/agent-auth/src/signing.ts
+++ b/packages/agent-auth/src/signing.ts
@@ -3,6 +3,12 @@ import {
   uint8ArrayFromHexString,
 } from "@turnkey/encoding";
 import { sha256 } from "@noble/hashes/sha256";
+import { sha512 } from "@noble/hashes/sha512";
+import {
+  buildSshsigSignedData,
+  buildSshsigEnvelope,
+  armorSshSignature,
+} from "./ssh-wire";
 
 /**
  * Encode a string as base64url (no padding).
@@ -79,6 +85,69 @@ export async function signJwt(
   const encodedSignature = bytesToBase64url(signatureBytes);
 
   return `${encodedHeader}.${encodedPayload}.${encodedSignature}`;
+}
+
+/**
+ * Sign a git commit with Ed25519 in SSHSIG format.
+ *
+ * Produces a standards-compliant SSHSIG armored signature that git recognizes
+ * for commit signing. The private key never leaves Turnkey's enclave.
+ *
+ * The signing key must be an Ed25519 wallet account address.
+ *
+ * @param client - TurnkeyApiClient (agent or admin)
+ * @param params - SSHSIG parameters
+ * @returns Armored SSH signature string
+ */
+export async function signSshCommit(
+  client: { signRawPayload: Function; [key: string]: any },
+  params: {
+    organizationId: string;
+    signingKey: string;
+    commitBuffer: string; // hex-encoded git commit content
+    publicKey: string; // Ed25519 public key hex (for SSHSIG envelope)
+    namespace?: string;
+  },
+): Promise<string> {
+  const namespace = params.namespace ?? "git";
+  const hashAlgorithm = "sha512";
+
+  // Step 1: Hash the commit content with SHA-512
+  const commitBytes = uint8ArrayFromHexString(params.commitBuffer);
+  const messageHash = sha512(commitBytes);
+
+  // Step 2: Build the "data to be signed" blob (what Ed25519 signs)
+  const signedData = buildSshsigSignedData({
+    namespace,
+    hashAlgorithm,
+    messageHash,
+  });
+
+  // Step 3: Send to Turnkey for Ed25519 signing
+  const hexPayload = uint8ArrayToHexString(signedData);
+  const signResult = await client.signRawPayload({
+    organizationId: params.organizationId,
+    signWith: params.signingKey,
+    payload: hexPayload,
+    encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
+    hashFunction: "HASH_FUNCTION_NOT_APPLICABLE", // Ed25519 does internal SHA-512 per RFC 8032
+  });
+
+  // Step 4: Assemble the 64-byte Ed25519 signature (r || s)
+  const r = signResult.r as string;
+  const s = signResult.s as string;
+  const signatureBytes = uint8ArrayFromHexString(r + s);
+
+  // Step 5: Build the SSHSIG output envelope
+  const envelope = buildSshsigEnvelope({
+    publicKeyHex: params.publicKey,
+    namespace,
+    hashAlgorithm,
+    signature: signatureBytes,
+  });
+
+  // Step 6: Armor and return
+  return armorSshSignature(envelope);
 }
 
 /**

--- a/packages/agent-auth/src/signing.ts
+++ b/packages/agent-auth/src/signing.ts
@@ -1,0 +1,117 @@
+import {
+  uint8ArrayToHexString,
+  uint8ArrayFromHexString,
+} from "@turnkey/encoding";
+import { sha256 } from "@noble/hashes/sha256";
+
+/**
+ * Encode a string as base64url (no padding).
+ */
+function toBase64url(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  const base64 = btoa(String.fromCharCode(...bytes));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Encode raw bytes as base64url (no padding).
+ */
+function bytesToBase64url(input: Uint8Array): string {
+  const base64 = btoa(String.fromCharCode(...input));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Sign a JWT with ES256 (P256) using the agent's wallet key.
+ *
+ * Produces a standards-compliant JWT (RFC 7515) with an ES256 signature.
+ * The signing key must be a P256 wallet account address.
+ *
+ * Claims (iat, exp, aud, etc.) are the caller's responsibility.
+ * This function does not auto-add any claims.
+ *
+ * @param client - TurnkeyApiClient (agent or admin)
+ * @param params - JWT parameters
+ * @returns Complete JWT string (header.payload.signature)
+ */
+export async function signJwt(
+  client: { signRawPayload: Function; [key: string]: any },
+  params: {
+    organizationId: string;
+    signingKey: string;
+    header?: Record<string, unknown>;
+    payload: Record<string, unknown>;
+  },
+): Promise<string> {
+  const header = params.header ?? { alg: "ES256", typ: "JWT" };
+
+  // Step 1: Base64url encode header and payload
+  const encodedHeader = toBase64url(JSON.stringify(header));
+  const encodedPayload = toBase64url(JSON.stringify(params.payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  // Step 2: SHA-256 hash client-side (Turnkey's P256 signer uses sign_prehash)
+  const signingInputBytes = new TextEncoder().encode(signingInput);
+  const digest = sha256(signingInputBytes);
+  const hexDigest = uint8ArrayToHexString(digest);
+
+  // Step 3: Sign the pre-hashed digest with Turnkey
+  const signResult = await client.signRawPayload({
+    organizationId: params.organizationId,
+    signWith: params.signingKey,
+    payload: hexDigest,
+    encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
+    hashFunction: "HASH_FUNCTION_NO_OP",
+  });
+
+  // Step 4: Assemble ES256 signature (raw r||s, NOT DER)
+  // Turnkey returns r and s as fixed 64 hex char strings ([u8; 32] in Rust)
+  const r = signResult.r as string;
+  const s = signResult.s as string;
+
+  if (r.length !== 64 || s.length !== 64) {
+    throw new Error(
+      `Unexpected signature component length: r=${r.length}, s=${s.length} (expected 64 each)`,
+    );
+  }
+
+  const signatureBytes = uint8ArrayFromHexString(r + s);
+  const encodedSignature = bytesToBase64url(signatureBytes);
+
+  return `${encodedHeader}.${encodedPayload}.${encodedSignature}`;
+}
+
+/**
+ * General-purpose message signing.
+ *
+ * Thin wrapper around sign_raw_payload that returns raw signature components.
+ * Use for webhook signatures, challenge-response auth, or custom protocols.
+ *
+ * @param client - TurnkeyApiClient (agent or admin)
+ * @param params - Signing parameters
+ * @returns Raw signature components { r, s, v } as hex strings
+ */
+export async function signMessage(
+  client: { signRawPayload: Function; [key: string]: any },
+  params: {
+    organizationId: string;
+    signingKey: string;
+    message: string;
+    encoding?: string;
+    hashFunction?: string;
+  },
+): Promise<{ r: string; s: string; v: string }> {
+  const result = await client.signRawPayload({
+    organizationId: params.organizationId,
+    signWith: params.signingKey,
+    payload: params.message,
+    encoding: params.encoding ?? "PAYLOAD_ENCODING_HEXADECIMAL",
+    hashFunction: params.hashFunction ?? "HASH_FUNCTION_SHA256",
+  });
+
+  return {
+    r: result.r as string,
+    s: result.s as string,
+    v: result.v as string,
+  };
+}

--- a/packages/agent-auth/src/signing.ts
+++ b/packages/agent-auth/src/signing.ts
@@ -11,11 +11,22 @@ import {
 } from "./ssh-wire";
 
 /**
+ * Convert Uint8Array to base64 string without stack overflow on large inputs.
+ */
+function bytesToBase64(input: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < input.length; i++) {
+    binary += String.fromCharCode(input[i]!);
+  }
+  return btoa(binary);
+}
+
+/**
  * Encode a string as base64url (no padding).
  */
 function toBase64url(input: string): string {
   const bytes = new TextEncoder().encode(input);
-  const base64 = btoa(String.fromCharCode(...bytes));
+  const base64 = bytesToBase64(bytes);
   return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
@@ -23,7 +34,7 @@ function toBase64url(input: string): string {
  * Encode raw bytes as base64url (no padding).
  */
 function bytesToBase64url(input: Uint8Array): string {
-  const base64 = btoa(String.fromCharCode(...input));
+  const base64 = bytesToBase64(input);
   return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
@@ -136,6 +147,13 @@ export async function signSshCommit(
   // Step 4: Assemble the 64-byte Ed25519 signature (r || s)
   const r = signResult.r as string;
   const s = signResult.s as string;
+
+  if (r.length !== 64 || s.length !== 64) {
+    throw new Error(
+      `Unexpected Ed25519 signature component length: r=${r.length}, s=${s.length} (expected 64 each)`,
+    );
+  }
+
   const signatureBytes = uint8ArrayFromHexString(r + s);
 
   // Step 5: Build the SSHSIG output envelope

--- a/packages/agent-auth/src/ssh-wire.ts
+++ b/packages/agent-auth/src/ssh-wire.ts
@@ -130,10 +130,14 @@ export function buildSshsigEnvelope(params: {
  *   -----END SSH SIGNATURE-----
  */
 export function armorSshSignature(binary: Uint8Array): string {
-  const base64 = btoa(String.fromCharCode(...binary));
+  let binaryStr = "";
+  for (let i = 0; i < binary.length; i++) {
+    binaryStr += String.fromCharCode(binary[i]!);
+  }
+  const base64 = btoa(binaryStr);
   // Wrap at 76 characters per line (standard PEM)
   const wrapped = base64.match(/.{1,76}/g)?.join("\n") ?? base64;
-  return `-----BEGIN SSH SIGNATURE-----\n${wrapped}\n-----END SSH SIGNATURE-----`;
+  return `-----BEGIN SSH SIGNATURE-----\n${wrapped}\n-----END SSH SIGNATURE-----\n`;
 }
 
 /**

--- a/packages/agent-auth/src/ssh-wire.ts
+++ b/packages/agent-auth/src/ssh-wire.ts
@@ -49,10 +49,10 @@ export function sshStringFromUtf8(str: string): Uint8Array {
  *
  * SSH public key blob format: sshString("ssh-ed25519") + sshString(32-byte-key)
  *
- * @param publicKeyHex - 32-byte Ed25519 public key as hex string (64 chars)
+ * @param publicKey - 32-byte Ed25519 public key as hex string (64 chars) or base58 (Solana address)
  */
-export function sshEd25519PublicKey(publicKeyHex: string): Uint8Array {
-  const keyBytes = hexToBytes(publicKeyHex);
+export function sshEd25519PublicKey(publicKey: string): Uint8Array {
+  const keyBytes = decodePublicKey(publicKey);
   if (keyBytes.length !== 32) {
     throw new Error(
       `Expected 32-byte Ed25519 public key, got ${keyBytes.length} bytes`,
@@ -145,4 +145,47 @@ function hexToBytes(hex: string): Uint8Array {
     bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
   }
   return bytes;
+}
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/**
+ * Decode a base58 string to Uint8Array.
+ */
+function base58ToBytes(str: string): Uint8Array {
+  const bytes: number[] = [0];
+  for (const char of str) {
+    const idx = BASE58_ALPHABET.indexOf(char);
+    if (idx === -1) throw new Error(`Invalid base58 character: ${char}`);
+    let carry = idx;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j]! * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  // Leading zeros
+  for (const char of str) {
+    if (char !== "1") break;
+    bytes.push(0);
+  }
+  return new Uint8Array(bytes.reverse());
+}
+
+/**
+ * Decode a public key that may be hex (64 chars) or base58 (Solana address format).
+ * Returns raw 32-byte Uint8Array.
+ */
+export function decodePublicKey(key: string): Uint8Array {
+  // If it's 64 hex chars, treat as raw hex
+  if (key.length === 64 && /^[0-9a-fA-F]+$/.test(key)) {
+    return hexToBytes(key);
+  }
+  // Otherwise try base58 (Solana address format)
+  return base58ToBytes(key);
 }

--- a/packages/agent-auth/src/ssh-wire.ts
+++ b/packages/agent-auth/src/ssh-wire.ts
@@ -1,0 +1,148 @@
+/**
+ * SSH wire format encoding utilities for SSHSIG envelope construction.
+ *
+ * SSH wire format uses 4-byte big-endian length prefixes before all strings/data.
+ * See: https://www.openssh.com/specs.html and PROTOCOL.sshsig
+ */
+
+/**
+ * Concatenate multiple Uint8Arrays into a single array.
+ */
+function concat(...arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
+/**
+ * Encode data in SSH wire format: 4-byte big-endian length prefix + data.
+ */
+export function sshString(data: Uint8Array): Uint8Array {
+  const len = new Uint8Array(4);
+  new DataView(len.buffer).setUint32(0, data.length);
+  return concat(len, data);
+}
+
+/**
+ * Write a uint32 in big-endian format.
+ */
+export function sshUint32(value: number): Uint8Array {
+  const buf = new Uint8Array(4);
+  new DataView(buf.buffer).setUint32(0, value);
+  return buf;
+}
+
+/**
+ * Encode a UTF-8 string in SSH wire format.
+ */
+export function sshStringFromUtf8(str: string): Uint8Array {
+  return sshString(new TextEncoder().encode(str));
+}
+
+/**
+ * Encode an Ed25519 public key in SSH wire format.
+ *
+ * SSH public key blob format: sshString("ssh-ed25519") + sshString(32-byte-key)
+ *
+ * @param publicKeyHex - 32-byte Ed25519 public key as hex string (64 chars)
+ */
+export function sshEd25519PublicKey(publicKeyHex: string): Uint8Array {
+  const keyBytes = hexToBytes(publicKeyHex);
+  if (keyBytes.length !== 32) {
+    throw new Error(
+      `Expected 32-byte Ed25519 public key, got ${keyBytes.length} bytes`,
+    );
+  }
+  return concat(sshStringFromUtf8("ssh-ed25519"), sshString(keyBytes));
+}
+
+/**
+ * Build the SSHSIG "data to be signed" blob.
+ *
+ * This is the data that Ed25519 signs (distinct from the output envelope).
+ * Format: sshString("SSHSIG") + sshString(namespace) + sshString(reserved) + sshString(hashAlgo) + sshString(hash)
+ */
+export function buildSshsigSignedData(params: {
+  namespace: string;
+  hashAlgorithm: string;
+  messageHash: Uint8Array;
+}): Uint8Array {
+  return concat(
+    sshStringFromUtf8("SSHSIG"),
+    sshStringFromUtf8(params.namespace),
+    sshStringFromUtf8(""), // reserved (empty)
+    sshStringFromUtf8(params.hashAlgorithm),
+    sshString(params.messageHash),
+  );
+}
+
+/**
+ * Build the SSHSIG output envelope (the binary blob that gets armored).
+ *
+ * Format:
+ *   "SSHSIG" (6 bytes, no null terminator in magic)
+ *   uint32 version = 1
+ *   sshString(publicKeyBlob)
+ *   sshString(namespace)
+ *   sshString(reserved = "")
+ *   sshString(hashAlgorithm)
+ *   sshString(signatureBlob)
+ *
+ * Where publicKeyBlob = sshString("ssh-ed25519") + sshString(32-byte-key)
+ * And signatureBlob = sshString("ssh-ed25519") + sshString(64-byte-sig)
+ */
+export function buildSshsigEnvelope(params: {
+  publicKeyHex: string;
+  namespace: string;
+  hashAlgorithm: string;
+  signature: Uint8Array;
+}): Uint8Array {
+  const magic = new TextEncoder().encode("SSHSIG");
+  const version = sshUint32(1);
+  const publicKeyBlob = sshEd25519PublicKey(params.publicKeyHex);
+  const signatureBlob = concat(
+    sshStringFromUtf8("ssh-ed25519"),
+    sshString(params.signature),
+  );
+
+  return concat(
+    magic,
+    version,
+    sshString(publicKeyBlob),
+    sshStringFromUtf8(params.namespace),
+    sshStringFromUtf8(""), // reserved
+    sshStringFromUtf8(params.hashAlgorithm),
+    sshString(signatureBlob),
+  );
+}
+
+/**
+ * Armor a binary SSHSIG envelope into PEM-like format.
+ *
+ * Output:
+ *   -----BEGIN SSH SIGNATURE-----
+ *   <base64, wrapped at 76 chars>
+ *   -----END SSH SIGNATURE-----
+ */
+export function armorSshSignature(binary: Uint8Array): string {
+  const base64 = btoa(String.fromCharCode(...binary));
+  // Wrap at 76 characters per line (standard PEM)
+  const wrapped = base64.match(/.{1,76}/g)?.join("\n") ?? base64;
+  return `-----BEGIN SSH SIGNATURE-----\n${wrapped}\n-----END SSH SIGNATURE-----`;
+}
+
+/**
+ * Convert a hex string to Uint8Array.
+ */
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3060,7 +3060,7 @@ importers:
         version: 0.9.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-dom@18.3.1(react@18.3.1))(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)
       '@solana/wallet-adapter-wallets':
         specifier: ^0.19.32
-        version: 0.19.37(@babel/runtime@7.28.4)(@react-native-async-storage/async-storage@1.24.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(@types/react@18.3.24)(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@18.3.1(react@18.3.1))(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 0.19.37(@babel/runtime@7.28.4)(@react-native-async-storage/async-storage@1.24.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(@types/react@18.3.24)(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@18.3.1(react@18.3.1))(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@solana/web3.js':
         specifier: ^1.95.8
         version: 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
@@ -3368,6 +3368,9 @@ importers:
       '@turnkey/crypto':
         specifier: workspace:*
         version: link:../crypto
+      '@turnkey/encoding':
+        specifier: workspace:*
+        version: link:../encoding
       '@turnkey/sdk-server':
         specifier: workspace:*
         version: link:../sdk-server
@@ -23988,11 +23991,11 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))':
+  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))':
+  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
@@ -24828,11 +24831,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana/wallet-adapter-trezor@0.1.6(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)':
+  '@solana/wallet-adapter-trezor@0.1.6(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
-      '@trezor/connect-web': 9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@trezor/connect-web': 9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       buffer: 6.0.3
     transitivePeerDependencies:
       - '@solana/sysvars'
@@ -24895,7 +24898,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.37(@babel/runtime@7.28.4)(@react-native-async-storage/async-storage@1.24.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(@types/react@18.3.24)(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@18.3.1(react@18.3.1))(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@solana/wallet-adapter-wallets@0.19.37(@babel/runtime@7.28.4)(@react-native-async-storage/async-storage@1.24.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(@types/react@18.3.24)(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@18.3.1(react@18.3.1))(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-avana': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))
@@ -24928,7 +24931,7 @@ snapshots:
       '@solana/wallet-adapter-tokenary': 0.1.16(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-tokenpocket': 0.4.23(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-torus': 0.11.32(@babel/runtime@7.28.4)(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)
-      '@solana/wallet-adapter-trezor': 0.1.6(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@solana/wallet-adapter-trezor': 0.1.6(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-trust': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-unsafe-burner': 0.1.11(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-walletconnect': 0.1.21(@react-native-async-storage/async-storage@1.24.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -25555,9 +25558,9 @@ snapshots:
       - react-native
       - utf-8-validate
 
-  '@trezor/blockchain-link@2.5.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)':
+  '@trezor/blockchain-link@2.5.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))
+      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -25606,9 +25609,9 @@ snapshots:
       - expo-localization
       - react-native
 
-  '@trezor/connect-web@9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)':
+  '@trezor/connect-web@9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@trezor/connect': 9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@trezor/connect': 9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@trezor/connect-common': 0.4.2(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)
       '@trezor/utils': 9.4.2(tslib@2.8.1)
       '@trezor/websocket-client': 1.2.2(bufferutil@4.0.9)(tslib@2.8.1)(utf-8-validate@5.0.10)
@@ -25627,7 +25630,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@trezor/connect@9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)':
+  '@trezor/connect@9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@ethereumjs/common': 10.0.0
       '@ethereumjs/tx': 10.0.0
@@ -25636,11 +25639,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip39': 1.6.0
       '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@trezor/blockchain-link': 2.5.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@trezor/blockchain-link': 2.5.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@trezor/blockchain-link-types': 1.4.2(tslib@2.8.1)
       '@trezor/blockchain-link-utils': 1.4.2(bufferutil@4.0.9)(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(utf-8-validate@5.0.10)
       '@trezor/connect-analytics': 1.3.5(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(tslib@2.8.1)
@@ -31482,7 +31485,7 @@ snapshots:
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.35.0(jiti@2.5.1))
@@ -31515,7 +31518,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -31680,7 +31683,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.4.3))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3365,6 +3365,9 @@ importers:
 
   packages/agent-auth:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.5.0
+        version: 1.8.0
       '@turnkey/crypto':
         specifier: workspace:*
         version: link:../crypto


### PR DESCRIPTION
## PRD

[Agent Auth Signing Helpers - Full PRD](https://gist.github.com/natefikru/2f3fc4ad8d67e13000283ca4f667f051)

## Summary

Adds signing helper functions to `@turnkey/agent-auth` that wrap `sign_raw_payload` with format-specific logic for common signing use cases. No backend changes.

**Three helpers:**
- `signJwt()`: Assemble and sign ES256 JWTs with the agent's P256 wallet key
- `signSshCommit()`: Sign git commits with Ed25519 in SSHSIG format (armored output)
- `signMessage()`: General-purpose signing wrapper returning raw r, s, v

**Also includes:**
- SSH wire format encoding utilities (`ssh-wire.ts`)
- Base58 (Solana address) decoding for Ed25519 public keys
- Signing helpers example (`examples/agent-auth/src/signing.ts`)

### Technical details

**signJwt:** SHA-256 hashes the signing input client-side, sends the 32-byte digest with `HASH_FUNCTION_NO_OP` (Turnkey's P256 signer uses `sign_prehash`). Signature is raw r||s per RFC 7515 (not DER). Claims (iat, exp) are the caller's responsibility.

**signSshCommit:** Constructs the SSHSIG "data to be signed" blob (distinct from the output envelope), signs via `sign_raw_payload` with `HASH_FUNCTION_NOT_APPLICABLE` (Ed25519 handles its own SHA-512 per RFC 8032), builds the SSHSIG output envelope with the public key and signature, and returns an armored SSH signature. Private key never leaves the enclave.

**signMessage:** Thin wrapper around `sign_raw_payload` with sensible defaults.

### Note on ETH signing

Turnkey already exposes `signTransaction()` as a first-class SDK method. No wrapper needed.

## Test plan

**Unit tests (64 passing, 28 new):**
- [x] signJwt: 3-part JWT format, ES256 header, custom headers, claims passed through, client-side SHA-256 with NO_OP, raw r||s signature, r/s length validation
- [x] signSshCommit: armored format, HASH_FUNCTION_NOT_APPLICABLE, namespace defaults, custom namespace, SSHSIG magic + version in envelope
- [x] signMessage: params with defaults, custom encoding/hashFunction, raw r/s/v return
- [x] SSH wire: sshString length prefix, sshUint32, sshEd25519PublicKey, buildSshsigSignedData, buildSshsigEnvelope, armorSshSignature
- [x] All 36 Phase 1 tests still pass

**Smoke test (22/22 passing against local Turnkey infra):**
- [x] signJwt produces decodable 3-part JWT with ES256 header
- [x] signSshCommit produces armored SSH signature with correct headers
- [x] signMessage returns r/s with correct lengths
- [x] All Phase 1 checks still pass (session lifecycle, policy enforcement, deletion)

**Build verification:**
- [x] `pnpm run typecheck` passes (tsc --noEmit, strict mode)
- [x] `pnpm run build` passes (rollup, dual ESM/CJS output)
- [x] `pnpm run prettier-all:check` passes

**Code review findings addressed:**
- [x] Replaced `String.fromCharCode(...spread)` with loop-based encoding (avoids stack overflow on large inputs)
- [x] Added trailing newline to armored SSH signature (matches ssh-keygen output)
- [x] Added r/s length validation to signSshCommit (parity with signJwt)
- [x] Base58 Solana address decoding for Ed25519 public keys