### PR TITLE
Ethan/app proofs codegen fix

### DIFF
--- a/.changeset/crazy-ghosts-rest.md
+++ b/.changeset/crazy-ghosts-rest.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/sdk-types": patch
+"@turnkey/core": patch
+---
+
+Patched the core sdk's client to allow passing in the `generateAppProofs` param to all activity requests

--- a/packages/core/scripts/codegen.js
+++ b/packages/core/scripts/codegen.js
@@ -602,15 +602,20 @@ const generateSDKClientFromSwagger = async (
 
       const versionedMethodName = latestVersions[resultKey].formattedKeyName;
 
+      // TODO: remove the ts-ignore once we ensure all request types have the generateAppProofs field
       codeBuffer.push(
         `\n\t${methodName} = async (input: SdkTypes.${inputType}, stampWith?: StamperType): Promise<SdkTypes.${responseType}> => {
       const { organizationId, timestampMs, ...rest } = input;
+
+      //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+      const generateAppProofs = input?.generateAppProofs ?? false;
       const session = await this.storageManager?.getActiveSession();
   
       return this.activity("${endpointPath}", {
         parameters: rest,
         organizationId: organizationId ?? (session?.organizationId ?? this.config.organizationId),
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "${activityType}"
       }, "${versionedMethodName}", stampWith);
     }`,
@@ -620,12 +625,14 @@ const generateSDKClientFromSwagger = async (
       codeBuffer.push(
         `\n\t${methodName} = async (input: SdkTypes.${inputType}, stampWith?: StamperType): Promise<SdkTypes.${responseType}> => {
       const { organizationId, timestampMs, ...rest } = input;
+      const generateAppProofs = input?.generateAppProofs ?? false;
       const session = await this.storageManager?.getActiveSession();
       return this.activityDecision("${endpointPath}",
         {
           parameters: rest,
           organizationId: organizationId ?? (session?.organizationId ?? this.config.organizationId),
           timestampMs: timestampMs ?? String(Date.now()),
+          generateAppProofs: generateAppProofs ?? false,
           type: "${activityType}"
         }, stampWith);
     }`,

--- a/packages/core/src/__generated__/sdk-client-base.ts
+++ b/packages/core/src/__generated__/sdk-client-base.ts
@@ -2256,6 +2256,7 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TApproveActivityResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
     return this.activityDecision(
       "/public/v1/submit/approve_activity",
@@ -2266,6 +2267,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_APPROVE_ACTIVITY",
       },
       stampWith,
@@ -2308,6 +2310,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateApiKeysResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2319,6 +2324,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_API_KEYS_V2",
       },
       "createApiKeysResult",
@@ -2362,6 +2368,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateAuthenticatorsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2373,6 +2382,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_AUTHENTICATORS_V2",
       },
       "createAuthenticatorsResult",
@@ -2416,6 +2426,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateFiatOnRampCredentialResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2427,6 +2440,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_FIAT_ON_RAMP_CREDENTIAL",
       },
       "createFiatOnRampCredentialResult",
@@ -2471,6 +2485,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateInvitationsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2482,6 +2499,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_INVITATIONS",
       },
       "createInvitationsResult",
@@ -2525,6 +2543,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateOauth2CredentialResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2536,6 +2557,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_OAUTH2_CREDENTIAL",
       },
       "createOauth2CredentialResult",
@@ -2579,6 +2601,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateOauthProvidersResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2590,6 +2615,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_OAUTH_PROVIDERS_V2",
       },
       "createOauthProvidersResultV2",
@@ -2633,6 +2659,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreatePoliciesResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2644,6 +2673,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_POLICIES",
       },
       "createPoliciesResult",
@@ -2687,6 +2717,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreatePolicyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2698,6 +2731,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_POLICY_V3",
       },
       "createPolicyResult",
@@ -2740,6 +2774,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreatePrivateKeyTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2751,6 +2788,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG",
       },
       "createPrivateKeyTagResult",
@@ -2794,6 +2832,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreatePrivateKeysResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2805,6 +2846,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
       },
       "createPrivateKeysResultV2",
@@ -2848,6 +2890,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateReadOnlySessionResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2859,6 +2904,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION",
       },
       "createReadOnlySessionResult",
@@ -2902,6 +2948,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateReadWriteSessionResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2913,6 +2962,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION_V2",
       },
       "createReadWriteSessionResultV2",
@@ -2956,6 +3006,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateSmartContractInterfaceResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -2967,6 +3020,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_SMART_CONTRACT_INTERFACE",
       },
       "createSmartContractInterfaceResult",
@@ -3011,6 +3065,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateSubOrganizationResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3022,6 +3079,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V8",
       },
       "createSubOrganizationResultV8",
@@ -3065,6 +3123,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateUserTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3076,6 +3137,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_USER_TAG",
       },
       "createUserTagResult",
@@ -3119,6 +3181,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateUsersResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3130,6 +3195,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_USERS_V4",
       },
       "createUsersResult",
@@ -3172,6 +3238,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3183,6 +3252,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_WALLET",
       },
       "createWalletResult",
@@ -3225,6 +3295,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateWalletAccountsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3236,6 +3309,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS",
       },
       "createWalletAccountsResult",
@@ -3279,6 +3353,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TCreateWebhookEndpointResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3290,6 +3367,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_CREATE_WEBHOOK_ENDPOINT",
       },
       "createWebhookEndpointResult",
@@ -3333,6 +3411,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteApiKeysResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3344,6 +3425,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_API_KEYS",
       },
       "deleteApiKeysResult",
@@ -3387,6 +3469,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteAuthenticatorsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3398,6 +3483,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_AUTHENTICATORS",
       },
       "deleteAuthenticatorsResult",
@@ -3441,6 +3527,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteFiatOnRampCredentialResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3452,6 +3541,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_FIAT_ON_RAMP_CREDENTIAL",
       },
       "deleteFiatOnRampCredentialResult",
@@ -3496,6 +3586,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteInvitationResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3507,6 +3600,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_INVITATION",
       },
       "deleteInvitationResult",
@@ -3550,6 +3644,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteOauth2CredentialResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3561,6 +3658,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_OAUTH2_CREDENTIAL",
       },
       "deleteOauth2CredentialResult",
@@ -3604,6 +3702,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteOauthProvidersResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3615,6 +3716,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_OAUTH_PROVIDERS",
       },
       "deleteOauthProvidersResult",
@@ -3658,6 +3760,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeletePoliciesResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3669,6 +3774,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_POLICIES",
       },
       "deletePoliciesResult",
@@ -3712,6 +3818,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeletePolicyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3723,6 +3832,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_POLICY",
       },
       "deletePolicyResult",
@@ -3765,6 +3875,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeletePrivateKeyTagsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3776,6 +3889,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_PRIVATE_KEY_TAGS",
       },
       "deletePrivateKeyTagsResult",
@@ -3819,6 +3933,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeletePrivateKeysResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3830,6 +3947,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_PRIVATE_KEYS",
       },
       "deletePrivateKeysResult",
@@ -3873,6 +3991,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteSmartContractInterfaceResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3884,6 +4005,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_SMART_CONTRACT_INTERFACE",
       },
       "deleteSmartContractInterfaceResult",
@@ -3928,6 +4050,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteSubOrganizationResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3939,6 +4064,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_SUB_ORGANIZATION",
       },
       "deleteSubOrganizationResult",
@@ -3982,6 +4108,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteUserTagsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -3993,6 +4122,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_USER_TAGS",
       },
       "deleteUserTagsResult",
@@ -4036,6 +4166,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteUsersResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4047,6 +4180,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_USERS",
       },
       "deleteUsersResult",
@@ -4089,6 +4223,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteWalletAccountsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4100,6 +4237,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_WALLET_ACCOUNTS",
       },
       "deleteWalletAccountsResult",
@@ -4143,6 +4281,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteWalletsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4154,6 +4295,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_WALLETS",
       },
       "deleteWalletsResult",
@@ -4196,6 +4338,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TDeleteWebhookEndpointResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4207,6 +4352,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT",
       },
       "deleteWebhookEndpointResult",
@@ -4250,6 +4396,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TEmailAuthResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4261,6 +4410,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_EMAIL_AUTH_V3",
       },
       "emailAuthResult",
@@ -4303,6 +4453,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TEthSendTransactionResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4314,6 +4467,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
       },
       "ethSendTransactionResult",
@@ -4357,6 +4511,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TExportPrivateKeyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4368,6 +4525,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_EXPORT_PRIVATE_KEY",
       },
       "exportPrivateKeyResult",
@@ -4411,6 +4569,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TExportWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4422,6 +4583,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_EXPORT_WALLET",
       },
       "exportWalletResult",
@@ -4464,6 +4626,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TExportWalletAccountResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4475,6 +4640,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_EXPORT_WALLET_ACCOUNT",
       },
       "exportWalletAccountResult",
@@ -4518,6 +4684,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TImportPrivateKeyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4529,6 +4698,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY",
       },
       "importPrivateKeyResult",
@@ -4572,6 +4742,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TImportWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4583,6 +4756,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_IMPORT_WALLET",
       },
       "importWalletResult",
@@ -4625,6 +4799,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TInitFiatOnRampResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4636,6 +4813,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP",
       },
       "initFiatOnRampResult",
@@ -4679,6 +4857,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TInitImportPrivateKeyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4690,6 +4871,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
       },
       "initImportPrivateKeyResult",
@@ -4733,6 +4915,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TInitImportWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4744,6 +4929,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_INIT_IMPORT_WALLET",
       },
       "initImportWalletResult",
@@ -4787,6 +4973,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TInitOtpResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4798,6 +4987,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_INIT_OTP_V3",
       },
       "initOtpResultV2",
@@ -4840,6 +5030,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TInitOtpAuthResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4851,6 +5044,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_INIT_OTP_AUTH_V3",
       },
       "initOtpAuthResultV2",
@@ -4893,6 +5087,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TInitUserEmailRecoveryResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4904,6 +5101,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_INIT_USER_EMAIL_RECOVERY_V2",
       },
       "initUserEmailRecoveryResult",
@@ -4947,6 +5145,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TOauthResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -4958,6 +5159,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_OAUTH",
       },
       "oauthResult",
@@ -5000,6 +5202,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TOauth2AuthenticateResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5011,6 +5216,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_OAUTH2_AUTHENTICATE",
       },
       "oauth2AuthenticateResult",
@@ -5054,6 +5260,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TOauthLoginResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5065,6 +5274,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_OAUTH_LOGIN",
       },
       "oauthLoginResult",
@@ -5107,6 +5317,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TOtpAuthResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5118,6 +5331,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_OTP_AUTH",
       },
       "otpAuthResult",
@@ -5160,6 +5374,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TOtpLoginResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5171,6 +5388,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_OTP_LOGIN",
       },
       "otpLoginResult",
@@ -5213,6 +5431,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TRecoverUserResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5224,6 +5445,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_RECOVER_USER",
       },
       "recoverUserResult",
@@ -5266,6 +5488,7 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TRejectActivityResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
     return this.activityDecision(
       "/public/v1/submit/reject_activity",
@@ -5276,6 +5499,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_REJECT_ACTIVITY",
       },
       stampWith,
@@ -5318,6 +5542,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TRemoveIpAllowlistResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5329,6 +5556,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST",
       },
       "removeIpAllowlistResult",
@@ -5372,6 +5600,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TRemoveOrganizationFeatureResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5383,6 +5614,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_REMOVE_ORGANIZATION_FEATURE",
       },
       "removeOrganizationFeatureResult",
@@ -5426,6 +5658,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TSetIpAllowlistResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5437,6 +5672,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_SET_IP_ALLOWLIST",
       },
       "setIpAllowlistResult",
@@ -5480,6 +5716,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TSetOrganizationFeatureResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5491,6 +5730,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_SET_ORGANIZATION_FEATURE",
       },
       "setOrganizationFeatureResult",
@@ -5534,6 +5774,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TSignRawPayloadResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5545,6 +5788,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
       },
       "signRawPayloadResult",
@@ -5588,6 +5832,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TSignRawPayloadsResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5599,6 +5846,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS",
       },
       "signRawPayloadsResult",
@@ -5642,6 +5890,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TSignTransactionResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5653,6 +5904,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
       },
       "signTransactionResult",
@@ -5696,6 +5948,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TSolSendTransactionResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5707,6 +5962,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_SOL_SEND_TRANSACTION",
       },
       "solSendTransactionResult",
@@ -5750,6 +6006,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TStampLoginResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5761,6 +6020,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_STAMP_LOGIN",
       },
       "stampLoginResult",
@@ -5803,6 +6063,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateFiatOnRampCredentialResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5814,6 +6077,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_FIAT_ON_RAMP_CREDENTIAL",
       },
       "updateFiatOnRampCredentialResult",
@@ -5858,6 +6122,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateOauth2CredentialResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5869,6 +6136,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_OAUTH2_CREDENTIAL",
       },
       "updateOauth2CredentialResult",
@@ -5912,6 +6180,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateOrganizationNameResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5923,6 +6194,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_ORGANIZATION_NAME",
       },
       "updateOrganizationNameResult",
@@ -5966,6 +6238,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdatePolicyResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -5977,6 +6252,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_POLICY_V2",
       },
       "updatePolicyResultV2",
@@ -6019,6 +6295,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdatePrivateKeyTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6030,6 +6309,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_PRIVATE_KEY_TAG",
       },
       "updatePrivateKeyTagResult",
@@ -6073,6 +6353,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateRootQuorumResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6084,6 +6367,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_ROOT_QUORUM",
       },
       "updateRootQuorumResult",
@@ -6127,6 +6411,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateUserResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6138,6 +6425,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_USER",
       },
       "updateUserResult",
@@ -6180,6 +6468,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateUserEmailResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6191,6 +6482,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_USER_EMAIL",
       },
       "updateUserEmailResult",
@@ -6234,6 +6526,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateUserNameResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6245,6 +6540,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_USER_NAME",
       },
       "updateUserNameResult",
@@ -6288,6 +6584,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateUserPhoneNumberResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6299,6 +6598,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER",
       },
       "updateUserPhoneNumberResult",
@@ -6342,6 +6642,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateUserTagResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6353,6 +6656,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_USER_TAG",
       },
       "updateUserTagResult",
@@ -6396,6 +6700,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateWalletResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6407,6 +6714,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_WALLET",
       },
       "updateWalletResult",
@@ -6449,6 +6757,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TUpdateWebhookEndpointResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6460,6 +6771,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT",
       },
       "updateWebhookEndpointResult",
@@ -6503,6 +6815,9 @@ export class TurnkeySDKClientBase {
     stampWith?: StamperType,
   ): Promise<SdkTypes.TVerifyOtpResponse> => {
     const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
     const session = await this.storageManager?.getActiveSession();
 
     return this.activity(
@@ -6514,6 +6829,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_VERIFY_OTP",
       },
       "verifyOtpResult",

--- a/packages/sdk-types/scripts/codegen.js
+++ b/packages/sdk-types/scripts/codegen.js
@@ -534,6 +534,35 @@ function generateApiTypes(swagger, prefix = "") {
         const intentDef = definitions[adjustedIntentTypeName];
         output += generateInlineProperties(intentDef, isAllOptional);
       }
+
+      // Emit any remaining top-level request fields (e.g. generateAppProofs)
+      // that aren't part of the structural envelope.
+      const STRUCTURAL = new Set([
+        "type",
+        "timestampMs",
+        "organizationId",
+        "parameters",
+      ]);
+      const requiredProps = Array.isArray(requestTypeDef.required)
+        ? requestTypeDef.required
+        : [];
+      for (const [prop, schema] of Object.entries(
+        requestTypeDef.properties || {},
+      )) {
+        if (STRUCTURAL.has(prop)) continue;
+        let type = "any";
+        if (schema.$ref) {
+          type = refToTs(schema.$ref);
+        } else if (schema.type) {
+          type = swaggerTypeToTs(schema.type, schema);
+        }
+        const desc = schema.description
+          ? `  /** ${schema.description} */\n`
+          : "";
+        const propName = isValidIdentifier(prop) ? prop : `"${prop}"`;
+        const required = requiredProps.includes(prop) ? "" : "?";
+        output += `${desc}  ${propName}${required}: ${type};\n`;
+      }
     } else if (methodType === "query" || methodType === "noop") {
       output += `  organizationId?: string;\n`;
       if (requestTypeDef.properties) {

--- a/packages/sdk-types/src/__generated__/types.ts
+++ b/packages/sdk-types/src/__generated__/types.ts
@@ -5497,6 +5497,7 @@ export type TApproveActivityBody = {
   organizationId?: string;
   /** An artifact verifying a User's action. */
   fingerprint: string;
+  generateAppProofs?: boolean;
 };
 
 export type TApproveActivityInput = { body: TApproveActivityBody };
@@ -5514,6 +5515,7 @@ export type TCreateApiKeysBody = {
   apiKeys: v1ApiKeyParamsV2[];
   /** Unique identifier for a given User. */
   userId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateApiKeysInput = { body: TCreateApiKeysBody };
@@ -5531,6 +5533,7 @@ export type TCreateAuthenticatorsBody = {
   authenticators: v1AuthenticatorParamsV2[];
   /** Unique identifier for a given User. */
   userId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateAuthenticatorsInput = { body: TCreateAuthenticatorsBody };
@@ -5556,6 +5559,7 @@ export type TCreateFiatOnRampCredentialBody = {
   encryptedPrivateApiKey?: string;
   /** If the on-ramp credential is a sandbox credential */
   sandboxMode?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateFiatOnRampCredentialInput = {
@@ -5573,6 +5577,7 @@ export type TCreateInvitationsBody = {
   organizationId?: string;
   /** A list of Invitations. */
   invitations: v1InvitationParams[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreateInvitationsInput = { body: TCreateInvitationsBody };
@@ -5592,6 +5597,7 @@ export type TCreateOauth2CredentialBody = {
   clientId: string;
   /** The client secret issued by the OAuth 2.0 provider encrypted to the TLS Fetcher quorum key */
   encryptedClientSecret: string;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateOauth2CredentialInput = {
@@ -5611,6 +5617,7 @@ export type TCreateOauthProvidersBody = {
   userId: string;
   /** A list of Oauth providers. */
   oauthProviders: v1OauthProviderParamsV2[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreateOauthProvidersInput = { body: TCreateOauthProvidersBody };
@@ -5626,6 +5633,7 @@ export type TCreatePoliciesBody = {
   organizationId?: string;
   /** An array of policy intents to be created. */
   policies: v1CreatePolicyIntentV3[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreatePoliciesInput = { body: TCreatePoliciesBody };
@@ -5649,6 +5657,7 @@ export type TCreatePolicyBody = {
   consensus?: string;
   /** Notes for a Policy. */
   notes: string;
+  generateAppProofs?: boolean;
 };
 
 export type TCreatePolicyInput = { body: TCreatePolicyBody };
@@ -5668,6 +5677,7 @@ export type TCreatePrivateKeyTagBody = {
   privateKeyTagName: string;
   /** A list of Private Key IDs. */
   privateKeyIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreatePrivateKeyTagInput = { body: TCreatePrivateKeyTagBody };
@@ -5683,6 +5693,7 @@ export type TCreatePrivateKeysBody = {
   organizationId?: string;
   /** A list of Private Keys. */
   privateKeys: v1PrivateKeyParams[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreatePrivateKeysInput = { body: TCreatePrivateKeysBody };
@@ -5706,6 +5717,7 @@ export type TCreateReadOnlySessionResponse = {
 export type TCreateReadOnlySessionBody = {
   timestampMs?: string;
   organizationId?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateReadOnlySessionInput = { body: TCreateReadOnlySessionBody };
@@ -5739,6 +5751,7 @@ export type TCreateReadWriteSessionBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated ReadWriteSession API keys */
   invalidateExisting?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateReadWriteSessionInput = {
@@ -5763,6 +5776,7 @@ export type TCreateSmartContractInterfaceBody = {
   label: string;
   /** Notes for a Smart Contract Interface. */
   notes?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateSmartContractInterfaceInput = {
@@ -5799,6 +5813,7 @@ export type TCreateSubOrganizationBody = {
   verificationToken?: string;
   /** Optional signature proving authorization for this sub-organization creation. The signature is over the verification token ID and the root user parameters for the root user associated with the verification token. Only required if a public key was provided during the verification step. */
   clientSignature?: v1ClientSignature;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateSubOrganizationInput = { body: TCreateSubOrganizationBody };
@@ -5818,6 +5833,7 @@ export type TCreateUserTagBody = {
   userTagName: string;
   /** A list of User IDs. */
   userIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreateUserTagInput = { body: TCreateUserTagBody };
@@ -5833,6 +5849,7 @@ export type TCreateUsersBody = {
   organizationId?: string;
   /** A list of Users. */
   users: v1UserParamsV4[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreateUsersInput = { body: TCreateUsersBody };
@@ -5854,6 +5871,7 @@ export type TCreateWalletBody = {
   accounts: v1WalletAccountParams[];
   /** Length of mnemonic to generate the Wallet seed. Defaults to 12. Accepted values: 12, 15, 18, 21, 24. */
   mnemonicLength?: number;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateWalletInput = { body: TCreateWalletBody };
@@ -5873,6 +5891,7 @@ export type TCreateWalletAccountsBody = {
   accounts: v1WalletAccountParams[];
   /** Indicates if the wallet accounts should be persisted. This is helpful if you'd like to see the addresses of different derivation paths without actually creating the accounts. Defaults to true. */
   persist?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TCreateWalletAccountsInput = { body: TCreateWalletAccountsBody };
@@ -5894,6 +5913,7 @@ export type TCreateWebhookEndpointBody = {
   name: string;
   /** Event subscriptions to create for this endpoint. */
   subscriptions?: v1WebhookSubscriptionParams[];
+  generateAppProofs?: boolean;
 };
 
 export type TCreateWebhookEndpointInput = { body: TCreateWebhookEndpointBody };
@@ -5911,6 +5931,7 @@ export type TDeleteApiKeysBody = {
   userId: string;
   /** A list of API Key IDs. */
   apiKeyIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteApiKeysInput = { body: TDeleteApiKeysBody };
@@ -5928,6 +5949,7 @@ export type TDeleteAuthenticatorsBody = {
   userId: string;
   /** A list of Authenticator IDs. */
   authenticatorIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteAuthenticatorsInput = { body: TDeleteAuthenticatorsBody };
@@ -5943,6 +5965,7 @@ export type TDeleteFiatOnRampCredentialBody = {
   organizationId?: string;
   /** The ID of the fiat on-ramp credential to delete */
   fiatOnrampCredentialId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteFiatOnRampCredentialInput = {
@@ -5960,6 +5983,7 @@ export type TDeleteInvitationBody = {
   organizationId?: string;
   /** Unique identifier for a given Invitation object. */
   invitationId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteInvitationInput = { body: TDeleteInvitationBody };
@@ -5975,6 +5999,7 @@ export type TDeleteOauth2CredentialBody = {
   organizationId?: string;
   /** The ID of the OAuth 2.0 credential to delete */
   oauth2CredentialId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteOauth2CredentialInput = {
@@ -5994,6 +6019,7 @@ export type TDeleteOauthProvidersBody = {
   userId: string;
   /** Unique identifier for a given Provider. */
   providerIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteOauthProvidersInput = { body: TDeleteOauthProvidersBody };
@@ -6009,6 +6035,7 @@ export type TDeletePoliciesBody = {
   organizationId?: string;
   /** List of unique identifiers for policies within an organization */
   policyIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TDeletePoliciesInput = { body: TDeletePoliciesBody };
@@ -6024,6 +6051,7 @@ export type TDeletePolicyBody = {
   organizationId?: string;
   /** Unique identifier for a given Policy. */
   policyId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TDeletePolicyInput = { body: TDeletePolicyBody };
@@ -6041,6 +6069,7 @@ export type TDeletePrivateKeyTagsBody = {
   organizationId?: string;
   /** A list of Private Key Tag IDs. */
   privateKeyTagIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TDeletePrivateKeyTagsInput = { body: TDeletePrivateKeyTagsBody };
@@ -6058,6 +6087,7 @@ export type TDeletePrivateKeysBody = {
   privateKeyIds: string[];
   /** Optional parameter for deleting the private keys, even if any have not been previously exported. If they have been exported, this field is ignored. */
   deleteWithoutExport?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TDeletePrivateKeysInput = { body: TDeletePrivateKeysBody };
@@ -6073,6 +6103,7 @@ export type TDeleteSmartContractInterfaceBody = {
   organizationId?: string;
   /** The ID of a Smart Contract Interface intended for deletion. */
   smartContractInterfaceId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteSmartContractInterfaceInput = {
@@ -6090,6 +6121,7 @@ export type TDeleteSubOrganizationBody = {
   organizationId?: string;
   /** Sub-organization deletion, by default, requires associated wallets and private keys to be exported for security reasons. Set this boolean to true to force sub-organization deletion even if some wallets or private keys within it have not been exported yet. Default: false. */
   deleteWithoutExport?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteSubOrganizationInput = { body: TDeleteSubOrganizationBody };
@@ -6107,6 +6139,7 @@ export type TDeleteUserTagsBody = {
   organizationId?: string;
   /** A list of User Tag IDs. */
   userTagIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteUserTagsInput = { body: TDeleteUserTagsBody };
@@ -6122,6 +6155,7 @@ export type TDeleteUsersBody = {
   organizationId?: string;
   /** A list of User IDs. */
   userIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteUsersInput = { body: TDeleteUsersBody };
@@ -6139,6 +6173,7 @@ export type TDeleteWalletAccountsBody = {
   walletAccountIds: string[];
   /** Optional parameter for deleting the wallet accounts, even if any have not been previously exported. If they have been exported, this field is ignored. */
   deleteWithoutExport?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteWalletAccountsInput = { body: TDeleteWalletAccountsBody };
@@ -6156,6 +6191,7 @@ export type TDeleteWalletsBody = {
   walletIds: string[];
   /** Optional parameter for deleting the wallets, even if any have not been previously exported. If they have been exported, this field is ignored. */
   deleteWithoutExport?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteWalletsInput = { body: TDeleteWalletsBody };
@@ -6171,6 +6207,7 @@ export type TDeleteWebhookEndpointBody = {
   organizationId?: string;
   /** Unique identifier of the webhook endpoint to delete. */
   endpointId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TDeleteWebhookEndpointInput = { body: TDeleteWebhookEndpointBody };
@@ -6204,6 +6241,7 @@ export type TEmailAuthBody = {
   sendFromEmailSenderName?: string;
   /** Optional custom email address to use as reply-to */
   replyToEmailAddress?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TEmailAuthInput = { body: TEmailAuthBody };
@@ -6245,6 +6283,7 @@ export type TEthSendTransactionBody = {
   maxPriorityFeePerGas?: string;
   /** The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
   gasStationNonce?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TEthSendTransactionInput = { body: TEthSendTransactionBody };
@@ -6264,6 +6303,7 @@ export type TExportPrivateKeyBody = {
   privateKeyId: string;
   /** Client-side public key generated by the user, to which the export bundle will be encrypted. */
   targetPublicKey: string;
+  generateAppProofs?: boolean;
 };
 
 export type TExportPrivateKeyInput = { body: TExportPrivateKeyBody };
@@ -6285,6 +6325,7 @@ export type TExportWalletBody = {
   targetPublicKey: string;
   /** The language of the mnemonic to export. Defaults to English. */
   language?: v1MnemonicLanguage;
+  generateAppProofs?: boolean;
 };
 
 export type TExportWalletInput = { body: TExportWalletBody };
@@ -6304,6 +6345,7 @@ export type TExportWalletAccountBody = {
   address: string;
   /** Client-side public key generated by the user, to which the export bundle will be encrypted. */
   targetPublicKey: string;
+  generateAppProofs?: boolean;
 };
 
 export type TExportWalletAccountInput = { body: TExportWalletAccountBody };
@@ -6329,6 +6371,7 @@ export type TImportPrivateKeyBody = {
   curve: v1Curve;
   /** Cryptocurrency-specific formats for a derived address (e.g., Ethereum). */
   addressFormats: v1AddressFormat[];
+  generateAppProofs?: boolean;
 };
 
 export type TImportPrivateKeyInput = { body: TImportPrivateKeyBody };
@@ -6352,6 +6395,7 @@ export type TImportWalletBody = {
   encryptedBundle: string;
   /** A list of wallet Accounts. */
   accounts: v1WalletAccountParams[];
+  generateAppProofs?: boolean;
 };
 
 export type TImportWalletInput = { body: TImportWalletBody };
@@ -6391,6 +6435,7 @@ export type TInitFiatOnRampBody = {
   sandboxMode?: boolean;
   /** Optional MoonPay Widget URL to sign when using MoonPay client SDKs with URL Signing enabled. */
   urlForSignature?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TInitFiatOnRampInput = { body: TInitFiatOnRampBody };
@@ -6406,6 +6451,7 @@ export type TInitImportPrivateKeyBody = {
   organizationId?: string;
   /** The ID of the User importing a Private Key. */
   userId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TInitImportPrivateKeyInput = { body: TInitImportPrivateKeyBody };
@@ -6421,6 +6467,7 @@ export type TInitImportWalletBody = {
   organizationId?: string;
   /** The ID of the User importing a Wallet. */
   userId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TInitImportWalletInput = { body: TInitImportWalletBody };
@@ -6460,6 +6507,7 @@ export type TInitOtpBody = {
   expirationSeconds?: string;
   /** Optional custom email address to use as reply-to */
   replyToEmailAddress?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TInitOtpInput = { body: TInitOtpBody };
@@ -6497,6 +6545,7 @@ export type TInitOtpAuthBody = {
   expirationSeconds?: string;
   /** Optional custom email address to use as reply-to */
   replyToEmailAddress?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TInitOtpAuthInput = { body: TInitOtpAuthBody };
@@ -6524,6 +6573,7 @@ export type TInitUserEmailRecoveryBody = {
   sendFromEmailSenderName?: string;
   /** Optional custom email address to use as reply-to */
   replyToEmailAddress?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TInitUserEmailRecoveryInput = { body: TInitUserEmailRecoveryBody };
@@ -6551,6 +6601,7 @@ export type TOauthBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Oauth API keys */
   invalidateExisting?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TOauthInput = { body: TOauthBody };
@@ -6576,6 +6627,7 @@ export type TOauth2AuthenticateBody = {
   nonce?: string;
   /** An optional P256 public key to which, if provided, the bearer token will be encrypted and returned via the `encrypted_bearer_token` claim of the OIDC Token */
   bearerTokenTargetPublicKey?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TOauth2AuthenticateInput = { body: TOauth2AuthenticateBody };
@@ -6597,6 +6649,7 @@ export type TOauthLoginBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TOauthLoginInput = { body: TOauthLoginBody };
@@ -6626,6 +6679,7 @@ export type TOtpAuthBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated OTP Auth API keys */
   invalidateExisting?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TOtpAuthInput = { body: TOtpAuthBody };
@@ -6649,6 +6703,7 @@ export type TOtpLoginBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login sessions */
   invalidateExisting?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TOtpLoginInput = { body: TOtpLoginBody };
@@ -6666,6 +6721,7 @@ export type TRecoverUserBody = {
   authenticator: v1AuthenticatorParamsV2;
   /** Unique identifier for the user performing recovery. */
   userId: string;
+  generateAppProofs?: boolean;
 };
 
 export type TRecoverUserInput = { body: TRecoverUserBody };
@@ -6679,6 +6735,7 @@ export type TRejectActivityBody = {
   organizationId?: string;
   /** An artifact verifying a User's action. */
   fingerprint: string;
+  generateAppProofs?: boolean;
 };
 
 export type TRejectActivityInput = { body: TRejectActivityBody };
@@ -6707,6 +6764,7 @@ export type TRemoveOrganizationFeatureBody = {
   organizationId?: string;
   /** Name of the feature to remove */
   name: v1FeatureName;
+  generateAppProofs?: boolean;
 };
 
 export type TRemoveOrganizationFeatureInput = {
@@ -6745,6 +6803,7 @@ export type TSetOrganizationFeatureBody = {
   name: v1FeatureName;
   /** Optional value for the feature. Will override existing values if feature is already set. */
   value: string;
+  generateAppProofs?: boolean;
 };
 
 export type TSetOrganizationFeatureInput = {
@@ -6772,6 +6831,7 @@ export type TSignRawPayloadBody = {
   encoding: v1PayloadEncoding;
   /** Hash function to apply to payload bytes before signing. This field must be set to HASH_FUNCTION_NOT_APPLICABLE for EdDSA/ed25519 signature requests; configurable payload hashing is not supported by RFC 8032. */
   hashFunction: v1HashFunction;
+  generateAppProofs?: boolean;
 };
 
 export type TSignRawPayloadInput = { body: TSignRawPayloadBody };
@@ -6792,6 +6852,7 @@ export type TSignRawPayloadsBody = {
   encoding: v1PayloadEncoding;
   /** Hash function to apply to payload bytes before signing. This field must be set to HASH_FUNCTION_NOT_APPLICABLE for EdDSA/ed25519 signature requests; configurable payload hashing is not supported by RFC 8032. */
   hashFunction: v1HashFunction;
+  generateAppProofs?: boolean;
 };
 
 export type TSignRawPayloadsInput = { body: TSignRawPayloadsBody };
@@ -6809,6 +6870,7 @@ export type TSignTransactionBody = {
   /** Raw unsigned transaction to be signed */
   unsignedTransaction: string;
   type: v1TransactionType;
+  generateAppProofs?: boolean;
 };
 
 export type TSignTransactionInput = { body: TSignTransactionBody };
@@ -6835,6 +6897,7 @@ export type TSolSendTransactionBody = {
     | "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY";
   /** user-provided blockhash for replay protection / deadline control. If omitted and sponsor=true, we fetch a fresh blockhash during execution */
   recentBlockhash?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TSolSendTransactionInput = { body: TSolSendTransactionBody };
@@ -6854,6 +6917,7 @@ export type TStampLoginBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TStampLoginInput = { body: TStampLoginBody };
@@ -6879,6 +6943,7 @@ export type TUpdateFiatOnRampCredentialBody = {
   encryptedSecretApiKey: string;
   /** Private API key for the on-ramp provider encrypted to our on-ramp encryption public key. Some providers, like Coinbase, require this additional key. */
   encryptedPrivateApiKey?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateFiatOnRampCredentialInput = {
@@ -6902,6 +6967,7 @@ export type TUpdateOauth2CredentialBody = {
   clientId: string;
   /** The client secret issued by the OAuth 2.0 provider encrypted to the TLS Fetcher quorum key */
   encryptedClientSecret: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateOauth2CredentialInput = {
@@ -6948,6 +7014,7 @@ export type TUpdatePolicyBody = {
   policyConsensus?: string;
   /** Accompanying notes for a Policy (optional). */
   policyNotes?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdatePolicyInput = { body: TUpdatePolicyBody };
@@ -6969,6 +7036,7 @@ export type TUpdatePrivateKeyTagBody = {
   addPrivateKeyIds: string[];
   /** A list of Private Key IDs to remove this tag from. */
   removePrivateKeyIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TUpdatePrivateKeyTagInput = { body: TUpdatePrivateKeyTagBody };
@@ -6984,6 +7052,7 @@ export type TUpdateRootQuorumBody = {
   threshold: number;
   /** The unique identifiers of users who comprise the quorum set. */
   userIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateRootQuorumInput = { body: TUpdateRootQuorumBody };
@@ -7007,6 +7076,7 @@ export type TUpdateUserBody = {
   userTagIds?: string[];
   /** The user's phone number in E.164 format e.g. +13214567890 */
   userPhoneNumber?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateUserInput = { body: TUpdateUserBody };
@@ -7026,6 +7096,7 @@ export type TUpdateUserEmailBody = {
   userEmail: string;
   /** Signed JWT containing a unique id, expiry, verification type, contact */
   verificationToken?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateUserEmailInput = { body: TUpdateUserEmailBody };
@@ -7043,6 +7114,7 @@ export type TUpdateUserNameBody = {
   userId: string;
   /** Human-readable name for a User. */
   userName: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateUserNameInput = { body: TUpdateUserNameBody };
@@ -7062,6 +7134,7 @@ export type TUpdateUserPhoneNumberBody = {
   userPhoneNumber: string;
   /** Signed JWT containing a unique id, expiry, verification type, contact */
   verificationToken?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateUserPhoneNumberInput = { body: TUpdateUserPhoneNumberBody };
@@ -7083,6 +7156,7 @@ export type TUpdateUserTagBody = {
   addUserIds: string[];
   /** A list of User IDs to remove this tag from. */
   removeUserIds: string[];
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateUserTagInput = { body: TUpdateUserTagBody };
@@ -7100,6 +7174,7 @@ export type TUpdateWalletBody = {
   walletId: string;
   /** Human-readable name for a Wallet. */
   walletName?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateWalletInput = { body: TUpdateWalletBody };
@@ -7123,6 +7198,7 @@ export type TUpdateWebhookEndpointBody = {
   name?: string;
   /** Whether this webhook endpoint is active. */
   isActive?: boolean;
+  generateAppProofs?: boolean;
 };
 
 export type TUpdateWebhookEndpointInput = { body: TUpdateWebhookEndpointBody };
@@ -7142,6 +7218,7 @@ export type TVerifyOtpBody = {
   encryptedOtpBundle: string;
   /** Expiration window (in seconds) indicating how long the verification token is valid for. If not provided, a default of 1 hour will be used. Maximum value is 86400 seconds (24 hours) */
   expirationSeconds?: string;
+  generateAppProofs?: boolean;
 };
 
 export type TVerifyOtpInput = { body: TVerifyOtpBody };


### PR DESCRIPTION
## Summary & Motivation

- The `generateAppProofs` param was not being exposed in `@turnkey/core`'s top level http client requests. This change adds them in.

## How I Tested These Changes

- Ran the codegen, tested the regenerated client locally

## Did you add a changeset?

- Yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
