### PR TITLE
Fix release workflow test environment

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Test (preprod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
         env:
+          NODE_ENV: development
           API_PUBLIC_KEY: ${{ secrets.PREPROD_API_PUBLIC_KEY }}
           API_PRIVATE_KEY: ${{ secrets.PREPROD_API_PRIVATE_KEY }}
           BASE_URL: ${{ secrets.PREPROD_BASE_URL }}
@@ -181,6 +182,7 @@ jobs:
       - name: Test (prod)
         run: anvil & pnpm run test-all && lsof -t -i tcp:8545 | xargs kill
         env:
+          NODE_ENV: development
           API_PUBLIC_KEY: ${{ secrets.API_PUBLIC_KEY }}
           API_PRIVATE_KEY: ${{ secrets.API_PRIVATE_KEY }}
           BASE_URL: "https://api.turnkey.com"


### PR DESCRIPTION
## Summary

Fixes the release workflow test jobs after `NODE_ENV: production` was added at the workflow level.

The `test-prod` and `test-pre-prod` jobs run the SDK test suite against prod/preprod Turnkey APIs, but the tests also start a local Anvil RPC at `http://127.0.0.1:8545`. The EIP-1193 provider intentionally rejects HTTP RPC URLs when `NODE_ENV=production`, so the release workflow currently fails before publish.

This matches the existing `js-build.yml` behavior by overriding only the test steps to `NODE_ENV: development`, while leaving build/publish workflow behavior unchanged.

## Testing

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/version-and-publish.yml`
- `node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/version-and-publish.yml','utf8')); console.log('workflow yaml parses')"`
