### PR TITLE
Chore: Setup concurrency for CI build

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch: # Allows manual invocation
 
+concurrency:
+  # We only want to cancel previous builds on PRs and let the pushes to main complete
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary & Motivation

There can be a lot of resources wasted on completing the whole `js-build` workflow on PRs, hence the concurrency setting

## How I Tested These Changes

CI

## Did you add a changeset?

Dev change only