### PR TITLE
returning credentialId in loginwithpasskey

### DIFF
--- a/.changeset/legal-dodos-lose.md
+++ b/.changeset/legal-dodos-lose.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/core": patch
+---
+
+return actual credentialId from loginWithPasskey instead of empty string

--- a/.changeset/legal-dodos-lose.md
+++ b/.changeset/legal-dodos-lose.md
@@ -2,4 +2,4 @@
 "@turnkey/core": patch
 ---
 
-return actual credentialId from loginWithPasskey instead of empty string
+return actual `credentialId` from `loginWithPasskey()` instead of empty string

--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -554,15 +554,35 @@ export class TurnkeyClient {
             TurnkeyErrorCodes.INTERNAL_ERROR,
           );
         }
-        const sessionResponse = await this.httpClient.stampLogin(
-          {
-            publicKey: generatedPublicKey,
-            organizationId:
-              params?.organizationId ?? this.config.organizationId,
-            expirationSeconds,
-          },
+
+        const loginPayload = {
+          publicKey: generatedPublicKey,
+          organizationId: params?.organizationId ?? this.config.organizationId,
+          expirationSeconds,
+        };
+
+        const passkeyLoginRequest = await this.httpClient.stampStampLogin(
+          loginPayload,
           StamperType.Passkey,
         );
+
+        if (!passkeyLoginRequest) {
+          throw new TurnkeyError(
+            "Failed to generate login payload for passkey login.",
+            TurnkeyErrorCodes.INTERNAL_ERROR,
+          );
+        }
+
+        const credentialId = (
+          JSON.parse(passkeyLoginRequest.stamp.stampHeaderValue) as {
+            credentialId: string;
+          }
+        ).credentialId;
+
+        const sessionResponse =
+          await this.httpClient.sendSignedRequest<TStampLoginResponse>(
+            passkeyLoginRequest,
+          );
 
         await this.storeSession({
           sessionToken: sessionResponse.session,
@@ -571,11 +591,7 @@ export class TurnkeyClient {
 
         return {
           sessionToken: sessionResponse.session,
-
-          // TODO: can we return the credentialId here?
-          // from a quick glance this is going to be difficult
-          // for now we return an empty string
-          credentialId: "",
+          credentialId,
         };
       },
       {

--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -573,6 +573,7 @@ export class TurnkeyClient {
           );
         }
 
+        // For passkey stamps, the stamp header value is JSON that includes the credentialId used to sign. Extract it here so we can return it to the caller.
         const credentialId = (
           JSON.parse(passkeyLoginRequest.stamp.stampHeaderValue) as {
             credentialId: string;


### PR DESCRIPTION
## Summary & Motivation
loginWithPasskey was returning an empty string for credentialId. This extracts the actual credential ID from the passkey stamp header and returns it.

## How I Tested These Changes
locally

## Did you add a changeset?

yes