### PR TITLE
fix: return ArrayBuffer from webauthn base64url decoder

### DIFF
--- a/packages/http/src/webauthn-json/base64url.ts
+++ b/packages/http/src/webauthn-json/base64url.ts
@@ -12,12 +12,11 @@ export function base64urlToBuffer(
   const str = atob(base64String);
 
   // Binary string to buffer
-  const buffer = new ArrayBuffer(str.length);
-  const byteView = new Uint8Array(buffer);
+  const byteView = new Uint8Array(str.length);
   for (let i = 0; i < str.length; i++) {
     byteView[i] = str.charCodeAt(i);
   }
-  return byteView;
+  return byteView.buffer;
 }
 
 export function bufferToBase64url(buffer: ArrayBuffer): Base64urlString {

--- a/packages/webauthn-stamper/src/webauthn-json/base64url.ts
+++ b/packages/webauthn-stamper/src/webauthn-json/base64url.ts
@@ -12,12 +12,11 @@ export function base64urlToBuffer(
   const str = atob(base64String);
 
   // Binary string to buffer
-  const buffer = new ArrayBuffer(str.length);
-  const byteView = new Uint8Array(buffer);
+  const byteView = new Uint8Array(str.length);
   for (let i = 0; i < str.length; i++) {
     byteView[i] = str.charCodeAt(i);
   }
-  return buffer;
+  return byteView.buffer;
 }
 
 export function bufferToBase64url(buffer: ArrayBuffer): Base64urlString {


### PR DESCRIPTION
The WebAuthn base64url helpers are typed to return `ArrayBuffer`. The `@turnkey/http` copy was returning the `Uint8Array` view instead, while the webauthn-stamper copy already returned the backing buffer.

This updates both duplicated helper copies to allocate the view directly and return `byteView.buffer`, so the runtime value matches the function signature without changing the decoded bytes.

Checked with:
- `pnpm --filter @turnkey/webauthn-stamper typecheck`
- `pnpm --filter @turnkey/http typecheck`
- `pnpm --filter @turnkey/webauthn-stamper exec jest --runInBand`
- a local runtime check comparing the old `@turnkey/http` return value with the updated `ArrayBuffer` result