### PR TITLE
Add composable policy templates to @turnkey/agent-auth (Phase 3/3)

### DIFF
--- a/examples/agent-auth/README.md
+++ b/examples/agent-auth/README.md
@@ -47,6 +47,17 @@ Demonstrates all three signing helpers:
 
 Shows JWT decoding, SSHSIG armored output, and the complete signing flow without ever exposing private keys.
 
+### Policy Templates (`pnpm run policies`)
+
+Demonstrates composable policy templates for fine-grained access control:
+
+- `allowAllSigning()`: Replace default with broader signing permissions
+- `allowEthTransaction()`: Restrict by chain, max value, allowed addresses
+- `allowErc20Transfer()`: Token-specific transfer policies
+- `allowEip712Signing()`: Domain-specific typed data signing
+
+Shows how templates compose to build a complete permission profile.
+
 ### Multi-Agent Swarm (`pnpm run multi-agent`)
 
 Provisions three agents with different capabilities (JWT, git, ETH signing) from the same parent org. Demonstrates:

--- a/examples/agent-auth/package.json
+++ b/examples/agent-auth/package.json
@@ -7,6 +7,7 @@
     "minimal": "pnpm tsx src/minimal.ts",
     "multi-agent": "pnpm tsx src/multi-agent.ts",
     "signing": "pnpm tsx src/signing.ts",
+    "policies": "pnpm tsx src/policies.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/agent-auth/src/policies.ts
+++ b/examples/agent-auth/src/policies.ts
@@ -1,0 +1,100 @@
+/**
+ * Policy templates example for @turnkey/agent-auth
+ *
+ * Demonstrates:
+ * - Using composable policy templates instead of raw condition strings
+ * - ETH transaction restrictions (chain, value, addresses)
+ * - ERC-20 transfer policies
+ * - Combining multiple policies for fine-grained access control
+ *
+ * Usage:
+ *   cp .env.local.example .env.local
+ *   # Fill in your Turnkey credentials
+ *   pnpm run policies
+ */
+
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { Turnkey } from "@turnkey/sdk-server";
+import {
+  createAgentSession,
+  deleteAgentSession,
+  presets,
+  policyTemplates,
+} from "@turnkey/agent-auth";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  const organizationId = process.env.ORGANIZATION_ID!;
+  const apiBaseUrl = process.env.BASE_URL!;
+
+  const turnkey = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    defaultOrganizationId: organizationId,
+  });
+
+  // Provision an agent with fine-grained ETH policies
+  console.log("Provisioning agent with policy templates...\n");
+  const session = await createAgentSession(
+    turnkey.apiClient(),
+    {
+      organizationId,
+      agentName: `policy-example-${Date.now()}`,
+      expirationSeconds: 600,
+      accounts: [presets.ethSigning()],
+      policies: [
+        // Allow all signing operations (replaces default sign_raw_payload policy)
+        policyTemplates.allowAllSigning(),
+
+        // Allow ETH transactions on mainnet and Polygon, max 1 ETH
+        policyTemplates.allowEthTransaction({
+          chainIds: [1, 137],
+          maxValue: "1000000000000000000",
+        }),
+
+        // Allow USDC transfers only
+        policyTemplates.allowErc20Transfer({
+          tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        }),
+
+        // Allow EIP-712 signing for Uniswap only
+        policyTemplates.allowEip712Signing({
+          domainName: "Uniswap",
+        }),
+      ],
+    },
+    { apiBaseUrl },
+  );
+
+  console.log("Agent provisioned with policy templates:");
+  console.log(`  Sub-org: ${session.subOrganizationId}`);
+  console.log(`  Policies created: ${session.policyIds.length}`);
+
+  // Show what each policy allows
+  console.log("\nPolicy breakdown:");
+  console.log(
+    "  1. allowAllSigning: sign_raw_payload + sign_transaction + sign_raw_payloads",
+  );
+  console.log(
+    "  2. allowEthTransaction: ETH transfers on chains 1,137 up to 1 ETH",
+  );
+  console.log("  3. allowErc20Transfer: USDC transfers only");
+  console.log("  4. allowEip712Signing: Uniswap typed data signing only");
+  console.log("\nEverything else is blocked by implicit deny.");
+
+  // Clean up
+  console.log("\nCleaning up...");
+  await deleteAgentSession(
+    {
+      subOrganizationId: session.subOrganizationId,
+      adminApiKey: session.adminApiKey,
+    },
+    { apiBaseUrl },
+  );
+  console.log("Done.");
+}
+
+main().catch(console.error);

--- a/packages/agent-auth/scripts/smoke-test.ts
+++ b/packages/agent-auth/scripts/smoke-test.ts
@@ -15,6 +15,7 @@ import {
   createAgentSession,
   deleteAgentSession,
   presets,
+  policyTemplates,
   signJwt,
   signSshCommit,
   signMessage,
@@ -71,6 +72,13 @@ async function main() {
           presets.jwtSigning(),
           presets.gitSigning({ exportKey: true }),
         ],
+        policies: [
+          policyTemplates.allowAllSigning(),
+          policyTemplates.allowEthTransaction({
+            chainIds: [1],
+            maxValue: "1000000000000000000",
+          }),
+        ],
       },
       { apiBaseUrl: API_BASE_URL },
     );
@@ -86,6 +94,10 @@ async function main() {
     check("JWT signing account", session.accounts[0]?.label === "jwt-signing");
     check("Git signing account", session.accounts[1]?.label === "git-signing");
     check("Has policy IDs", session.policyIds.length > 0);
+    check(
+      "Policy dedup: allowAllSigning replaces default (2 policies, not 3)",
+      session.policyIds.length === 2,
+    );
     check("Has expiry", !!session.expiresAt);
     check(
       "Git signing account has exportBundle",

--- a/packages/agent-auth/src/__tests__/create-session-test.ts
+++ b/packages/agent-auth/src/__tests__/create-session-test.ts
@@ -569,4 +569,72 @@ describe("createAgentSession", () => {
       expect(result.accounts[2]!.publicKey).toBe("secp-addr");
     });
   });
+
+  describe("blended identity (delegatedBy)", () => {
+    it("encodes email in sub-org name when delegatedBy.email provided", async () => {
+      await createAgentSession(mockParentClient, {
+        ...baseRequest,
+        delegatedBy: { email: "alice@company.com", source: "oauth" },
+      });
+
+      const subOrgArgs =
+        mockParentClient.createSubOrganization.mock.calls[0]![0];
+      expect(subOrgArgs.subOrganizationName).toBe(
+        "test-agent [delegated:alice@company.com]",
+      );
+    });
+
+    it("encodes userId in sub-org name when only userId provided", async () => {
+      await createAgentSession(mockParentClient, {
+        ...baseRequest,
+        delegatedBy: { userId: "user-uuid-123" },
+      });
+
+      const subOrgArgs =
+        mockParentClient.createSubOrganization.mock.calls[0]![0];
+      expect(subOrgArgs.subOrganizationName).toBe(
+        "test-agent [delegated:user-uuid-123]",
+      );
+    });
+
+    it("uses 'unknown' when delegatedBy has no email or userId", async () => {
+      await createAgentSession(mockParentClient, {
+        ...baseRequest,
+        delegatedBy: { source: "oauth" },
+      });
+
+      const subOrgArgs =
+        mockParentClient.createSubOrganization.mock.calls[0]![0];
+      expect(subOrgArgs.subOrganizationName).toBe(
+        "test-agent [delegated:unknown]",
+      );
+    });
+
+    it("leaves sub-org name unchanged when delegatedBy is undefined", async () => {
+      await createAgentSession(mockParentClient, baseRequest);
+
+      const subOrgArgs =
+        mockParentClient.createSubOrganization.mock.calls[0]![0];
+      expect(subOrgArgs.subOrganizationName).toBe("test-agent");
+    });
+
+    it("returns delegatedBy in the result", async () => {
+      const delegatedBy = {
+        email: "alice@company.com",
+        userId: "user-123",
+        source: "oauth",
+      };
+      const result = await createAgentSession(mockParentClient, {
+        ...baseRequest,
+        delegatedBy,
+      });
+
+      expect(result.delegatedBy).toEqual(delegatedBy);
+    });
+
+    it("returns undefined delegatedBy when not provided", async () => {
+      const result = await createAgentSession(mockParentClient, baseRequest);
+      expect(result.delegatedBy).toBeUndefined();
+    });
+  });
 });

--- a/packages/agent-auth/src/__tests__/create-session-test.ts
+++ b/packages/agent-auth/src/__tests__/create-session-test.ts
@@ -251,6 +251,26 @@ describe("createAgentSession", () => {
         "<AGENT_USER_ID>",
       );
     });
+
+    it("skips default signing policy when user provides one covering sign_raw_payload", async () => {
+      await createAgentSession(mockParentClient, {
+        ...baseRequest,
+        policies: [
+          {
+            policyName: "allow-all-signing",
+            effect: "EFFECT_ALLOW",
+            condition:
+              "activity.type in ['ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2', 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2']",
+            consensus: "approvers.any(user, user.id == '<AGENT_USER_ID>')",
+          },
+        ],
+      });
+
+      const policiesArgs = mockSubOrgApiClient.createPolicies.mock.calls[0]![0];
+      // Only user policy, no default (dedup)
+      expect(policiesArgs.policies).toHaveLength(1);
+      expect(policiesArgs.policies[0].policyName).toBe("allow-all-signing");
+    });
   });
 
   describe("error handling: createUsers fails", () => {

--- a/packages/agent-auth/src/__tests__/policy-templates-test.ts
+++ b/packages/agent-auth/src/__tests__/policy-templates-test.ts
@@ -1,0 +1,251 @@
+import {
+  allowSignRawPayloads,
+  allowAllSigning,
+  allowEthTransaction,
+  allowErc20Transfer,
+  allowEip712Signing,
+  allowSolTransfer,
+  allowSplTransfer,
+  allowExportWalletAccount,
+  allowCreateWalletAccounts,
+  combineConditions,
+} from "../policy-templates";
+
+describe("signing templates", () => {
+  it("allowSignRawPayloads returns correct policy", () => {
+    const policy = allowSignRawPayloads();
+    expect(policy.effect).toBe("EFFECT_ALLOW");
+    expect(policy.condition).toBe(
+      "activity.type == 'ACTIVITY_TYPE_SIGN_RAW_PAYLOADS'",
+    );
+    expect(policy.consensus).toContain("<AGENT_USER_ID>");
+  });
+
+  it("allowAllSigning uses in operator with all signing types", () => {
+    const policy = allowAllSigning();
+    expect(policy.effect).toBe("EFFECT_ALLOW");
+    expect(policy.condition).toContain("activity.type in [");
+    expect(policy.condition).toContain("ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2");
+    expect(policy.condition).toContain("ACTIVITY_TYPE_SIGN_TRANSACTION_V2");
+    expect(policy.condition).toContain("ACTIVITY_TYPE_SIGN_RAW_PAYLOADS");
+    // Uses `in` not `||`
+    expect(policy.condition).not.toContain("||");
+  });
+});
+
+describe("ethereum templates", () => {
+  describe("allowEthTransaction", () => {
+    it("default (no options) checks only activity type", () => {
+      const policy = allowEthTransaction();
+      expect(policy.effect).toBe("EFFECT_ALLOW");
+      expect(policy.condition).toBe(
+        "activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2'",
+      );
+      expect(policy.consensus).toContain("<AGENT_USER_ID>");
+    });
+
+    it("with chainIds adds chain restriction", () => {
+      const policy = allowEthTransaction({ chainIds: [1, 137] });
+      expect(policy.condition).toContain("eth.tx.chain_id in [1, 137]");
+    });
+
+    it("with maxValue adds value cap", () => {
+      const policy = allowEthTransaction({
+        maxValue: "1000000000000000000",
+      });
+      expect(policy.condition).toContain("eth.tx.value <= 1000000000000000000");
+    });
+
+    it("with maxValue zero is valid", () => {
+      const policy = allowEthTransaction({ maxValue: "0" });
+      expect(policy.condition).toContain("eth.tx.value <= 0");
+    });
+
+    it("with allowedAddresses lowercases and uses in operator", () => {
+      const policy = allowEthTransaction({
+        allowedAddresses: ["0xAbC123", "0xDeF456"],
+      });
+      expect(policy.condition).toContain(
+        "eth.tx.to in ['0xabc123', '0xdef456']",
+      );
+    });
+
+    it("with walletId adds wallet restriction", () => {
+      const policy = allowEthTransaction({ walletId: "wallet-uuid" });
+      expect(policy.condition).toContain("wallet.id == 'wallet-uuid'");
+    });
+
+    it("with all options combines with &&", () => {
+      const policy = allowEthTransaction({
+        chainIds: [1],
+        maxValue: "1000",
+        allowedAddresses: ["0xabc"],
+        walletId: "w1",
+      });
+      const parts = policy.condition!.split(" && ");
+      expect(parts).toHaveLength(5); // activity type + 4 restrictions
+    });
+  });
+
+  describe("allowErc20Transfer", () => {
+    it("checks token address and function selector", () => {
+      const policy = allowErc20Transfer({
+        tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      });
+      expect(policy.condition).toContain(
+        "eth.tx.to == '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'",
+      );
+      expect(policy.condition).toContain("eth.tx.data[0..10] == '0xa9059cbb'");
+    });
+
+    it("with allowedRecipients adds contract_call_args check", () => {
+      const policy = allowErc20Transfer({
+        tokenAddress: "0xtoken",
+        allowedRecipients: ["0xRecipient1"],
+      });
+      expect(policy.condition).toContain(
+        "eth.tx.contract_call_args['to'] in ['0xrecipient1']",
+      );
+    });
+
+    it("with chainIds adds chain restriction", () => {
+      const policy = allowErc20Transfer({
+        tokenAddress: "0xtoken",
+        chainIds: [1],
+      });
+      expect(policy.condition).toContain("eth.tx.chain_id in [1]");
+    });
+  });
+
+  describe("allowEip712Signing", () => {
+    it("default checks only activity type", () => {
+      const policy = allowEip712Signing();
+      expect(policy.condition).toBe(
+        "activity.type == 'ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2'",
+      );
+    });
+
+    it("with domainName restricts domain", () => {
+      const policy = allowEip712Signing({ domainName: "Uniswap" });
+      expect(policy.condition).toContain(
+        "eth.eip_712.domain.name == 'Uniswap'",
+      );
+    });
+
+    it("with primaryType restricts type", () => {
+      const policy = allowEip712Signing({ primaryType: "Order" });
+      expect(policy.condition).toContain("eth.eip_712.primary_type == 'Order'");
+    });
+  });
+});
+
+describe("solana templates", () => {
+  describe("allowSolTransfer", () => {
+    it("default checks only activity type", () => {
+      const policy = allowSolTransfer();
+      expect(policy.condition).toBe(
+        "activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2'",
+      );
+    });
+
+    it("with allowedRecipients restricts destinations", () => {
+      const policy = allowSolTransfer({
+        allowedRecipients: ["SolAddr1", "SolAddr2"],
+      });
+      expect(policy.condition).toContain(
+        "solana.tx.transfers.all(t, t.to in ['SolAddr1', 'SolAddr2'])",
+      );
+      // Solana addresses are case-sensitive (not lowercased)
+      expect(policy.condition).toContain("SolAddr1");
+    });
+  });
+
+  describe("allowSplTransfer", () => {
+    it("default checks only activity type", () => {
+      const policy = allowSplTransfer();
+      expect(policy.condition).toBe(
+        "activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2'",
+      );
+    });
+
+    it("with tokenMint restricts token", () => {
+      const policy = allowSplTransfer({ tokenMint: "TokenMintAddr" });
+      expect(policy.condition).toContain(
+        "solana.tx.spl_transfers.all(t, t.token_mint == 'TokenMintAddr')",
+      );
+    });
+
+    it("with allowedRecipients restricts destinations", () => {
+      const policy = allowSplTransfer({
+        allowedRecipients: ["Recipient1"],
+      });
+      expect(policy.condition).toContain(
+        "solana.tx.spl_transfers.all(t, t.to in ['Recipient1'])",
+      );
+    });
+  });
+});
+
+describe("wallet templates", () => {
+  it("allowExportWalletAccount returns correct policy", () => {
+    const policy = allowExportWalletAccount();
+    expect(policy.effect).toBe("EFFECT_ALLOW");
+    expect(policy.condition).toBe(
+      "activity.type == 'ACTIVITY_TYPE_EXPORT_WALLET_ACCOUNT'",
+    );
+  });
+
+  it("allowCreateWalletAccounts returns correct policy", () => {
+    const policy = allowCreateWalletAccounts();
+    expect(policy.effect).toBe("EFFECT_ALLOW");
+    expect(policy.condition).toBe(
+      "activity.type == 'ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS'",
+    );
+  });
+});
+
+describe("utility", () => {
+  it("combineConditions joins with &&", () => {
+    const result = combineConditions(["a == 1", "b == 2", "c == 3"]);
+    expect(result).toBe("a == 1 && b == 2 && c == 3");
+  });
+
+  it("combineConditions with single condition returns it as-is", () => {
+    const result = combineConditions(["a == 1"]);
+    expect(result).toBe("a == 1");
+  });
+
+  it("combineConditions throws on empty array", () => {
+    expect(() => combineConditions([])).toThrow(
+      "combineConditions requires at least one condition",
+    );
+  });
+});
+
+describe("all templates use EFFECT_ALLOW and AGENT_USER_ID placeholder", () => {
+  const allTemplates = [
+    allowSignRawPayloads(),
+    allowAllSigning(),
+    allowEthTransaction(),
+    allowErc20Transfer({ tokenAddress: "0x0" }),
+    allowEip712Signing(),
+    allowSolTransfer(),
+    allowSplTransfer(),
+    allowExportWalletAccount(),
+    allowCreateWalletAccounts(),
+  ];
+
+  it.each(allTemplates.map((t) => [t.policyName, t]))(
+    "%s uses EFFECT_ALLOW",
+    (_name, template) => {
+      expect((template as any).effect).toBe("EFFECT_ALLOW");
+    },
+  );
+
+  it.each(allTemplates.map((t) => [t.policyName, t]))(
+    "%s uses AGENT_USER_ID placeholder in consensus",
+    (_name, template) => {
+      expect((template as any).consensus).toContain("<AGENT_USER_ID>");
+    },
+  );
+});

--- a/packages/agent-auth/src/create-session.ts
+++ b/packages/agent-auth/src/create-session.ts
@@ -45,6 +45,12 @@ export async function createAgentSession(
   const agentAnchorKeyPair = generateP256KeyPair();
   const agentSessionKeyPair = generateP256KeyPair();
 
+  // Step 1b: Build sub-org name with optional delegation suffix (blended identity)
+  const delegationSuffix = request.delegatedBy
+    ? ` [delegated:${request.delegatedBy.email ?? request.delegatedBy.userId ?? "unknown"}]`
+    : "";
+  const subOrgName = `${request.agentName}${delegationSuffix}`;
+
   // Step 2: Build wallet accounts from request
   const walletAccounts = (request.accounts ?? []).map((account, i) => ({
     curve: account.curve,
@@ -65,7 +71,7 @@ export async function createAgentSession(
   // SDK methods destructure {organizationId, timestampMs, ...rest} and wrap rest as parameters
   const subOrgResponse = await parentClient.createSubOrganization({
     organizationId: request.organizationId,
-    subOrganizationName: request.agentName,
+    subOrganizationName: subOrgName,
     rootUsers: [
       {
         userName: `${request.agentName}-admin`,
@@ -288,5 +294,6 @@ export async function createAgentSession(
     accounts,
     policyIds,
     expiresAt,
+    ...(request.delegatedBy ? { delegatedBy: request.delegatedBy } : {}),
   };
 }

--- a/packages/agent-auth/src/create-session.ts
+++ b/packages/agent-auth/src/create-session.ts
@@ -195,11 +195,19 @@ export async function createAgentSession(
   }
 
   // Step 6: Create policies (as root admin)
-  const defaultPolicies = [defaultSigningPolicy(agentUserId)];
+  // Dedup: skip default signing policy if user already provides one that covers sign_raw_payload
   const userPolicies = resolvePolicyPlaceholders(
     request.policies ?? [],
     agentUserId,
   );
+  const userCoversSignRawPayload = userPolicies.some(
+    (p) =>
+      p.condition?.includes("ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2") ||
+      p.condition?.includes("ACTIVITY_TYPE_SIGN_RAW_PAYLOAD"),
+  );
+  const defaultPolicies = userCoversSignRawPayload
+    ? []
+    : [defaultSigningPolicy(agentUserId)];
   const allPolicies = [...defaultPolicies, ...userPolicies];
 
   let policyIds: string[] = [];

--- a/packages/agent-auth/src/index.ts
+++ b/packages/agent-auth/src/index.ts
@@ -10,6 +10,7 @@ export type {
   AgentPolicyParams,
   CreateAgentSessionRequest,
   CreateAgentSessionResult,
+  DelegatedByInfo,
   DeleteAgentSessionRequest,
   DeleteAgentSessionResult,
 } from "./types";

--- a/packages/agent-auth/src/index.ts
+++ b/packages/agent-auth/src/index.ts
@@ -3,6 +3,7 @@ export { deleteAgentSession } from "./delete-session";
 export { signJwt, signSshCommit, signMessage } from "./signing";
 export * as presets from "./presets";
 export * as policies from "./policies";
+export * as policyTemplates from "./policy-templates";
 export type {
   AgentAccountConfig,
   AgentAccountResult,

--- a/packages/agent-auth/src/policy-templates.ts
+++ b/packages/agent-auth/src/policy-templates.ts
@@ -1,0 +1,264 @@
+/**
+ * Composable policy template builders for @turnkey/agent-auth.
+ *
+ * Each template returns an AgentPolicyParams with:
+ * - EFFECT_ALLOW (never DENY, implicit deny handles the rest)
+ * - <AGENT_USER_ID> placeholder in consensus (resolved by createAgentSession)
+ * - Typed options for common restrictions
+ *
+ * Chain-specific conditions (eth.tx.*, solana.tx.*) produce MissingKeyword
+ * errors when evaluated against non-matching activity types. The UMP evaluator
+ * treats these as Outcome::Error (functionally equivalent to "does not match").
+ * This is safe by design.
+ */
+
+import type { AgentPolicyParams } from "./types";
+
+const AGENT_CONSENSUS = "approvers.any(user, user.id == '<AGENT_USER_ID>')";
+
+// ---------------------------------------------------------------------------
+// Signing Policies
+// ---------------------------------------------------------------------------
+
+/**
+ * Allow batch signing (sign_raw_payloads).
+ */
+export function allowSignRawPayloads(): AgentPolicyParams {
+  return {
+    policyName: "allow-sign-raw-payloads",
+    effect: "EFFECT_ALLOW",
+    condition: "activity.type == 'ACTIVITY_TYPE_SIGN_RAW_PAYLOADS'",
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+/**
+ * Allow all signing operations: sign_raw_payload, sign_transaction, and sign_raw_payloads.
+ * Uses the `in` operator (not `||`) because UMP does not short-circuit logical operators.
+ */
+export function allowAllSigning(): AgentPolicyParams {
+  return {
+    policyName: "allow-all-signing",
+    effect: "EFFECT_ALLOW",
+    condition:
+      "activity.type in ['ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2', 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2', 'ACTIVITY_TYPE_SIGN_RAW_PAYLOADS']",
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ethereum Policies
+// ---------------------------------------------------------------------------
+
+/**
+ * Allow Ethereum transactions with optional restrictions.
+ *
+ * @param opts.chainIds - Restrict to specific chain IDs (e.g., [1, 137])
+ * @param opts.maxValue - Max transaction value in wei (as string for big numbers)
+ * @param opts.allowedAddresses - Restrict destination addresses (auto-lowercased)
+ * @param opts.walletId - Restrict to a specific wallet
+ */
+export function allowEthTransaction(opts?: {
+  chainIds?: number[];
+  maxValue?: string;
+  allowedAddresses?: string[];
+  walletId?: string;
+}): AgentPolicyParams {
+  const conditions: string[] = [
+    "activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2'",
+  ];
+
+  if (opts?.chainIds?.length) {
+    conditions.push(`eth.tx.chain_id in [${opts.chainIds.join(", ")}]`);
+  }
+  if (opts?.maxValue !== undefined) {
+    conditions.push(`eth.tx.value <= ${opts.maxValue}`);
+  }
+  if (opts?.allowedAddresses?.length) {
+    const addrs = opts.allowedAddresses
+      .map((a) => `'${a.toLowerCase()}'`)
+      .join(", ");
+    conditions.push(`eth.tx.to in [${addrs}]`);
+  }
+  if (opts?.walletId) {
+    conditions.push(`wallet.id == '${opts.walletId}'`);
+  }
+
+  return {
+    policyName: "allow-eth-transaction",
+    effect: "EFFECT_ALLOW",
+    condition: conditions.join(" && "),
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+/**
+ * Allow ERC-20 token transfers.
+ * Detects the `transfer(address,uint256)` function selector (0xa9059cbb).
+ *
+ * @param opts.tokenAddress - ERC-20 contract address (auto-lowercased)
+ * @param opts.allowedRecipients - Restrict transfer recipients
+ * @param opts.chainIds - Restrict to specific chains
+ */
+export function allowErc20Transfer(opts: {
+  tokenAddress: string;
+  allowedRecipients?: string[];
+  chainIds?: number[];
+}): AgentPolicyParams {
+  const conditions: string[] = [
+    "activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2'",
+    `eth.tx.to == '${opts.tokenAddress.toLowerCase()}'`,
+    "eth.tx.data[0..10] == '0xa9059cbb'",
+  ];
+
+  if (opts.allowedRecipients?.length) {
+    // ERC-20 transfer recipient is the first argument in calldata
+    const recipients = opts.allowedRecipients
+      .map((a) => `'${a.toLowerCase()}'`)
+      .join(", ");
+    conditions.push(`eth.tx.contract_call_args['to'] in [${recipients}]`);
+  }
+  if (opts.chainIds?.length) {
+    conditions.push(`eth.tx.chain_id in [${opts.chainIds.join(", ")}]`);
+  }
+
+  return {
+    policyName: "allow-erc20-transfer",
+    effect: "EFFECT_ALLOW",
+    condition: conditions.join(" && "),
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+/**
+ * Allow EIP-712 typed data signing with optional domain/type restrictions.
+ *
+ * @param opts.domainName - Restrict to a specific dApp domain name
+ * @param opts.primaryType - Restrict to a specific primary type
+ */
+export function allowEip712Signing(opts?: {
+  domainName?: string;
+  primaryType?: string;
+}): AgentPolicyParams {
+  const conditions: string[] = [
+    "activity.type == 'ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2'",
+  ];
+
+  if (opts?.domainName) {
+    conditions.push(`eth.eip_712.domain.name == '${opts.domainName}'`);
+  }
+  if (opts?.primaryType) {
+    conditions.push(`eth.eip_712.primary_type == '${opts.primaryType}'`);
+  }
+
+  return {
+    policyName: "allow-eip712-signing",
+    effect: "EFFECT_ALLOW",
+    condition: conditions.join(" && "),
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Solana Policies
+// ---------------------------------------------------------------------------
+
+/**
+ * Allow native SOL transfers with optional recipient restrictions.
+ *
+ * @param opts.allowedRecipients - Restrict transfer destinations (case-sensitive for Solana)
+ */
+export function allowSolTransfer(opts?: {
+  allowedRecipients?: string[];
+}): AgentPolicyParams {
+  const conditions: string[] = [
+    "activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2'",
+  ];
+
+  if (opts?.allowedRecipients?.length) {
+    const recipients = opts.allowedRecipients.map((a) => `'${a}'`).join(", ");
+    conditions.push(`solana.tx.transfers.all(t, t.to in [${recipients}])`);
+  }
+
+  return {
+    policyName: "allow-sol-transfer",
+    effect: "EFFECT_ALLOW",
+    condition: conditions.join(" && "),
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+/**
+ * Allow SPL token transfers with optional token and recipient restrictions.
+ *
+ * @param opts.tokenMint - Restrict to a specific token mint address (case-sensitive)
+ * @param opts.allowedRecipients - Restrict transfer destinations (case-sensitive)
+ */
+export function allowSplTransfer(opts?: {
+  tokenMint?: string;
+  allowedRecipients?: string[];
+}): AgentPolicyParams {
+  const conditions: string[] = [
+    "activity.type == 'ACTIVITY_TYPE_SIGN_TRANSACTION_V2'",
+  ];
+
+  if (opts?.tokenMint) {
+    conditions.push(
+      `solana.tx.spl_transfers.all(t, t.token_mint == '${opts.tokenMint}')`,
+    );
+  }
+  if (opts?.allowedRecipients?.length) {
+    const recipients = opts.allowedRecipients.map((a) => `'${a}'`).join(", ");
+    conditions.push(`solana.tx.spl_transfers.all(t, t.to in [${recipients}])`);
+  }
+
+  return {
+    policyName: "allow-spl-transfer",
+    effect: "EFFECT_ALLOW",
+    condition: conditions.join(" && "),
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wallet & Key Management Policies
+// ---------------------------------------------------------------------------
+
+/**
+ * Allow exporting wallet account keys via HPKE.
+ */
+export function allowExportWalletAccount(): AgentPolicyParams {
+  return {
+    policyName: "allow-export-wallet-account",
+    effect: "EFFECT_ALLOW",
+    condition: "activity.type == 'ACTIVITY_TYPE_EXPORT_WALLET_ACCOUNT'",
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+/**
+ * Allow creating new accounts in an existing wallet.
+ */
+export function allowCreateWalletAccounts(): AgentPolicyParams {
+  return {
+    policyName: "allow-create-wallet-accounts",
+    effect: "EFFECT_ALLOW",
+    condition: "activity.type == 'ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS'",
+    consensus: AGENT_CONSENSUS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Combine multiple condition strings into a single AND expression.
+ * Useful for building custom policies from reusable condition fragments.
+ */
+export function combineConditions(conditions: string[]): string {
+  if (conditions.length === 0) {
+    throw new Error("combineConditions requires at least one condition");
+  }
+  return conditions.join(" && ");
+}

--- a/packages/agent-auth/src/policy-templates.ts
+++ b/packages/agent-auth/src/policy-templates.ts
@@ -53,6 +53,9 @@ export function allowAllSigning(): AgentPolicyParams {
 /**
  * Allow Ethereum transactions with optional restrictions.
  *
+ * Note: Without any options, this allows ALL sign_transaction activities
+ * (not just ETH). Use `chainIds` to restrict to specific EVM chains.
+ *
  * @param opts.chainIds - Restrict to specific chain IDs (e.g., [1, 137])
  * @param opts.maxValue - Max transaction value in wei (as string for big numbers)
  * @param opts.allowedAddresses - Restrict destination addresses (auto-lowercased)
@@ -165,6 +168,9 @@ export function allowEip712Signing(opts?: {
 
 /**
  * Allow native SOL transfers with optional recipient restrictions.
+ *
+ * Note: Without `allowedRecipients`, this allows ALL sign_transaction activities
+ * (not just Solana). Use `allowedRecipients` to add Solana-specific restrictions.
  *
  * @param opts.allowedRecipients - Restrict transfer destinations (case-sensitive for Solana)
  */

--- a/packages/agent-auth/src/types.ts
+++ b/packages/agent-auth/src/types.ts
@@ -1,4 +1,18 @@
 /**
+ * Information about the human user who delegated authority to this agent.
+ * Used for audit logging (blended identity, OWASP ASI03).
+ * Encoded in the sub-org name so it appears in every Turnkey activity log.
+ */
+export interface DelegatedByInfo {
+  /** Human user identifier (user ID, username, etc.) */
+  userId?: string;
+  /** Human user email */
+  email?: string;
+  /** How the human authenticated (e.g., "oauth", "passkey", "api-key") */
+  source?: string;
+}
+
+/**
  * Configuration for a wallet account to be created for the agent.
  * Use presets from `./presets` for common configurations, or specify custom curve/path combos.
  */
@@ -46,6 +60,11 @@ export interface CreateAgentSessionRequest {
   accounts?: AgentAccountConfig[];
   /** Additional ALLOW policies beyond the default sign_raw_payload policy */
   policies?: AgentPolicyParams[];
+  /**
+   * Optional: human user who delegated authority to this agent (blended identity).
+   * Encoded in the sub-org name for audit logging. Appears in every Turnkey activity log.
+   */
+  delegatedBy?: DelegatedByInfo;
 }
 
 export interface AgentAccountResult {
@@ -82,6 +101,8 @@ export interface CreateAgentSessionResult {
   policyIds: string[];
   /** ISO 8601 expiry timestamp (advisory, based on expirationSeconds from request) */
   expiresAt: string;
+  /** The delegating human's identity, if provided in the request */
+  delegatedBy?: DelegatedByInfo;
 }
 
 export interface DeleteAgentSessionRequest {


### PR DESCRIPTION
## PRD

[Agent Auth Policy Templates - Full PRD](https://gist.github.com/natefikru/d46717101e5cd588b6fb741076ca9b5c)

## Summary

Composable policy template builders for `@turnkey/agent-auth`. Express intent ("allow ETH transfers up to 1 ETH") instead of raw UMP condition expressions.

**Templates:**
- **Signing:** `allowSignRawPayloads()`, `allowAllSigning()`
- **Ethereum:** `allowEthTransaction(opts)`, `allowErc20Transfer(opts)`, `allowEip712Signing(opts)`
- **Solana:** `allowSolTransfer(opts)`, `allowSplTransfer(opts)`
- **Wallet:** `allowExportWalletAccount()`, `allowCreateWalletAccounts()`
- **Utility:** `combineConditions()`

All templates are ALLOW-only (DENY has absolute precedence in UMP). Implicit deny handles everything not explicitly allowed.

### Key design decisions

- Uses `in` operator for `allowAllSigning` (UMP does not short-circuit `||`)
- ETH addresses auto-lowercased (case-insensitive matching)
- Solana addresses NOT lowercased (case-sensitive)
- `<AGENT_USER_ID>` placeholder resolved during `createAgentSession`
- No `allowReadWalletData` (reads are not policy-gated in Turnkey)
- Chain-specific conditions produce `Outcome::Error` for non-matching activities (safe by design)

## Phases

- [x] Phase 3a: All templates + tests (43 new, 107 total)
- [x] Phase 3b: Smoke test + examples + dedup logic
- [x] Phase 3c: Strategy doc update + code review

## Test plan

- [x] Every template returns EFFECT_ALLOW
- [x] Every template uses `<AGENT_USER_ID>` in consensus
- [x] ETH addresses lowercased
- [x] Options correctly reflected in condition strings
- [x] `allowAllSigning` uses `in` operator (not `||`)
- [x] `combineConditions` joins with `&&`, throws on empty
- [x] All 107 tests pass
- [x] Typecheck passes
- [x] Build passes
- [x] Prettier passes