### PR TITLE
fix(with-walletconnect-pay): center demo video in readme

### DIFF
--- a/examples/with-walletconnect-pay/README.md
+++ b/examples/with-walletconnect-pay/README.md
@@ -4,7 +4,9 @@ This example shows how to integrate [`@walletconnect/pay`](https://www.npmjs.com
 
 ## Demo
 
-https://github.com/user-attachments/assets/01af3375-9bd8-4063-851b-0a90e84a0e70
+<div align="center">
+  <video src="https://github.com/user-attachments/assets/01af3375-9bd8-4063-851b-0a90e84a0e70" controls width="400"></video>
+</div>
 
 ## Getting started
 


### PR DESCRIPTION
## Summary & Motivation

Centers a demo video in `/examples/with-walletconnect-pay`.

## How I Tested These Changes

Previewed the markdown file to check video alignment.

## Did you add a changeset?

No, this is just a readme update.