### PR TITLE
Add SDK helper for Turnkey webhook signature verification

### DIFF
--- a/.changeset/webhook-signature-helper.md
+++ b/.changeset/webhook-signature-helper.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": minor
+---
+
+Add a helper for verifying Turnkey webhook signatures.

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -33,3 +33,39 @@ const decryptedData = hpkeDecrypt({
 // Convert decrypted data back to string
 const decryptedText = new TextDecoder().decode(decryptedData);
 ```
+
+## Verifying Turnkey webhooks
+
+Use `@turnkey/crypto` directly when you want to manage verification-key fetching and caching yourself. Verification must use the exact raw request body bytes that Turnkey sent, the Turnkey signature headers, Turnkey webhook verification keys, and an explicit `maxTimestampAgeMs` replay window.
+
+Turnkey sends these signature headers with the body: `x-turnkey-timestamp`, `x-turnkey-event-id`, `x-turnkey-signature-key-id`, `x-turnkey-signature-algorithm`, `x-turnkey-signature-version`, and `x-turnkey-signature`. Pass the complete headers object through as received.
+
+`x-turnkey-event-id` is stable across retry attempts for the same webhook event. Use it as the deduplication or idempotency key after signature verification succeeds.
+
+```ts
+import { verifyTurnkeyWebhookSignature } from "@turnkey/crypto";
+
+const body = req.body; // Buffer from express.raw(), not parsed JSON
+const verificationKeys = [
+  {
+    keyId: process.env.TURNKEY_WEBHOOK_KEY_ID!,
+    publicKey: process.env.TURNKEY_WEBHOOK_PUBLIC_KEY!, // Hex-encoded Ed25519 public key
+    algorithm: "ed25519",
+  },
+];
+
+const result = verifyTurnkeyWebhookSignature({
+  headers: req.headers,
+  body,
+  verificationKeys,
+  maxTimestampAgeMs: 5 * 60 * 1000,
+});
+
+if (!result.ok) {
+  throw new Error(`Invalid Turnkey webhook: ${result.reason}`);
+}
+
+const event = JSON.parse(body.toString("utf8"));
+```
+
+Do not verify a parsed and re-stringified JSON object. Even harmless-looking changes to whitespace or key ordering will change the signed payload.

--- a/packages/crypto/documents/docs.md
+++ b/packages/crypto/documents/docs.md
@@ -1,0 +1,40 @@
+---
+title: "Crypto"
+description: "The [`@turnkey/crypto`](https://www.npmjs.com/package/@turnkey/crypto) package exposes low-level cryptographic helpers used across Turnkey SDKs."
+---
+
+## Webhook Verification
+
+Use `@turnkey/crypto` directly when you want to fetch and cache Turnkey's webhook verification keys yourself. Verification requires the exact raw body bytes, Turnkey signature headers, verification keys, and a required `maxTimestampAgeMs` replay window.
+
+Turnkey sends these signature headers with the body: `x-turnkey-timestamp`, `x-turnkey-event-id`, `x-turnkey-signature-key-id`, `x-turnkey-signature-algorithm`, `x-turnkey-signature-version`, and `x-turnkey-signature`. Pass the complete headers object through as received.
+
+`x-turnkey-event-id` is stable across retry attempts for the same webhook event. Use it as the deduplication or idempotency key after signature verification succeeds.
+
+```ts
+import { verifyTurnkeyWebhookSignature } from "@turnkey/crypto";
+
+const body = req.body; // Buffer from express.raw(), not parsed JSON
+const verificationKeys = [
+  {
+    keyId: process.env.TURNKEY_WEBHOOK_KEY_ID!,
+    publicKey: process.env.TURNKEY_WEBHOOK_PUBLIC_KEY!, // Hex-encoded Ed25519 public key
+    algorithm: "ed25519",
+  },
+];
+
+const result = verifyTurnkeyWebhookSignature({
+  headers: req.headers,
+  body,
+  verificationKeys,
+  maxTimestampAgeMs: 5 * 60 * 1000,
+});
+
+if (!result.ok) {
+  throw new Error(`Invalid Turnkey webhook: ${result.reason}`);
+}
+
+const event = JSON.parse(body.toString("utf8"));
+```
+
+Do not verify a parsed and re-stringified JSON object. The signed payload is the raw bytes Turnkey sent.

--- a/packages/crypto/src/__tests__/webhooks-test.ts
+++ b/packages/crypto/src/__tests__/webhooks-test.ts
@@ -1,0 +1,325 @@
+import { test, expect, describe } from "@jest/globals";
+import { ed25519 } from "@noble/curves/ed25519";
+import { uint8ArrayToHexString } from "@turnkey/encoding";
+import {
+  TurnkeyWebhookVerificationFailureReasons,
+  verifyTurnkeyWebhookSignature,
+  type TurnkeyWebhookVerificationKey,
+} from "../";
+import { buildSignedInput } from "../webhooks";
+
+const PRIVATE_KEY = new Uint8Array([
+  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+  0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+  0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+]);
+
+const KEY_ID = "webhook-key-1";
+const EVENT_ID = "evt_123";
+const TIMESTAMP_MS = 1_700_000_000_000;
+const NOW_MS = TIMESTAMP_MS + 1_000;
+const MAX_TIMESTAMP_AGE_MS = 5 * 60 * 1_000;
+const BODY = '{"type":"activity.created","data":{"id":"act_123"}}';
+
+describe("verifyTurnkeyWebhookSignature", () => {
+  test("verifies a valid signature with plain record headers", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: {
+        "x-turnkey-timestamp": String(TIMESTAMP_MS),
+        "X-Turnkey-Event-Id": EVENT_ID,
+        "x-turnkey-signature-key-id": KEY_ID,
+        "X-Turnkey-Signature-Algorithm": "ed25519",
+        "x-turnkey-signature-version": "v1",
+        "X-Turnkey-Signature": fixture.signature,
+      },
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      eventId: EVENT_ID,
+      keyId: KEY_ID,
+      timestampMs: TIMESTAMP_MS,
+    });
+  });
+
+  test("verifies a valid signature with Headers and Uint8Array body", () => {
+    const body = new TextEncoder().encode(BODY);
+    const fixture = createFixture({ body });
+    const headers = new Headers({
+      "X-Turnkey-Timestamp": String(TIMESTAMP_MS),
+      "X-Turnkey-Event-Id": EVENT_ID,
+      "X-Turnkey-Signature-Key-Id": KEY_ID,
+      "X-Turnkey-Signature-Algorithm": "ed25519",
+      "X-Turnkey-Signature-Version": "v1",
+      "X-Turnkey-Signature": fixture.signature,
+    });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers,
+      body,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("verifies a valid signature with string array header values and ArrayBuffer body", () => {
+    const body = new TextEncoder().encode(BODY).buffer;
+    const fixture = createFixture({ body });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: {
+        "x-turnkey-timestamp": [String(TIMESTAMP_MS)],
+        "x-turnkey-event-id": [EVENT_ID],
+        "x-turnkey-signature-key-id": [KEY_ID],
+        "x-turnkey-signature-algorithm": ["ed25519"],
+        "x-turnkey-signature-version": ["v1"],
+        "x-turnkey-signature": [fixture.signature],
+      },
+      body,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects a tampered body", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: fixture.headers,
+      body: `${BODY}\n`,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.InvalidSignature,
+    });
+  });
+
+  test("rejects a tampered signature", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: {
+        ...fixture.headers,
+        "x-turnkey-signature": `00${fixture.signature.slice(2)}`,
+      },
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.InvalidSignature,
+    });
+  });
+
+  test("rejects a short signature", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: {
+        ...fixture.headers,
+        "x-turnkey-signature": fixture.signature.slice(2),
+      },
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.InvalidSignature,
+    });
+  });
+
+  test("rejects a tampered signed header", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: {
+        ...fixture.headers,
+        "x-turnkey-event-id": "evt_tampered",
+      },
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.InvalidSignature,
+    });
+  });
+
+  test("rejects a missing required header", () => {
+    const fixture = createFixture({ body: BODY });
+    const { "x-turnkey-signature": _signature, ...headers } = fixture.headers;
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers,
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.MissingHeader,
+      headerName: "x-turnkey-signature",
+    });
+  });
+
+  test("rejects a missing key", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: fixture.headers,
+      body: BODY,
+      verificationKeys: [],
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.MissingKey,
+    });
+  });
+
+  test("rejects a short verification key", () => {
+    const fixture = createFixture({ body: BODY });
+    const verificationKey = fixture.verificationKeys[0]!;
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: fixture.headers,
+      body: BODY,
+      verificationKeys: [
+        {
+          ...verificationKey,
+          publicKey: verificationKey.publicKey.slice(2),
+        },
+      ],
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.InvalidVerificationKey,
+    });
+  });
+
+  test("rejects a stale timestamp", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: fixture.headers,
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: TIMESTAMP_MS + MAX_TIMESTAMP_AGE_MS + 1,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: TurnkeyWebhookVerificationFailureReasons.StaleTimestamp,
+    });
+  });
+
+  test("rejects an unsupported algorithm", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: {
+        ...fixture.headers,
+        "x-turnkey-signature-algorithm": "ecdsa",
+      },
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        TurnkeyWebhookVerificationFailureReasons.UnsupportedSignatureAlgorithm,
+    });
+  });
+
+  test("rejects an unsupported version", () => {
+    const fixture = createFixture({ body: BODY });
+
+    const result = verifyTurnkeyWebhookSignature({
+      headers: {
+        ...fixture.headers,
+        "x-turnkey-signature-version": "v2",
+      },
+      body: BODY,
+      verificationKeys: fixture.verificationKeys,
+      maxTimestampAgeMs: MAX_TIMESTAMP_AGE_MS,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        TurnkeyWebhookVerificationFailureReasons.UnsupportedSignatureVersion,
+    });
+  });
+});
+
+function createFixture({ body }: { body: string | Uint8Array | ArrayBuffer }) {
+  const publicKey = ed25519.getPublicKey(PRIVATE_KEY);
+  const verificationKeys: TurnkeyWebhookVerificationKey[] = [
+    {
+      keyId: KEY_ID,
+      publicKey: uint8ArrayToHexString(publicKey),
+      algorithm: "ed25519",
+    },
+  ];
+  const signedInput = buildSignedInput({
+    version: "v1",
+    algorithm: "ed25519",
+    keyId: KEY_ID,
+    timestampMs: String(TIMESTAMP_MS),
+    eventId: EVENT_ID,
+    body,
+  });
+  const signature = uint8ArrayToHexString(
+    ed25519.sign(signedInput, PRIVATE_KEY),
+  );
+
+  return {
+    verificationKeys,
+    signature,
+    headers: {
+      "x-turnkey-timestamp": String(TIMESTAMP_MS),
+      "x-turnkey-event-id": EVENT_ID,
+      "x-turnkey-signature-key-id": KEY_ID,
+      "x-turnkey-signature-algorithm": "ed25519",
+      "x-turnkey-signature-version": "v1",
+      "x-turnkey-signature": signature,
+    },
+  };
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -2,6 +2,20 @@ export * from "./crypto";
 export * from "./turnkey";
 export * from "./proof";
 export {
+  TurnkeyWebhookVerificationFailureReasons,
+  verifyTurnkeyWebhookSignature,
+} from "./webhooks";
+export type {
+  TurnkeyWebhookBody,
+  TurnkeyWebhookHeaders,
+  TurnkeyWebhookVerificationFailure,
+  TurnkeyWebhookVerificationFailureReason,
+  TurnkeyWebhookVerificationKey,
+  TurnkeyWebhookVerificationResult,
+  TurnkeyWebhookVerificationSuccess,
+  VerifyTurnkeyWebhookSignatureParams,
+} from "./webhooks";
+export {
   PRODUCTION_SIGNER_SIGN_PUBLIC_KEY,
   PRODUCTION_NOTARIZER_SIGN_PUBLIC_KEY,
   PRODUCTION_TLS_FETCHER_ENCRYPT_PUBLIC_KEY,

--- a/packages/crypto/src/webhooks.ts
+++ b/packages/crypto/src/webhooks.ts
@@ -1,0 +1,314 @@
+import { ed25519 } from "@noble/curves/ed25519";
+import { uint8ArrayFromHexString } from "@turnkey/encoding";
+
+export type TurnkeyWebhookVerificationKey = {
+  keyId: string;
+  publicKey: string;
+  algorithm?: "ed25519";
+};
+
+export type TurnkeyWebhookHeaders =
+  | Headers
+  | Record<string, string | string[] | undefined>;
+
+export type TurnkeyWebhookBody = string | Uint8Array | ArrayBuffer;
+
+export type VerifyTurnkeyWebhookSignatureParams = {
+  headers: TurnkeyWebhookHeaders;
+  body: TurnkeyWebhookBody;
+  verificationKeys: TurnkeyWebhookVerificationKey[];
+  maxTimestampAgeMs: number;
+  nowMs?: number;
+};
+
+export const TurnkeyWebhookVerificationFailureReasons = {
+  InvalidMaxTimestampAge: "invalid_max_timestamp_age",
+  InvalidNow: "invalid_now",
+  MissingHeader: "missing_header",
+  InvalidTimestamp: "invalid_timestamp",
+  StaleTimestamp: "stale_timestamp",
+  UnsupportedSignatureVersion: "unsupported_signature_version",
+  UnsupportedSignatureAlgorithm: "unsupported_signature_algorithm",
+  MissingKey: "missing_key",
+  InvalidVerificationKeyAlgorithm: "invalid_verification_key_algorithm",
+  InvalidVerificationKey: "invalid_verification_key",
+  InvalidSignature: "invalid_signature",
+} as const;
+
+export type TurnkeyWebhookVerificationFailureReason =
+  (typeof TurnkeyWebhookVerificationFailureReasons)[keyof typeof TurnkeyWebhookVerificationFailureReasons];
+
+export type TurnkeyWebhookVerificationSuccess = {
+  ok: true;
+  eventId: string;
+  keyId: string;
+  timestampMs: number;
+};
+
+export type TurnkeyWebhookVerificationFailure = {
+  ok: false;
+  reason: TurnkeyWebhookVerificationFailureReason;
+  headerName?: string;
+};
+
+export type TurnkeyWebhookVerificationResult =
+  | TurnkeyWebhookVerificationSuccess
+  | TurnkeyWebhookVerificationFailure;
+
+const HEADER_TIMESTAMP = "x-turnkey-timestamp";
+const HEADER_EVENT_ID = "x-turnkey-event-id";
+const HEADER_KEY_ID = "x-turnkey-signature-key-id";
+const HEADER_ALGORITHM = "x-turnkey-signature-algorithm";
+const HEADER_VERSION = "x-turnkey-signature-version";
+const HEADER_SIGNATURE = "x-turnkey-signature";
+
+const SUPPORTED_VERSION = "v1";
+const SUPPORTED_ALGORITHM = "ed25519";
+const PUBLIC_KEY_BYTE_LENGTH = 32;
+const ED25519_SIGNATURE_BYTE_LENGTH = 64;
+
+/**
+ * Verifies a Turnkey webhook signature with caller-provided Ed25519
+ * verification keys.
+ *
+ * Pass the exact raw request body bytes Turnkey sent, the request headers, and
+ * a bounded `maxTimestampAgeMs` replay window. The function returns a typed
+ * failure result for invalid webhook input instead of throwing, so handlers can
+ * reject expected verification failures without exception-driven control flow.
+ */
+export function verifyTurnkeyWebhookSignature({
+  headers,
+  body,
+  verificationKeys,
+  maxTimestampAgeMs,
+  nowMs = Date.now(),
+}: VerifyTurnkeyWebhookSignatureParams): TurnkeyWebhookVerificationResult {
+  if (!Number.isFinite(maxTimestampAgeMs) || maxTimestampAgeMs < 0) {
+    return invalid(
+      TurnkeyWebhookVerificationFailureReasons.InvalidMaxTimestampAge,
+    );
+  }
+  if (!Number.isFinite(nowMs)) {
+    return invalid(TurnkeyWebhookVerificationFailureReasons.InvalidNow);
+  }
+
+  const timestampHeader = getRequiredHeader(headers, HEADER_TIMESTAMP);
+  if (!timestampHeader.ok) {
+    return timestampHeader;
+  }
+  const eventIdHeader = getRequiredHeader(headers, HEADER_EVENT_ID);
+  if (!eventIdHeader.ok) {
+    return eventIdHeader;
+  }
+  const keyIdHeader = getRequiredHeader(headers, HEADER_KEY_ID);
+  if (!keyIdHeader.ok) {
+    return keyIdHeader;
+  }
+  const algorithmHeader = getRequiredHeader(headers, HEADER_ALGORITHM);
+  if (!algorithmHeader.ok) {
+    return algorithmHeader;
+  }
+  const versionHeader = getRequiredHeader(headers, HEADER_VERSION);
+  if (!versionHeader.ok) {
+    return versionHeader;
+  }
+  const signatureHeader = getRequiredHeader(headers, HEADER_SIGNATURE);
+  if (!signatureHeader.ok) {
+    return signatureHeader;
+  }
+
+  const timestampMs = parseTimestampMs(timestampHeader.value);
+  if (timestampMs === undefined) {
+    return invalid(TurnkeyWebhookVerificationFailureReasons.InvalidTimestamp);
+  }
+
+  if (Math.abs(nowMs - timestampMs) > maxTimestampAgeMs) {
+    return invalid(TurnkeyWebhookVerificationFailureReasons.StaleTimestamp);
+  }
+
+  if (versionHeader.value !== SUPPORTED_VERSION) {
+    return invalid(
+      TurnkeyWebhookVerificationFailureReasons.UnsupportedSignatureVersion,
+    );
+  }
+  if (algorithmHeader.value !== SUPPORTED_ALGORITHM) {
+    return invalid(
+      TurnkeyWebhookVerificationFailureReasons.UnsupportedSignatureAlgorithm,
+    );
+  }
+
+  const key = verificationKeys.find(
+    (candidate) => candidate.keyId === keyIdHeader.value,
+  );
+  if (!key) {
+    return invalid(TurnkeyWebhookVerificationFailureReasons.MissingKey);
+  }
+  const publicKeyResult = getPublicKeyBytes(key);
+  if (!publicKeyResult.ok) {
+    return publicKeyResult;
+  }
+
+  const signatureResult = hexToBytes(
+    signatureHeader.value,
+    ED25519_SIGNATURE_BYTE_LENGTH,
+    TurnkeyWebhookVerificationFailureReasons.InvalidSignature,
+  );
+  if (!signatureResult.ok) {
+    return signatureResult;
+  }
+
+  const signedInput = buildSignedInput({
+    version: versionHeader.value,
+    algorithm: algorithmHeader.value,
+    keyId: keyIdHeader.value,
+    timestampMs: timestampHeader.value,
+    eventId: eventIdHeader.value,
+    body,
+  });
+
+  let verified = false;
+  try {
+    verified = ed25519.verify(
+      signatureResult.value,
+      signedInput,
+      publicKeyResult.value,
+    );
+  } catch {
+    return invalid(TurnkeyWebhookVerificationFailureReasons.InvalidSignature);
+  }
+  if (!verified) {
+    return invalid(TurnkeyWebhookVerificationFailureReasons.InvalidSignature);
+  }
+
+  return {
+    ok: true,
+    eventId: eventIdHeader.value,
+    keyId: keyIdHeader.value,
+    timestampMs,
+  };
+}
+
+export function buildSignedInput({
+  version,
+  algorithm,
+  keyId,
+  timestampMs,
+  eventId,
+  body,
+}: {
+  version: string;
+  algorithm: string;
+  keyId: string;
+  timestampMs: string;
+  eventId: string;
+  body: TurnkeyWebhookBody;
+}): Uint8Array {
+  const prefix = new TextEncoder().encode(
+    `${version}.${algorithm}.${keyId}.${timestampMs}.${eventId}.`,
+  );
+  const bodyBytes = bodyToBytes(body);
+  const signedInput = new Uint8Array(prefix.length + bodyBytes.length);
+  signedInput.set(prefix, 0);
+  signedInput.set(bodyBytes, prefix.length);
+  return signedInput;
+}
+
+function bodyToBytes(body: TurnkeyWebhookBody): Uint8Array {
+  if (typeof body === "string") {
+    return new TextEncoder().encode(body);
+  }
+  if (body instanceof Uint8Array) {
+    return body;
+  }
+  return new Uint8Array(body);
+}
+
+function getRequiredHeader(
+  headers: TurnkeyWebhookHeaders,
+  name: string,
+): { ok: true; value: string } | TurnkeyWebhookVerificationFailure {
+  const value = getHeader(headers, name);
+  if (value === undefined || value === "") {
+    return invalid(TurnkeyWebhookVerificationFailureReasons.MissingHeader, {
+      headerName: name,
+    });
+  }
+  return { ok: true, value };
+}
+
+function getHeader(
+  headers: TurnkeyWebhookHeaders,
+  name: string,
+): string | undefined {
+  if (isHeaders(headers)) {
+    return headers.get(name) ?? undefined;
+  }
+
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    if (headerName.toLowerCase() !== name) {
+      continue;
+    }
+    if (Array.isArray(headerValue)) {
+      return headerValue[0];
+    }
+    return headerValue;
+  }
+  return undefined;
+}
+
+function isHeaders(headers: TurnkeyWebhookHeaders): headers is Headers {
+  return typeof Headers !== "undefined" && headers instanceof Headers;
+}
+
+function parseTimestampMs(timestamp: string): number | undefined {
+  if (!/^[0-9]+$/.test(timestamp)) {
+    return undefined;
+  }
+  const parsed = Number(timestamp);
+  if (!Number.isSafeInteger(parsed)) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function getPublicKeyBytes(
+  key: TurnkeyWebhookVerificationKey,
+): { ok: true; value: Uint8Array } | TurnkeyWebhookVerificationFailure {
+  if (key.algorithm !== undefined && key.algorithm !== SUPPORTED_ALGORITHM) {
+    return invalid(
+      TurnkeyWebhookVerificationFailureReasons.InvalidVerificationKeyAlgorithm,
+    );
+  }
+
+  return hexToBytes(
+    key.publicKey,
+    PUBLIC_KEY_BYTE_LENGTH,
+    TurnkeyWebhookVerificationFailureReasons.InvalidVerificationKey,
+  );
+}
+
+function hexToBytes(
+  input: string,
+  expectedLength: number,
+  reason: TurnkeyWebhookVerificationFailureReason,
+): { ok: true; value: Uint8Array } | TurnkeyWebhookVerificationFailure {
+  if (input.length !== expectedLength * 2) {
+    return invalid(reason);
+  }
+
+  try {
+    return {
+      ok: true,
+      value: uint8ArrayFromHexString(input),
+    };
+  } catch {
+    return invalid(reason);
+  }
+}
+
+function invalid(
+  reason: TurnkeyWebhookVerificationFailureReason,
+  details: Omit<TurnkeyWebhookVerificationFailure, "ok" | "reason"> = {},
+): TurnkeyWebhookVerificationFailure {
+  return { ok: false, reason, ...details };
+}


### PR DESCRIPTION
## Summary
- Add a pure @turnkey/crypto helper for verifying Turnkey webhook signatures
- Support exact raw body verification against caller-provided Ed25519 verification keys
- Cover valid signatures, tampered payloads/headers/signatures, missing keys, stale timestamps, and unsupported protocol values
- Add crypto package docs for raw-body usage

## Notes
- This intentionally does not add a server-side key discovery/fetching helper yet; discovery endpoint shape is still undecided and should be handled in a follow-up.

## Tests
- pnpm --filter @turnkey/crypto test -- webhooks-test.ts
- pnpm --filter @turnkey/crypto typecheck
- pnpm --filter @turnkey/crypto test