### PR TITLE
Fix codegen to work with validateTvcImage query

### DIFF
--- a/packages/core/scripts/codegen.js
+++ b/packages/core/scripts/codegen.js
@@ -169,7 +169,8 @@ function methodTypeFromMethodName(methodName) {
   if (
     methodName.startsWith("get") ||
     methodName.startsWith("list") ||
-    methodName.startsWith("test")
+    methodName.startsWith("test") ||
+    methodName.startsWith("validate")
   ) {
     return "query";
   }

--- a/packages/sdk-browser/scripts/codegen.js
+++ b/packages/sdk-browser/scripts/codegen.js
@@ -79,7 +79,8 @@ function methodTypeFromMethodName(methodName) {
   if (
     methodName.startsWith("get") ||
     methodName.startsWith("list") ||
-    methodName.startsWith("test")
+    methodName.startsWith("test") ||
+    methodName.startsWith("validate")
   ) {
     return "query";
   }

--- a/packages/sdk-server/scripts/codegen.js
+++ b/packages/sdk-server/scripts/codegen.js
@@ -75,7 +75,8 @@ function methodTypeFromMethodName(methodName) {
   if (
     methodName.startsWith("get") ||
     methodName.startsWith("list") ||
-    methodName.startsWith("test")
+    methodName.startsWith("test") ||
+    methodName.startsWith("validate")
   ) {
     return "query";
   }

--- a/packages/sdk-types/scripts/codegen.js
+++ b/packages/sdk-types/scripts/codegen.js
@@ -258,7 +258,8 @@ function methodTypeFromMethodName(methodName) {
   if (
     methodName.startsWith("tget") ||
     methodName.startsWith("tlist") ||
-    methodName.startsWith("ttest")
+    methodName.startsWith("ttest") ||
+    methodName.startsWith("validate")
   ) {
     return "query";
   }


### PR DESCRIPTION
## Summary & Motivation

Fixes a problem with running the codegen against [latest mono `main`](https://github.com/tkhq/mono/commit/df97c7c8764b383da098285be5907e46497b5f50)

## How I Tested These Changes

Run `make -C proto sync/js-sdk` from `mono`

## Did you add a changeset?

None required