### PR TITLE
Chore: leverage turbo cache in build workflow

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -128,8 +128,10 @@ jobs:
           BANNED_TO_ADDRESS: ${{ secrets.PREPROD_BANNED_TO_ADDRESS }}
           SOLANA_TEST_ORG_API_PRIVATE_KEY: ${{ secrets.SOLANA_TEST_ORG_API_PRIVATE_KEY }}
           WALLET_ID: ${{ secrets.PREPROD_WALLET_ID }}
+  
   test-end-to-end:
     runs-on: ubuntu-latest
+    needs: build
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
## Summary & Motivation

If we let the `build` step populate the build cache, we save some time on the jobs to follow. Since `test-end-to-end` is not a bottleneck, the workflow duration start-to-end will not be affected

## How I Tested These Changes

CI

## Did you add a changeset?

None needed