### PR TITLE
Add with-vaultsfyi example

### DIFF
--- a/examples/with-vaultsfyi/.env.local.example
+++ b/examples/with-vaultsfyi/.env.local.example
@@ -1,0 +1,21 @@
+# Turnkey – root user (used only for policy creation)
+TURNKEY_API_PRIVATE_KEY=
+TURNKEY_API_PUBLIC_KEY=
+TURNKEY_BASE_URL=https://api.turnkey.com
+TURNKEY_ORGANIZATION_ID=
+
+# Turnkey – non-root user (used for signing)
+NONROOT_API_PRIVATE_KEY=
+NONROOT_API_PUBLIC_KEY=
+
+# The non-root user ID (for the policy consensus rule)
+NONROOT_USER_ID=
+
+# Address or key ID to sign with
+SIGN_WITH=
+
+# RPC endpoint (e.g. https://base-mainnet.infura.io/v3/<YOUR_KEY>)
+RPC_URL=
+
+# vaults.fyi
+VAULTS_FYI_API_KEY=

--- a/examples/with-vaultsfyi/README.md
+++ b/examples/with-vaultsfyi/README.md
@@ -57,7 +57,7 @@ Now open `.env.local` and add the missing environment variables:
 - `NONROOT_API_PUBLIC_KEY`
 - `NONROOT_API_PRIVATE_KEY`
 - `RPC_URL`
-- `VAULTS_FYI_API_KEY` — get one at [vaults.fyi](https://docs.vaults.fyi)
+- `VAULTS_FYI_API_KEY` — sign up at the [vaults.fyi portal](https://portal.vaults.fyi) to get one
 
 ### 3/ Discover yield opportunities
 

--- a/examples/with-vaultsfyi/README.md
+++ b/examples/with-vaultsfyi/README.md
@@ -1,0 +1,97 @@
+# Example: `with-vaultsfyi`
+
+[vaults.fyi](https://vaults.fyi) is a DeFi yield aggregator that lets you discover, deposit, and withdraw from yield-generating vaults across multiple protocols and networks through a single API. This example shows how to use a Turnkey wallet with the vaults.fyi SDK to interact with DeFi vaults. It provides the following scripts:
+
+- `setupPolicy.ts` discovers target contract addresses via dry-run and creates a Turnkey policy scoping a non-root user to only those addresses
+- `discover.ts` finds the best yield opportunities for your wallet on a given network
+- `deposit.ts` deposits into a vault (amount in base units)
+- `positions.ts` lists all DeFi positions for your wallet
+- `withdraw.ts` redeems your full position from a vault
+- `setupRewardsPolicy.ts` discovers reward claim addresses and creates a policy for them
+- `claimRewards.ts` claims any pending rewards on a given network
+
+On top of it, we showcase the power of the Turnkey policy engine by allowing a non-root Turnkey user to only sign the specific transactions with the addresses discovered from vaults.fyi:
+
+- `setupPolicy.ts` uses an organization root user (RootQuorum) to create specific policies for a non-root user that will be used to sign the transactions.
+
+## Getting started
+
+### 1/ Cloning the example
+
+Make sure you have `Node.js` installed locally; we recommend using Node v20+.
+
+```bash
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/with-vaultsfyi/
+```
+
+### 2/ Setting up Turnkey
+
+The first step is to set up your Turnkey organization and account. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
+
+- A root user with a public/private API key pair within the Turnkey parent organization
+- An organization ID
+
+The next step is to create another user within the organization with a different API key and remove it from the root quorum. You can do this from the Turnkey [dashboard](https://app.turnkey.com/dashboard/security/updateRootQuorum) or [API](https://docs.turnkey.com/api-reference/activities/update-root-quorum). Here's a simple [script](https://github.com/tkhq/sdk/blob/main/examples/kitchen-sink/src/sdk-server/updateRootQuorum.ts) that shows how to update the root quorum using `@turnkey/sdk-server`.
+
+Finally, make sure you have a [wallet](https://app.turnkey.com/dashboard/wallets) with an Ethereum wallet account created within this organization and have it funded with some ETH and the deposit token on your target network.
+
+Once you've gathered these values, add them to a new `.env.local` file. Notice that your private key should be securely managed and **_never_** be committed to git.
+
+```bash
+cp .env.local.example .env.local
+```
+
+Now open `.env.local` and add the missing environment variables:
+
+- `TURNKEY_API_PUBLIC_KEY`
+- `TURNKEY_API_PRIVATE_KEY`
+- `TURNKEY_BASE_URL`
+- `TURNKEY_ORGANIZATION_ID`
+- `SIGN_WITH`
+- `NONROOT_USER_ID`
+- `NONROOT_API_PUBLIC_KEY`
+- `NONROOT_API_PRIVATE_KEY`
+- `RPC_URL`
+- `VAULTS_FYI_API_KEY` — get one at [vaults.fyi](https://docs.vaults.fyi)
+
+### 3/ Discover yield opportunities
+
+```bash
+pnpm discover <network>
+```
+
+### 4/ Setting up the policy for the non-root user
+
+```bash
+pnpm setup-policy <network> <vaultId>
+```
+
+### 5/ Deposit into a vault
+
+```bash
+pnpm deposit <network> <vaultId> <amount>
+```
+
+### 6/ List positions
+
+```bash
+pnpm positions <network>
+```
+
+### 7/ Full withdraw from a vault
+
+```bash
+pnpm withdraw <network> <vaultId>
+```
+
+### 8/ Set up rewards policy and claim rewards
+
+```bash
+pnpm setup-rewards-policy <network>
+pnpm claim-rewards <network>
+```

--- a/examples/with-vaultsfyi/package.json
+++ b/examples/with-vaultsfyi/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@turnkey/with-vaultsfyi",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "build": "pnpm -w run build-all",
+    "setup-policy": "tsx src/setupPolicy.ts",
+    "discover": "tsx src/discover.ts",
+    "deposit": "tsx src/deposit.ts",
+    "positions": "tsx src/positions.ts",
+    "withdraw": "tsx src/withdraw.ts",
+    "setup-rewards-policy": "tsx src/setupRewardsPolicy.ts",
+    "claim-rewards": "tsx src/claimRewards.ts",
+    "clean": "rimraf ./dist ./.cache",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@turnkey/sdk-server": "workspace:*",
+    "@turnkey/viem": "workspace:*",
+    "@vaultsfyi/sdk": "^2.3.1",
+    "dotenv": "^16.0.3",
+    "viem": "^2.24.2"
+  }
+}

--- a/examples/with-vaultsfyi/src/claimRewards.ts
+++ b/examples/with-vaultsfyi/src/claimRewards.ts
@@ -1,0 +1,56 @@
+import {
+  createClients,
+  vaultsFyi,
+  executeActions,
+  resolveNetwork,
+} from "./shared";
+
+const networkArg = process.argv[2];
+
+if (!networkArg) {
+  console.error("Usage: pnpm claim-rewards <network>");
+  process.exit(1);
+}
+
+async function main() {
+  const { network, chain } = resolveNetwork(networkArg!);
+  const { walletClient, publicClient, userAddress } = await createClients(chain);
+
+  const rewardsContext = await vaultsFyi.getRewardsTransactionsContext({
+    path: { userAddress },
+  });
+
+  const rewards = rewardsContext.claimable[network] ?? [];
+
+  if (rewards.length === 0) {
+    console.log(`No claimable rewards on ${network}.`);
+    process.exit(0);
+  }
+
+  for (const r of rewards) {
+    console.log(
+      `Claimable: ${r.asset.claimableAmount} ${r.asset.symbol} (${r.asset.claimableAmountInUsd ?? "?"} USD)`,
+    );
+  }
+
+  const claimIds = rewards.map((r) => r.claimId);
+
+  const claim = await vaultsFyi.getRewardsClaimActions({
+    path: { userAddress },
+    query: { claimIds },
+  });
+
+  await executeActions(
+    walletClient,
+    publicClient,
+    claim[network].actions,
+    claim[network].currentActionIndex,
+  );
+
+  console.log("Rewards claimed.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-vaultsfyi/src/deposit.ts
+++ b/examples/with-vaultsfyi/src/deposit.ts
@@ -1,0 +1,47 @@
+import {
+  createClients,
+  vaultsFyi,
+  executeActions,
+  resolveNetwork,
+  getAssetAddress,
+} from "./shared";
+
+const [networkArg, vaultId, amount] = process.argv.slice(2);
+
+if (!networkArg || !vaultId || !amount) {
+  console.error("Usage: pnpm deposit <network> <vaultId> <amount>");
+  process.exit(1);
+}
+
+async function main() {
+  const { network, chain } = resolveNetwork(networkArg!);
+  const { walletClient, publicClient, userAddress } = await createClients(chain);
+
+  const assetAddress = await getAssetAddress(network, vaultId!);
+
+  const { currentActionIndex, actions } = await vaultsFyi.getActions({
+    path: {
+      action: "deposit",
+      userAddress,
+      network,
+      vaultId: vaultId!,
+    },
+    query: {
+      assetAddress,
+      amount: amount!,
+    },
+  });
+
+  console.log(
+    `${actions.length} steps, starting at index ${currentActionIndex}`,
+  );
+
+  await executeActions(walletClient, publicClient, actions, currentActionIndex);
+
+  console.log("Deposit complete.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-vaultsfyi/src/discover.ts
+++ b/examples/with-vaultsfyi/src/discover.ts
@@ -1,0 +1,37 @@
+import { createClients, vaultsFyi, resolveNetwork } from "./shared";
+
+const networkArg = process.argv[2];
+
+if (!networkArg) {
+  console.error("Usage: pnpm discover <network>");
+  process.exit(1);
+}
+
+async function main() {
+  const { network, chain } = resolveNetwork(networkArg!);
+  const { userAddress } = await createClients(chain);
+  console.log("Wallet address:", userAddress);
+
+  const recommendations = await vaultsFyi.getDepositOptions({
+    path: { userAddress },
+    query: {
+      allowedNetworks: [network],
+      onlyTransactional: true,
+      minUsdAssetValueThreshold: 0.1,
+    },
+  });
+
+  for (const balance of recommendations.userBalances) {
+    console.log(`\nAsset: ${balance.asset?.symbol ?? "unknown"}`);
+    for (const opt of balance.depositOptions) {
+      console.log(
+        `  ${opt.name} (${opt.protocol.name}) – ${(opt.apy.total * 100).toFixed(2)}% APY – vaultId: ${opt.vaultId}`,
+      );
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-vaultsfyi/src/positions.ts
+++ b/examples/with-vaultsfyi/src/positions.ts
@@ -1,0 +1,34 @@
+import { createClients, vaultsFyi, resolveNetwork } from "./shared";
+
+const networkArg = process.argv[2];
+
+if (!networkArg) {
+  console.error("Usage: pnpm positions <network>");
+  process.exit(1);
+}
+
+async function main() {
+  const { chain } = resolveNetwork(networkArg!);
+  const { userAddress } = await createClients(chain);
+
+  const { data: positions } = await vaultsFyi.getPositions({
+    path: { userAddress },
+  });
+
+  if (positions.length === 0) {
+    console.log("No positions found.");
+  } else {
+    for (const p of positions) {
+      console.log(
+        `${p.protocol.name} ${p.name} on ${p.network.name}: \n` +
+        `${p.lpToken?.balanceUsd ?? "?"} USD, ${(p.apy.total * 100).toFixed(2)}% APY \n` +
+        `(vault address: ${p.vaultId})`,
+      );
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-vaultsfyi/src/setupPolicy.ts
+++ b/examples/with-vaultsfyi/src/setupPolicy.ts
@@ -1,0 +1,62 @@
+import { Turnkey } from "@turnkey/sdk-server";
+import { vaultsFyi, resolveNetwork, getAssetAddress } from "./shared";
+
+const [networkArg, vaultId] = process.argv.slice(2);
+
+if (!networkArg || !vaultId) {
+  console.error("Usage: pnpm setup-policy <network> <vaultId>");
+  process.exit(1);
+}
+
+async function main() {
+  const { network } = resolveNetwork(networkArg!);
+
+  const turnkeyClient = new Turnkey({
+    apiBaseUrl: process.env.TURNKEY_BASE_URL!,
+    apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY!,
+    apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY!,
+    defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID!,
+  }).apiClient();
+
+  const userId = process.env.NONROOT_USER_ID!;
+  const userAddress = process.env.SIGN_WITH!;
+
+  const assetAddress = await getAssetAddress(network, vaultId!);
+  console.log(`Asset address: ${assetAddress}`);
+
+  // Discover deposit + redeem target addresses via dry-run
+  const [deposit, redeem] = await Promise.all([
+    vaultsFyi.getActions({
+      path: { action: "deposit", userAddress, network, vaultId: vaultId! },
+      query: { assetAddress, amount: "1" },
+    }),
+    vaultsFyi.getActions({
+      path: { action: "redeem", userAddress, network, vaultId: vaultId! },
+      query: { assetAddress, amount: "1" },
+    }),
+  ]);
+
+  const targets = [
+    ...new Set(
+      [...deposit.actions, ...redeem.actions].map((a) => a.tx.to.toLowerCase()),
+    ),
+  ];
+  const addressList = targets.map((a) => `'${a}'`).join(", ");
+
+  console.log("Discovered target addresses:", targets);
+
+  const { policyId } = await turnkeyClient.createPolicy({
+    policyName: `Allow non-root user to interact with vault ${vaultId}`,
+    effect: "EFFECT_ALLOW",
+    consensus: `approvers.any(user, user.id == '${userId}')`,
+    condition: `eth.tx.to in [${addressList}]`,
+    notes: "vaults.fyi cookbook: deposit + redeem addresses",
+  });
+
+  console.log("Policy created:", policyId);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-vaultsfyi/src/setupRewardsPolicy.ts
+++ b/examples/with-vaultsfyi/src/setupRewardsPolicy.ts
@@ -1,0 +1,64 @@
+import { Turnkey } from "@turnkey/sdk-server";
+import { vaultsFyi, resolveNetwork } from "./shared";
+
+const networkArg = process.argv[2];
+
+if (!networkArg) {
+  console.error("Usage: pnpm setup-rewards-policy <network>");
+  process.exit(1);
+}
+
+async function main() {
+  const { network } = resolveNetwork(networkArg!);
+
+  const turnkeyClient = new Turnkey({
+    apiBaseUrl: process.env.TURNKEY_BASE_URL!,
+    apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY!,
+    apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY!,
+    defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID!,
+  }).apiClient();
+
+  const userId = process.env.NONROOT_USER_ID!;
+  const userAddress = process.env.SIGN_WITH!;
+
+  const rewardsContext = await vaultsFyi.getRewardsTransactionsContext({
+    path: { userAddress },
+  });
+
+  const rewards = rewardsContext.claimable[network] ?? [];
+
+  if (rewards.length === 0) {
+    console.log(
+      `No claimable rewards on ${network} — nothing to build a policy for.`,
+    );
+    process.exit(0);
+  }
+
+  const claimIds = rewards.map((r) => r.claimId);
+  const claim = await vaultsFyi.getRewardsClaimActions({
+    path: { userAddress },
+    query: { claimIds },
+  });
+
+  const targets = [
+    ...new Set(claim[network].actions.map((a) => a.tx.to.toLowerCase())),
+  ];
+  const addressList = targets.map((a) => `'${a}'`).join(", ");
+
+  console.log("Discovered reward claim addresses:", targets);
+
+  const { policyId } = await turnkeyClient.createPolicy({
+    policyName: `Allow non-root user to claim rewards on ${network}`,
+    effect: "EFFECT_ALLOW",
+    consensus: `approvers.any(user, user.id == '${userId}')`,
+    condition: `eth.tx.to in [${addressList}]`,
+    notes: "vaults.fyi cookbook: reward claim addresses",
+  });
+
+  console.log("Policy created:", policyId);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-vaultsfyi/src/shared.ts
+++ b/examples/with-vaultsfyi/src/shared.ts
@@ -1,0 +1,148 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+import { createAccount } from "@turnkey/viem";
+import { Turnkey } from "@turnkey/sdk-server";
+import { VaultsSdk, SUPPORTED_NETWORKS } from "@vaultsfyi/sdk";
+import {
+  createWalletClient,
+  createPublicClient,
+  http,
+  type Account,
+  type Chain,
+} from "viem";
+import {
+  mainnet,
+  base,
+  arbitrum,
+  optimism,
+  polygon,
+} from "viem/chains";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+export type Network = (typeof SUPPORTED_NETWORKS)[number];
+
+// ── Network resolution ──
+
+const CHAIN_BY_NETWORK: Record<string, Chain> = {
+  mainnet,
+  base,
+  arbitrum,
+  optimism,
+  polygon,
+};
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+export function resolveNetwork(network: string): {
+  network: Network;
+  chain: Chain;
+} {
+  if (!SUPPORTED_NETWORKS.includes(network as Network)) {
+    throw new Error(
+      `Unsupported network "${network}". Supported: ${SUPPORTED_NETWORKS.join(", ")}`,
+    );
+  }
+  const chain = CHAIN_BY_NETWORK[network];
+  if (!chain) {
+    throw new Error(
+      `No viem chain configured for "${network}". Add it to CHAIN_BY_NETWORK in shared.ts`,
+    );
+  }
+  return { network: network as Network, chain };
+}
+
+// ── vaults.fyi SDK client ──
+
+export const vaultsFyi = new VaultsSdk({
+  apiKey: requireEnv("VAULTS_FYI_API_KEY"),
+});
+
+// ── Turnkey viem client (non-root) ──
+
+export async function createClients(chain: Chain) {
+  const turnkey = new Turnkey({
+    apiBaseUrl: requireEnv("TURNKEY_BASE_URL"),
+    apiPrivateKey: requireEnv("NONROOT_API_PRIVATE_KEY"),
+    apiPublicKey: requireEnv("NONROOT_API_PUBLIC_KEY"),
+    defaultOrganizationId: requireEnv("TURNKEY_ORGANIZATION_ID"),
+  });
+
+  const turnkeyAccount = await createAccount({
+    client: turnkey.apiClient() as any,
+    organizationId: requireEnv("TURNKEY_ORGANIZATION_ID"),
+    signWith: requireEnv("SIGN_WITH"),
+  });
+
+  const transport = http(requireEnv("RPC_URL"));
+
+  const walletClient = createWalletClient({
+    account: turnkeyAccount as Account,
+    chain,
+    transport,
+  });
+
+  const publicClient = createPublicClient({
+    chain,
+    transport,
+  });
+
+  return {
+    walletClient,
+    publicClient,
+    userAddress: turnkeyAccount.address,
+  };
+}
+
+// ── Fetch asset address from vault ──
+
+export async function getAssetAddress(
+  network: Network,
+  vaultId: string,
+): Promise<string> {
+  const vault = await vaultsFyi.getVault({
+    path: { network, vaultId },
+  });
+  return vault.asset.address;
+}
+
+// ── Execute vaults.fyi action steps ──
+
+type ActionStep = {
+  name: string;
+  tx: { to: string; chainId: number; data?: string; value?: string };
+};
+
+export async function executeActions(
+  walletClient: Awaited<ReturnType<typeof createClients>>["walletClient"],
+  publicClient: Awaited<ReturnType<typeof createClients>>["publicClient"],
+  actions: ActionStep[],
+  currentActionIndex: number,
+) {
+  for (const step of actions.slice(currentActionIndex)) {
+    console.log(`Sending: ${step.name}...`);
+
+    const hash = await walletClient.sendTransaction({
+      account: walletClient.account!,
+      to: step.tx.to as `0x${string}`,
+      data: step.tx.data as `0x${string}` | undefined,
+      value: step.tx.value ? BigInt(step.tx.value) : undefined,
+    });
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash,
+      confirmations: 2,
+    });
+
+    if (receipt.status === "reverted") {
+      throw new Error(
+        `"${step.name}" reverted on-chain: https://basescan.org/tx/${hash}`,
+      );
+    }
+    console.log(`  ✓ confirmed: https://basescan.org/tx/${hash}`);
+  }
+}

--- a/examples/with-vaultsfyi/src/withdraw.ts
+++ b/examples/with-vaultsfyi/src/withdraw.ts
@@ -1,0 +1,47 @@
+import {
+  createClients,
+  vaultsFyi,
+  executeActions,
+  resolveNetwork,
+  getAssetAddress,
+} from "./shared";
+
+const [networkArg, vaultId] = process.argv.slice(2);
+
+if (!networkArg || !vaultId) {
+  console.error("Usage: pnpm withdraw <network> <vaultId>");
+  process.exit(1);
+}
+
+async function main() {
+  const { network, chain } = resolveNetwork(networkArg!);
+  const { walletClient, publicClient, userAddress } = await createClients(chain);
+
+  const assetAddress = await getAssetAddress(network, vaultId!);
+
+  const { currentActionIndex, actions } = await vaultsFyi.getActions({
+    path: {
+      action: "redeem",
+      userAddress,
+      network,
+      vaultId: vaultId!,
+    },
+    query: {
+      assetAddress,
+      all: true,
+    },
+  });
+
+  console.log(
+    `${actions.length} steps, starting at index ${currentActionIndex}`,
+  );
+
+  await executeActions(walletClient, publicClient, actions, currentActionIndex);
+
+  console.log("Withdraw complete.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/with-vaultsfyi/tsconfig.json
+++ b/examples/with-vaultsfyi/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3190,6 +3190,24 @@ importers:
         specifier: 5.4.3
         version: 5.4.3
 
+  examples/with-vaultsfyi:
+    dependencies:
+      '@turnkey/sdk-server':
+        specifier: workspace:*
+        version: link:../../packages/sdk-server
+      '@turnkey/viem':
+        specifier: workspace:*
+        version: link:../../packages/viem
+      '@vaultsfyi/sdk':
+        specifier: ^2.3.1
+        version: 2.3.1(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.6.1
+      viem:
+        specifier: ^2.24.2
+        version: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+
   examples/with-viem:
     dependencies:
       '@turnkey/api-key-stamper':
@@ -6846,9 +6864,6 @@ packages:
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
-  '@noble/curves@1.4.0':
-    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
-
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
@@ -9886,6 +9901,9 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@vaultsfyi/sdk@2.3.1':
+    resolution: {integrity: sha512-9pxaJsMFVEUYMtVCb2uPGQnUVL2LxF2ydiTFrtwYAu6T331ec4oyCHmg4Wws9MpjGSoww4VbR+NdzMJn65AhlA==}
 
   '@wagmi/connectors@5.11.2':
     resolution: {integrity: sha512-OkiElOI8xXGPDZE5UdG6NgDT3laSkEh9llX1DDapUnfnKecK3Tr/HUf5YzgwDhEoox8mdxp+8ZCjtnTKz56SdA==}
@@ -16674,6 +16692,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  x402-fetch@0.7.0:
+    resolution: {integrity: sha512-HS7v6wsIVrU8TvAGBwRmA3I+ZXbanPraA3OMj90y6Hn1Mej1wAELOK4VpGh6zI8d6w5E464BnGu9o0FE+8DRAA==}
+
   x402@0.7.2:
     resolution: {integrity: sha512-JleP1GmeOP1bEuwzFVtjusL3t5H1PGufROrBKg5pj/MfcGswkBvfB6j5Gm5UeA+kwp0ZmOkkHAqkoHF1WexbsQ==}
 
@@ -18750,6 +18771,26 @@ snapshots:
       - zod
     optional: true
 
+  '@base-org/account@1.1.1(bufferutil@4.0.9)(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.4.3)(zod@3.25.76)
+      preact: 10.28.2
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zustand: 5.0.3(@types/react@19.2.4)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bgd-labs/aave-address-book@4.29.1(viem@2.37.5(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))':
@@ -19167,6 +19208,26 @@ snapshots:
       - utf-8-validate
       - zod
     optional: true
+
+  '@coinbase/wallet-sdk@4.3.6(bufferutil@4.0.9)(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.4.3)(zod@3.25.76)
+      preact: 10.28.2
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zustand: 5.0.3(@types/react@19.2.4)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
 
   '@coral-xyz/borsh@0.26.0(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -21486,10 +21547,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.2
 
-  '@noble/curves@1.4.0':
-    dependencies:
-      '@noble/hashes': 1.4.0
-
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -23044,6 +23101,41 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@reown/appkit-controllers@1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      valtio: 1.13.2(react@19.2.4)
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@reown/appkit-pay@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@19.1.17)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(utf-8-validate@5.0.10)))(@types/react@19.1.17)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -23161,6 +23253,42 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(@types/react@18.2.14)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.2.14)(react@18.2.0))(zod@4.1.11)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@18.2.14)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-pay@1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.4))(zod@3.25.76)
+      lit: 3.3.0
+      valtio: 1.13.2(react@19.2.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23383,6 +23511,43 @@ snapshots:
       - valtio
       - zod
 
+  '@reown/appkit-scaffold-ui@1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.4))(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.4))(zod@3.25.76)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      lit: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - valtio
+      - zod
+
   '@reown/appkit-ui@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.2(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -23528,6 +23693,41 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
       '@reown/appkit-controllers': 1.7.8(@types/react@18.2.14)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      lit: 3.3.0
+      qrcode: 1.5.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-ui@1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -23722,6 +23922,44 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
       valtio: 1.13.2(@types/react@18.2.14)(react@18.2.0)
       viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-utils@1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.4))(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-polyfills': 1.7.8
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      valtio: 1.13.2(react@19.2.4)
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23959,6 +24197,49 @@ snapshots:
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@18.2.14)(react@18.2.0)
       viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit@1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-pay': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-polyfills': 1.7.8
+      '@reown/appkit-scaffold-ui': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.4))(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.4))(zod@3.25.76)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)
+      '@walletconnect/types': 2.21.0
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      bs58: 6.0.0
+      valtio: 1.13.2(react@19.2.4)
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -24274,7 +24555,7 @@ snapshots:
 
   '@scure/bip32@1.4.0':
     dependencies:
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
 
@@ -25882,7 +26163,6 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.2
       react: 19.2.4
-    optional: true
 
   '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27070,6 +27350,43 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.4
 
+  '@vaultsfyi/sdk@2.3.1(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      x402-fetch: 0.7.0(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - ws
+
   '@wagmi/connectors@5.11.2(0886e6e69fc90cbe245a6f4438be7d16)':
     dependencies:
       '@base-org/account': 1.1.1(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(zod@4.1.11)
@@ -27178,6 +27495,53 @@ snapshots:
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
       porto: 0.2.19(@tanstack/react-query@5.90.2(react@18.2.0))(@types/react@18.2.14)(@wagmi/core@2.21.2(@types/react@18.2.14)(react@18.2.0)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@18.2.0))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@18.2.0)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@18.2.0))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.17.5(@tanstack/react-query@5.90.2(react@18.2.0))(@types/react@18.2.14)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    optionalDependencies:
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - wagmi
+      - zod
+
+  '@wagmi/connectors@5.11.2(@tanstack/react-query@5.90.2(react@19.2.4))(@wagmi/core@2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(wagmi@2.17.5(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@base-org/account': 1.1.1(bufferutil@4.0.9)(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.0.9)(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@gemini-wallet/core': 0.2.0(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))
+      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@wagmi/core': 2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))
+      '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      porto: 0.2.19(@tanstack/react-query@5.90.2(react@19.2.4))(@wagmi/core@2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)))(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(wagmi@2.17.5(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@3.25.76))
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
     optionalDependencies:
       typescript: 5.4.3
     transitivePeerDependencies:
@@ -27341,6 +27705,20 @@ snapshots:
       mipd: 0.0.7(typescript@5.4.3)
       viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@18.2.14)(react@18.2.0)(use-sync-external-store@1.4.0(react@18.2.0))
+    optionalDependencies:
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.4.3)
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+      zustand: 5.0.0(@types/react@19.2.4)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
     optionalDependencies:
       typescript: 5.4.3
     transitivePeerDependencies:
@@ -28002,6 +28380,47 @@ snapshots:
       '@walletconnect/types': 2.21.1
       '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
       '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/ethereum-provider@2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit': 1.7.8(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.20.2(@babel/core@7.28.5))(@types/react@18.3.24)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(utf-8-validate@5.0.10)))
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/types': 2.21.1
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -31589,6 +32008,10 @@ snapshots:
     dependencies:
       valtio: 1.13.2(@types/react@19.2.4)(react@19.2.4)
     optional: true
+
+  derive-valtio@0.1.0(valtio@1.13.2(react@19.2.4)):
+    dependencies:
+      valtio: 1.13.2(react@19.2.4)
 
   des.js@1.1.0:
     dependencies:
@@ -35775,6 +36198,26 @@ snapshots:
       - immer
       - use-sync-external-store
 
+  porto@0.2.19(@tanstack/react-query@5.90.2(react@19.2.4))(@wagmi/core@2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)))(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(wagmi@2.17.5(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@3.25.76)):
+    dependencies:
+      '@wagmi/core': 2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))
+      hono: 4.12.5
+      idb-keyval: 6.2.2
+      mipd: 0.0.7(typescript@5.4.3)
+      ox: 0.9.8(typescript@5.4.3)(zod@4.1.11)
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+      zod: 4.1.11
+      zustand: 5.0.3(@types/react@19.2.4)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
+    optionalDependencies:
+      '@tanstack/react-query': 5.90.2(react@19.2.4)
+      react: 19.2.4
+      typescript: 5.4.3
+      wagmi: 2.17.5(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - use-sync-external-store
+
   poseidon-lite@0.2.1: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -38382,7 +38825,6 @@ snapshots:
   use-sync-external-store@1.2.0(react@19.2.4):
     dependencies:
       react: 19.2.4
-    optional: true
 
   use-sync-external-store@1.4.0(react@18.2.0):
     dependencies:
@@ -38395,7 +38837,6 @@ snapshots:
   use-sync-external-store@1.4.0(react@19.2.4):
     dependencies:
       react: 19.2.4
-    optional: true
 
   use-sync-external-store@1.5.0(react@18.2.0):
     dependencies:
@@ -38499,6 +38940,14 @@ snapshots:
       '@types/react': 19.2.4
       react: 19.2.4
     optional: true
+
+  valtio@1.13.2(react@19.2.4):
+    dependencies:
+      derive-valtio: 0.1.0(valtio@1.13.2(react@19.2.4))
+      proxy-compare: 2.6.0
+      use-sync-external-store: 1.2.0(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
 
   varuint-bitcoin@1.1.2:
     dependencies:
@@ -38961,6 +39410,45 @@ snapshots:
       - utf-8-validate
       - zod
 
+  wagmi@2.17.5(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@3.25.76):
+    dependencies:
+      '@tanstack/react-query': 5.90.2(react@19.2.4)
+      '@wagmi/connectors': 5.11.2(@tanstack/react-query@5.90.2(react@19.2.4))(@wagmi/core@2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(wagmi@2.17.5(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/core': 2.21.2(react@19.2.4)(typescript@5.4.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))
+      react: 19.2.4
+      use-sync-external-store: 1.4.0(react@19.2.4)
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11)
+    optionalDependencies:
+      typescript: 5.4.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - immer
+      - ioredis
+      - supports-color
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -39342,6 +39830,45 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
+  x402-fetch@0.7.0(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      x402: 0.7.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - ws
+
   x402@0.7.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@tanstack/react-query@5.90.2(react@18.2.0))(@types/react@18.2.14)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.2.0)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@scure/base': 1.2.6
@@ -39356,6 +39883,55 @@ snapshots:
       '@wallet-standard/features': 1.1.0
       viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi: 2.17.5(@tanstack/react-query@5.90.2(react@18.2.0))(@types/react@18.2.14)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - ws
+
+  x402@0.7.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@scure/base': 1.2.6
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-features': 1.3.0
+      '@wallet-standard/app': 1.1.0
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+      viem: 2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      wagmi: 2.17.5(@tanstack/react-query@5.90.2(react@19.2.4))(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.4)(typescript@5.4.3)(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.0.9)(typescript@5.4.3)(utf-8-validate@5.0.10)(zod@4.1.11))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -39528,7 +40104,6 @@ snapshots:
       '@types/react': 19.2.4
       react: 19.2.4
       use-sync-external-store: 1.4.0(react@19.2.4)
-    optional: true
 
   zustand@5.0.0(@types/react@19.2.4)(react@19.2.4)(use-sync-external-store@1.5.0(react@19.2.4)):
     optionalDependencies:
@@ -39559,7 +40134,6 @@ snapshots:
       '@types/react': 19.2.4
       react: 19.2.4
       use-sync-external-store: 1.4.0(react@19.2.4)
-    optional: true
 
   zustand@5.0.3(@types/react@19.2.4)(react@19.2.4)(use-sync-external-store@1.5.0(react@19.2.4)):
     optionalDependencies:


### PR DESCRIPTION
## Summary & Motivation
Adds a with-vaultsfyi example showing how to use Turnkey wallets with the vaults.fyi SDK to discover, deposit into, and withdraw from DeFi yield vaults, including scoped policies for non-root users. Companion to the vaults.fyi cookbook guide.

## How I Tested These Changes
Manually tested all of the scripts.

## Did you add a changeset?
No, it's example code.
