### PR TITLE
Add trailing slash in redirect url

### DIFF
--- a/examples/with-react-native-wallet-kit/README.md
+++ b/examples/with-react-native-wallet-kit/README.md
@@ -140,7 +140,7 @@ Turnkey’s OAuth flows use a fixed origin and redirect service. Configure your 
 https://oauth-redirect.turnkey.com/?scheme=withreactnativewalletkit
 ```
 
-> **Note**: notice the `/` before the query string — this is required. Apple in particular performs strict URL matching and will reject the flow with "invalid web redirect url" if the slash is missing.
+> **Note**: register the URI exactly as shown, including the `/` before the query string.
 
 If you change the scheme, update both `app.json` (`expo.scheme`) and `EXPO_PUBLIC_APP_SCHEME` in `.env`.
 

--- a/examples/with-react-native-wallet-kit/README.md
+++ b/examples/with-react-native-wallet-kit/README.md
@@ -140,6 +140,8 @@ Turnkey’s OAuth flows use a fixed origin and redirect service. Configure your 
 https://oauth-redirect.turnkey.com/?scheme=withreactnativewalletkit
 ```
 
+> **Note**: notice the `/` before the query string — this is required. Apple in particular performs strict URL matching and will reject the flow with "invalid web redirect url" if the slash is missing.
+
 If you change the scheme, update both `app.json` (`expo.scheme`) and `EXPO_PUBLIC_APP_SCHEME` in `.env`.
 
 ### 2. Set your client IDs in `.env`

--- a/examples/with-react-native-wallet-kit/README.md
+++ b/examples/with-react-native-wallet-kit/README.md
@@ -137,7 +137,7 @@ Turnkey’s OAuth flows use a fixed origin and redirect service. Configure your 
 - Authorized redirect URI (use your app scheme):
 
 ```
-https://oauth-redirect.turnkey.com?scheme=withreactnativewalletkit
+https://oauth-redirect.turnkey.com/?scheme=withreactnativewalletkit
 ```
 
 If you change the scheme, update both `app.json` (`expo.scheme`) and `EXPO_PUBLIC_APP_SCHEME` in `.env`.


### PR DESCRIPTION
## Summary & Motivation

Without the slash, Apple will reject the OAuth flow with "invalid web redirect url".

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
