### PR TITLE
Chore: Isolate end-to-end workflow

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -12,9 +12,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
 
-env:
-  NODE_ENV: production
-
 jobs:
   build:
     name: Build
@@ -33,55 +30,6 @@ jobs:
     secrets: inherit
 
   test-end-to-end:
-    runs-on: ubuntu-latest
+    name: Test (end-to-end)
     needs: build
-    timeout-minutes: 60
-
-    env:
-      NEXT_PUBLIC_BASE_URL: https://api.preprod.turnkey.engineering
-      NEXT_PUBLIC_AUTH_PROXY_URL: https://authproxy.preprod.turnkey.engineering
-      NEXT_PUBLIC_ORGANIZATION_ID: 7f947121-11a0-4906-bf7c-76712396a20d
-      NEXT_PUBLIC_AUTH_PROXY_ID: 8ffb4198-a41e-4d14-b7b8-ada33f410d7a
-      NEXT_PUBLIC_AUTH_IFRAME_URL: https://auth.preprod.turnkey.engineering
-      NEXT_PUBLIC_EXPORT_IFRAME_URL: https://export.preprod.turnkey.engineering
-      NEXT_PUBLIC_IMPORT_IFRAME_URL: https://import.preprod.turnkey.engineering
-      NEXT_PUBLIC_OAUTH_REDIRECT_URI: http://127.0.0.1:3000/
-      NEXT_PUBLIC_GOOGLE_CLIENT_ID: <Google OIDC client ID>
-      NEXT_PUBLIC_APPLE_CLIENT_ID: <Apple OIDC client ID>
-      NEXT_PUBLIC_FACEBOOK_CLIENT_ID: <Facebook OIDC client ID>
-      NEXT_PUBLIC_DISCORD_CLIENT_ID: <Discord OIDC client ID>
-      NEXT_PUBLIC_X_CLIENT_ID: <X OIDC client ID>
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      # Install and cache JS toolchain and dependencies (node_modules)
-      - name: Setup JS
-        uses: ./.github/actions/js-setup
-
-      # Install playwright browsers
-      - name: Setup Playwright
-        id: playwright-setup
-        uses: ./.github/actions/playwright-setup
-
-      # We only want to build the examples/with-sdk-js and its dependencies
-      - name: Build
-        run: pnpm build --filter=./examples/with-sdk-js...
-
-      - name: Run Playwright tests
-        run: pnpm exec playwright test --reporter=line,html
-        working-directory: examples/with-sdk-js
-        env:
-          CI: "true"
-          NODE_ENV: development
-          PLAYWRIGHT_BROWSERS_PATH: ${{ steps.playwright-setup.outputs.cache }}
-
-      - name: Upload Playwright report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: playwright-report
-          path: examples/with-sdk-js/playwright-report
-          retention-days: 30
+    uses: ./.github/workflows/reusable-test-end-to-end.yml

--- a/.github/workflows/reusable-test-end-to-end.yml
+++ b/.github/workflows/reusable-test-end-to-end.yml
@@ -1,0 +1,60 @@
+name: Test (E2E)
+
+on:
+  workflow_call:
+
+env:
+  NODE_ENV: production
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      NEXT_PUBLIC_BASE_URL: https://api.preprod.turnkey.engineering
+      NEXT_PUBLIC_AUTH_PROXY_URL: https://authproxy.preprod.turnkey.engineering
+      NEXT_PUBLIC_ORGANIZATION_ID: 7f947121-11a0-4906-bf7c-76712396a20d
+      NEXT_PUBLIC_AUTH_PROXY_ID: 8ffb4198-a41e-4d14-b7b8-ada33f410d7a
+      NEXT_PUBLIC_AUTH_IFRAME_URL: https://auth.preprod.turnkey.engineering
+      NEXT_PUBLIC_EXPORT_IFRAME_URL: https://export.preprod.turnkey.engineering
+      NEXT_PUBLIC_IMPORT_IFRAME_URL: https://import.preprod.turnkey.engineering
+      NEXT_PUBLIC_OAUTH_REDIRECT_URI: http://127.0.0.1:3000/
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: <Google OIDC client ID>
+      NEXT_PUBLIC_APPLE_CLIENT_ID: <Apple OIDC client ID>
+      NEXT_PUBLIC_FACEBOOK_CLIENT_ID: <Facebook OIDC client ID>
+      NEXT_PUBLIC_DISCORD_CLIENT_ID: <Discord OIDC client ID>
+      NEXT_PUBLIC_X_CLIENT_ID: <X OIDC client ID>
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Install and cache JS toolchain and dependencies (node_modules)
+      - name: Setup JS
+        uses: ./.github/actions/js-setup
+
+      # Install playwright browsers
+      - name: Setup Playwright
+        id: playwright-setup
+        uses: ./.github/actions/playwright-setup
+
+      # We only want to build the examples/with-sdk-js and its dependencies
+      - name: Build
+        run: pnpm build --filter=./examples/with-sdk-js...
+
+      - name: Run Playwright tests
+        run: pnpm exec playwright test --reporter=line,html
+        working-directory: examples/with-sdk-js
+        env:
+          CI: "true"
+          NODE_ENV: development
+          PLAYWRIGHT_BROWSERS_PATH: ${{ steps.playwright-setup.outputs.cache }}
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: examples/with-sdk-js/playwright-report
+          retention-days: 30


### PR DESCRIPTION
## Summary & Motivation

Just to keep things symmetrical as far as the reusable workflows go. Might also be worth adding `test-end-to-end` to the publish workflow

## How I Tested These Changes

CI

## Did you add a changeset?

Dev changes only