### PR TITLE
fix: disable sourcemaps that reference unpublished src files

### DIFF
--- a/rollup.config.base.mjs
+++ b/rollup.config.base.mjs
@@ -14,7 +14,7 @@ const getFormatConfig = (format) => {
       entryFileNames: `[name].${format === "esm" ? "mjs" : "js"}`,
       preserveModules: true,
       preserveModulesRoot: "src",
-      sourcemap: true,
+      sourcemap: false,
     },
     plugins: [
       typescript({
@@ -24,8 +24,8 @@ const getFormatConfig = (format) => {
           outDir: "dist",
           composite: false,
           declaration: format === "esm",
-          declarationMap: format === "esm",
-          sourceMap: true,
+          declarationMap: false,
+          sourceMap: false,
           skipLibCheck: true,
         },
       }),


### PR DESCRIPTION
Sourcemap generation was enabled in rollup.config.base.mjs, producing .map files that reference src/ files not included in published packages. This causes warnings in Vite and other bundlers.

Disables sourcemap output and declaration maps to resolve the issue.

Closes tkhq/sdk#1265
