### PR TITLE
Chore: use base tsconfig for examples

### DIFF
--- a/examples/email-auth-local-storage/src/pages/_document.tsx
+++ b/examples/email-auth-local-storage/src/pages/_document.tsx
@@ -1,7 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
 class Example extends Document {
-  render() {
+  override render() {
     return (
       <Html>
         <Head>

--- a/examples/email-auth-local-storage/tsconfig.json
+++ b/examples/email-auth-local-storage/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/import-export-with-rwk/src/app/dashboard/page.tsx
+++ b/examples/import-export-with-rwk/src/app/dashboard/page.tsx
@@ -65,7 +65,7 @@ export default function Dashboard() {
   // Initialize default wallet & account
   useEffect(() => {
     if (!selectedWalletId && embeddedWallets.length > 0) {
-      setSelectedWalletId(embeddedWallets[0].walletId);
+      setSelectedWalletId(embeddedWallets[0]?.walletId ?? null);
     }
   }, [embeddedWallets, selectedWalletId]);
 
@@ -75,7 +75,7 @@ export default function Dashboard() {
       selectedWallet.accounts?.length &&
       !selectedAccountAddress
     ) {
-      setSelectedAccountAddress(selectedWallet.accounts[0].address);
+      setSelectedAccountAddress(selectedWallet.accounts[0]?.address ?? null);
     }
   }, [selectedWallet, selectedAccountAddress]);
 
@@ -509,11 +509,11 @@ export default function Dashboard() {
                       <>
                         <div className="font-mono break-all">
                           <span className="font-semibold">Address Format:</span>{" "}
-                          {selectedPrivateKey.addresses[0].format}
+                          {selectedPrivateKey.addresses[0]?.format}
                         </div>
                         <div className="font-mono break-all">
                           <span className="font-semibold">Address:</span>{" "}
-                          {selectedPrivateKey.addresses[0].address}
+                          {selectedPrivateKey.addresses[0]?.address}
                         </div>
                       </>
                     ) : (

--- a/examples/import-export-with-rwk/tsconfig.json
+++ b/examples/import-export-with-rwk/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/magic-link-auth/src/app/providers.tsx
+++ b/examples/magic-link-auth/src/app/providers.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/navigation";
 import {
   TurnkeyProvider,
   type TurnkeyProviderConfig,
-  type CreateSubOrgParams,
 } from "@turnkey/react-wallet-kit";
 import "@turnkey/react-wallet-kit/styles.css";
 

--- a/examples/magic-link-auth/src/server/actions/completeAuth.ts
+++ b/examples/magic-link-auth/src/server/actions/completeAuth.ts
@@ -57,7 +57,7 @@ export async function completeAuth(params: {
 function extractEmailFromVerificationToken(token: string): string {
   try {
     const [, payloadBase64] = token.split(".");
-    const payloadJson = Buffer.from(payloadBase64, "base64url").toString();
+    const payloadJson = Buffer.from(payloadBase64!, "base64url").toString();
     const payload = JSON.parse(payloadJson);
     const email = payload.contact;
     if (!email)

--- a/examples/magic-link-auth/tsconfig.json
+++ b/examples/magic-link-auth/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/oauth/tsconfig.json
+++ b/examples/oauth/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/otp-auth/with-backend/src/app/dashboard/page.tsx
+++ b/examples/otp-auth/with-backend/src/app/dashboard/page.tsx
@@ -131,7 +131,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!selectedAccount && embeddedAccounts.length > 0) {
-      setSelectedAccount(embeddedAccounts[0].account);
+      setSelectedAccount(embeddedAccounts[0]!.account);
     }
   }, [embeddedAccounts, selectedAccount]);
 
@@ -299,14 +299,14 @@ export default function Dashboard() {
           throw new Error("Set NEXT_PUBLIC_RPC_ETH for embedded EVM.");
         const tx = await buildEvmDemoTx({
           address: selectedAccount.address as `0x${string}`,
-          rpcUrl: ETH_RPC,
+          rpcUrl: ETH_RPC!,
         });
         const unsignedHex = serializeTransaction(tx);
         unsignedTransaction = unsignedHex.startsWith("0x")
           ? unsignedHex
           : `0x${unsignedHex}`;
         transactionType = "TRANSACTION_TYPE_ETHEREUM";
-        rpcUrl = ETH_RPC;
+        rpcUrl = ETH_RPC!;
       } else if (isSol) {
         const solRpc = SOL_RPC || clusterApiUrl("devnet");
         unsignedTransaction = await buildUnsignedSolanaTxHex(

--- a/examples/otp-auth/with-backend/tsconfig.json
+++ b/examples/otp-auth/with-backend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/otp-auth/without-backend/src/app/dashboard/page.tsx
+++ b/examples/otp-auth/without-backend/src/app/dashboard/page.tsx
@@ -131,7 +131,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!selectedAccount && embeddedAccounts.length > 0) {
-      setSelectedAccount(embeddedAccounts[0].account);
+      setSelectedAccount(embeddedAccounts[0]?.account ?? null);
     }
   }, [embeddedAccounts, selectedAccount]);
 

--- a/examples/otp-auth/without-backend/tsconfig.json
+++ b/examples/otp-auth/without-backend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/react-wallet-kit/src/app/layout.tsx
+++ b/examples/react-wallet-kit/src/app/layout.tsx
@@ -22,7 +22,7 @@ function RootLayout({ children }: RootLayoutProps) {
       closeOnClick: false,
       pauseOnHover: true,
       draggable: true,
-      progress: undefined,
+      progress: 0,
       transition: Slide,
     });
 

--- a/examples/react-wallet-kit/src/components/3D/Background.tsx
+++ b/examples/react-wallet-kit/src/components/3D/Background.tsx
@@ -18,12 +18,14 @@ function FadeInWrapper(props: {
   useEffect(() => {
     if (startVisible) {
       setVisible(true);
-      return;
+      return () => {};
     }
     if (progress === 100) {
       const timeout = setTimeout(() => setVisible(true), 50); // Fade in after a short delay
       return () => clearTimeout(timeout);
     }
+
+    return () => {};
   }, [progress, startVisible]);
 
   return (

--- a/examples/react-wallet-kit/src/components/3D/TurnkeyLogo.tsx
+++ b/examples/react-wallet-kit/src/components/3D/TurnkeyLogo.tsx
@@ -73,6 +73,8 @@ export function TurnkeyLogo(props: TurnkeyLogoProps) {
 
       return () => clearTimeout(timeout);
     }
+
+    return () => {};
   }, [modalStack.length]);
 
   // Make Turnkey logo wireframe.

--- a/examples/react-wallet-kit/src/components/Disclosure.tsx
+++ b/examples/react-wallet-kit/src/components/Disclosure.tsx
@@ -6,7 +6,7 @@ import {
 } from "@headlessui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
-import { type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 interface PanelDisclosureProps {
   title: string;

--- a/examples/react-wallet-kit/src/components/Svg.tsx
+++ b/examples/react-wallet-kit/src/components/Svg.tsx
@@ -1,6 +1,6 @@
 interface SVGProps {
-  className?: string;
-  style?: React.CSSProperties;
+  className?: string | undefined;
+  style?: React.CSSProperties | undefined;
 }
 
 export function TurnkeyLogoSVG(props: SVGProps) {

--- a/examples/react-wallet-kit/src/components/Switch.tsx
+++ b/examples/react-wallet-kit/src/components/Switch.tsx
@@ -32,7 +32,7 @@ export function ToggleSwitch(props: ToggleSwitchProps) {
       {label && <span className="text-sm">{label}</span>}
       <Switch
         checked={checked}
-        disabled={disabled}
+        disabled={disabled ?? false}
         onChange={onChange}
         className={clsx(
           "relative flex items-center rounded-full transition",

--- a/examples/react-wallet-kit/src/components/demo/AuthButtons/AuthenticatorButton.tsx
+++ b/examples/react-wallet-kit/src/components/demo/AuthButtons/AuthenticatorButton.tsx
@@ -1,7 +1,6 @@
 import { KeySVG } from "@/components/Svg";
 import { AuthToggleButton } from "./index";
 import { useTurnkey } from "@turnkey/react-wallet-kit";
-import { toast } from "react-toastify";
 
 export default function AuthenticatorButton({
   canRemoveAuthMethod,
@@ -10,9 +9,6 @@ export default function AuthenticatorButton({
 }) {
   const { user, handleAddPasskey, handleRemovePasskey } = useTurnkey();
   const authenticator = user?.authenticators?.[0];
-
-  const notify = () =>
-    toast.error("Error: Cannot remove your last authenticator.");
 
   return (
     <AuthToggleButton

--- a/examples/react-wallet-kit/src/components/demo/AuthButtons/SocialButton.tsx
+++ b/examples/react-wallet-kit/src/components/demo/AuthButtons/SocialButton.tsx
@@ -1,6 +1,6 @@
 import { AuthToggleButton } from "./index";
 import { useTurnkey } from "@turnkey/react-wallet-kit";
-import { OAuthProviders } from "@turnkey/sdk-types";
+import type { OAuthProviders } from "@turnkey/sdk-types";
 
 interface SocialButtonProps {
   canRemoveAuthMethod: boolean;

--- a/examples/react-wallet-kit/src/components/demo/ConfigViewer.tsx
+++ b/examples/react-wallet-kit/src/components/demo/ConfigViewer.tsx
@@ -32,7 +32,7 @@ function renderValue(value: any, indentLevel = 2, key?: string): string {
   const indent = " ".repeat(indentLevel);
 
   if (key && envVars[key]) {
-    return envVars[key];
+    return envVars[key]!;
   }
 
   if (Array.isArray(value)) {

--- a/examples/react-wallet-kit/src/components/demo/DeleteSubOrgWarning.tsx
+++ b/examples/react-wallet-kit/src/components/demo/DeleteSubOrgWarning.tsx
@@ -9,8 +9,7 @@ import { useState } from "react";
 import { Spinner } from "../Spinners";
 
 export default function DeleteSubOrgWarning() {
-  const { session, user, wallets, deleteSubOrganization, logout } =
-    useTurnkey();
+  const { session, wallets, deleteSubOrganization, logout } = useTurnkey();
   const { isMobile, closeModal } = useModal();
 
   const [deleteWithoutExport, setDeleteWithoutExport] = useState(false);

--- a/examples/react-wallet-kit/src/components/demo/DemoPanel.tsx
+++ b/examples/react-wallet-kit/src/components/demo/DemoPanel.tsx
@@ -14,11 +14,8 @@ import {
 } from "@headlessui/react";
 import {
   ConnectedWallet,
-  ExportType,
   useModal,
   useTurnkey,
-  Wallet,
-  WalletAccount,
   WalletSource,
 } from "@turnkey/react-wallet-kit";
 import { useEffect, useState } from "react";
@@ -58,12 +55,10 @@ export default function DemoPanel() {
 
   const { pushPage } = useModal();
 
-  const [selectedWallet, setSelectedWallet] = useState<Wallet | undefined>(
-    wallets[0] || null, // Initialize with null if wallets[0] is undefined
+  const [selectedWallet, setSelectedWallet] = useState(wallets[0]);
+  const [selectedWalletAccount, setSelectedWalletAccount] = useState(
+    wallets[0]?.accounts[0],
   );
-  const [selectedWalletAccount, setSelectedWalletAccount] = useState<
-    WalletAccount | undefined
-  >(wallets[0]?.accounts[0] || null); // Initialize with null if no accounts exist
 
   const [connectedWallets, setConnectedWallets] = useState<
     ConnectedWallet[] | undefined
@@ -91,13 +86,13 @@ export default function DemoPanel() {
 
     if (
       !selectedWallet ||
-      !wallets.find((w) => w.walletId === selectedWallet.walletId)
+      !wallets?.find((w) => w.walletId === selectedWallet.walletId)
     ) {
-      setSelectedWallet(wallets[0]);
-      setSelectedWalletAccount(wallets[0]?.accounts[0]);
+      setSelectedWallet(wallets?.[0]);
+      setSelectedWalletAccount(wallets?.[0]?.accounts?.[0]);
     }
-    if (!selectedWalletAccount && wallets[0]?.accounts.length > 0) {
-      setSelectedWalletAccount(wallets[0].accounts[0]);
+    if (!selectedWalletAccount && wallets?.[0]?.accounts?.length) {
+      setSelectedWalletAccount(wallets?.[0]?.accounts?.[0]);
     }
 
     const cw = wallets.filter(
@@ -203,6 +198,8 @@ export default function DemoPanel() {
                           </div>
                         </MenuItem>
                       );
+
+                    return null;
                   })}
                 {wallets.length !== 1 && (
                   <hr className="border-icon-text-light dark:border-icon-text-dark w-full" />
@@ -226,7 +223,7 @@ export default function DemoPanel() {
                         newWallets[0];
                       setSelectedWallet(newWallet);
                       setSelectedWalletAccount(
-                        newWallet.accounts[0] || undefined,
+                        newWallet?.accounts?.[0] || undefined,
                       );
                     }}
                     className="relative hover:cursor-pointer flex items-center justify-center gap-2 w-full px-3 py-2 rounded-md text-xs bg-icon-background-light dark:bg-icon-background-dark text-icon-text-light dark:text-icon-text-dark"

--- a/examples/react-wallet-kit/src/components/demo/UserSettings.tsx
+++ b/examples/react-wallet-kit/src/components/demo/UserSettings.tsx
@@ -16,7 +16,7 @@ import SocialButton from "./AuthButtons/SocialButton";
 import AuthenticatorButton from "./AuthButtons/AuthenticatorButton";
 import DeleteSubOrgWarning from "./DeleteSubOrgWarning";
 import { Button, Transition } from "@headlessui/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function UserSettings() {
   const {

--- a/examples/react-wallet-kit/src/constants.ts
+++ b/examples/react-wallet-kit/src/constants.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CreateSubOrgParams,
   TurnkeyProviderConfig,
 } from "@turnkey/react-wallet-kit";
@@ -35,10 +35,12 @@ export const initialConfig: TurnkeyProviderConfig = {
     process.env.NEXT_PUBLIC_EXPORT_IFRAME_URL || "https://export.turnkey.com",
   auth: {
     oauthConfig: {
-      google: { primaryClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID },
-      facebook: { primaryClientId: process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID },
-      apple: { primaryClientId: process.env.NEXT_PUBLIC_APPLE_CLIENT_ID },
-      oauthRedirectUri: process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI,
+      google: { primaryClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID! },
+      facebook: {
+        primaryClientId: process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID!,
+      },
+      apple: { primaryClientId: process.env.NEXT_PUBLIC_APPLE_CLIENT_ID! },
+      oauthRedirectUri: process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI!,
       openOauthInPage: true,
     },
     autoRefreshSession: true,

--- a/examples/react-wallet-kit/src/providers/config/ConfigProvider.tsx
+++ b/examples/react-wallet-kit/src/providers/config/ConfigProvider.tsx
@@ -20,7 +20,7 @@ import { ThreeDimensionalBackground } from "@/components/3D/Background";
 import { TurnkeySVG } from "@/components/Svg";
 import { isHardwareAccelerationEnabled, kebab, useScreenSize } from "@/utils";
 import { Slide, ToastContainer } from "react-toastify";
-import { DemoConfig } from "@/types";
+import type { DemoConfig } from "@/types";
 import {
   TurnkeyProviderConfig,
   TurnkeyCallbacks,
@@ -48,7 +48,7 @@ export function useTurnkeyConfig() {
 
 interface TurnkeyConfigProviderProps {
   initialConfig: TurnkeyProviderConfig;
-  callbacks?: TurnkeyCallbacks;
+  callbacks: TurnkeyCallbacks;
   children: ReactNode;
 }
 

--- a/examples/react-wallet-kit/src/providers/config/Panel.tsx
+++ b/examples/react-wallet-kit/src/providers/config/Panel.tsx
@@ -15,11 +15,11 @@ import { SliderField } from "@/components/Slider";
 import { ColourPicker } from "@/components/Color";
 import { PanelDisclosure } from "@/components/Disclosure";
 import { useEffect } from "react";
-import { TurnkeyProviderConfig } from "@turnkey/react-wallet-kit";
+import type { TurnkeyProviderConfig } from "@turnkey/react-wallet-kit";
 import ConfigViewer from "@/components/demo/ConfigViewer";
 import { completeTheme, textColour } from "@/utils";
 import { Button, Checkbox } from "@headlessui/react";
-import { DemoConfig } from "@/types";
+import type { DemoConfig } from "@/types";
 import {
   AppleSVG,
   DiscordSVG,
@@ -129,7 +129,7 @@ export function TurnkeyConfigPanel() {
     const currentOrder = config.ui?.authModal?.methodOrder ?? [];
     const reordered = Array.from(currentOrder);
     const [moved] = reordered.splice(result.source.index, 1);
-    reordered.splice(result.destination.index, 0, moved);
+    reordered.splice(result.destination.index, 0, moved!);
 
     handleSetConfig({
       ui: {

--- a/examples/react-wallet-kit/src/types.ts
+++ b/examples/react-wallet-kit/src/types.ts
@@ -1,17 +1,23 @@
 export interface DemoConfig {
   backgroundEnabled: boolean;
-  ui?: {
-    light?: {
-      background: string;
-      text: string;
-      panelBackground: string;
-      draggableBackground: string;
-    };
-    dark?: {
-      background: string;
-      text: string;
-      panelBackground: string;
-      draggableBackground: string;
-    };
-  };
+  ui?:
+    | {
+        light?:
+          | {
+              background: string;
+              text: string;
+              panelBackground: string;
+              draggableBackground: string;
+            }
+          | undefined;
+        dark?:
+          | {
+              background: string;
+              text: string;
+              panelBackground: string;
+              draggableBackground: string;
+            }
+          | undefined;
+      }
+    | undefined;
 }

--- a/examples/react-wallet-kit/src/utils.ts
+++ b/examples/react-wallet-kit/src/utils.ts
@@ -3,7 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import nacl from "tweetnacl";
 import { Buffer } from "buffer";
 
-import { createPublicClient, http, verifyMessage } from "viem";
+import { createPublicClient, http } from "viem";
 import { mainnet } from "viem/chains";
 import {
   normalizePadding,
@@ -33,7 +33,7 @@ export function useScreenSize() {
 export function completeTheme(modalBackgroundColour: string) {
   const { L, C, h } = hexToOklch(modalBackgroundColour);
 
-  const isLight = L > 0.7;
+  const isLight = L! > 0.7;
 
   const iconBackgroundLMultiplier = isLight ? 0.8 : 1.5;
   const iconTextLMultiplier = isLight ? 0.3 : 6;
@@ -43,27 +43,27 @@ export function completeTheme(modalBackgroundColour: string) {
   const panelBackgroundLMultiplier = isLight ? 0.95 : 0.7;
 
   const iconBackgroundL = isLight
-    ? Math.max(L * iconBackgroundLMultiplier, 0.95)
-    : Math.max(L * iconBackgroundLMultiplier, 0.2);
+    ? Math.max(L! * iconBackgroundLMultiplier, 0.95)
+    : Math.max(L! * iconBackgroundLMultiplier, 0.2);
   const iconTextL = isLight
-    ? Math.min(L * iconTextLMultiplier, 0.9)
-    : Math.max(L * iconTextLMultiplier, 0.7);
+    ? Math.min(L! * iconTextLMultiplier, 0.9)
+    : Math.max(L! * iconTextLMultiplier, 0.7);
 
   const buttonBackgroundL = isLight
-    ? Math.min(L * buttonBackgroundLMultiplier, 0.95)
-    : Math.max(L * buttonBackgroundLMultiplier, 0.2);
+    ? Math.min(L! * buttonBackgroundLMultiplier, 0.95)
+    : Math.max(L! * buttonBackgroundLMultiplier, 0.2);
 
   const backgroundL = isLight
-    ? L > 0.9
+    ? L! > 0.9
       ? 0.9
-      : Math.min(L * backgroundLMultiplier, 0.9)
-    : Math.max(L * backgroundLMultiplier, 0.25);
+      : Math.min(L! * backgroundLMultiplier, 0.9)
+    : Math.max(L! * backgroundLMultiplier, 0.25);
   const draggableBackgroundL = isLight
-    ? Math.min(L * draggableBackgroundLMultiplier, 0.9)
-    : Math.max(L * draggableBackgroundLMultiplier, 0.3);
+    ? Math.min(L! * draggableBackgroundLMultiplier, 0.9)
+    : Math.max(L! * draggableBackgroundLMultiplier, 0.3);
   const panelBackgroundL = isLight
-    ? Math.min(L * panelBackgroundLMultiplier, 1)
-    : Math.max(L * panelBackgroundLMultiplier, 0.2);
+    ? Math.min(L! * panelBackgroundLMultiplier, 1)
+    : Math.max(L! * panelBackgroundLMultiplier, 0.2);
 
   const iconBackground = oklchToHex({ L: iconBackgroundL, C, h });
   const iconText = oklchToHex({ L: iconTextL, C, h });
@@ -86,7 +86,7 @@ export function completeTheme(modalBackgroundColour: string) {
 export function textColour(colour: string, highContrast = false) {
   // Use OKLCh for perceptual lightness
   const { L, C, h } = hexToOklch(colour);
-  const isLight = L > 0.5;
+  const isLight = L! > 0.5;
 
   // Use pure black or white for maximum contrast
   return isLight
@@ -97,7 +97,7 @@ export function textColour(colour: string, highContrast = false) {
 export function logoColour(colour: string) {
   // Use OKLCh for perceptual lightness
   const { L, C, h } = hexToOklch(colour);
-  const isLight = L > 0.6;
+  const isLight = L! > 0.6;
 
   // Use a slightly darker or lighter shade for logo
   return isLight ? oklchToHex({ L: 0.5, C, h }) : oklchToHex({ L: 0.7, C, h });
@@ -128,9 +128,9 @@ function linearToSrgb(u: number) {
 // multiply a 3×3 matrix by a 3-vector
 function mat3Mul(mat: number[], [x, y, z]: [number, number, number]) {
   return [
-    mat[0] * x + mat[1] * y + mat[2] * z,
-    mat[3] * x + mat[4] * y + mat[5] * z,
-    mat[6] * x + mat[7] * y + mat[8] * z,
+    mat[0]! * x + mat[1]! * y + mat[2]! * z,
+    mat[3]! * x + mat[4]! * y + mat[5]! * z,
+    mat[6]! * x + mat[7]! * y + mat[8]! * z,
   ];
 }
 
@@ -153,9 +153,9 @@ function linearSrgbToOklab([lr, lg, lb]: [number, number, number]) {
   );
 
   // cube-root
-  let l = Math.cbrt(l_),
-    m = Math.cbrt(m_),
-    s = Math.cbrt(s_);
+  let l = Math.cbrt(l_!),
+    m = Math.cbrt(m_!),
+    s = Math.cbrt(s_!);
 
   // to OKLab
   return mat3Mul(
@@ -202,8 +202,8 @@ function hexToOklch(hex: string) {
   // to OKLab
   let [L, a, b] = linearSrgbToOklab(rgb01);
   // to cylindrical LCh
-  let C = Math.hypot(a, b);
-  let h = (Math.atan2(b, a) * 180) / Math.PI;
+  let C = Math.hypot(a!, b!);
+  let h = (Math.atan2(b!, a!) * 180) / Math.PI;
   if (h < 0) h += 360;
   return { L, C, h };
 }
@@ -221,9 +221,9 @@ function oklchToHex({ L, C, h }: { L: number; C: number; h: number }) {
   let [lr, lg, lb] = oklabToLinearSrgb([L, a, b]);
   // gamma-correct & clamp & scale
   const to255 = (x: number) => Math.round(clamp01(linearToSrgb(x)) * 255);
-  let r = to255(lr),
-    g = to255(lg),
-    b8 = to255(lb);
+  let r = to255(lr!),
+    g = to255(lg!),
+    b8 = to255(lb!);
   // hex
   return "#" + [r, g, b8].map((v) => v.toString(16).padStart(2, "0")).join("");
 }

--- a/examples/react-wallet-kit/tsconfig.json
+++ b/examples/react-wallet-kit/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/wallet-auth/with-backend/src/app/dashboard/page.tsx
+++ b/examples/wallet-auth/with-backend/src/app/dashboard/page.tsx
@@ -133,7 +133,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!selectedAccount && allAccounts.length > 0) {
-      setSelectedAccount(allAccounts[0].account);
+      setSelectedAccount(allAccounts[0]!.account);
     }
   }, [allAccounts, selectedAccount]);
 
@@ -301,7 +301,7 @@ export default function Dashboard() {
         // Build with a fresh nonce at submit time
         const tx = await buildEvmDemoTx({
           address: selectedAccount.address as `0x${string}`,
-          rpcUrl: ETH_RPC,
+          rpcUrl: ETH_RPC!,
         });
         const unsignedHex = serializeTransaction(tx);
         unsignedTransaction = unsignedHex.startsWith("0x")

--- a/examples/wallet-auth/with-backend/src/app/page.tsx
+++ b/examples/wallet-auth/with-backend/src/app/page.tsx
@@ -9,7 +9,7 @@ import {
   type WalletProvider,
 } from "@turnkey/react-wallet-kit";
 import { getSuborgsAction, createSuborgAction } from "@/server/actions/turnkey";
-import { TStampLoginResponse } from "@turnkey/sdk-types";
+import type { TStampLoginResponse } from "@turnkey/sdk-types";
 
 type CurveType = "API_KEY_CURVE_ED25519" | "API_KEY_CURVE_SECP256K1";
 
@@ -77,7 +77,7 @@ export default function AuthPage() {
   const handlePickWalletName = (name: string) => {
     const variants = providerGroups[name] || [];
     if (variants.length === 1) {
-      void handleProviderVariant(variants[0]);
+      void handleProviderVariant(variants[0]!);
     } else {
       setSelectedWalletName(name);
     }
@@ -216,7 +216,7 @@ export default function AuthPage() {
             ) : (
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 {Object.keys(providerGroups).map((name) => {
-                  const first = providerGroups[name][0];
+                  const first = providerGroups[name]![0];
                   return (
                     <button
                       key={name}
@@ -225,14 +225,14 @@ export default function AuthPage() {
                     >
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
-                        src={first.info.icon || ""}
+                        src={first!.info.icon || ""}
                         alt={name}
                         className="h-6 w-6 rounded-full"
                       />
                       <div className="text-sm font-medium text-gray-800">
                         {name}
                       </div>
-                      {providerGroups[name].length > 1 && (
+                      {providerGroups[name]!.length > 1 && (
                         <span className="ml-auto text-[10px] rounded bg-gray-100 px-2 py-0.5 text-gray-600">
                           multiple
                         </span>

--- a/examples/wallet-auth/with-backend/tsconfig.json
+++ b/examples/wallet-auth/with-backend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/wallet-auth/without-backend/src/app/dashboard/page.tsx
+++ b/examples/wallet-auth/without-backend/src/app/dashboard/page.tsx
@@ -133,7 +133,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!selectedAccount && allAccounts.length > 0) {
-      setSelectedAccount(allAccounts[0].account);
+      setSelectedAccount(allAccounts[0]!.account);
     }
   }, [allAccounts, selectedAccount]);
 
@@ -301,7 +301,7 @@ export default function Dashboard() {
         // Build with a fresh nonce at submit time
         const tx = await buildEvmDemoTx({
           address: selectedAccount.address as `0x${string}`,
-          rpcUrl: ETH_RPC,
+          rpcUrl: ETH_RPC!,
         });
         const unsignedHex = serializeTransaction(tx);
         unsignedTransaction = unsignedHex.startsWith("0x")

--- a/examples/wallet-auth/without-backend/tsconfig.json
+++ b/examples/wallet-auth/without-backend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/wallet-export-sign/src/components/ExportWallet.tsx
+++ b/examples/wallet-export-sign/src/components/ExportWallet.tsx
@@ -4,7 +4,7 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 
 import styles from "../pages/index.module.css";
-import { IframeStamper } from "@turnkey/iframe-stamper";
+import type { IframeStamper } from "@turnkey/iframe-stamper";
 import { Export } from "@/components/Export";
 
 type ExportWalletProps = {

--- a/examples/wallet-export-sign/src/components/ExportWalletAccount.tsx
+++ b/examples/wallet-export-sign/src/components/ExportWalletAccount.tsx
@@ -4,7 +4,7 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 
 import styles from "../pages/index.module.css";
-import { IframeStamper, KeyFormat } from "@turnkey/iframe-stamper";
+import { type IframeStamper, KeyFormat } from "@turnkey/iframe-stamper";
 import { Export } from "@/components/Export";
 
 type ExportWalletAccountProps = {

--- a/examples/wallet-export-sign/src/components/WalletsTable.tsx
+++ b/examples/wallet-export-sign/src/components/WalletsTable.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import * as React from "react";
-import { Dispatch, SetStateAction } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import cx from "classnames";
 import { useRouter } from "next/router";
 
@@ -8,7 +8,7 @@ import styles from "../pages/index.module.css";
 
 // We can pull this import from @turnkey/sdk-browser, @turnkey/sdk-server, or @turnkey/http.
 // Electing to import from @turnkey/sdk-server as it's the only one we install for this example.
-import { TurnkeyApiTypes } from "@turnkey/sdk-server";
+import type { TurnkeyApiTypes } from "@turnkey/sdk-server";
 
 type TWallet = TurnkeyApiTypes["v1Wallet"];
 

--- a/examples/wallet-export-sign/src/pages/_document.tsx
+++ b/examples/wallet-export-sign/src/pages/_document.tsx
@@ -1,7 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
 class Example extends Document {
-  render() {
+  override render() {
     return (
       <Html>
         <Head>

--- a/examples/wallet-export-sign/src/pages/index.tsx
+++ b/examples/wallet-export-sign/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { WalletsTable } from "@/components/WalletsTable";
 
 // We can pull this import from @turnkey/sdk-browser, @turnkey/sdk-server, or @turnkey/http.
 // Electing to import from @turnkey/sdk-server as it's the only one we install for this example.
-import { TurnkeyApiTypes } from "@turnkey/sdk-server";
+import type { TurnkeyApiTypes } from "@turnkey/sdk-server";
 
 type TWallet = TurnkeyApiTypes["v1Wallet"];
 
@@ -19,7 +19,6 @@ export default function ExportPage() {
   const [wallets, setWallets] = useState<TWallet[]>([]);
   const [selectedWallet, setSelectedWallet] = useState<string | null>(null);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
-  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
 
   // Get current user and wallets
   useEffect(() => {

--- a/examples/wallet-export-sign/src/pages/wallet/[id].tsx
+++ b/examples/wallet-export-sign/src/pages/wallet/[id].tsx
@@ -11,7 +11,7 @@ import { ExportWalletAccount } from "@/components/ExportWalletAccount";
 
 // We can pull this import from @turnkey/sdk-browser, @turnkey/sdk-server, or @turnkey/http.
 // Electing to import from @turnkey/sdk-server as it's the only one we install for this example.
-import { TurnkeyApiTypes } from "@turnkey/sdk-server";
+import type { TurnkeyApiTypes } from "@turnkey/sdk-server";
 
 type TWalletAccount = TurnkeyApiTypes["v1WalletAccount"];
 type TWallet = TurnkeyApiTypes["v1Wallet"];

--- a/examples/wallet-export-sign/tsconfig.json
+++ b/examples/wallet-export-sign/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-agent-wallet/src/app/dashboard/setup/page.tsx
+++ b/examples/with-agent-wallet/src/app/dashboard/setup/page.tsx
@@ -13,9 +13,9 @@ interface PolicyDetail {
   policyId: string;
   policyName: string;
   effect: string;
-  condition?: string;
-  consensus?: string;
-  notes?: string;
+  condition?: string | undefined;
+  consensus?: string | undefined;
+  notes?: string | undefined;
 }
 
 interface AgentSetup {

--- a/examples/with-agent-wallet/src/app/dashboard/test/page.tsx
+++ b/examples/with-agent-wallet/src/app/dashboard/test/page.tsx
@@ -386,7 +386,7 @@ export default function TestPage() {
                       ev.payload.status !==
                         "ACTIVITY_STATUS_CONSENSUS_NEEDED" && (
                         <div className="font-mono break-all">
-                          {approvalResults[ev.payload.id].startsWith("0x") ? (
+                          {approvalResults[ev.payload.id]?.startsWith("0x") ? (
                             <span className="text-green-700">
                               tx:{" "}
                               <a
@@ -398,11 +398,11 @@ export default function TestPage() {
                                 {approvalResults[ev.payload.id]}
                               </a>
                             </span>
-                          ) : approvalResults[ev.payload.id].startsWith(
+                          ) : approvalResults[ev.payload.id]?.startsWith(
                               "error:",
                             ) ? (
                             <span className="text-red-600">
-                              {approvalResults[ev.payload.id].slice(6)}
+                              {approvalResults[ev.payload.id]?.slice(6)}
                             </span>
                           ) : (
                             <span className="text-gray-400">

--- a/examples/with-agent-wallet/src/scripts/webhook.ts
+++ b/examples/with-agent-wallet/src/scripts/webhook.ts
@@ -84,7 +84,7 @@ async function main() {
       process.exit(1);
     }
 
-    const endpoint = webhookEndpoints[0];
+    const endpoint = webhookEndpoints[0]!;
     await turnkey.apiClient().updateWebhookEndpoint({
       organizationId,
       endpointId: endpoint.endpointId,

--- a/examples/with-agent-wallet/tsconfig.json
+++ b/examples/with-agent-wallet/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-breeze/src/app/page.tsx
+++ b/examples/with-breeze/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function BreezeStakingPage() {
   const [processing, setProcessing] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [txid, setTxid] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
 
   const turnkeySigner = activeWalletAccount
     ? new TurnkeySigner({
@@ -72,7 +72,7 @@ export default function BreezeStakingPage() {
 
   useEffect(() => {
     if (!activeWalletAccount && solAccounts.length > 0) {
-      setActiveWalletAccount(solAccounts[0]);
+      setActiveWalletAccount(solAccounts[0]!);
     }
   }, [wallets]);
 

--- a/examples/with-breeze/tsconfig.json
+++ b/examples/with-breeze/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-cosigning/src/lib/activity-events.ts
+++ b/examples/with-cosigning/src/lib/activity-events.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { ActivityEventEnvelope, ActivityWebhookPayload } from "./types";
+import type { ActivityEventEnvelope, ActivityWebhookPayload } from "./types";
 
 const ACTIVITY_EVENT = "activity-update";
 const MAX_RECENT_EVENTS = 50;

--- a/examples/with-cosigning/src/scripts/webhook.ts
+++ b/examples/with-cosigning/src/scripts/webhook.ts
@@ -86,7 +86,7 @@ async function main() {
       process.exit(1);
     }
 
-    const endpoint = webhookEndpoints[0];
+    const endpoint = webhookEndpoints[0]!;
     await turnkey.apiClient().updateWebhookEndpoint({
       organizationId,
       endpointId: endpoint.endpointId,

--- a/examples/with-cosigning/tsconfig.json
+++ b/examples/with-cosigning/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,13 +9,15 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
       "@/*": ["./src/*"],
       "react": ["./node_modules/@types/react"]

--- a/examples/with-delegated/client-side/src/server/actions/validatePolicy.ts
+++ b/examples/with-delegated/client-side/src/server/actions/validatePolicy.ts
@@ -51,6 +51,5 @@ export async function validatePolicyAction(
     }
   }
 
-  const ok = results.every((r) => r.ok);
   return { results };
 }

--- a/examples/with-delegated/client-side/tsconfig.json
+++ b/examples/with-delegated/client-side/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/with-eth-passkeys-galore/src/pages/_app.tsx
+++ b/examples/with-eth-passkeys-galore/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { AppProps } from "next/app";
+import type { AppProps } from "next/app";
 import Head from "next/head";
 
 import { TurnkeyProvider } from "@turnkey/sdk-react";

--- a/examples/with-eth-passkeys-galore/src/pages/api/createSubOrg.ts
+++ b/examples/with-eth-passkeys-galore/src/pages/api/createSubOrg.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { refineNonNull } from "@/utils";
-import { TWalletDetails } from "@/types";
+import type { TWalletDetails } from "@/types";
 
 // Default path for the first Ethereum address in a new HD wallet.
 // See https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki, paths are in the form:
@@ -71,7 +71,7 @@ export default async function createUser(
     const wallet = refineNonNull(createSubOrgResponse.wallet);
 
     const walletId = wallet.walletId;
-    const walletAddress = wallet.addresses[0];
+    const walletAddress = wallet.addresses[0]!;
 
     res.status(200).json({
       id: walletId,

--- a/examples/with-eth-passkeys-galore/src/pages/index.tsx
+++ b/examples/with-eth-passkeys-galore/src/pages/index.tsx
@@ -17,7 +17,7 @@ import { createAccount } from "@turnkey/viem";
 import { useTurnkey } from "@turnkey/sdk-react";
 
 import styles from "./index.module.css";
-import { TWalletDetails } from "../types";
+import type { TWalletDetails } from "../types";
 
 type subOrgFormData = {
   subOrgName: string;
@@ -222,7 +222,7 @@ export default function Home() {
     });
 
     if (!credential?.encodedChallenge || !credential?.attestation) {
-      return false;
+      return;
     }
 
     const res = await axios.post("/api/createSubOrg", {
@@ -254,7 +254,7 @@ export default function Home() {
       }
 
       const walletsResponse = await passkeyClient?.getWallets();
-      if (!walletsResponse?.wallets[0].walletId) {
+      if (!walletsResponse?.wallets[0]?.walletId) {
         return;
       }
 
@@ -263,7 +263,7 @@ export default function Home() {
         organizationId: loginResponse?.organizationId,
         walletId,
       });
-      if (!walletAccountsResponse?.accounts[0].address) {
+      if (!walletAccountsResponse?.accounts[0]?.address) {
         return;
       }
 

--- a/examples/with-eth-passkeys-galore/tsconfig.json
+++ b/examples/with-eth-passkeys-galore/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-export-and-sign-escrow/app/layout.tsx
+++ b/examples/with-export-and-sign-escrow/app/layout.tsx
@@ -2,7 +2,7 @@
 
 import "@turnkey/react-wallet-kit/styles.css";
 import "./globals.css";
-import { StamperType, TurnkeyProvider } from "@turnkey/react-wallet-kit";
+import { TurnkeyProvider } from "@turnkey/react-wallet-kit";
 
 interface RootLayoutProps {
   children: React.ReactNode;

--- a/examples/with-export-and-sign-escrow/app/page.tsx
+++ b/examples/with-export-and-sign-escrow/app/page.tsx
@@ -5,7 +5,7 @@ import nacl from "tweetnacl";
 import { PublicKey } from "@solana/web3.js";
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { AuthState, useTurnkey, WalletSource } from "@turnkey/react-wallet-kit";
-import { v1PrivateKey } from "@turnkey/sdk-types";
+import type { v1PrivateKey } from "@turnkey/sdk-types";
 
 // Constants
 const IFRAME_CONTAINER_ID = "turnkey-export-and-sign-iframe-container-id";

--- a/examples/with-export-and-sign-escrow/tsconfig.json
+++ b/examples/with-export-and-sign-escrow/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-federated-passkeys/src/app/util.ts
+++ b/examples/with-federated-passkeys/src/app/util.ts
@@ -1,4 +1,4 @@
-import { TFormattedWallet } from "./types";
+import type { TFormattedWallet } from "./types";
 
 export function refineNonNull<T>(
   input: T | null | undefined,
@@ -17,8 +17,8 @@ export function refineNonNull<T>(
  * @param wallet
  */
 export function getNextPath(wallet: TFormattedWallet): string {
-  const lastAccount = wallet.accounts[wallet.accounts.length - 1];
-  const lastAccountNum = parseInt(lastAccount.path.split("/")[5]);
+  const lastAccount = wallet.accounts[wallet.accounts.length - 1]!;
+  const lastAccountNum = parseInt(lastAccount.path.split("/")[5]!);
   return lastAccount.path
     .split("/")
     .slice(0, 5)

--- a/examples/with-federated-passkeys/src/pages/_app.tsx
+++ b/examples/with-federated-passkeys/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { AppProps } from "next/app";
+import type { AppProps } from "next/app";
 import Head from "next/head";
 
 import { TurnkeyProvider } from "@turnkey/sdk-react";

--- a/examples/with-federated-passkeys/src/pages/api/createSubOrg.ts
+++ b/examples/with-federated-passkeys/src/pages/api/createSubOrg.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import {
   Turnkey as TurnkeyServerSDK,
-  TurnkeyApiTypes,
+  type TurnkeyApiTypes,
 } from "@turnkey/sdk-server";
-import { CreateSubOrgResponse } from "@/app/types";
+import type { CreateSubOrgResponse } from "@/app/types";
 
 type TAttestation = TurnkeyApiTypes["v1Attestation"];
 
@@ -77,7 +77,7 @@ export default async function createUser(
 
     const subOrgId = refineNonNull(completedActivity?.subOrganizationId);
     const wallet = refineNonNull(completedActivity?.wallet);
-    const walletAddress = wallet.addresses?.[0];
+    const walletAddress = wallet.addresses?.[0]!;
 
     res.status(200).json({
       subOrgId: subOrgId,

--- a/examples/with-federated-passkeys/src/pages/api/getWallet.ts
+++ b/examples/with-federated-passkeys/src/pages/api/getWallet.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import {
   Turnkey as TurnkeyServerSDK,
-  TurnkeyApiTypes,
+  type TurnkeyApiTypes,
 } from "@turnkey/sdk-server";
-import { GetWalletRequest, TFormattedWallet } from "@/app/types";
+import type { GetWalletRequest, TFormattedWallet } from "@/app/types";
 
 type TWalletAccount = TurnkeyApiTypes["v1WalletAccount"];
 
@@ -33,7 +33,7 @@ export default async function getWallet(
     });
     const accountsResponse = await turnkeyClient.apiClient().getWalletAccounts({
       organizationId: organizationId,
-      walletId: walletsResponse.wallets[0].walletId,
+      walletId: walletsResponse.wallets[0]!.walletId,
     });
 
     const accounts = accountsResponse.accounts.map((acc: TWalletAccount) => {
@@ -44,8 +44,8 @@ export default async function getWallet(
     });
 
     res.status(200).json({
-      id: walletsResponse.wallets[0].walletId,
-      name: walletsResponse.wallets[0].walletName,
+      id: walletsResponse.wallets[0]!.walletId,
+      name: walletsResponse.wallets[0]!.walletName,
       accounts: accounts,
     });
   } catch (e) {

--- a/examples/with-federated-passkeys/src/pages/api/proxyRequest.ts
+++ b/examples/with-federated-passkeys/src/pages/api/proxyRequest.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { TSignedRequest } from "@turnkey/http";
+import type { TSignedRequest } from "@turnkey/http";
 import axios from "axios";
 
 type TResponse = {

--- a/examples/with-federated-passkeys/src/pages/index.tsx
+++ b/examples/with-federated-passkeys/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import axios from "axios";
 import * as React from "react";
 import { useTurnkey } from "@turnkey/sdk-react";
-import { CreateSubOrgResponse, TFormattedWallet } from "@/app/types";
+import type { CreateSubOrgResponse, TFormattedWallet } from "@/app/types";
 import { getNextPath } from "@/app/util";
 
 type subOrgFormData = {
@@ -17,7 +17,7 @@ type walletAccountFormData = {
 };
 
 export default function Home() {
-  const { turnkey, passkeyClient } = useTurnkey();
+  const { passkeyClient } = useTurnkey();
 
   const [subOrgId, setSubOrgId] = React.useState<string | null>(null);
   const [wallet, setWallet] = React.useState<TFormattedWallet | null>(null);

--- a/examples/with-federated-passkeys/tsconfig.json
+++ b/examples/with-federated-passkeys/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-indexed-db/src/app/page.tsx
+++ b/examples/with-indexed-db/src/app/page.tsx
@@ -75,7 +75,7 @@ export default function AuthPage() {
         publicKey: { user: { name: siteInfo, displayName: siteInfo } },
       })) || {};
 
-    const resp = await server.createSuborg({
+    await server.createSuborg({
       passkey: {
         authenticatorName: "First Passkey",
         challenge: encodedChallenge,

--- a/examples/with-indexed-db/tsconfig.json
+++ b/examples/with-indexed-db/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-jupiter/src/app/page.tsx
+++ b/examples/with-jupiter/src/app/page.tsx
@@ -101,7 +101,7 @@ export default function JupiterSwapPage() {
 
   useEffect(() => {
     if (!activeWalletAccount && solAccounts.length > 0) {
-      setActiveWalletAccount(solAccounts[0]);
+      setActiveWalletAccount(solAccounts[0]!);
     }
   }, [wallets]);
 

--- a/examples/with-jupiter/tsconfig.json
+++ b/examples/with-jupiter/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-proxy-signed-requests/src/app/dashboard/page.tsx
+++ b/examples/with-proxy-signed-requests/src/app/dashboard/page.tsx
@@ -38,7 +38,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!selectedAccount && embeddedAccounts.length > 0) {
-      setSelectedAccount(embeddedAccounts[0].account);
+      setSelectedAccount(embeddedAccounts[0]!.account);
     }
   }, [embeddedAccounts, selectedAccount]);
 

--- a/examples/with-proxy-signed-requests/tsconfig.json
+++ b/examples/with-proxy-signed-requests/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-sdk-js/e2e/export-import-wallet.spec.ts
+++ b/examples/with-sdk-js/e2e/export-import-wallet.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from "@playwright/test";
-import { walletKitSelectors, withSdkJsSelectors } from "./helpers/selectors";
+import { test } from "@playwright/test";
 import { authenticateWithPasskey } from "./shared/auth";
 
 test.beforeEach(async ({ page }) => {

--- a/examples/with-sdk-js/e2e/remove-auth-method.spec.ts
+++ b/examples/with-sdk-js/e2e/remove-auth-method.spec.ts
@@ -13,7 +13,7 @@ async function waitForAnyError(page: Page, re: RegExp): Promise<string> {
   ]);
 }
 
-test("disallow removing last auth method", async ({ page, baseURL }) => {
+test("disallow removing last auth method", async ({ page }) => {
   await authenticateWithPasskey(page);
 
   await page.getByTestId(withSdkJsSelectors.modals.removePasskeyModal).click();

--- a/examples/with-sdk-js/e2e/session-management-methods.spec.ts
+++ b/examples/with-sdk-js/e2e/session-management-methods.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { withSdkJsSelectors } from "./helpers/selectors";
 import { authenticateWithPasskey } from "./shared/auth";
 import { waitForConsole } from "./helpers/console-listener";

--- a/examples/with-sdk-js/src/app/layout.tsx
+++ b/examples/with-sdk-js/src/app/layout.tsx
@@ -2,7 +2,7 @@
 
 import "@turnkey/react-wallet-kit/styles.css";
 import "./global.css";
-import { StamperType, TurnkeyProvider } from "@turnkey/react-wallet-kit";
+import { TurnkeyProvider } from "@turnkey/react-wallet-kit";
 
 interface RootLayoutProps {
   children: React.ReactNode;
@@ -27,19 +27,19 @@ function RootLayout({ children }: RootLayoutProps) {
             auth: {
               oauthConfig: {
                 google: {
-                  primaryClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+                  primaryClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
                 },
                 apple: {
-                  primaryClientId: process.env.NEXT_PUBLIC_APPLE_CLIENT_ID,
+                  primaryClientId: process.env.NEXT_PUBLIC_APPLE_CLIENT_ID!,
                 },
                 facebook: {
-                  primaryClientId: process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID,
+                  primaryClientId: process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID!,
                 },
-                x: { primaryClientId: process.env.NEXT_PUBLIC_X_CLIENT_ID },
+                x: { primaryClientId: process.env.NEXT_PUBLIC_X_CLIENT_ID! },
                 discord: {
-                  primaryClientId: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
+                  primaryClientId: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID!,
                 },
-                oauthRedirectUri: process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI,
+                oauthRedirectUri: process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI!,
               },
               autoRefreshSession: true,
             },

--- a/examples/with-sdk-js/src/app/page.tsx
+++ b/examples/with-sdk-js/src/app/page.tsx
@@ -3,11 +3,10 @@ import Image from "next/image";
 
 import { useEffect, useState } from "react";
 import {
-  externaldatav1Address,
   OAuthProviders,
-  v1AddressFormat,
-  v1CreatePolicyIntentV3,
-  v1PrivateKey,
+  type v1AddressFormat,
+  type v1CreatePolicyIntentV3,
+  type v1PrivateKey,
 } from "@turnkey/sdk-types";
 import {
   AuthState,
@@ -219,7 +218,7 @@ export default function AuthPage() {
   };
   const handleOnRamp = async () => {
     try {
-      if (!wallets.length || !wallets[0].accounts?.length) {
+      if (!wallets.length || !wallets[0]?.accounts?.length) {
         console.error("No wallets available for onramp");
         return;
       }
@@ -248,7 +247,7 @@ export default function AuthPage() {
     const turnkeyAccount = await createAccount({
       client: httpClient!,
       organizationId: session?.organizationId!,
-      signWith: wallets[0].accounts[0].address,
+      signWith: wallets[0]!.accounts[0]!.address!,
     });
 
     const viemClient = createWalletClient({
@@ -311,8 +310,8 @@ export default function AuthPage() {
   const showSigningModal = async () => {
     if (
       (wallets.length === 0 && !wallets[0]) ||
-      !wallets[0].accounts ||
-      wallets[0].accounts.length < 1
+      !wallets[0]!.accounts ||
+      wallets[0]!.accounts.length < 1
     ) {
       console.error("No wallets available to sign message");
       return;
@@ -321,7 +320,7 @@ export default function AuthPage() {
     const result = await turnkey.handleSignMessage({
       message:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. . Sed id maximus elit. Mauris lacus ligula, dictum nec purus sit amet, mollis tempor nisl. Morbi neque lectus, tempor sed tristique sit amet, ornare eget dui",
-      walletAccount: wallets[0].accounts[0],
+      walletAccount: wallets[0]!.accounts[0]!,
     });
     console.log("Signing result:", result);
   };
@@ -405,7 +404,7 @@ export default function AuthPage() {
               Object.keys(allSessions).map((key: string) => (
                 <div
                   data-testid={`session-${key}`}
-                  key={allSessions[key].publicKey}
+                  key={allSessions[key]!.publicKey}
                   className="p-2 text-xs border bg-neutral-100 rounded"
                 >
                   <p className="truncate">
@@ -413,16 +412,18 @@ export default function AuthPage() {
                     <span data-testid={`session-key-${key}`}>{key}</span>
                   </p>
                   <p className="max-w-lg break-words line-clamp-3">
-                    Token: {allSessions[key].token}
+                    Token: {allSessions[key]!.token}
                   </p>
-                  <p className="truncate">Expiry: {allSessions[key].expiry}</p>
+                  <p className="truncate">Expiry: {allSessions[key]!.expiry}</p>
                   <p className="truncate">
-                    Session Public Key: {allSessions[key].publicKey}
+                    Session Public Key: {allSessions[key]!.publicKey}
                   </p>
                   <p className="truncate">
-                    Organization ID: {allSessions[key].organizationId}
+                    Organization ID: {allSessions[key]!.organizationId}
                   </p>
-                  <p className="truncate">User ID: {allSessions[key].userId}</p>
+                  <p className="truncate">
+                    User ID: {allSessions[key]!.userId}
+                  </p>
                 </div>
               ))}
           </div>
@@ -504,7 +505,7 @@ export default function AuthPage() {
           <div className="flex flex-wrap gap-2">
             {wallets && wallets.length > 0
               ? wallets.map((wallet: Wallet) => {
-                  let count = 0;
+                  const count = 0;
                   if (wallet.source === WalletSource.Embedded)
                     return (
                       <div
@@ -637,7 +638,8 @@ export default function AuthPage() {
                         </button>
                       </div>
                     );
-                  count++;
+
+                  return null;
                 })
               : null}
           </div>
@@ -697,7 +699,7 @@ export default function AuthPage() {
           <div className="flex flex-wrap gap-2">
             {privateKeys && privateKeys.length > 0
               ? privateKeys.map((privateKey: v1PrivateKey) => {
-                  let count = 0;
+                  const count = 0;
                   return (
                     <div
                       key={privateKey.privateKeyId}
@@ -741,7 +743,6 @@ export default function AuthPage() {
                       </button>
                     </div>
                   );
-                  count++;
                 })
               : null}
           </div>
@@ -808,7 +809,7 @@ export default function AuthPage() {
                   }
 
                   await turnkey.handleExportPrivateKey({
-                    privateKeyId: res.privateKeys[0].privateKeyId,
+                    privateKeyId: res.privateKeys[0]!.privateKeyId,
                     keyFormat: KeyFormat.BitcoinTestNetWIF,
                   });
                 }}
@@ -1136,7 +1137,8 @@ export default function AuthPage() {
                   }
                   console.log(
                     await turnkey.handleRemovePasskey({
-                      authenticatorId: user?.authenticators[0]?.authenticatorId,
+                      authenticatorId:
+                        user?.authenticators[0]?.authenticatorId ?? "",
                       successPageDuration: 5000,
                     }),
                   );
@@ -1530,7 +1532,7 @@ export default function AuthPage() {
                 console.log(
                   "Successfully signed message",
                   await turnkey.httpClient?.signRawPayload({
-                    signWith: res.privateKeys[0].privateKeyId,
+                    signWith: res.privateKeys[0]!.privateKeyId,
                     payload: "Hello, Turnkey!",
                     encoding: "PAYLOAD_ENCODING_TEXT_UTF8",
                     hashFunction: "HASH_FUNCTION_NOT_APPLICABLE",
@@ -1874,6 +1876,8 @@ export default function AuthPage() {
                         </button>
                       </div>
                     );
+
+                  return null;
                 })
               : null}
           </div>
@@ -1900,7 +1904,7 @@ export default function AuthPage() {
             onClick={async () => {
               const providers = await turnkey.fetchWalletProviders();
               console.log("Wallet Providers:", providers);
-              await turnkey.connectWalletAccount(providers[4]);
+              await turnkey.connectWalletAccount(providers[4]!);
             }}
             style={{
               backgroundColor: "rebeccapurple",
@@ -1916,7 +1920,7 @@ export default function AuthPage() {
             onClick={async () => {
               const walletProviders = await turnkey.fetchWalletProviders();
               const request = await turnkey.buildWalletLoginRequest({
-                walletProvider: walletProviders[0],
+                walletProvider: walletProviders[0]!,
                 expirationSeconds: "123",
               });
 
@@ -1938,7 +1942,7 @@ export default function AuthPage() {
               const provider = await turnkey.fetchWalletProviders(Chain.Solana);
               console.log("Injected Solana Provider:", provider);
               await turnkey.signUpWithWallet({
-                walletProvider: provider[1],
+                walletProvider: provider[1]!,
               });
             }}
             style={{
@@ -1957,7 +1961,7 @@ export default function AuthPage() {
               const provider = await turnkey.fetchWalletProviders(Chain.Solana);
               console.log("Injected Solana Provider:", provider);
               await turnkey.loginWithWallet({
-                walletProvider: provider[0],
+                walletProvider: provider[0]!,
               });
             }}
             style={{
@@ -1976,7 +1980,7 @@ export default function AuthPage() {
               const provider = await turnkey.fetchWalletProviders(Chain.Solana);
               console.log("Injected Solana Provider:", provider);
               await turnkey.loginOrSignupWithWallet({
-                walletProvider: provider[0],
+                walletProvider: provider[0]!,
               });
             }}
             style={{
@@ -2573,7 +2577,7 @@ export default function AuthPage() {
               );
               setOrganizationId(session?.organizationId || "");
               setUserId(session?.userId || "");
-              setActiveWalletAccount(wallets[0].accounts[0]);
+              setActiveWalletAccount(wallets[0]?.accounts[0] || null);
             }}
             style={{
               backgroundColor: "salmon",

--- a/examples/with-sdk-js/tsconfig.json
+++ b/examples/with-sdk-js/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-sdk-server/tsconfig.json
+++ b/examples/with-sdk-server/tsconfig.json
@@ -1,10 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "esModuleInterop": true,
     "lib": ["es2020"],
     "module": "es2022",
     "preserveConstEnums": true,
-    "moduleResolution": "node",
     "strict": true,
     "sourceMap": true,
     "target": "es2022",

--- a/examples/with-solana-passkeys/src/pages/_app.tsx
+++ b/examples/with-solana-passkeys/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { AppProps } from "next/app";
+import type { AppProps } from "next/app";
 import Head from "next/head";
 
 import { TurnkeyProvider } from "@turnkey/sdk-react";

--- a/examples/with-solana-passkeys/src/pages/api/createSubOrg.ts
+++ b/examples/with-solana-passkeys/src/pages/api/createSubOrg.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { refineNonNull } from "@/utils";
-import { TWalletDetails } from "@/types";
+import type { TWalletDetails } from "@/types";
 
 // Default path for the first Solana address in a new HD wallet.
 // See https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki, paths are in the form:
@@ -71,7 +71,7 @@ export default async function createUser(
     const wallet = refineNonNull(createSubOrgResponse.wallet);
 
     const walletId = wallet.walletId;
-    const walletAddress = wallet.addresses[0];
+    const walletAddress = wallet.addresses[0]!;
 
     res.status(200).json({
       id: walletId,

--- a/examples/with-solana-passkeys/src/pages/index.tsx
+++ b/examples/with-solana-passkeys/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Transaction, VersionedTransaction } from "@solana/web3.js";
+import { VersionedTransaction } from "@solana/web3.js";
 import Image from "next/image";
 import { useForm } from "react-hook-form";
 import axios from "axios";
@@ -6,7 +6,7 @@ import { bs58 } from "@turnkey/encoding";
 import { useState, useEffect } from "react";
 
 import styles from "./index.module.css";
-import { TWalletDetails } from "../types";
+import type { TWalletDetails } from "../types";
 
 import { useTurnkey } from "@turnkey/sdk-react";
 import { TurnkeySigner } from "@turnkey/solana";
@@ -160,7 +160,7 @@ export default function Home() {
     });
 
     if (!credential?.encodedChallenge || !credential?.attestation) {
-      return false;
+      return;
     }
 
     const res = await axios.post("/api/createSubOrg", {
@@ -191,7 +191,7 @@ export default function Home() {
       }
 
       const walletsResponse = await passkeyClient?.getWallets();
-      if (!walletsResponse?.wallets[0].walletId) {
+      if (!walletsResponse?.wallets[0]?.walletId) {
         return;
       }
 
@@ -200,7 +200,7 @@ export default function Home() {
         organizationId: loginResponse?.organizationId,
         walletId,
       });
-      if (!walletAccountsResponse?.accounts[0].address) {
+      if (!walletAccountsResponse?.accounts[0]?.address) {
         return;
       }
 

--- a/examples/with-solana-passkeys/tsconfig.json
+++ b/examples/with-solana-passkeys/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -8,8 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/with-tx-webhooks/src/app/api/balance-events/route.ts
+++ b/examples/with-tx-webhooks/src/app/api/balance-events/route.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BalanceWebhookEventEnvelope,
   BalanceWebhookSseMessage,
 } from "@/lib/types";

--- a/examples/with-tx-webhooks/src/app/api/tx-events/route.ts
+++ b/examples/with-tx-webhooks/src/app/api/tx-events/route.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   TxStatusWebhookEventEnvelope,
   TxStatusWebhookSseMessage,
 } from "@/lib/types";

--- a/examples/with-tx-webhooks/src/app/page.tsx
+++ b/examples/with-tx-webhooks/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
-import { BalanceWebhookEventEnvelope } from "@/lib/types";
+import type { BalanceWebhookEventEnvelope } from "@/lib/types";
 import { BalanceFeed } from "@/components/BalanceFeed";
 import { TxStatusFeed } from "@/components/TxStatusFeed";
 

--- a/examples/with-tx-webhooks/src/app/webhook/balance-updates/route.ts
+++ b/examples/with-tx-webhooks/src/app/webhook/balance-updates/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { BalanceConfirmedWebhookPayload } from "@/lib/types";
+import type { BalanceConfirmedWebhookPayload } from "@/lib/types";
 import { getBalanceWebhookEventStore } from "@/lib/webhook-events";
 
 export const runtime = "nodejs";

--- a/examples/with-tx-webhooks/src/app/webhook/tx-updates/route.ts
+++ b/examples/with-tx-webhooks/src/app/webhook/tx-updates/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { TxStatusWebhookPayload } from "@/lib/types";
+import type { TxStatusWebhookPayload } from "@/lib/types";
 import { getTxStatusWebhookEventStore } from "@/lib/webhook-events";
 
 export const runtime = "nodejs";

--- a/examples/with-tx-webhooks/src/components/BalanceFeed.tsx
+++ b/examples/with-tx-webhooks/src/components/BalanceFeed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
+import type {
   BalanceWebhookEventEnvelope,
   BalanceWebhookSseMessage,
 } from "@/lib/types";

--- a/examples/with-tx-webhooks/src/components/TxStatusFeed.tsx
+++ b/examples/with-tx-webhooks/src/components/TxStatusFeed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
+import type {
   TxStatusWebhookEventEnvelope,
   TxStatusWebhookSseMessage,
 } from "@/lib/types";

--- a/examples/with-tx-webhooks/src/lib/turnkey.ts
+++ b/examples/with-tx-webhooks/src/lib/turnkey.ts
@@ -208,7 +208,7 @@ async function estimateGasLimit(params: {
   from: string;
   to: string;
   value: string;
-  data?: string;
+  data?: string | undefined;
   fallback: string;
 }) {
   try {
@@ -241,7 +241,7 @@ export async function sendEthTransactionUnsponsored(params: {
   amountBaseUnits: string;
   caip2: string;
   assetType: SendAssetType;
-  tokenContractAddress?: string;
+  tokenContractAddress?: string | undefined;
 }) {
   if (!isSupportedEvmCaip2(params.caip2)) {
     throw new Error(
@@ -330,7 +330,7 @@ async function buildUnsignedSolanaTransactionHex(params: {
   amountBaseUnits: string;
   caip2: SupportedSvmCaip2;
   assetType: "NATIVE" | "SPL";
-  tokenMintAddress?: string;
+  tokenMintAddress?: string | undefined;
 }) {
   const connection = new Connection(getSolanaRpcUrl(params.caip2), "confirmed");
   const fromPubkey = new PublicKey(params.from);
@@ -410,7 +410,7 @@ export async function sendSolanaTransactionUnsponsored(params: {
   amountBaseUnits: string;
   caip2: string;
   assetType: "NATIVE" | "SPL";
-  tokenMintAddress?: string;
+  tokenMintAddress?: string | undefined;
 }) {
   const normalizedCaip2 = normalizeSvmCaip2(params.caip2);
   if (!normalizedCaip2) {
@@ -469,8 +469,8 @@ export async function sendAssetTransactionUnsponsored(params: {
   amountBaseUnits: string;
   caip2: string;
   assetType: SendAssetType;
-  tokenContractAddress?: string;
-  tokenMintAddress?: string;
+  tokenContractAddress?: string | undefined;
+  tokenMintAddress?: string | undefined;
 }) {
   if (params.caip2.startsWith("eip155:")) {
     if (params.assetType === "SPL") {

--- a/examples/with-tx-webhooks/src/lib/webhook-events.ts
+++ b/examples/with-tx-webhooks/src/lib/webhook-events.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import {
+import type {
   BalanceWebhookPayload,
   BalanceWebhookEventEnvelope,
   TxStatusWebhookPayload,

--- a/examples/with-tx-webhooks/tsconfig.json
+++ b/examples/with-tx-webhooks/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/examples/with-x/credential-upload.tsx
+++ b/examples/with-x/credential-upload.tsx
@@ -28,7 +28,7 @@ dotenv.config({ path: "./.env.local" });
   }
 
   // obtain the client secret from the arguments
-  const client_secret = args[0];
+  const client_secret = args[0]!;
 
   // encrypt the client secret to TLS Fetchers public key
   const encryptedClientSecret = await encryptOauth2ClientSecret(client_secret);

--- a/examples/with-x/src/app/auth/turnkey/x/route.ts
+++ b/examples/with-x/src/app/auth/turnkey/x/route.ts
@@ -100,7 +100,7 @@ export async function POST(req: Request) {
       filterValue: oauth2AuthenticateResponse.oidcToken,
     });
 
-    let subOrgId;
+    let subOrgId: string;
 
     if (getSubOrgIdsResponse.organizationIds.length == 0) {
       // if no user was found with that OIDC Token create a new sub-organization
@@ -130,8 +130,8 @@ export async function POST(req: Request) {
         });
 
       subOrgId =
-        createSubOrgResponse.activity.result.createSubOrganizationResultV8
-          ?.subOrganizationId;
+        createSubOrgResponse.activity.result.createSubOrganizationResultV8!
+          .subOrganizationId;
     } else if (getSubOrgIdsResponse.organizationIds.length > 1) {
       // multiple sub orgs with the same OIDC token, shouldn't be possible
       return NextResponse.json(
@@ -139,7 +139,7 @@ export async function POST(req: Request) {
         { status: 400 },
       );
     } else {
-      subOrgId = getSubOrgIdsResponse.organizationIds[0];
+      subOrgId = getSubOrgIdsResponse.organizationIds[0]!;
     }
 
     // a user was found with that OIDC token, try logging them in
@@ -164,20 +164,20 @@ export async function POST(req: Request) {
   }
 }
 
-// Gets the encrypted bearer token from the b64-encoded OIDC ID Token
-function getEncryptedBearerTokenFromOidcToken(
-  token: string,
-): string | undefined {
-  const payloadSeg = token.split(".")[1];
-  if (!payloadSeg) throw new Error("Invalid JWT");
+// // Gets the encrypted bearer token from the b64-encoded OIDC ID Token
+// function getEncryptedBearerTokenFromOidcToken(
+//   token: string,
+// ): string | undefined {
+//   const payloadSeg = token.split(".")[1];
+//   if (!payloadSeg) throw new Error("Invalid JWT");
 
-  // base64url -> base64 (and pad)
-  const b64 = payloadSeg.replace(/-/g, "+").replace(/_/g, "/");
-  const padded = b64 + "===".slice((b64.length + 3) % 4);
+//   // base64url -> base64 (and pad)
+//   const b64 = payloadSeg.replace(/-/g, "+").replace(/_/g, "/");
+//   const padded = b64 + "===".slice((b64.length + 3) % 4);
 
-  const json = Buffer.from(padded, "base64").toString("utf8");
-  const claims = JSON.parse(json) as Record<string, unknown>;
+//   const json = Buffer.from(padded, "base64").toString("utf8");
+//   const claims = JSON.parse(json) as Record<string, unknown>;
 
-  // Your example token actually has "encrypted_bearer_token".
-  return claims["encrypted_bearer_token"] as string | undefined;
-}
+//   // Your example token actually has "encrypted_bearer_token".
+//   return claims["encrypted_bearer_token"] as string | undefined;
+// }

--- a/examples/with-x/tsconfig.json
+++ b/examples/with-x/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Summary & Motivation

Lots of the examples were not using `tsconfig.base.json`. When plugged in, there was a bunch of type errors that needed fixing (mostly adding `!` since I assume the code is working and it just needed a bit of a forceful persuasion to compile; adding `type` to type-only imports, removing unused variables etc).

Of course we would ideally not have any `!` in the code but the scope of this problem is massive, this is just a starting point.

## How I Tested These Changes

Locally + CI

## Did you add a changeset?

Dev changes only