### PR TITLE
add appName param to the magic-link-auth example

### DIFF
--- a/examples/magic-link-auth/src/server/actions/sendMagicLink.ts
+++ b/examples/magic-link-auth/src/server/actions/sendMagicLink.ts
@@ -18,6 +18,7 @@ export async function sendMagicLink({ email }: SendMagicLinkParams) {
   // we send a magic link to the user’s email
   const { otpId } = await turnkeyClient.initOtp({
     contact: email,
+    appName: "Magic Link Demo",
     otpType: OtpType.Email,
     emailCustomization: {
       // %s will be replaced with the otpCode when sending the email


### PR DESCRIPTION
## Summary & Motivation
Add appName parameter to the initOtp call in the magic-link-auth example.
## How I Tested These Changes
Cloned the example, ran it locally, and confirmed the runtime error when appName is missing.
## Did you add a changeset?
No
