### PR TITLE
fix: support nonce for theme overrides

### DIFF
--- a/packages/react-wallet-kit/src/providers/TurnkeyProvider.tsx
+++ b/packages/react-wallet-kit/src/providers/TurnkeyProvider.tsx
@@ -22,6 +22,7 @@ export function TurnkeyProvider({
         <TurnkeyThemeOverrides
           light={config.ui?.colors?.light}
           dark={config.ui?.colors?.dark}
+          nonce={config.ui?.styleNonce}
         />
         {children}
 

--- a/packages/react-wallet-kit/src/providers/theme/Overrides.tsx
+++ b/packages/react-wallet-kit/src/providers/theme/Overrides.tsx
@@ -16,8 +16,9 @@ export type ThemeOverrides = {
 export function TurnkeyThemeOverrides(props: {
   light?: Partial<ThemeOverrides> | undefined;
   dark?: Partial<ThemeOverrides> | undefined;
+  nonce?: string | undefined;
 }) {
-  const { light, dark } = props;
+  const { light, dark, nonce } = props;
   const generateCSSVars = (theme?: Partial<ThemeOverrides>) => {
     if (!theme) return "";
     return Object.entries(theme)
@@ -33,7 +34,7 @@ export function TurnkeyThemeOverrides(props: {
   };
 
   return (
-    <style>
+    <style nonce={nonce}>
       {`
         :root {
           ${generateCSSVars(light)}

--- a/packages/react-wallet-kit/src/types/base.ts
+++ b/packages/react-wallet-kit/src/types/base.ts
@@ -148,6 +148,8 @@ export interface TurnkeyProviderConfig extends TurnkeySDKClientConfig {
     backgroundBlur?: string | number; // e.g., 10, "1rem"
     /** whether to render the modal in the provider. */
     renderModalInProvider?: boolean; // If true, the modal will be rendered as a child of the TurnkeyProvider instead of a sibling to the body. This is useful for font inheritance, and css manipulations to modals.
+    /** nonce applied to the injected theme override style tag for strict CSP support. */
+    styleNonce?: string;
     /** whether to suppress missing styles error. */
     supressMissingStylesError?: boolean; // If true, the Turnkey styles missing error will no longer show. It's possible that styles can be imported but not detected properly. This will suppress the error in that case.
   };


### PR DESCRIPTION
Adds an optional `styleNonce` config value for React Wallet Kit and passes it to the injected theme override `<style>` tag.

This addresses #1296 for apps with a strict Content Security Policy. Existing behavior is unchanged when no nonce is provided.

Validation:
- `corepack pnpm prettier --check packages/react-wallet-kit/src/providers/TurnkeyProvider.tsx packages/react-wallet-kit/src/providers/theme/Overrides.tsx packages/react-wallet-kit/src/types/base.ts`
- `git diff --check`

I also checked the focused package scripts, but the selected packages do not expose package-level `typecheck` or `build` scripts in this workspace.