### PR TITLE
Spark support: Update Spark signer with the new API methods

### DIFF
--- a/examples/with-spark/.env.local.example
+++ b/examples/with-spark/.env.local.example
@@ -21,7 +21,10 @@ API_PRIVATE_KEY=
 
 # The Turnkey address that holds the same private key
 # as the Spark identity key derived from the mnemonic above.
-TURNKEY_IDENTITY_ADDRESS=
+TURNKEY_ECDSA_ADDRESS=
+
+TURNKEY_SPARK_ADDRESS=
+
 # Compressed 33-byte public key (hex) of the identity key held in Turnkey.
 # Used by TurnkeySparkSigner.getIdentityPublicKey() without a round-trip.
 IDENTITY_PUBLIC_KEY_HEX=

--- a/examples/with-spark/src/index.ts
+++ b/examples/with-spark/src/index.ts
@@ -47,7 +47,8 @@ async function main() {
     "API_PUBLIC_KEY",
     "API_PRIVATE_KEY",
     "ORGANIZATION_ID",
-    "TURNKEY_IDENTITY_ADDRESS",
+    "TURNKEY_SPARK_ADDRESS",
+    "TURNKEY_ECDSA_ADDRESS",
     "IDENTITY_PUBLIC_KEY_HEX",
     "RECEIVER_SPARK_ADDRESS",
   ] as const;
@@ -65,7 +66,8 @@ async function main() {
     process.env.TRANSFER_AMOUNT ?? String(mintAmount),
   );
   const receiverSparkAddress = process.env.RECEIVER_SPARK_ADDRESS!;
-  const turnkeyIdentityAddress = process.env.TURNKEY_IDENTITY_ADDRESS!;
+  const turnkeyEcdsaAddress = process.env.TURNKEY_ECDSA_ADDRESS!;
+  const turnkeySparkAddress = process.env.TURNKEY_SPARK_ADDRESS!;
   const identityPublicKeyHex = process.env.IDENTITY_PUBLIC_KEY_HEX!;
 
   // Initialize Turnkey client
@@ -77,11 +79,12 @@ async function main() {
   });
 
   // Create the Turnkey-backed signer
-  const signer = new TurnkeySparkSigner(
-    turnkeyClient,
-    turnkeyIdentityAddress,
+  const signer = new TurnkeySparkSigner({
+    client: turnkeyClient,
+    sparkAddress: turnkeySparkAddress,
+    ecdsaAddress: turnkeyEcdsaAddress,
     identityPublicKeyHex,
-  );
+  });
 
   // Initialize IssuerSparkWallet with Turnkey signer.
   // Cast to `any` is safe: the mismatched methods (subtractAndSplitSecretWithProofsGivenDerivations,

--- a/packages/spark/jest.config.js
+++ b/packages/spark/jest.config.js
@@ -4,7 +4,6 @@ const config = {
     "\\.[jt]sx?$": "@turnkey/jest-config/transformer.js",
   },
   testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/node_modules/"],
-  setupFiles: ["dotenv/config"],
 };
 
 module.exports = config;

--- a/packages/spark/package.json
+++ b/packages/spark/package.json
@@ -53,10 +53,15 @@
     "@noble/hashes": "^1.4.0",
     "@scure/bip39": "^1.3.0",
     "@scure/btc-signer": "^1.5.0",
+    "@turnkey/encoding": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",
-    "@turnkey/core": "workspace:*"
+    "@turnkey/core": "workspace:*",
+    "async-retry": "1.3.3"
   },
   "devDependencies": {
+    "@types/async-retry": "1.4.8",
+    "@types/jest": "^29.5.3",
+    "jest": "29.7.0",
     "typescript": "5.4.3"
   },
   "engines": {

--- a/packages/spark/src/__tests__/key-management.test.ts
+++ b/packages/spark/src/__tests__/key-management.test.ts
@@ -1,0 +1,242 @@
+import { describe } from "node:test";
+import { TurnkeyKeyManager } from "../key-management";
+
+describe("TurnkeyKeyManager", () => {
+  describe("get", () => {
+    it("should return undefined if fetch is not implemented and a key is not present", async () => {
+      class TestManager extends TurnkeyKeyManager<string> {}
+
+      const manager = new TestManager();
+      const result = await manager.get("test");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should throw if fetch throws and a key is not present", async () => {
+      const error = new Error("Fetch error");
+      const fetchSpy = jest.fn().mockRejectedValue(error);
+      class TestManager extends TurnkeyKeyManager<string> {
+        override fetch = fetchSpy;
+      }
+
+      const manager = new TestManager();
+
+      await expect(manager.get("test")).rejects.toThrow(error);
+    });
+
+    it("should refetch if fetch throws and a key is not present", async () => {
+      const error1 = new Error("Fetch error 1");
+      const error2 = new Error("Fetch error 2");
+      const value = new Uint8Array([1, 2, 3]);
+      const fetchSpy = jest
+        .fn()
+        .mockRejectedValueOnce(error1)
+        .mockRejectedValueOnce(error2)
+        .mockResolvedValue(value);
+      class TestManager extends TurnkeyKeyManager<string> {
+        override fetch = fetchSpy;
+      }
+
+      const manager = new TestManager();
+
+      await expect(manager.get("test")).rejects.toThrow(error1);
+      await expect(manager.get("test")).rejects.toThrow(error2);
+
+      const result = await manager.get("test");
+      expect(result).toBe(value);
+    });
+
+    it("should not refetch an existing value", async () => {
+      const value = new Uint8Array([1, 2, 3]);
+      const fetchSpy = jest.fn().mockResolvedValue(value);
+      class TestManager extends TurnkeyKeyManager<string> {
+        override fetch = fetchSpy;
+      }
+
+      const manager = new TestManager();
+      const result = await manager.get("test");
+      expect(result).toBe(value);
+
+      const resultAgain = await manager.get("test");
+      expect(resultAgain).toBe(value);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith("test");
+    });
+
+    it("should not refetch if a fetch is already in progress", async () => {
+      let resolve: (value: Uint8Array) => void;
+      const promise = new Promise<Uint8Array>((res) => {
+        resolve = res;
+      });
+
+      const value = new Uint8Array([1, 2, 3]);
+      const fetchSpy = jest.fn().mockReturnValue(promise);
+      class TestManager extends TurnkeyKeyManager<string> {
+        override fetch = fetchSpy;
+      }
+
+      const manager = new TestManager();
+      const resultPromise = manager.get("test");
+      const resultAgainPromise = manager.get("test");
+
+      resolve!(value);
+
+      const result = await resultPromise;
+      const resultAgain = await resultAgainPromise;
+
+      expect(result).toBe(value);
+      expect(resultAgain).toBe(value);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith("test");
+    });
+
+    it("should not create race conditions if value is being set during a fetch", async () => {
+      let resolve: (value: Uint8Array) => void;
+      const promise = new Promise<Uint8Array>((res) => {
+        resolve = res;
+      });
+
+      const fetchedValue = new Uint8Array([1, 2, 3]);
+      const storedValue = new Uint8Array([4, 5, 6]);
+      const fetchSpy = jest.fn().mockReturnValue(promise);
+      class TestManager extends TurnkeyKeyManager<string> {
+        override fetch = fetchSpy;
+      }
+
+      const manager = new TestManager();
+      const resultPromise = manager.get("test");
+
+      manager.set("test", storedValue);
+
+      resolve!(fetchedValue);
+
+      const result = await resultPromise;
+
+      expect(result).toBe(storedValue);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith("test");
+    });
+
+    it("should return a stored values if key is present", async () => {
+      class TestManager extends TurnkeyKeyManager<string> {}
+
+      const manager = new TestManager();
+
+      const key = "test";
+      const value = new Uint8Array([1, 2, 3]);
+
+      manager.set(key, value);
+      const result = await manager.get(key);
+
+      expect(result).toBe(value);
+    });
+  });
+
+  describe("set", () => {
+    it("should store the value for a key", async () => {
+      class TestManager extends TurnkeyKeyManager<string> {}
+
+      const manager = new TestManager();
+
+      const key = "test";
+      const value = new Uint8Array([1, 2, 3]);
+
+      manager.set(key, value);
+      const result = await manager.get(key);
+
+      expect(result).toBe(value);
+    });
+
+    it("should wipe an existing value before setting a new value for the same key", async () => {
+      class TestManager extends TurnkeyKeyManager<string> {}
+
+      const manager = new TestManager();
+
+      const key = "test";
+      const oldValue = new Uint8Array([1, 2, 3]);
+      const newValue = new Uint8Array([4, 5, 6]);
+
+      manager.set(key, oldValue);
+      manager.set(key, newValue);
+
+      const result = await manager.get(key);
+      expect(result).toBe(newValue);
+      expect(oldValue).toEqual(new Uint8Array([0, 0, 0]));
+    });
+
+    it("should not overwrite a value with itself", async () => {
+      class TestManager extends TurnkeyKeyManager<string> {}
+
+      const manager = new TestManager();
+
+      const key = "test";
+      const value = new Uint8Array([1, 2, 3]);
+
+      manager.set(key, value);
+      manager.set(key, value);
+
+      const result = await manager.get(key);
+
+      expect(value).toEqual(new Uint8Array([1, 2, 3]));
+      expect(result).toEqual(new Uint8Array([1, 2, 3]));
+    });
+  });
+
+  describe("delete", () => {
+    it("should not do anything if a key does not exist", async () => {
+      class TestManager extends TurnkeyKeyManager<string> {}
+
+      const manager = new TestManager();
+
+      const key = "test";
+      manager.delete(key);
+
+      const result = await manager.get(key);
+      expect(result).toBeUndefined();
+    });
+
+    it("should wipe an existing value", async () => {
+      class TestManager extends TurnkeyKeyManager<string> {}
+
+      const manager = new TestManager();
+
+      const key = "test";
+      const value = new Uint8Array([1, 2, 3]);
+
+      manager.set(key, value);
+      manager.delete(key);
+
+      const result = await manager.get(key);
+      expect(result).toBeUndefined();
+      expect(value).toEqual(new Uint8Array([0, 0, 0]));
+    });
+
+    it("should not create race conditions if value is being deleted during a fetch", async () => {
+      let resolve: (value: Uint8Array) => void;
+      const promise = new Promise<Uint8Array>((res) => {
+        resolve = res;
+      });
+
+      const fetchedValue = new Uint8Array([1, 2, 3]);
+      const fetchSpy = jest.fn().mockReturnValue(promise);
+      class TestManager extends TurnkeyKeyManager<string> {
+        override fetch = fetchSpy;
+      }
+
+      const key = "test";
+      const manager = new TestManager();
+      const resultPromise = manager.get(key);
+
+      manager.delete(key);
+
+      resolve!(fetchedValue);
+
+      const result = await resultPromise;
+      expect(result).toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(key);
+    });
+  });
+});

--- a/packages/spark/src/constants.ts
+++ b/packages/spark/src/constants.ts
@@ -1,0 +1,4 @@
+export const SPARK_IDENTITY_SUFFIX = "/0'";
+export const SPARK_SIGNING_SUFFIX = "/1'";
+export const SPARK_DEPOSIT_SUFFIX = "/2'";
+export const SPARK_STATIC_DEPOSIT_SUFFIX = "/3'";

--- a/packages/spark/src/index.ts
+++ b/packages/spark/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./constants";
 export * from "./signer";

--- a/packages/spark/src/key-management.ts
+++ b/packages/spark/src/key-management.ts
@@ -1,0 +1,247 @@
+import type {
+  TurnkeyApiClient,
+  v1AddressFormat,
+  v1WalletAccount,
+} from "@turnkey/sdk-server";
+import { SPARK_IDENTITY_SUFFIX } from "./constants";
+import { uint8ArrayFromHexString } from "@turnkey/encoding";
+import asyncRetry from "async-retry";
+import {
+  compressedPublicKeyHexFromAccount,
+  isAlreadyExistsError,
+  isNotFoundError,
+} from "./utils";
+
+const COMPRESSED_ADDRESS_FORMAT: v1AddressFormat = "ADDRESS_FORMAT_COMPRESSED";
+
+export abstract class TurnkeyKeyManager<K, V extends Uint8Array = Uint8Array> {
+  // Holds promises for in-flight fetches to prevent duplicate fetches for the same key
+  private readonly promises: Map<K, Promise<void>> = new Map();
+
+  // Holds the actual key-value pairs. Values are Uint8Arrays that can be wiped in place.
+  private readonly values: Map<K, V>;
+
+  constructor(values: Map<K, V> = new Map()) {
+    this.values = new Map(values);
+  }
+
+  async get(id: K): Promise<V | undefined> {
+    // If we already have the value, return it immediately
+    if (this.values.has(id)) return this.values.get(id);
+
+    // If there is no in-flight fetch for this id, start one
+    if (!this.promises.has(id)) {
+      // We'll create a promise that fetches the value and stores it once fetched.
+      // This promise will be stored in the `promises` map to indicate that a fetch is in progress for this id.
+      //
+      // In order to not get into any issues with JS task scheduling, this promise will encapsulate
+      // the entire fetch-and-store logic, including the final storing of the fetched value and the cleanup of the promise from the map.
+      const fetched = this.fetch(id)
+        .then((value) => {
+          // If we don't get anything, forget about it
+          if (value == null) return;
+
+          // Before we store anything, we check if the promise in the map is still the same one we created.
+          // If it isn't, it means that either:
+          // - The value was deleted while we were fetching
+          // - The value was set while we were fetching
+          if (this.promises.get(id) === fetched) this.set(id, value);
+        })
+        .finally(() => {
+          // We clean up the promise from the map once it's done. Again, we check if it's still the same
+          if (this.promises.get(id) === fetched) this.promises.delete(id);
+        });
+
+      // Store the promise in the map to indicate that a fetch is in progress for this id
+      this.promises.set(id, fetched);
+    }
+
+    // Wait for any in-flights to complete
+    await this.promises.get(id);
+
+    // And return the value
+    return this.values.get(id);
+  }
+
+  set(id: K, value: V): void {
+    // Overwriting a value with itself is a no-op
+    if (this.values.get(id) === value) return;
+
+    // We first wipe any existing value
+    this.delete(id);
+
+    // Only then do we set the new one
+    this.values.set(id, value);
+  }
+
+  async delete(id: K): Promise<void> {
+    // Remove any in-flight fetch for this id
+    this.promises.delete(id);
+
+    // If there was a value, wipe it and remove it from the map
+    if (this.values.has(id)) {
+      const oldValue = this.values.get(id)!;
+
+      this.values.delete(id);
+      await this.wipe(oldValue);
+    }
+  }
+
+  // Subclasses can implement this method to fetch a value for a given id.
+  protected async fetch(_id: K): Promise<V | undefined> {
+    return undefined;
+  }
+
+  // Subclasses can implement this method to wipe a value in place before it's deleted or overwritten.
+  // This is important for security-sensitive values like cryptographic keys.
+  protected async wipe(value: V): Promise<void> {
+    value.fill(0);
+  }
+}
+
+export class TurnkeySparkSecretKeyManager extends TurnkeyKeyManager<number> {
+  protected override async wipe(value: Uint8Array): Promise<void> {
+    value.fill(0);
+  }
+}
+
+export class TurnkeySparkSigningKeyManager extends TurnkeyKeyManager<string> {
+  constructor(
+    private readonly apiClient: TurnkeyApiClient,
+    private readonly sparkAddress: string,
+    private readonly walletId?: string,
+    values?: Map<string, Uint8Array>,
+  ) {
+    super(values);
+  }
+
+  protected override fetch(path: string): Promise<Uint8Array> {
+    return this.createOrReuseSparkAccountPublicKey(path);
+  }
+
+  protected override async wipe(value: Uint8Array): Promise<void> {
+    value.fill(0);
+  }
+
+  protected async createOrReuseSparkAccountPublicKey(
+    relativePath: string,
+  ): Promise<Uint8Array> {
+    const sparkAccount = await this.findSparkIdentityAccount();
+    if (!sparkAccount.account.path.endsWith(SPARK_IDENTITY_SUFFIX)) {
+      throw new Error(
+        `Spark identity account path must end in ${SPARK_IDENTITY_SUFFIX}, got ${sparkAccount.account.path}`,
+      );
+    }
+
+    const basePath = sparkAccount.account.path.slice(
+      0,
+      -SPARK_IDENTITY_SUFFIX.length,
+    );
+    const path = `${basePath}${relativePath}`;
+    let account = await this.fetchWalletAccountByPath(
+      sparkAccount.walletId,
+      path,
+    );
+
+    if (!account || !compressedPublicKeyHexFromAccount(account)) {
+      account = await this.createWalletAccount(sparkAccount.walletId, path);
+    }
+
+    const publicKeyHex = account && compressedPublicKeyHexFromAccount(account);
+    if (!publicKeyHex) {
+      throw new Error(`Could not load Spark account public key for ${path}`);
+    }
+
+    return uint8ArrayFromHexString(publicKeyHex);
+  }
+
+  private async findSparkIdentityAccount(): Promise<{
+    walletId: string;
+    account: v1WalletAccount;
+  }> {
+    let walletIds: string[];
+    if (this.walletId != null) {
+      walletIds = [this.walletId];
+    } else {
+      const { wallets } = await this.apiClient.getWallets({
+        organizationId: this.apiClient.config.organizationId,
+      });
+
+      walletIds = wallets.map(({ walletId }) => walletId);
+    }
+
+    for (const walletId of walletIds) {
+      const accounts = await this.getWalletAccounts(walletId);
+      const account = accounts.find(
+        (candidate) => candidate.address === this.sparkAddress,
+      );
+
+      if (account) return { walletId, account };
+    }
+
+    throw new Error(
+      `Could not find a Turnkey wallet containing Spark address ${this.sparkAddress}`,
+    );
+  }
+
+  private async fetchWalletAccountByPath(
+    walletId: string,
+    path: string,
+  ): Promise<v1WalletAccount | undefined> {
+    try {
+      const { account } = await this.apiClient.getWalletAccount({
+        organizationId: this.apiClient.config.organizationId,
+        walletId,
+        path,
+      });
+      return account;
+    } catch (err) {
+      if (isNotFoundError(err)) return undefined;
+      throw err;
+    }
+  }
+
+  private async createWalletAccount(
+    walletId: string,
+    path: string,
+  ): Promise<v1WalletAccount> {
+    try {
+      await this.apiClient.createWalletAccounts({
+        organizationId: this.apiClient.config.organizationId,
+        walletId,
+        accounts: [
+          {
+            curve: "CURVE_SECP256K1",
+            pathFormat: "PATH_FORMAT_BIP32",
+            path,
+            addressFormat: COMPRESSED_ADDRESS_FORMAT,
+          },
+        ],
+      });
+    } catch (err) {
+      if (!isAlreadyExistsError(err)) throw err;
+    }
+
+    return await asyncRetry(
+      async () => {
+        const account = await this.fetchWalletAccountByPath(walletId, path);
+
+        if (account && compressedPublicKeyHexFromAccount(account))
+          return account;
+
+        throw new Error(`Could not fetch wallet account for path ${path}`);
+      },
+      { retries: 6, minTimeout: 500, factor: 1.2 },
+    );
+  }
+
+  private async getWalletAccounts(
+    walletId: string,
+  ): Promise<v1WalletAccount[]> {
+    const { accounts } = await this.apiClient.getWalletAccounts({
+      organizationId: this.apiClient.config.organizationId,
+      walletId,
+    });
+    return accounts;
+  }
+}

--- a/packages/spark/src/signer.ts
+++ b/packages/spark/src/signer.ts
@@ -206,9 +206,13 @@ export interface LightningReceiveResult {
 }
 
 export interface TurnkeySparkSignerOptions {
+  client: TurnkeyServerSDK;
+  sparkAddress: string;
+  ecdsaAddress: string;
+  identityPublicKeyHex: string;
   walletId?: string | undefined;
   depositPublicKeyHex?: string | undefined;
-  staticDepositPublicKeys?: Record<number, string> | undefined;
+  staticDepositPublicKeysHex?: Record<number, string> | undefined;
 }
 
 export class TurnkeySparkSigner implements SparkSigner {
@@ -223,13 +227,15 @@ export class TurnkeySparkSigner implements SparkSigner {
   private readonly secretKeyManager: TurnkeySparkSecretKeyManager;
   private readonly signingKeyManager: TurnkeySparkSigningKeyManager;
 
-  constructor(
-    client: TurnkeyServerSDK,
-    sparkAddress: string,
-    ecdsaAddress: string,
-    identityPublicKeyHex: string,
-    options: TurnkeySparkSignerOptions = {},
-  ) {
+  constructor({
+    client,
+    sparkAddress,
+    ecdsaAddress,
+    identityPublicKeyHex,
+    depositPublicKeyHex,
+    staticDepositPublicKeysHex,
+    walletId,
+  }: TurnkeySparkSignerOptions) {
     this.client = client;
     this.sparkAddress = sparkAddress;
     this.ecdsaAddress = ecdsaAddress;
@@ -238,19 +244,17 @@ export class TurnkeySparkSigner implements SparkSigner {
     this.signingKeyManager = new TurnkeySparkSigningKeyManager(
       client.apiClient(),
       sparkAddress,
-      options.walletId,
+      walletId,
     );
 
     this.secretKeyManager = new TurnkeySparkSecretKeyManager();
 
-    if (options.depositPublicKeyHex) {
-      this.setDepositSigningKey(
-        uint8ArrayFromHexString(options.depositPublicKeyHex),
-      );
+    if (depositPublicKeyHex) {
+      this.setDepositSigningKey(uint8ArrayFromHexString(depositPublicKeyHex));
     }
 
     for (const [index, publicKeyHex] of Object.entries(
-      options.staticDepositPublicKeys ?? {},
+      staticDepositPublicKeysHex ?? {},
     )) {
       this.setStaticDepositSigningKey(
         Number(index),

--- a/packages/spark/src/signer.ts
+++ b/packages/spark/src/signer.ts
@@ -1,102 +1,318 @@
 /**
  * TurnkeySparkSigner — implements the SparkSigner interface, delegating all
- * signing to Turnkey.
+ * signing and key operations to Turnkey.
  *
- * The Spark SDK authenticates to its signing operators by:
- *   1. Fetching a challenge from the SO (protobuf-encoded, SHA-256 hashed)
- *   2. Signing the hash with the identity key via ECDSA → DER bytes
- *   3. Sending the DER signature + public key to verify_challenge
- *
- * That means the critical methods for authentication are:
+ * Authentication (identity key operations):
  *   - getIdentityPublicKey()
- *   - signMessageWithIdentityKey()  ← ECDSA, DER-encoded output
+ *   - signMessageWithIdentityKey()   ← ECDSA via compressed address, or Schnorr via Spark address
+ *   - signSchnorrWithIdentityKey()   ← BIP340 Schnorr via Spark address
  *
- * Token operations additionally need:
- *   - signSchnorrWithIdentityKey()  ← Schnorr, 64-byte compact output
+ * Turnkey's signRawPayload dispatches Schnorr vs ECDSA based on the address
+ * format. The signer usually holds two addresses for the same underlying key:
+ *   - sparkAddress  → ADDRESS_FORMAT_SPARK_* → SchnorrPlain (BIP340)
+ *   - ecdsaAddress  → ADDRESS_FORMAT_COMPRESSED → ECDSA
+ * If a wallet was imported with only its Spark-formatted address available,
+ * ecdsaAddress may also be set to the Spark address for Schnorr identity
+ * signatures.
  *
- * Operations requireing FROST and ECIES are not implemented at the moment, but coming soon.
+ * FROST signing (via SPARK_SIGN_FROST activity):
+ *   - getRandomSigningCommitment()   ← returns mutable placeholder
+ *   - signFrost()                    ← calls Turnkey, mutates commitment
+ *   - aggregateFrost()               ← client-side signature aggregation
+ *
+ * Package construction — separate activities, no FROST signing:
+ *   - prepareTransfer()              ← SPARK_PREPARE_TRANSFER
+ *   - prepareClaim()                 ← SPARK_CLAIM_TRANSFER
+ *   - prepareLightningReceive()      ← SPARK_PREPARE_LIGHTNING_RECEIVE
+ *   - getDepositSigningKey()         ← create/reuse deterministic DEPOSIT account public key
+ *
+ * ## Why subtractSplitAndEncrypt is not implemented
+ *
+ * The Spark SDK's transfer flow calls subtractSplitAndEncrypt() per-leaf and
+ * immediately uses the raw Feldman shares to build per-operator packages.
+ * Turnkey's enclave does this entire operation atomically inside a single
+ * SPARK_PREPARE_TRANSFER call — raw shares never leave the enclave boundary.
+ * Use prepareTransfer() instead of the SDK's built-in transfer method.
+ *
+ * ## Deferred Commitment Pattern
+ *
+ * The Spark SDK generates user nonce commitments before signing (getRandomSigningCommitment),
+ * but Turnkey's SPARK_SIGN_FROST generates the nonce and signs in one call. We bridge this
+ * by returning a mutable placeholder from getRandomSigningCommitment, then mutating it with
+ * Turnkey's real commitment values inside signFrost. The SDK holds the same object reference,
+ * so it picks up the real values when building the transfer package.
  */
 
-import { secp256k1 } from "@noble/curves/secp256k1"; // used in validateMessageWithIdentityKey
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha2";
 import { mnemonicToSeed } from "@scure/bip39";
-import type { SparkSigner } from "@buildonspark/spark-sdk";
-import type { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
+import {
+  getSparkFrost,
+  type SparkSigner,
+  type SignFrostParams,
+  type AggregateFrostParams,
+  type SigningCommitmentWithOptionalNonce,
+  type SigningCommitment,
+  type KeyDerivation,
+  type SplitSecretWithProofsParams,
+  type SubtractSplitAndEncryptParams,
+  type SubtractSplitAndEncryptResult,
+  type VerifiableSecretShare,
+  type SigningNonce,
+} from "@buildonspark/spark-sdk";
+import {
+  uint8ArrayToHexString,
+  uint8ArrayFromHexString,
+} from "@turnkey/encoding";
+import type {
+  Turnkey as TurnkeyServerSDK,
+  v1SparkFrostCommitment,
+  v1SparkKeyDerivation,
+  v1SparkLeafPublicKey,
+  v1SparkSignatureRequest,
+} from "@turnkey/sdk-server";
+import {
+  SPARK_DEPOSIT_SUFFIX,
+  SPARK_SIGNING_SUFFIX,
+  SPARK_STATIC_DEPOSIT_SUFFIX,
+} from "./constants";
+import {
+  TurnkeySparkSecretKeyManager,
+  TurnkeySparkSigningKeyManager,
+} from "./key-management";
+import { areBytesEqual, compressedPublicKeyHexFromString } from "./utils";
 
-const hex = (bytes: Uint8Array) => Buffer.from(bytes).toString("hex");
+/**
+ * Validate the new-leaf pubkey envelope returned by PREPARE_/SPARK_CLAIM_TRANSFER:
+ * one entry per input leaf, no duplicates, every returned leafId expected.
+ *
+ * The format/curve-point validation of each pubkey happens later in
+ * `seedLeafSigningKeys` at the trust boundary. Anything that gets through both
+ * checks but is still wrong (e.g., a valid curve point that isn't HD(leaf_id))
+ * is bounded by FROST aggregation: operators' shares actually sum to HD(leaf_id),
+ * so a lying signer's signature simply fails to verify on-chain — DOS rather
+ * than loss-of-funds.
+ *
+ * Missing pubkeys altogether means the matching mono change isn't deployed;
+ * refusing here surfaces the version skew immediately instead of silently
+ * falling back to per-leaf pubkey-derivation round-trips.
+ */
+function requireNewLeafPubkeys(
+  activity: string,
+  pubkeys: Array<{ leafId: string; publicKey: string }> | undefined,
+  expectedLeafIds: string[],
+): void {
+  const got = pubkeys?.length ?? 0;
+  if (got !== expectedLeafIds.length) {
+    throw new Error(
+      `${activity} returned ${got} new-leaf pubkeys, expected ${expectedLeafIds.length}. ` +
+        `This SDK requires the matching mono change that surfaces ` +
+        `newLeafPublicKeys on PREPARE_/SPARK_CLAIM_TRANSFER results.`,
+    );
+  }
+  const expected = new Set(expectedLeafIds);
+  const seen = new Set<string>();
+  for (const { leafId } of pubkeys!) {
+    if (!expected.has(leafId)) {
+      throw new Error(
+        `${activity} returned newLeafPublicKey for unexpected leafId ${leafId}`,
+      );
+    }
+    if (seen.has(leafId)) {
+      throw new Error(
+        `${activity} returned duplicate newLeafPublicKey for leafId ${leafId}`,
+      );
+    }
+    seen.add(leafId);
+  }
+}
 
-const notImplemented = (method: string) => () => {
-  throw new Error(
-    `TurnkeySparkSigner.${method} is not implemented. ` +
-      `This method requires operations that are not yet expressible via Turnkey's signRawPayload API.`,
+const BIP32_HARDENED_RESERVED = 0x80000000;
+
+const signingHdLeafChild = (leafId: string): number => {
+  const digest = sha256(Buffer.from(leafId, "utf8"));
+  return (
+    (((digest[0]! << 24) |
+      (digest[1]! << 16) |
+      (digest[2]! << 8) |
+      digest[3]!) >>>
+      0) %
+    BIP32_HARDENED_RESERVED
   );
 };
 
+/**
+ * Transfer leaf input for prepareTransfer(). Matches SparkTransferLeaf proto.
+ */
+export interface TransferLeafInput {
+  leafId: string;
+  oldLeafDerivation: KeyDerivation;
+  newLeafDerivation: KeyDerivation;
+  refundSignature?: string;
+  directRefundSignature?: string;
+  directFromCpfpRefundSignature?: string;
+}
+
+/**
+ * Operator recipient for prepareTransfer(). Matches SparkOperatorRecipient proto.
+ */
+export interface OperatorRecipientInput {
+  operatorId: string;
+  encryptionPublicKey: string;
+}
+
+/**
+ * Claim leaf input for prepareClaim(). Matches SparkClaimLeaf proto.
+ */
+export interface ClaimLeafInput {
+  leafId: string;
+  ciphertext: string;
+  senderSignature: string;
+}
+
+/**
+ * Result from prepareTransfer(). Contains encrypted operator packages and
+ * the DER user signature — ready to forward to Spark operators.
+ */
+export interface TransferResult {
+  operatorPackages: Array<{
+    operatorId: string;
+    encryptedPackage: string;
+  }>;
+  transferUserSignature: string;
+  newLeafPublicKeys?: Array<{ leafId: string; publicKey: string }> | undefined;
+}
+
+/**
+ * Result from prepareClaim().
+ */
+export interface ClaimResult {
+  operatorPackages: Array<{
+    operatorId: string;
+    encryptedPackage: string;
+  }>;
+  newLeafPublicKeys?: Array<{ leafId: string; publicKey: string }> | undefined;
+}
+
+/**
+ * Result from prepareLightningReceive().
+ */
+export interface LightningReceiveResult {
+  paymentHash: string;
+  operatorPackages: Array<{
+    operatorId: string;
+    encryptedPackage: string;
+  }>;
+}
+
+export interface TurnkeySparkSignerOptions {
+  walletId?: string | undefined;
+  depositPublicKeyHex?: string | undefined;
+  staticDepositPublicKeys?: Record<number, string> | undefined;
+}
+
 export class TurnkeySparkSigner implements SparkSigner {
   private readonly client: TurnkeyServerSDK;
-  /** The Turnkey address used for the Spark identity key */
-  private readonly identityKeyAddress: string;
+  /** Spark-formatted address → signRawPayload returns BIP340 Schnorr */
+  private readonly sparkAddress: string;
+  /** Compressed address for ECDSA, or Spark address when only Schnorr identity signing is available */
+  private readonly ecdsaAddress: string;
   /** Compressed 33-byte public key (02/03 prefix) */
   private readonly identityPublicKeyHex: string;
 
+  private readonly secretKeyManager: TurnkeySparkSecretKeyManager;
+  private readonly signingKeyManager: TurnkeySparkSigningKeyManager;
+
   constructor(
     client: TurnkeyServerSDK,
-    identityKeyAddress: string,
+    sparkAddress: string,
+    ecdsaAddress: string,
     identityPublicKeyHex: string,
+    options: TurnkeySparkSignerOptions = {},
   ) {
     this.client = client;
-    this.identityKeyAddress = identityKeyAddress;
+    this.sparkAddress = sparkAddress;
+    this.ecdsaAddress = ecdsaAddress;
     this.identityPublicKeyHex = identityPublicKeyHex;
+
+    this.signingKeyManager = new TurnkeySparkSigningKeyManager(
+      client.apiClient(),
+      sparkAddress,
+      options.walletId,
+    );
+
+    this.secretKeyManager = new TurnkeySparkSecretKeyManager();
+
+    if (options.depositPublicKeyHex) {
+      this.setDepositSigningKey(
+        uint8ArrayFromHexString(options.depositPublicKeyHex),
+      );
+    }
+
+    for (const [index, publicKeyHex] of Object.entries(
+      options.staticDepositPublicKeys ?? {},
+    )) {
+      this.setStaticDepositSigningKey(
+        Number(index),
+        uint8ArrayFromHexString(publicKeyHex),
+      );
+    }
   }
+
+  // ---------------------------------------------------------------------------
+  // Identity key operations (already working)
+  // ---------------------------------------------------------------------------
 
   getIdentityPublicKey(): Promise<Uint8Array> {
-    return Promise.resolve(Buffer.from(this.identityPublicKeyHex, "hex"));
+    return Promise.resolve(uint8ArrayFromHexString(this.identityPublicKeyHex));
   }
 
-  /**
-   * ECDSA sign over the message (which the Spark SDK pre-hashes with SHA-256
-   * before calling this method). Returns DER-encoded bytes by default, or
-   * compact 64-byte bytes when compact=true.
-   *
-   * Turnkey's signRawPayload with HASH_FUNCTION_NO_OP signs the payload
-   * exactly as provided, returning (r, s) as hex strings.
-   */
   async signMessageWithIdentityKey(
     message: Uint8Array,
-    _compact?: boolean,
+    compact?: boolean,
   ): Promise<Uint8Array> {
     const { r, s } = await this.client.apiClient().signRawPayload({
-      signWith: this.identityKeyAddress,
+      signWith: this.ecdsaAddress,
       encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
       hashFunction: "HASH_FUNCTION_NO_OP",
-      payload: hex(message),
+      payload: uint8ArrayToHexString(message),
     });
 
-    // Zero-pad r and s to 32 bytes each in case of leading-zero stripping.
-    // The Turnkey key is a Schnorr (Taproot) key so signRawPayload returns
-    // Schnorr (r, s). The Spark SO's verify_challenge tries both ECDSA and
-    // Schnorr — return the raw 64-byte compact form so the Schnorr path succeeds.
-    // DER-wrapping these bytes (70 bytes) would fail both paths.
-    const rPadded = r.padStart(64, "0");
-    const sPadded = s.padStart(64, "0");
-    return Buffer.from(rPadded + sPadded, "hex");
+    const rBuf = Buffer.from(r.padStart(64, "0"), "hex");
+    const sBuf = Buffer.from(s.padStart(64, "0"), "hex");
+
+    // Spark accepts either DER ECDSA or 64-byte Schnorr identity signatures.
+    // Use compact bytes only for explicit compact requests or when signWith is
+    // Spark-formatted. ECDSA signatures may also return v=00, so v is not a
+    // reliable discriminator here.
+    if (compact || this.ecdsaAddress.startsWith("spark")) {
+      return Buffer.concat([rBuf, sBuf]);
+    }
+
+    const sig = new secp256k1.Signature(
+      BigInt("0x" + rBuf.toString("hex")),
+      BigInt("0x" + sBuf.toString("hex")),
+    );
+    return Buffer.from(sig.toBytes("der"));
   }
 
-  /**
-   * Schnorr sign over the message (used for token operations).
-   * The Spark SDK passes the 32-byte message directly — noble's schnorr.sign
-   * does NOT hash internally, so we send it to Turnkey with NO_OP.
-   */
   async signSchnorrWithIdentityKey(message: Uint8Array): Promise<Uint8Array> {
-    const { r, s } = await this.client.apiClient().signRawPayload({
-      signWith: this.identityKeyAddress,
+    const { r, s, v } = await this.client.apiClient().signRawPayload({
+      signWith: this.sparkAddress,
       encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
       hashFunction: "HASH_FUNCTION_NO_OP",
-      payload: hex(message),
+      payload: uint8ArrayToHexString(message),
     });
 
-    const rPadded = r.padStart(64, "0");
-    const sPadded = s.padStart(64, "0");
-    return Buffer.from(rPadded + sPadded, "hex");
+    if (v !== "00") {
+      throw new Error(
+        `Expected BIP340 Schnorr (v=00) from Spark address, got v=${v}`,
+      );
+    }
+
+    const rBuf = Buffer.from(r.padStart(64, "0"), "hex");
+    const sBuf = Buffer.from(s.padStart(64, "0"), "hex");
+    return Buffer.concat([rBuf, sBuf]);
   }
 
   async validateMessageWithIdentityKey(
@@ -115,47 +331,638 @@ export class TurnkeySparkSigner implements SparkSigner {
     _seed: Uint8Array | string,
     _accountNumber?: number,
   ): Promise<string> {
-    // No key derivation needed — Turnkey holds the keys. Return the identity
-    // public key hex as the default signer does, since callers use this return
-    // value to identify the wallet.
     return this.identityPublicKeyHex;
   }
 
-  // --- Not implemented: ---
+  // ---------------------------------------------------------------------------
+  // FROST signing — bridges to SPARK_SIGN_FROST
+  // ---------------------------------------------------------------------------
 
-  getDepositSigningKey = notImplemented("getDepositSigningKey");
+  /**
+   * Returns a mutable placeholder commitment. The real commitment values are
+   * populated by signFrost() when Turnkey's SPARK_SIGN_FROST returns.
+   *
+   * The SDK holds a reference to this object and reads commitment.hiding/binding
+   * AFTER signFrost() completes, so the mutation propagates correctly.
+   */
+  async getRandomSigningCommitment(): Promise<SigningCommitmentWithOptionalNonce> {
+    const placeholder: SigningCommitmentWithOptionalNonce = {
+      commitment: {
+        hiding: new Uint8Array(33),
+        binding: new Uint8Array(33),
+      },
+    };
+    return placeholder;
+  }
 
-  getStaticDepositSigningKey = notImplemented("getStaticDepositSigningKey");
+  /**
+   * Nonce is not available client-side — Turnkey generates it internally.
+   * Returns undefined, which the SDK handles gracefully (the nonce is only
+   * needed by the local signer implementation, not by the coordinator).
+   */
+  getNonceForSelfCommitment(
+    _selfCommitment: SigningCommitmentWithOptionalNonce,
+  ): SigningNonce | undefined {
+    return undefined;
+  }
 
-  getStaticDepositSecretKey = notImplemented("getStaticDepositSecretKey");
+  /**
+   * Calls Turnkey's SPARK_SIGN_FROST activity. Generates a fresh nonce inside
+   * the enclave, signs, and returns the partial signature. Mutates
+   * params.selfCommitment with the real (hiding, binding) values from Turnkey.
+   */
+  async signFrost(params: SignFrostParams): Promise<Uint8Array> {
+    const [signature] = await this.signFrostBatch([params]);
+    return signature!;
+  }
 
-  generateMnemonic = notImplemented("generateMnemonic");
+  /**
+   * Batched FROST signing: one SPARK_SIGN_FROST activity for many signature
+   * requests. Mutates each params[i].selfCommitment.commitment with the real
+   * (hiding, binding) values returned by Turnkey, matching signFrost behavior.
+   *
+   * Used by signRefundsBatched (turnkeyInternal.ts) to collapse the SDK's
+   * per-leaf-per-direction signing loop into a single Turnkey round-trip.
+   */
+  async signFrostBatch(params: SignFrostParams[]): Promise<Uint8Array[]> {
+    if (params.length === 0) return [];
 
-  signFrost = notImplemented("signFrost");
+    params.forEach(({ adaptorPubKey }, i) => {
+      if (
+        adaptorPubKey !== undefined &&
+        adaptorPubKey.length !== 0 &&
+        adaptorPubKey.length !== 33
+      ) {
+        throw new Error(
+          `signFrostBatch[${i}]: adaptorPubKey must be omitted, empty, or ` +
+            `a 33-byte compressed secp256k1 point (got length=${adaptorPubKey.length})`,
+        );
+      }
+    });
 
-  aggregateFrost = notImplemented("aggregateFrost");
+    const signatureRequests = params.map(signFrostParamsToSignatureRequest);
 
-  decryptEcies = notImplemented("decryptEcies");
+    const result = await this.client.apiClient().sparkSignFrost({
+      signWith: this.sparkAddress,
+      signatures: signatureRequests,
+    });
 
-  getRandomSigningCommitment = notImplemented("getRandomSigningCommitment");
+    if (result.signatures.length !== params.length) {
+      throw new Error(
+        `SPARK_SIGN_FROST returned ${result.signatures.length} signatures; expected ${params.length}`,
+      );
+    }
 
-  getNonceForSelfCommitment = notImplemented("getNonceForSelfCommitment");
+    return result.signatures.map((sig, i) => {
+      const commitment = params[i]!.selfCommitment.commitment;
+      commitment.hiding = uint8ArrayFromHexString(sig.hiding);
+      commitment.binding = uint8ArrayFromHexString(sig.binding);
+      return uint8ArrayFromHexString(sig.signatureShare);
+    });
+  }
 
-  getPublicKeyFromDerivation = notImplemented("getPublicKeyFromDerivation");
+  async aggregateFrost(params: AggregateFrostParams): Promise<Uint8Array> {
+    const sparkFrost = getSparkFrost();
+    return sparkFrost.aggregateFrost({
+      message: params.message,
+      statechainSignatures: params.statechainSignatures,
+      statechainPublicKeys: params.statechainPublicKeys,
+      verifyingKey: params.verifyingKey,
+      statechainCommitments: params.statechainCommitments,
+      selfCommitment: params.selfCommitment.commitment,
+      selfPublicKey: params.publicKey,
+      selfSignature: params.selfSignature,
+      adaptorPubKey: params.adaptorPubKey,
+    });
+  }
 
-  subtractPrivateKeysGivenDerivationPaths = notImplemented(
-    "subtractPrivateKeysGivenDerivationPaths",
-  );
+  // ---------------------------------------------------------------------------
+  // Transfer / Claim — Turnkey-specific methods
+  //
+  // The SDK's built-in transfer() calls subtractSplitAndEncrypt() per-leaf
+  // and immediately uses raw Feldman shares to build per-operator packages.
+  // Turnkey's enclave does this atomically — shares never leave the enclave.
+  // Use these methods instead of the SDK's built-in transfer/claim flow.
+  // ---------------------------------------------------------------------------
 
-  subtractAndSplitSecretWithProofsGivenDerivations = notImplemented(
-    "subtractAndSplitSecretWithProofsGivenDerivations",
-  );
+  /**
+   * Prepare a transfer: build encrypted operator packages and the DER user
+   * signature for an outbound BTC transfer via SPARK_PREPARE_TRANSFER.
+   *
+   * FROST signing happens separately — the SDK's signing flow already
+   * produces refund signatures via signFrost() per leaf before this is called.
+   */
+  async prepareTransfer(params: {
+    transferId: string;
+    leaves: TransferLeafInput[];
+    threshold: number;
+    operatorRecipients: OperatorRecipientInput[];
+    receiverPublicKey: string;
+  }): Promise<TransferResult> {
+    const leaves = params.leaves.map((l) => ({
+      leafId: l.leafId,
+      oldLeafDerivation: keyDerivationToSparkKeyDerivation(l.oldLeafDerivation),
+      newLeafDerivation: keyDerivationToSparkKeyDerivation(l.newLeafDerivation),
+      refundSignature: l.refundSignature ?? "",
+      directRefundSignature: l.directRefundSignature ?? "",
+      directFromCpfpRefundSignature: l.directFromCpfpRefundSignature ?? "",
+    }));
 
-  subtractSplitAndEncrypt = notImplemented("subtractSplitAndEncrypt");
+    const result = await this.client.apiClient().sparkPrepareTransfer({
+      signWith: this.sparkAddress,
+      transfer: {
+        transferId: params.transferId,
+        leaves,
+        threshold: params.threshold,
+        operatorRecipients: params.operatorRecipients,
+        receiverPublicKey: params.receiverPublicKey,
+      },
+    });
 
-  splitSecretWithProofs = notImplemented("splitSecretWithProofs");
+    requireNewLeafPubkeys(
+      "SPARK_PREPARE_TRANSFER",
+      result.newLeafPublicKeys,
+      params.leaves.map((l) => {
+        if (l.newLeafDerivation.type !== "leaf") {
+          throw new Error(
+            `prepareTransfer requires newLeafDerivation.type === "leaf", got ${l.newLeafDerivation.type}`,
+          );
+        }
+        return l.newLeafDerivation.path;
+      }),
+    );
+    this.seedLeafSigningKeys(result.newLeafPublicKeys);
 
-  signTransactionIndex = notImplemented("signTransactionIndex");
+    return {
+      operatorPackages: result.operatorPackages ?? [],
+      transferUserSignature: result.transferUserSignature ?? "",
+      newLeafPublicKeys: result.newLeafPublicKeys,
+    };
+  }
 
-  htlcHMAC = notImplemented("htlcHMAC");
+  /**
+   * Prepare a claim: build encrypted operator packages for inbound leaves
+   * via SPARK_CLAIM_TRANSFER. The claim just rotates leaf keys — no FROST.
+   */
+  async prepareClaim(params: {
+    leaves: ClaimLeafInput[];
+    threshold: number;
+    operatorRecipients: OperatorRecipientInput[];
+    transferId: string;
+    senderIdentityPublicKey: string;
+  }): Promise<ClaimResult> {
+    const result = await this.client.apiClient().sparkClaimTransfer({
+      signWith: this.sparkAddress,
+      claim: {
+        leaves: params.leaves,
+        threshold: params.threshold,
+        transferId: params.transferId,
+        operatorRecipients: params.operatorRecipients,
+        senderIdentityPublicKey: params.senderIdentityPublicKey,
+      },
+    });
+
+    requireNewLeafPubkeys(
+      "SPARK_CLAIM_TRANSFER",
+      result.newLeafPublicKeys,
+      params.leaves.map((l) => l.leafId),
+    );
+    this.seedLeafSigningKeys(result.newLeafPublicKeys);
+
+    return {
+      operatorPackages: result.operatorPackages ?? [],
+      newLeafPublicKeys: result.newLeafPublicKeys,
+    };
+  }
+
+  /**
+   * Prepare a Lightning receive via SPARK_PREPARE_LIGHTNING_RECEIVE: generate
+   * a preimage inside Turnkey, split it into encrypted operator packages, and
+   * return only the payment hash plus encrypted packages. The raw
+   * preimage/shares never enter client JS.
+   */
+  async prepareLightningReceive(params: {
+    threshold: number;
+    operatorRecipients: OperatorRecipientInput[];
+  }): Promise<LightningReceiveResult> {
+    if (params.threshold < 2) {
+      throw new Error("Lightning receive threshold must be at least 2");
+    }
+
+    const result = await this.client.apiClient().sparkPrepareLightningReceive({
+      signWith: this.sparkAddress,
+      lightningReceive: {
+        threshold: params.threshold,
+        operatorRecipients: params.operatorRecipients,
+      },
+    });
+
+    if (!result.paymentHash) {
+      throw new Error(
+        "SPARK_PREPARE_LIGHTNING_RECEIVE returned no payment hash",
+      );
+    }
+
+    return {
+      paymentHash: result.paymentHash,
+      operatorPackages: result.operatorPackages ?? [],
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public-key access without key-operation activities
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The Spark SDK's transfer flow calls this per-leaf and immediately uses
+   * raw Feldman shares. Turnkey's enclave produces fully-encrypted operator
+   * packages atomically — raw shares never leave the enclave boundary.
+   *
+   * Use prepareTransfer() instead of the SDK's built-in transfer method.
+   */
+  async subtractSplitAndEncrypt(
+    _params: SubtractSplitAndEncryptParams,
+  ): Promise<SubtractSplitAndEncryptResult> {
+    throw new Error(
+      "TurnkeySparkSigner does not support subtractSplitAndEncrypt. " +
+        "Turnkey's enclave performs subtract-split-encrypt atomically inside " +
+        "SPARK_PREPARE_TRANSFER — raw shares never leave the enclave. " +
+        "Use TurnkeySparkSigner.prepareTransfer() instead of the SDK's " +
+        "built-in transfer method.",
+    );
+  }
+
+  async getPublicKeyFromDerivation(
+    keyDerivation?: KeyDerivation,
+  ): Promise<Uint8Array> {
+    if (!keyDerivation) {
+      return this.getIdentityPublicKey();
+    }
+
+    switch (keyDerivation.type) {
+      case "deposit":
+        return this.getDepositSigningKey();
+      case "static_deposit":
+        return this.getStaticDepositSigningKey(Number(keyDerivation.path));
+      case "leaf":
+        return this.getLeafSigningKey(String(keyDerivation.path));
+      default:
+        throw new Error(
+          `Unsupported key derivation type: ${keyDerivation.type}`,
+        );
+    }
+  }
+
+  async getPublicKeysFromDerivations(
+    keyDerivations: KeyDerivation[],
+  ): Promise<Uint8Array[]> {
+    return Promise.all(
+      keyDerivations.map((keyDerivation) =>
+        this.getPublicKeyFromDerivation(keyDerivation),
+      ),
+    );
+  }
+
+  async getLeafSigningKey(leafId: string): Promise<Uint8Array> {
+    const child = signingHdLeafChild(leafId);
+    const path = `${SPARK_SIGNING_SUFFIX}/${child}'`;
+
+    const key = await this.signingKeyManager.get(path);
+    if (key == null) {
+      throw new Error(`No signing key found for leafId ${leafId}.`);
+    }
+
+    return key;
+  }
+
+  setLeafSigningKey(leafId: string, key: Uint8Array) {
+    const child = signingHdLeafChild(leafId);
+    const path = `${SPARK_SIGNING_SUFFIX}/${child}'`;
+
+    this.signingKeyManager.set(path, key);
+  }
+
+  /**
+   * Seed leafSigningKeys from new-leaf pubkeys returned by
+   * SPARK_PREPARE_TRANSFER / SPARK_CLAIM_TRANSFER. Subsequent
+   * getLeafSigningKey lookups for these leaves hit cache instead of
+   * round-tripping to Turnkey.
+   *
+   * Validation at the trust boundary: each pubkey must be hex-formatted, decode
+   * to a valid secp256k1 point, and be distinct across the batch (each
+   * HD-derived leaf signing key is unique by construction). A malformed or
+   * duplicate entry would silently corrupt every later FROST signature that
+   * uses it, so we fail loud here.
+   */
+  private seedLeafSigningKeys(
+    entries: v1SparkLeafPublicKey[] | undefined,
+  ): void {
+    if (!entries) return;
+
+    const seenPubkeys = new Set<string>();
+    for (const { leafId, publicKey } of entries) {
+      if (!compressedPublicKeyHexFromString(publicKey)) {
+        throw new Error(
+          `signer returned malformed pubkey for leaf ${leafId}: ` +
+            `expected 66 hex chars (33-byte compressed secp256k1), got ${publicKey.length}`,
+        );
+      }
+
+      try {
+        secp256k1.Point.fromHex(publicKey);
+      } catch {
+        throw new Error(
+          `signer returned non-secp256k1 pubkey for leaf ${leafId}`,
+        );
+      }
+
+      const normalized = publicKey.toLowerCase();
+      if (seenPubkeys.has(normalized)) {
+        throw new Error(
+          `signer returned duplicate pubkey across leaves in one response; ` +
+            `each HD-derived leaf signing key must be unique`,
+        );
+      }
+      seenPubkeys.add(normalized);
+
+      this.setLeafSigningKey(leafId, uint8ArrayFromHexString(publicKey));
+    }
+  }
+
+  async getDepositSigningKey(): Promise<Uint8Array> {
+    const path = SPARK_DEPOSIT_SUFFIX;
+    const key = await this.signingKeyManager.get(path);
+    if (key == null) {
+      throw new Error(
+        `No deposit signing key found at suffix ${SPARK_DEPOSIT_SUFFIX}.`,
+      );
+    }
+
+    return key;
+  }
+
+  private setDepositSigningKey(key: Uint8Array): void {
+    const path = SPARK_DEPOSIT_SUFFIX;
+    this.signingKeyManager.set(path, key);
+  }
+
+  async getStaticDepositSigningKey(idx: number): Promise<Uint8Array> {
+    if (!Number.isInteger(idx) || idx < 0) {
+      throw new Error(`Invalid static deposit index: ${idx}`);
+    }
+
+    const path = `${SPARK_STATIC_DEPOSIT_SUFFIX}/${idx}'`;
+    const key = await this.signingKeyManager.get(path);
+    if (key == null) {
+      throw new Error(
+        `No static deposit signing key found for index ${idx} at ${path}.`,
+      );
+    }
+
+    return key;
+  }
+
+  private setStaticDepositSigningKey(idx: number, key: Uint8Array): void {
+    const path = `${SPARK_STATIC_DEPOSIT_SUFFIX}/${idx}'`;
+    this.signingKeyManager.set(path, key);
+  }
+
+  /**
+   * Cache an exported static-deposit private key in process memory.
+   *
+   * **Trust boundary deviation.** This is the only `TurnkeySparkSigner`
+   * method that puts a private key in client-side JS memory. Every other
+   * Spark key stays inside Turnkey's enclave; static-deposit is the
+   * exception because the Spark SDK's claim path requires the raw secret
+   * client-side and there is no enclave-only alternative today.
+   *
+   * The secret must come from `exportWalletAccount` against the Turnkey
+   * static-deposit account at `idx`. This method validates the secret
+   * derives the expected secp256k1 pubkey before caching; mismatched
+   * keys throw without storing.
+   *
+   * **Hygiene — read this.** Once cached, the secret is plaintext on
+   * the JS heap and exposed to memory disclosure (process dumps,
+   * debugger attach, swap-to-disk, log accidents, RCE). To minimize
+   * exposure:
+   *   - Prefer the `installStaticDepositSecretKey` helper, which
+   *     exports + caches + zeros the local copy in one call.
+   *   - Wrap the claim call in a `try`/`finally` and call
+   *     `clearStaticDepositSecretKey(idx)` in `finally` so the cache
+   *     is zeroed even on error.
+   *   - Don't run static-deposit claims from long-lived daemons.
+   *     Use a short-lived process, ideally one that doesn't service
+   *     other untrusted requests during the claim window.
+   *   - Don't log this value or anything derived from it.
+   */
+  async setStaticDepositSecretKey(
+    idx: number,
+    secretKey: Uint8Array,
+  ): Promise<void> {
+    if (secretKey.length !== 32) {
+      throw new Error(
+        `Static deposit secret key must be 32 bytes, got ${secretKey.length}`,
+      );
+    }
+
+    const expectedPublicKey = await this.getStaticDepositSigningKey(idx);
+    const actualPublicKey = secp256k1.getPublicKey(secretKey);
+    if (!areBytesEqual(actualPublicKey, expectedPublicKey)) {
+      throw new Error(
+        `Exported static deposit key at index ${idx} does not match Spark-derived public key`,
+      );
+    }
+
+    this.secretKeyManager.set(idx, new Uint8Array(secretKey));
+  }
+
+  /**
+   * Returns the cached static-deposit secret for `idx`. Throws if no
+   * secret was pre-loaded via `setStaticDepositSecretKey`.
+   *
+   * Called by the Spark SDK's static-deposit claim path. There is no
+   * enclave-only fallback — the SDK's claim flow needs the raw secret
+   * client-side, so if you haven't exported and cached it the claim
+   * cannot proceed. See `setStaticDepositSecretKey` for the trust-
+   * boundary caveats and lifecycle hygiene.
+   */
+  async getStaticDepositSecretKey(idx: number): Promise<Uint8Array> {
+    const secretKey = await this.secretKeyManager.get(idx);
+    if (secretKey) {
+      return new Uint8Array(secretKey);
+    }
+    throw new Error(
+      `TurnkeySparkSigner.getStaticDepositSecretKey(${idx}): no secret cached. ` +
+        "The Spark SDK's static-deposit claim path needs the raw private " +
+        "key client-side; call installStaticDepositSecretKey (export from " +
+        "Turnkey + cache) before invoking the claim, and " +
+        "clearStaticDepositSecretKey afterward. There is no enclave-only " +
+        "static-deposit-claim path today — see " +
+        "src/spark-deposit/static.ts for the recommended pattern.",
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Not needed for Turnkey-backed wallets
+  //
+  // Each method below explains why it's unsupported and where the equivalent
+  // Turnkey-driven flow lives (if any). Errors here surface only when SDK
+  // code paths we don't normally exercise call into them — file an issue if
+  // you hit one in a flow that should work.
+  // ---------------------------------------------------------------------------
+
+  async generateMnemonic(): Promise<string> {
+    throw new Error(
+      "TurnkeySparkSigner.generateMnemonic is not supported. Wallets are " +
+        "created via Turnkey's CREATE_WALLET activity (see setup.ts), not " +
+        "from a client-generated mnemonic. The wallet seed lives inside " +
+        "Turnkey's enclave and never leaves.",
+    );
+  }
+
+  async subtractPrivateKeysGivenDerivationPaths(
+    _first: string,
+    _second: string,
+  ): Promise<Uint8Array> {
+    throw new Error(
+      "TurnkeySparkSigner.subtractPrivateKeysGivenDerivationPaths is not " +
+        "supported. This primitive is only used by the SDK's built-in " +
+        "transfer/claim flows; the Turnkey integration replaces those with " +
+        "SPARK_PREPARE_TRANSFER / SPARK_CLAIM_TRANSFER which compute the " +
+        "tweak scalar atomically inside the enclave. Use " +
+        "TurnkeySparkSigner.prepareTransfer or prepareClaim instead.",
+    );
+  }
+
+  async subtractAndSplitSecretWithProofsGivenDerivations(
+    _params: Omit<SplitSecretWithProofsParams, "secret"> & {
+      first: KeyDerivation;
+      second?: KeyDerivation | undefined;
+    },
+  ): Promise<VerifiableSecretShare[]> {
+    throw new Error(
+      "TurnkeySparkSigner.subtractAndSplitSecretWithProofsGivenDerivations " +
+        "is not supported. The SDK's built-in transfer/claim flows call " +
+        "this; the Turnkey integration replaces them with " +
+        "SPARK_PREPARE_TRANSFER / SPARK_CLAIM_TRANSFER which subtract + " +
+        "Feldman-split atomically inside the enclave (raw shares never " +
+        "leave). Use TurnkeySparkSigner.prepareTransfer or prepareClaim.",
+    );
+  }
+
+  async splitSecretWithProofs(): Promise<VerifiableSecretShare[]> {
+    throw new Error(
+      "TurnkeySparkSigner.splitSecretWithProofs is not supported. The SDK's " +
+        "built-in Lightning-receive path calls this with a client-generated " +
+        "preimage; the Turnkey integration replaces it with " +
+        "SPARK_PREPARE_LIGHTNING_RECEIVE which generates the preimage and " +
+        "Feldman-splits it inside the enclave (the preimage never enters " +
+        "client JS). Use TurnkeySparkSigner.prepareLightningReceive.",
+    );
+  }
+
+  signTransactionIndex(): void {
+    throw new Error(
+      "TurnkeySparkSigner.signTransactionIndex is not supported. The Turnkey " +
+        "integration uses signFrostBatch for FROST signing and signRawPayload " +
+        "for identity signatures; no Turnkey-driven flow needs raw " +
+        "transaction-index ECDSA signing with a client-held private key.",
+    );
+  }
+
+  async htlcHMAC(): Promise<Uint8Array> {
+    throw new Error(
+      "TurnkeySparkSigner.htlcHMAC is not supported. Turnkey-driven Lightning " +
+        "flows route through src/internal/turnkeyLightning.ts " +
+        "(SPARK_PREPARE_LIGHTNING_RECEIVE for receives, the swap-based send " +
+        "path) and do not require client-side preimage derivation. " +
+        "If you need raw HTLC primitives (atomic swaps, manual LSP " +
+        "integration), pass an explicit `preimage` to wallet.createHTLC(...) " +
+        "— the Spark SDK skips htlcHMAC when preimage is provided. For " +
+        "deterministic wallet-seed-derived preimages, a SPARK_HTLC_HMAC " +
+        "Turnkey activity would be needed (not built today; file an issue " +
+        "if you have a use case).",
+    );
+  }
+
+  async decryptEcies(): Promise<Uint8Array> {
+    throw new Error(
+      "TurnkeySparkSigner.decryptEcies is not supported. The SDK's built-in " +
+        "claim flow calls this to decrypt the inbound ciphertext using the " +
+        "wallet identity key client-side; the Turnkey integration replaces " +
+        "the entire claim flow with SPARK_CLAIM_TRANSFER which performs " +
+        "ECIES decryption inside the enclave (identity key never leaves). " +
+        "Use TurnkeySparkSigner.prepareClaim — see src/internal/turnkeyClaim.ts.",
+    );
+  }
 }
+
+const signFrostParamsToSignatureRequest = (
+  params: SignFrostParams,
+): v1SparkSignatureRequest => ({
+  derivation: keyDerivationToSparkKeyDerivation(params.keyDerivation),
+  message: uint8ArrayToHexString(params.message),
+  verifyingKey: uint8ArrayToHexString(params.verifyingKey),
+  operatorCommitments: Object.entries(
+    params.statechainCommitments ?? {},
+  ).flatMap(([id, commitment]) =>
+    commitment
+      ? [statechainCommitmentToSparkFrostCommitment(id, commitment)]
+      : [],
+  ),
+  adaptorPublicKey: adaptorPubKeyToSparkAdaptorPublicKey(params.adaptorPubKey),
+});
+
+const adaptorPubKeyToSparkAdaptorPublicKey = (
+  adaptorPubKey: Uint8Array | undefined,
+): string => {
+  if (adaptorPubKey === undefined || adaptorPubKey.length === 0) return "";
+
+  // adaptorPubKey may be omitted (undefined) or empty (`new Uint8Array()`,
+  // how the Spark SDK signals non-adaptor signs) — both forward as plain
+  // FROST. Any other length is a caller bug: SPARK_SIGN_FROST would
+  // either reject (non-33-byte → enclave InvalidArgument) or, for a 33-
+  // byte non-curve-point, fail downstream aggregation. Reject at the SDK
+  // boundary so the error points at the call site, not the enclave.
+  if (adaptorPubKey.length !== 33) {
+    throw new Error(
+      `adaptorPubKey must be omitted, empty, or ` +
+        `a 33-byte compressed secp256k1 point (got ${uint8ArrayToHexString(adaptorPubKey)})`,
+    );
+  }
+
+  return uint8ArrayToHexString(adaptorPubKey);
+};
+
+/**
+ * Maps an SDK KeyDerivation to the proto SparkKeyDerivation oneof shape with
+ * the signingLeaf variant selected.
+ *
+ * The three call sites — SPARK_SIGN_FROST signature requests and
+ * SPARK_PREPARE_TRANSFER's {old,new}_leaf_derivation — accept the polymorphic
+ * SparkKeyDerivation, but the SDK only drives the signingLeaf variant; other
+ * derivation types are rejected here.
+ */
+const keyDerivationToSparkKeyDerivation = (
+  kd: KeyDerivation,
+): v1SparkKeyDerivation => {
+  if (kd.type !== "leaf") {
+    throw new Error(
+      `Expected leaf KeyDerivation for SparkKeyDerivation signingLeaf, got ${kd.type}`,
+    );
+  }
+
+  return { signingLeaf: { leafId: String(kd.path) } };
+};
+
+/** Maps operator commitment to proto shape. */
+const statechainCommitmentToSparkFrostCommitment = (
+  id: string,
+  commitment: SigningCommitment,
+): v1SparkFrostCommitment => {
+  return {
+    id,
+    hiding: uint8ArrayToHexString(commitment.hiding),
+    binding: uint8ArrayToHexString(commitment.binding),
+  };
+};

--- a/packages/spark/src/utils.ts
+++ b/packages/spark/src/utils.ts
@@ -1,0 +1,42 @@
+import type { v1WalletAccount } from "@turnkey/core";
+
+const COMPRESSED_PUBLIC_KEY_REGEX = /^[0-9a-fA-F]{66}$/;
+
+export const compressedPublicKeyHexFromAccount = (
+  account: v1WalletAccount,
+): string | undefined => {
+  return compressedPublicKeyHexFromString(account.publicKey ?? account.address);
+};
+
+export const compressedPublicKeyHexFromString = (
+  key: string,
+): string | undefined => {
+  return COMPRESSED_PUBLIC_KEY_REGEX.test(key) ? key : undefined;
+};
+
+export const areBytesEqual = (a: Uint8Array, b: Uint8Array): boolean =>
+  a.length === b.length && a.every((byte, i) => byte === b[i]);
+
+export const isAlreadyExistsError = (err: unknown): boolean => {
+  if (err == null) return false;
+
+  const candidate = err as { code?: unknown; message?: unknown };
+  return (
+    candidate.code === 6 ||
+    candidate.code === "ALREADY_EXISTS" ||
+    String(candidate.message ?? err).includes("already exists")
+  );
+};
+
+export const isNotFoundError = (err: unknown): boolean => {
+  if (err == null) return false;
+
+  const candidate = err as { code?: unknown; message?: unknown };
+  return (
+    candidate.code === 5 ||
+    candidate.code === "NOT_FOUND" ||
+    String(candidate.message ?? err)
+      .toLowerCase()
+      .includes("not found")
+  );
+};

--- a/packages/spark/tsconfig.json
+++ b/packages/spark/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "tsBuildInfoFile": "./.cache/.tsbuildinfo"
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo",
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"],
-  "exclude": ["dist", "node_modules"],
-  "references": [{ "path": "../http" }]
+  "exclude": ["dist", "node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4302,10 +4302,25 @@ importers:
       '@turnkey/core':
         specifier: workspace:*
         version: link:../core
+      '@turnkey/encoding':
+        specifier: workspace:*
+        version: link:../encoding
       '@turnkey/sdk-server':
         specifier: workspace:*
         version: link:../sdk-server
+      async-retry:
+        specifier: 1.3.3
+        version: 1.3.3
     devDependencies:
+      '@types/async-retry':
+        specifier: 1.4.8
+        version: 1.4.8
+      '@types/jest':
+        specifier: ^29.5.3
+        version: 29.5.14
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@24.7.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.7.1)(typescript@5.4.3))
       typescript:
         specifier: 5.4.3
         version: 5.4.3
@@ -8106,8 +8121,8 @@ packages:
   '@safe-global/safe-apps-sdk@9.1.0':
     resolution: {integrity: sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==}
 
-  '@safe-global/safe-deployments@1.37.56':
-    resolution: {integrity: sha512-HF3ETre/KSP3nCOZ72XEbq5U56gOGgYLJ22LxOAnR8+YzMjzZ8cpnHpx5Z31Zt1xkUTGSCMi9XF950lJt6WbsQ==}
+  '@safe-global/safe-deployments@1.37.44':
+    resolution: {integrity: sha512-fdmWxU7U5FLqfIl2aFFRFKBiOxWVAFYtpbneJIYfeNObvAnFsoQDKN4qym2hCDKTuIrnfX2jv8tqfrIxxMyOpA==}
 
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
@@ -24853,7 +24868,7 @@ snapshots:
   '@safe-global/protocol-kit@3.0.2(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
       '@noble/hashes': 1.8.0
-      '@safe-global/safe-deployments': 1.37.56
+      '@safe-global/safe-deployments': 1.37.44
       ethereumjs-util: 7.1.5
       ethers: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       semver: 7.7.3
@@ -24906,7 +24921,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-deployments@1.37.56':
+  '@safe-global/safe-deployments@1.37.44':
     dependencies:
       semver: 7.7.3
 


### PR DESCRIPTION
## Summary & Motivation

This PR takes the improvements made by @andrewkmin in #1284 and isolates the changes made to the signer only.

Several changes were made to the original implementation:
- Prefetching accounts was a hanging promise (i.e. a memory leak). Prefetching has been removed from this PR since it's already large enough and will be added as a separate piece later on
- The key management got its own (tested) class/classes that combines a `Map` and server-side account fetching into a read/write safe object

## How I Tested These Changes

Added unit tests for the `TurnkeyValueManager`, that's that

## Did you add a changeset?

This package is not being published yet.