### PR TITLE
Validate provider for non-PKCE OAuth responses

### DIFF
--- a/packages/react-native-wallet-kit/src/tests/oauth-test.ts
+++ b/packages/react-native-wallet-kit/src/tests/oauth-test.ts
@@ -249,6 +249,15 @@ describe("OAuth utils", () => {
       });
     });
 
+    it("rejects non-PKCE popup hashes when provider state does not match", () => {
+      const state = encodeURIComponent(
+        "provider=apple&flow=popup&publicKey=pk1&sessionKey=sess1",
+      );
+      const url = `https://example.com/callback#id_token=tok123&state=${state}`;
+
+      expect(parseOAuthResponse(url, OAuthProviders.GOOGLE)).toBeNull();
+    });
+
     it("parses PKCE popup search params (Discord) with provider validation", () => {
       const state = encodeURIComponent(
         "provider=discord&flow=popup&publicKey=pk2&sessionKey=sess2",

--- a/packages/react-native-wallet-kit/src/utils/oauth.ts
+++ b/packages/react-native-wallet-kit/src/utils/oauth.ts
@@ -247,8 +247,8 @@ export function parseOAuthResponse(
         return null;
       }
     } else {
-      // Non-PKCE providers must have idToken
-      if (!idToken) {
+      // Non-PKCE providers must have idToken and matching provider in state
+      if (!idToken || provider !== expectedProvider) {
         return null;
       }
     }


### PR DESCRIPTION
## Summary

Validates the OAuth `provider` state for non-PKCE popup responses, matching the existing validation already applied to PKCE providers.

## Why

`parseOAuthResponse(url, expectedProvider)` currently rejects PKCE popup responses when the provider in state does not match `expectedProvider`, but non-PKCE providers only require an `id_token`.

That means a popup handler expecting Google can accept a hash whose state says another provider, as long as an `id_token` is present. This can route a mismatched OAuth response through the wrong popup handler.

This change makes non-PKCE validation require both:

- `id_token` is present
- `provider === expectedProvider`

and adds a regression test for the mismatch case.
