### PR TITLE
fix: stop publishing broken source maps

### DIFF
--- a/rollup.config.base.mjs
+++ b/rollup.config.base.mjs
@@ -14,7 +14,7 @@ const getFormatConfig = (format) => {
       entryFileNames: `[name].${format === "esm" ? "mjs" : "js"}`,
       preserveModules: true,
       preserveModulesRoot: "src",
-      sourcemap: true,
+      sourcemap: false,
     },
     plugins: [
       typescript({
@@ -24,8 +24,8 @@ const getFormatConfig = (format) => {
           outDir: "dist",
           composite: false,
           declaration: format === "esm",
-          declarationMap: format === "esm",
-          sourceMap: true,
+          declarationMap: false,
+          sourceMap: false,
           skipLibCheck: true,
         },
       }),


### PR DESCRIPTION
## Summary

- Disables emitted JavaScript sourcemaps in the shared Rollup config.
- Disables TypeScript declaration maps for ESM builds.
- Keeps generated declarations enabled while avoiding `.map` files that point to unpublished `src/` files.

Closes #1265.

## Validation

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @turnkey/crypto build`
- Verified `packages/crypto/dist` no longer contains `.map` files or `sourceMappingURL` comments after build.
- `corepack pnpm prettier --check rollup.config.base.mjs`
- `git diff --check`

Note: the package build completed and emitted the expected `dist` output, but Rollup still printed existing workspace resolution warnings for local packages such as `@turnkey/encoding` and `@turnkey/sdk-types`. Those warnings are unrelated to this sourcemap change and were present during local package builds.
