### PR TITLE
fix: move next to sdk-react dev dependencies

### DIFF
--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -65,7 +65,6 @@
     "@turnkey/wallet-stamper": "workspace:*",
     "jwt-decode": "^4.0.0",
     "libphonenumber-js": "^1.11.14",
-    "next": "15.5.18",
     "react-apple-login": "^1.1.6",
     "react-international-phone": "^4.3.0",
     "usehooks-ts": "^3.1.1"
@@ -81,7 +80,8 @@
   },
   "devDependencies": {
     "postcss-import": "^16.1.0",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "next": "15.5.18"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4137,9 +4137,6 @@ importers:
       libphonenumber-js:
         specifier: ^1.11.14
         version: 1.12.15
-      next:
-        specifier: 15.5.18
-        version: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       react-apple-login:
         specifier: ^1.1.6
         version: 1.1.6(prop-types@15.8.1)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
@@ -4150,6 +4147,9 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(react@18.3.1)
     devDependencies:
+      next:
+        specifier: 15.5.18
+        version: 15.5.18(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       postcss-import:
         specifier: ^16.1.0
         version: 16.1.1(postcss@8.5.6)


### PR DESCRIPTION
## Summary

- Moves `next` out of `@turnkey/sdk-react` runtime dependencies.
- Keeps the same pinned `next` version in dev dependencies for local package development/build tooling.
- Updates the `pnpm-lock.yaml` importer entry accordingly.

Closes #854.

## Validation

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @turnkey/sdk-react build`
- `corepack pnpm prettier --check packages/sdk-react/package.json pnpm-lock.yaml`
- `git diff --check`

Note: `@turnkey/sdk-react` build completed and emitted `dist`. Rollup still prints existing workspace type-resolution warnings for local Turnkey packages during isolated package builds; those are unrelated to moving `next` between dependency sections.
