### PR TITLE
Landon/nonce

### DIFF
--- a/.changeset/rich-moose-drive.md
+++ b/.changeset/rich-moose-drive.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Add optional `config.ui.styleNonce` to forward a CSP nonce to the injected theme override style tag for strict CSP support in dynamically-rendered apps.

--- a/.changeset/rich-moose-drive.md
+++ b/.changeset/rich-moose-drive.md
@@ -3,3 +3,4 @@
 ---
 
 Add optional `config.ui.styleNonce` to forward a CSP nonce to the injected theme override style tag for strict CSP support in dynamically-rendered apps.
+Thanks to @samsamtrum for the original PR!

--- a/packages/react-wallet-kit/src/providers/TurnkeyProvider.tsx
+++ b/packages/react-wallet-kit/src/providers/TurnkeyProvider.tsx
@@ -22,6 +22,7 @@ export function TurnkeyProvider({
         <TurnkeyThemeOverrides
           light={config.ui?.colors?.light}
           dark={config.ui?.colors?.dark}
+          nonce={config.ui?.styleNonce}
         />
         {children}
 

--- a/packages/react-wallet-kit/src/providers/theme/Overrides.tsx
+++ b/packages/react-wallet-kit/src/providers/theme/Overrides.tsx
@@ -16,8 +16,9 @@ export type ThemeOverrides = {
 export function TurnkeyThemeOverrides(props: {
   light?: Partial<ThemeOverrides> | undefined;
   dark?: Partial<ThemeOverrides> | undefined;
+  nonce?: string | undefined;
 }) {
-  const { light, dark } = props;
+  const { light, dark, nonce } = props;
   const generateCSSVars = (theme?: Partial<ThemeOverrides>) => {
     if (!theme) return "";
     return Object.entries(theme)
@@ -33,7 +34,7 @@ export function TurnkeyThemeOverrides(props: {
   };
 
   return (
-    <style>
+    <style nonce={nonce}>
       {`
         :root {
           ${generateCSSVars(light)}

--- a/packages/react-wallet-kit/src/types/base.ts
+++ b/packages/react-wallet-kit/src/types/base.ts
@@ -148,7 +148,7 @@ export interface TurnkeyProviderConfig extends TurnkeySDKClientConfig {
     backgroundBlur?: string | number; // e.g., 10, "1rem"
     /** whether to render the modal in the provider. */
     renderModalInProvider?: boolean; // If true, the modal will be rendered as a child of the TurnkeyProvider instead of a sibling to the body. This is useful for font inheritance, and css manipulations to modals.
-    /** nonce applied to the injected theme override style tag for strict CSP support. Only supported in dynamically-rendered apps in React 19*/
+    /** Nonce applied to the injected theme override <style> tag for strict CSP. Only works in dynamically-rendered apps. */
     styleNonce?: string;
     /** whether to suppress missing styles error. */
     supressMissingStylesError?: boolean; // If true, the Turnkey styles missing error will no longer show. It's possible that styles can be imported but not detected properly. This will suppress the error in that case.

--- a/packages/react-wallet-kit/src/types/base.ts
+++ b/packages/react-wallet-kit/src/types/base.ts
@@ -148,6 +148,8 @@ export interface TurnkeyProviderConfig extends TurnkeySDKClientConfig {
     backgroundBlur?: string | number; // e.g., 10, "1rem"
     /** whether to render the modal in the provider. */
     renderModalInProvider?: boolean; // If true, the modal will be rendered as a child of the TurnkeyProvider instead of a sibling to the body. This is useful for font inheritance, and css manipulations to modals.
+    /** nonce applied to the injected theme override style tag for strict CSP support. */
+    styleNonce?: string;
     /** whether to suppress missing styles error. */
     supressMissingStylesError?: boolean; // If true, the Turnkey styles missing error will no longer show. It's possible that styles can be imported but not detected properly. This will suppress the error in that case.
   };

--- a/packages/react-wallet-kit/src/types/base.ts
+++ b/packages/react-wallet-kit/src/types/base.ts
@@ -148,7 +148,7 @@ export interface TurnkeyProviderConfig extends TurnkeySDKClientConfig {
     backgroundBlur?: string | number; // e.g., 10, "1rem"
     /** whether to render the modal in the provider. */
     renderModalInProvider?: boolean; // If true, the modal will be rendered as a child of the TurnkeyProvider instead of a sibling to the body. This is useful for font inheritance, and css manipulations to modals.
-    /** nonce applied to the injected theme override style tag for strict CSP support. */
+    /** nonce applied to the injected theme override style tag for strict CSP support. Only supported in dynamically-rendered apps in React 19*/
     styleNonce?: string;
     /** whether to suppress missing styles error. */
     supressMissingStylesError?: boolean; // If true, the Turnkey styles missing error will no longer show. It's possible that styles can be imported but not detected properly. This will suppress the error in that case.


### PR DESCRIPTION
## Summary & Motivation

Adds optional `config.ui.styleNonce` so consumers with strict CSP can pass a per-request nonce to the `<style>` tag. Without this, strict-CSP apps can't use the SDK because the inline style gets blocked.  No effect when un-set

Closes #1334 

## How I Tested These Changes

locally

## Did you add a changeset?

yes
