### PR TITLE
Fix build for magic OTP example

### DIFF
--- a/examples/magic-link-auth/package.json
+++ b/examples/magic-link-auth/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tailwindcss/postcss": "4.1.13",
     "@turnkey/react-wallet-kit": "workspace:*",
+    "@turnkey/crypto": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
     "@types/node": "20.3.1",
     "@types/react": "18.2.14",

--- a/examples/magic-link-auth/package.json
+++ b/examples/magic-link-auth/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.1.13",

--- a/examples/magic-link-auth/src/app/page.tsx
+++ b/examples/magic-link-auth/src/app/page.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useState } from "react";
 import { sendMagicLink } from "@/server/actions/sendMagicLink";
-import { AuthState, ClientState, useTurnkey } from "@turnkey/react-wallet-kit";
-import { completeAuth } from "@/server/actions/completeAuth";
+import { AuthState, ClientState, getClientSignatureMessageForLogin, useTurnkey } from "@turnkey/react-wallet-kit";
+import { completeAuth, verifyOtpAction } from "@/server/actions/completeAuth";
 import { useRouter } from "next/navigation";
+import { v1ClientSignature } from "@turnkey/sdk-server";
+import { encryptOtpCodeToBundle } from "@turnkey/crypto";
 
 function LoginPage() {
   const router = useRouter();
-  const { clientState, authState, createApiKeyPair, storeSession } =
+  const { clientState, authState, createApiKeyPair, storeSession, signWithApiKey } =
     useTurnkey();
 
   const [email, setEmail] = useState("");
@@ -29,11 +31,12 @@ function LoginPage() {
 
     try {
       setIsSubmitting(true);
-      const otpId = await sendMagicLink({ email });
+      const { otpId, otpEncryptionTargetBundle } = await sendMagicLink({ email });
 
-      // we store the otpId in local storage to use it later when the user clicks the magic link
+      // we store the otpId and otpEncryptionTargetBundle in local storage to use it later when the user clicks the magic link
       // since its needed to verify the otp code
       window.localStorage.setItem("turnkey_otp_id", otpId);
+      window.localStorage.setItem("turnkey_otp_encryption_target_bundle", otpEncryptionTargetBundle);
 
       setIsSent(true);
     } finally {
@@ -65,8 +68,6 @@ function LoginPage() {
   }, [authState, router]);
 
   const loginOrSignUp = async (otpCode: string) => {
-    const publicKey = await createApiKeyPair();
-
     // get the otpId from local storage
     const otpId = window.localStorage.getItem("turnkey_otp_id");
 
@@ -74,11 +75,48 @@ function LoginPage() {
       throw new Error("No otpId found in local storage.");
     }
 
-    const session = await completeAuth({ otpId, otpCode, publicKey });
+    const otpEncryptionTargetBundle = window.localStorage.getItem("turnkey_otp_encryption_target_bundle");
+
+    if (!otpEncryptionTargetBundle) {
+      throw new Error("No otpEncryptionTargetBundle found in local storage.");
+    }
+
+    const publicKey = await createApiKeyPair();
+    const encryptedOtpBundle = await encryptOtpCodeToBundle(
+        otpCode.trim(),
+        otpEncryptionTargetBundle,
+        publicKey,
+      );
+
+      // Verify the encrypted bundle → get a verificationToken and the sub-org
+      // ID. Sub-org creation is gated here, after Turnkey validates the OTP.
+      const { verificationToken, subOrgId } = await verifyOtpAction({
+        otpId,
+        encryptedOtpBundle,
+      });
+
+    // signature over the new key
+    // The token's publicKey is the canonical source — it was embedded inside
+      // the encrypted bundle by the enclave and equals the key we just created.
+      const { message, publicKey: tokenPublicKey } =
+        getClientSignatureMessageForLogin({ verificationToken });
+      const signature = await signWithApiKey({
+        message,
+        publicKey: tokenPublicKey,
+      });
+      const clientSignature: v1ClientSignature = {
+        scheme: "CLIENT_SIGNATURE_SCHEME_API_P256",
+        publicKey: tokenPublicKey,
+        message,
+        signature,
+      };
+
+    const session = await completeAuth({ otpId, otpEncryptionTargetBundle, publicKey, clientSignature });
     await storeSession({ sessionToken: session });
 
-    // remove the otpId from local storage since we don't need it anymore
+    // remove the otpId and otpEncryptionTargetBundle from local storage since we don't need them anymore
     window.localStorage.removeItem("turnkey_otp_id");
+    window.localStorage.removeItem("turnkey_otp_encryption_target_bundle");
   };
 
   return (

--- a/examples/magic-link-auth/src/server/actions/completeAuth.ts
+++ b/examples/magic-link-auth/src/server/actions/completeAuth.ts
@@ -1,17 +1,47 @@
 "use server";
 
-import { Turnkey, TurnkeyApiClient } from "@turnkey/sdk-server";
+import { Turnkey, TurnkeyApiClient, v1ClientSignature } from "@turnkey/sdk-server";
+
+// Step 1: verify the encrypted OTP bundle → returns a verificationToken and
+// the sub-org ID. Sub-org lookup/creation is done here, after Turnkey has
+// validated the OTP
+export async function verifyOtpAction(params: {
+  otpId: string;
+  encryptedOtpBundle: string;
+}) {
+  const turnkeyClient = new Turnkey({
+    apiBaseUrl: "https://api.turnkey.com",
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    defaultOrganizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
+  }).apiClient();
+
+  const { verificationToken } = await turnkeyClient.verifyOtp({
+    otpId: params.otpId,
+    encryptedOtpBundle: params.encryptedOtpBundle,
+  });
+  if (!verificationToken) {
+    throw new Error("Verification token not found after OTP verification.");
+  }
+
+  const email = extractEmailFromVerificationToken(verificationToken);
+  const subOrgId = await getOrCreateSuborgForEmail(turnkeyClient, email);
+
+  return { verificationToken, subOrgId };
+}
 
 type CompleteAuthParams = {
   otpId: string;
-  otpCode: string;
+  otpEncryptionTargetBundle: string;
   publicKey: string;
+  clientSignature: v1ClientSignature
 };
 
 export async function completeAuth({
   otpId,
-  otpCode,
+  otpEncryptionTargetBundle,
   publicKey,
+  clientSignature,
 }: CompleteAuthParams) {
   const turnkeyClient = new Turnkey({
     apiBaseUrl: "https://api.turnkey.com",
@@ -23,7 +53,7 @@ export async function completeAuth({
   // we cerify the OTP code to get a verification token
   const { verificationToken } = await turnkeyClient.verifyOtp({
     otpId,
-    otpCode,
+    encryptedOtpBundle: otpEncryptionTargetBundle,
   });
   if (!verificationToken) {
     throw new Error("Verification token not found after OTP verification.");
@@ -40,6 +70,7 @@ export async function completeAuth({
     organizationId: subOrgId,
     verificationToken,
     publicKey,
+    clientSignature,
   });
 
   if (!session) {

--- a/examples/magic-link-auth/src/server/actions/sendMagicLink.ts
+++ b/examples/magic-link-auth/src/server/actions/sendMagicLink.ts
@@ -15,20 +15,27 @@ export async function sendMagicLink({ email }: SendMagicLinkParams) {
     defaultOrganizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
   }).apiClient();
 
+  console.warn({ priv: process.env.API_PRIVATE_KEY, pub: process.env.API_PUBLIC_KEY });
+
   // we send a magic link to the user’s email
-  const { otpId } = await turnkeyClient.initOtp({
+  const { otpId, otpEncryptionTargetBundle } = await turnkeyClient.initOtp({
     contact: email,
     appName: "Magic Link Demo",
     otpType: OtpType.Email,
     emailCustomization: {
       // %s will be replaced with the otpCode when sending the email
-      magicLinkTemplate: "http://localhost:3000?otpCode=%s",
+      magicLinkTemplate: "http://localhost:3001?otpCode=%s",
     },
   });
 
   if (!otpId) {
     throw new Error("Failed to initialize OTP: missing otpId in response.");
   }
+  if (!otpEncryptionTargetBundle) {
+    throw new Error(
+      "Failed to initialize OTP: missing otpEncryptionTargetBundle in response.",
+    );
+  }
 
-  return otpId;
+  return { otpId, otpEncryptionTargetBundle };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 4.1.13
         version: 4.1.13
+      '@turnkey/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
       '@turnkey/react-wallet-kit':
         specifier: workspace:*
         version: link:../../packages/react-wallet-kit


### PR DESCRIPTION
## Summary & Motivation

`typecheck` command was missing from `examples/magic-link-auth` so a build issue has gone undetected. This PR brings the code from the updated examples to fix the build & adds the `typecheck` command to make sure it does not come back.

## How I Tested These Changes

Locally + CI

## Did you add a changeset?

Example only changes