### PR TITLE
Fix (moderately) broken CI install

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,5 @@
 {
-  "installCommand": "csb:install",
-  "buildCommand": "csb:build",
+  "buildCommand": "build-all",
   "packages": [
     "packages/cosmjs",
     "packages/eip-1193-provider",

--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -41,12 +41,8 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
-    - name: Audit the lockfiles to catch peer dependency issues
-      run: pnpm install -r --lockfile-only
-      shell: bash
-
     - name: Install dependencies
-      run: pnpm install -r --frozen-lockfile
+      run: pnpm install --frozen-lockfile
       shell: bash
 
     - name: Install Foundry

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-preserve-directives": "^1.1.2",
     "tsx": "^3.12.7",
-    "turbo": "^2.4.4",
+    "turbo": "^2.9.14",
     "typedoc": "^0.28.1",
     "typedoc-plugin-markdown": "^4.6.0",
     "typescript": "5.4.3"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "build:watch": "tsc --build tsconfig.mono.json --watch",
     "build": "turbo --filter \"./packages/**\" build",
     "generate-docs": "typedoc --options typedoc.json",
-    "csb:install": "corepack enable && pnpm install -r",
-    "csb:build": "pnpm run build-all",
     "clean-all": "pnpm run -r clean",
     "prettier-all:check": "prettier --check \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml,mjs}\" --ignore-path ./.prettierignore",
     "prettier-all:write": "prettier --write \"**/*.{css,html,js,json,md,ts,tsx,yaml,yml,mjs}\" --ignore-path ./.prettierignore",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-preserve-directives": "^1.1.2",
     "tsx": "^3.12.7",
-    "turbo": "^2.9.14",
+    "turbo": "^2.4.4",
     "typedoc": "^0.28.1",
     "typedoc-plugin-markdown": "^4.6.0",
     "typescript": "5.4.3"


### PR DESCRIPTION
## Summary & Motivation

Our CI installation action is currently moderately broken:

```sh
# First we run this which updates the lockfile
pnpm install -r --lockfile-only

# Which means that --frozen-lockfile will never give us an error (it has just been updated by the command above)
pnpm install -r --frozen-lockfile
```

## How I Tested These Changes

I updated `turbo` version in [this commit](https://github.com/tkhq/sdk/pull/1318/changes/b157e56f7c5c3aeb647465c7509a5eaa496a0830) and let the [build run](https://github.com/tkhq/sdk/actions/runs/26108069465/job/76777368766?pr=1318). As you can see, `Setup JS` succeeded and the error only got caught in `Ensure git is clean` step.

I then pushed the second commit with a fix and you can see that it [failed very early on](https://github.com/tkhq/sdk/actions/runs/26108551048/job/76779113955?pr=1318), giving immediate feedback.

I then reverted the `turbo` version update in [this commit](https://github.com/tkhq/sdk/pull/1318/changes/83fb1d849e01a7529f4323de11cfefac9814aa9c) and added a [small cleanup](https://github.com/tkhq/sdk/pull/1318/changes/59c49fd0f3af77fb82ffb62caa17ed45cefc354d) - codesandbox scripts are no longer necessary since `corepack` is enabled by default.