### PR TITLE
Fix personal_sign and eth_sign

### DIFF
--- a/.changeset/eip1193-personal-sign-eip191.md
+++ b/.changeset/eip1193-personal-sign-eip191.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/eip-1193-provider": patch
+---
+
+Fix `personal_sign` and `eth_sign` to sign the keccak256 of the EIP-191-prefixed message

--- a/packages/eip-1193-provider/src/__tests__/index.test.ts
+++ b/packages/eip-1193-provider/src/__tests__/index.test.ts
@@ -9,7 +9,7 @@ import {
   numberToHex,
   parseEther,
   parseGwei,
-  recoverAddress,
+  recoverMessageAddress,
   stringToHex,
   verifyTypedData,
   type EIP1474Methods,
@@ -276,8 +276,8 @@ describe("Test Turnkey EIP-1193 Provider", () => {
             });
             expect(signature).not.toBeUndefined();
             expect(signature).not.toBe("");
-            const address = await recoverAddress({
-              hash: messageDigest,
+            const address = await recoverMessageAddress({
+              message: { raw: messageDigest },
               signature: signature!,
             });
             expect(getAddress(address)).toBe(getAddress(signerAddress));
@@ -294,8 +294,8 @@ describe("Test Turnkey EIP-1193 Provider", () => {
             });
             expect(signature).not.toBeUndefined();
             expect(signature).not.toBe("");
-            const address = await recoverAddress({
-              hash: messageDigest,
+            const address = await recoverMessageAddress({
+              message: { raw: messageDigest },
               signature: signature!,
             });
             expect(getAddress(address)).toBe(getAddress(signerAddress));

--- a/packages/eip-1193-provider/src/index.ts
+++ b/packages/eip-1193-provider/src/index.ts
@@ -12,7 +12,12 @@ import {
   ChainDisconnectedError,
   Hex,
 } from "viem";
-import { getAddress, getHttpRpcClient, hashTypedData } from "viem/utils";
+import {
+  getAddress,
+  getHttpRpcClient,
+  hashMessage,
+  hashTypedData,
+} from "viem/utils";
 
 import EventEmitter from "events";
 import { preprocessTransaction, validateChain } from "./utils";
@@ -146,7 +151,7 @@ export const createEIP1193Provider = async (
 
           const signedMessage = await signMessage({
             organizationId,
-            message,
+            message: hashMessage({ raw: message }),
             signWith: getAddress(signWith),
             client: turnkeyClient,
           });
@@ -159,7 +164,7 @@ export const createEIP1193Provider = async (
 
           const signedMessage = await signMessage({
             organizationId,
-            message,
+            message: hashMessage({ raw: message }),
             signWith: getAddress(signWith),
             client: turnkeyClient,
           });


### PR DESCRIPTION
Previously `personal_sign` and `eth_sign` methods passed the message straight to `HASH_FUNCTION_NO_OP`, so the returned signatures did not verify against  original message using standard tooling (`verifyMessage` / `recoverMessageAddress`). This was not compat with SIWE for example
