### PR TITLE
update tempo examples: unit handling, gas limits, and add new multicall flow

### DIFF
--- a/examples/with-tempo/README.md
+++ b/examples/with-tempo/README.md
@@ -42,7 +42,7 @@ Now open `.env.local` and add the missing environment variables:
 
 ### 3/ Running the scripts
 
-The following is the default:
+#### Single transfer
 
 ```bash
 $ pnpm start
@@ -51,7 +51,7 @@ $ pnpm start
 This script will do the following:
 
 1. connect to and check your testnet balance
-2. send some TIP-20 token via a type 2 EIP-1559 transaction
+2. send a TIP-20 token transfer
 
 The script constructs a transaction, signs it with Turnkey and broadcasts through Tempo's client RPC.
 If the script exits because your account isn't funded, you can request funds on https://docs.tempo.xyz/guide/use-accounts/add-funds.
@@ -67,21 +67,73 @@ Network:
 Address:
         0xDC608F098255C89B36da905D9132A9Ee3DD266D9
 
+Token:
+        AlphaUSD (6 decimals)
+
 Nonce:
         5
 
-✔ Amount to send … 1
-✔ Destination address … 0xDC608F098255C89B36da905D9132A9Ee3DD266D9
+✔ Amount to send (atomic units, 6 decimals) … 1000000
+✔ Destination address (default to TKHQ warchest) … 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7
 ✔ Sponsor fees via sponsor.moderato.tempo.xyz? … yes
 
 AlphaUSD balance for 0xDC608F098255C89B36da905D9132A9Ee3DD266D9:
         1000000
 
 Receipt:
-        https://explore.tempo.xyz/tx/0x71ab0cbbd90b0774be500da229e81596b9402f90fe8cf91ee49002eec77307ec
+        https://explore.testnet.tempo.xyz/tx/0x71ab0cbbd90b0774be500da229e81596b9402f90fe8cf91ee49002eec77307ec
 
-Sent 1 AlphaUSD to 0xDC608F098255C89B36da905D9132A9Ee3DD266D9!
+Sent 1 AlphaUSD to 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7!
         https://docs.tempo.xyz/guide/payments/sponsor-user-fees
+```
+
+#### Batch transfers (multicall)
+
+```bash
+$ pnpm start-multicall
+```
+
+This script demonstrates Tempo's native batch call support — multiple TIP-20 token transfers are sent atomically in a single transaction. All calls either succeed together or revert together.
+
+See the following for a sample output:
+
+```
+Network:
+        Tempo Testnet (Moderato) (chain ID 42431)
+
+Address:
+        0xDC608F098255C89B36da905D9132A9Ee3DD266D9
+
+Token:
+        AlphaUSD (6 decimals)
+
+Nonce:
+        6
+
+✔ Number of transfers to batch … 3
+✔ Destination address (default to TKHQ warchest) … 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7
+✔ Sponsor fees via sponsor.moderato.tempo.xyz? … yes
+✔ Amount for transfer 1/3 (atomic units, 6 decimals) … 1000000
+✔ Amount for transfer 2/3 (atomic units, 6 decimals) … 1000000
+✔ Amount for transfer 3/3 (atomic units, 6 decimals) … 1000000
+
+AlphaUSD balance for 0xDC608F098255C89B36da905D9132A9Ee3DD266D9:
+        1000000
+
+Sending batch of:
+        3 transfers...
+
+Receipt:
+        https://explore.testnet.tempo.xyz/tx/0x...
+
+Sent 3 AlphaUSD to 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7 in 3 batched transfers!
+        https://docs.tempo.xyz/protocol/transactions#batch-calls
+
+AlphaUSD balance for sender (0xDC608F098255C89B36da905D9132A9Ee3DD266D9):
+        997
+
+AlphaUSD balance for destination (0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7):
+        3
 ```
 
 Note: if you have a consensus-related policy resembling the following

--- a/examples/with-tempo/README.md
+++ b/examples/with-tempo/README.md
@@ -102,38 +102,38 @@ Network:
         Tempo Testnet (Moderato) (chain ID 42431)
 
 Address:
-        0xDC608F098255C89B36da905D9132A9Ee3DD266D9
+        0xCa4127b4E1BaEABB52c2D01FC0e0f1AE8D5655aC
 
 Token:
         AlphaUSD (6 decimals)
 
 Nonce:
-        6
+        3
 
 ✔ Number of transfers to batch … 3
-✔ Destination address (default to TKHQ warchest) … 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7
-✔ Sponsor fees via sponsor.moderato.tempo.xyz? … yes
+✔ Destination address (default to TKHQ warchest) … 0xD91d92a978AC1E8d5F22EcAb787A10c7676D8311
+✔ Sponsor fees via sponsor.moderato.tempo.xyz? … no
 ✔ Amount for transfer 1/3 (atomic units, 6 decimals) … 1000000
 ✔ Amount for transfer 2/3 (atomic units, 6 decimals) … 1000000
 ✔ Amount for transfer 3/3 (atomic units, 6 decimals) … 1000000
 
-AlphaUSD balance for 0xDC608F098255C89B36da905D9132A9Ee3DD266D9:
-        1000000
+AlphaUSD balance for 0xCa4127b4E1BaEABB52c2D01FC0e0f1AE8D5655aC:
+        999994.982637
 
-Sending batch of:
+Sending batch of
         3 transfers...
 
 Receipt:
-        https://explore.testnet.tempo.xyz/tx/0x...
+        https://explore.testnet.tempo.xyz/tx/0xeaa50711e31bf654d5c9db3bc52a3edd4255c1506a9bd810436179b918110ea6
 
-Sent 3 AlphaUSD to 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7 in 3 batched transfers!
+Sent 3 AlphaUSD total (3 batched transfers) to 0xD91d92a978AC1E8d5F22EcAb787A10c7676D8311!
         https://docs.tempo.xyz/protocol/transactions#batch-calls
 
-AlphaUSD balance for sender (0xDC608F098255C89B36da905D9132A9Ee3DD266D9):
-        997
+AlphaUSD balance for sender (0xCa4127b4E1BaEABB52c2D01FC0e0f1AE8D5655aC):
+        999991.981594
 
-AlphaUSD balance for destination (0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7):
-        3
+AlphaUSD balance for destination (0xD91d92a978AC1E8d5F22EcAb787A10c7676D8311):
+        7
 ```
 
 Note: if you have a consensus-related policy resembling the following

--- a/examples/with-tempo/package.json
+++ b/examples/with-tempo/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "start": "tsx src/index.ts",
+    "start-multicall": "tsx src/multicall.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/with-tempo/src/index.ts
+++ b/examples/with-tempo/src/index.ts
@@ -17,7 +17,7 @@ import {
 import { Turnkey as TurnkeySDKServer } from "@turnkey/sdk-server";
 import { createAccount } from "@turnkey/viem";
 import { createNewWallet } from "./turnkey";
-import { print } from "./util";
+import { estimateTempoGas, print } from "./util";
 
 // @ts-ignore
 const PATH_USD = "0x20c0000000000000000000000000000000000000" as const;
@@ -142,10 +142,10 @@ async function main() {
   const sponsorAccount =
     useSponsor && process.env.SPONSOR_WITH
       ? ((await createAccount({
-          client: sdk.apiClient(),
-          organizationId: process.env.ORGANIZATION_ID!,
-          signWith: process.env.SPONSOR_WITH,
-        })) as Account)
+        client: sdk.apiClient(),
+        organizationId: process.env.ORGANIZATION_ID!,
+        signWith: process.env.SPONSOR_WITH,
+      })) as Account)
       : undefined;
 
   if (sponsorAccount) {
@@ -155,12 +155,21 @@ async function main() {
   // Fee payer: custom sponsor account, public endpoint (true), or self (undefined)
   const feePayer = useSponsor ? (sponsorAccount ?? true) : undefined;
 
+  const estimatedGas = await estimateTempoGas(client,
+    [Actions.token.transfer.call({
+      amount: BigInt(amount),
+      token: ALPHA_USD,
+      to: destination as `0x${string}`,
+    })],
+    5n
+  );
+
   const { receipt } = await client.token.transferSync({
     amount: BigInt(amount),
     token: ALPHA_USD,
     to: destination as `0x${string}`,
     feePayer,
-    gas: 2000000n, // temp workaround: need to manually set higher gas limit
+    gas: estimatedGas,
     feeToken: ALPHA_USD,
   });
 

--- a/examples/with-tempo/src/index.ts
+++ b/examples/with-tempo/src/index.ts
@@ -142,10 +142,10 @@ async function main() {
   const sponsorAccount =
     useSponsor && process.env.SPONSOR_WITH
       ? ((await createAccount({
-        client: sdk.apiClient(),
-        organizationId: process.env.ORGANIZATION_ID!,
-        signWith: process.env.SPONSOR_WITH,
-      })) as Account)
+          client: sdk.apiClient(),
+          organizationId: process.env.ORGANIZATION_ID!,
+          signWith: process.env.SPONSOR_WITH,
+        })) as Account)
       : undefined;
 
   if (sponsorAccount) {
@@ -155,13 +155,16 @@ async function main() {
   // Fee payer: custom sponsor account, public endpoint (true), or self (undefined)
   const feePayer = useSponsor ? (sponsorAccount ?? true) : undefined;
 
-  const estimatedGas = await estimateTempoGas(client,
-    [Actions.token.transfer.call({
-      amount: BigInt(amount),
-      token: ALPHA_USD,
-      to: destination as `0x${string}`,
-    })],
-    5n
+  const estimatedGas = await estimateTempoGas(
+    client,
+    [
+      Actions.token.transfer.call({
+        amount: BigInt(amount),
+        token: ALPHA_USD,
+        to: destination as `0x${string}`,
+      }),
+    ],
+    5n,
   );
 
   const { receipt } = await client.token.transferSync({

--- a/examples/with-tempo/src/multicall.ts
+++ b/examples/with-tempo/src/multicall.ts
@@ -112,12 +112,12 @@ async function main() {
     `${await client.getTransactionCount({ address: client.account.address })}`,
   );
 
-  const { amount, destination, useSponsor } = await prompts([
+  const { numTransfers, destination, useSponsor } = await prompts([
     {
-      type: "text",
-      name: "amount",
-      message: `Amount to send (atomic units, ${decimals} decimals)`,
-      initial: "1000000",
+      type: "number",
+      name: "numTransfers",
+      message: "Number of transfers to batch",
+      initial: 3,
     },
     {
       type: "text",
@@ -134,6 +134,23 @@ async function main() {
       initial: true,
     },
   ]);
+
+  if (!numTransfers || numTransfers <= 0) {
+    console.log("No transfers to send.");
+    return;
+  }
+
+  // Collect amount for each transfer
+  const amounts: string[] = [];
+  for (let i = 0; i < numTransfers; i++) {
+    const { amount } = await prompts({
+      type: "text",
+      name: "amount",
+      message: `Amount for transfer ${i + 1}/${numTransfers} (atomic units, ${decimals} decimals)`,
+      initial: "1000000",
+    });
+    amounts.push(amount);
+  }
 
   console.log();
 
@@ -155,23 +172,56 @@ async function main() {
   // Fee payer: custom sponsor account, public endpoint (true), or self (undefined)
   const feePayer = useSponsor ? (sponsorAccount ?? true) : undefined;
 
-  const { receipt } = await client.token.transferSync({
-    amount: BigInt(amount),
-    token: ALPHA_USD,
-    to: destination as `0x${string}`,
+  // Build batch transfer calls
+  const calls = amounts.map((amount) =>
+    Actions.token.transfer.call({
+      amount: BigInt(amount),
+      token: ALPHA_USD,
+      to: destination as `0x${string}`,
+    }),
+  );
+
+  print("Sending batch of", `${calls.length} transfers...`);
+
+  // Send all transfers atomically in a single Tempo transaction with native batch calls
+  const receipt = await client.sendTransactionSync({
+    calls,
     feePayer,
-    gas: 2000000n, // temp workaround: need to manually set higher gas limit
     feeToken: ALPHA_USD,
+    gas: 2000000n, // temp workaround: need to manually set higher gas limit for batch calls
   });
 
   print(
     "Receipt:",
     `https://explore.testnet.tempo.xyz/tx/${receipt.transactionHash}`,
   );
+
+  const totalAmount = amounts.reduce((sum, a) => sum + BigInt(a), 0n);
   print(
-    `Sent ${formatUnits(BigInt(amount), decimals)} ${name} to ${destination}!`,
-    "https://docs.tempo.xyz/guide/payments/sponsor-user-fees",
+    `Sent ${formatUnits(totalAmount, decimals)} ${name} to ${destination} in ${calls.length} batched transfers!`,
+    "https://docs.tempo.xyz/protocol/transactions#batch-calls",
   );
+
+  // Log post-transfer balances
+  const senderBalance = await Actions.token.getBalance(client, {
+    token: ALPHA_USD,
+    account: client.account.address,
+  });
+  print(
+    `${name} balance for sender (${client.account.address}):`,
+    formatUnits(senderBalance, decimals),
+  );
+
+  if (destination.toLowerCase() !== client.account.address.toLowerCase()) {
+    const destinationBalance = await Actions.token.getBalance(client, {
+      token: ALPHA_USD,
+      account: destination as `0x${string}`,
+    });
+    print(
+      `${name} balance for destination (${destination}):`,
+      formatUnits(destinationBalance, decimals),
+    );
+  }
 }
 
 main().catch((e) => {

--- a/examples/with-tempo/src/multicall.ts
+++ b/examples/with-tempo/src/multicall.ts
@@ -159,10 +159,10 @@ async function main() {
   const sponsorAccount =
     useSponsor && process.env.SPONSOR_WITH
       ? ((await createAccount({
-        client: sdk.apiClient(),
-        organizationId: process.env.ORGANIZATION_ID!,
-        signWith: process.env.SPONSOR_WITH,
-      })) as Account)
+          client: sdk.apiClient(),
+          organizationId: process.env.ORGANIZATION_ID!,
+          signWith: process.env.SPONSOR_WITH,
+        })) as Account)
       : undefined;
 
   if (sponsorAccount) {
@@ -184,7 +184,6 @@ async function main() {
   print("Sending batch of", `${calls.length} transfers...`);
 
   const estimatedGas = await estimateTempoGas(client, calls, 5n);
-
 
   // Send all transfers atomically in a single Tempo transaction with native batch calls
   const receipt = await client.sendTransactionSync({

--- a/examples/with-tempo/src/multicall.ts
+++ b/examples/with-tempo/src/multicall.ts
@@ -200,7 +200,7 @@ async function main() {
 
   const totalAmount = amounts.reduce((sum, a) => sum + BigInt(a), 0n);
   print(
-    `Sent ${formatUnits(totalAmount, decimals)} ${name} to ${destination} in ${calls.length} batched transfers!`,
+    `Sent ${formatUnits(totalAmount, decimals)} ${name} total (${calls.length} batched transfers) to ${destination}!`,
     "https://docs.tempo.xyz/protocol/transactions#batch-calls",
   );
 

--- a/examples/with-tempo/src/multicall.ts
+++ b/examples/with-tempo/src/multicall.ts
@@ -17,7 +17,7 @@ import {
 import { Turnkey as TurnkeySDKServer } from "@turnkey/sdk-server";
 import { createAccount } from "@turnkey/viem";
 import { createNewWallet } from "./turnkey";
-import { print } from "./util";
+import { estimateTempoGas, print } from "./util";
 
 // @ts-ignore
 const PATH_USD = "0x20c0000000000000000000000000000000000000" as const;
@@ -159,10 +159,10 @@ async function main() {
   const sponsorAccount =
     useSponsor && process.env.SPONSOR_WITH
       ? ((await createAccount({
-          client: sdk.apiClient(),
-          organizationId: process.env.ORGANIZATION_ID!,
-          signWith: process.env.SPONSOR_WITH,
-        })) as Account)
+        client: sdk.apiClient(),
+        organizationId: process.env.ORGANIZATION_ID!,
+        signWith: process.env.SPONSOR_WITH,
+      })) as Account)
       : undefined;
 
   if (sponsorAccount) {
@@ -183,12 +183,15 @@ async function main() {
 
   print("Sending batch of", `${calls.length} transfers...`);
 
+  const estimatedGas = await estimateTempoGas(client, calls, 5n);
+
+
   // Send all transfers atomically in a single Tempo transaction with native batch calls
   const receipt = await client.sendTransactionSync({
     calls,
     feePayer,
     feeToken: ALPHA_USD,
-    gas: 2000000n, // temp workaround: need to manually set higher gas limit for batch calls
+    gas: estimatedGas,
   });
 
   print(

--- a/examples/with-tempo/src/util.ts
+++ b/examples/with-tempo/src/util.ts
@@ -22,3 +22,14 @@ export function refineNonNull<T>(
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export async function estimateTempoGas(client: any, calls: any[], buffer: bigint) {
+  const estimatedGas = await client.estimateGas({
+    calls
+  });
+
+
+  const gasWithBuffer = (estimatedGas * (buffer + 100n)) / 100n;
+
+  return gasWithBuffer;
+}

--- a/examples/with-tempo/src/util.ts
+++ b/examples/with-tempo/src/util.ts
@@ -23,11 +23,14 @@ export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function estimateTempoGas(client: any, calls: any[], buffer: bigint) {
+export async function estimateTempoGas(
+  client: any,
+  calls: any[],
+  buffer: bigint,
+) {
   const estimatedGas = await client.estimateGas({
-    calls
+    calls,
   });
-
 
   const gasWithBuffer = (estimatedGas * (buffer + 100n)) / 100n;
 


### PR DESCRIPTION
$title

## Summary & Motivation

It was time to get back in here to update:
- default Tempo block explorer links (now that mainnet is live)
- hardcoded gas limits
- unit formatting
- add a new `multicall` flow to test newly released Tempo policy engine functionality

## How I Tested These Changes
- local invocation

## Did you add a changeset?
- no need! only touching an example, not a package

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
