### PR TITLE
Chore: bump upload artifact action

### DIFF
--- a/.github/workflows/reusable-test-end-to-end.yml
+++ b/.github/workflows/reusable-test-end-to-end.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: examples/with-sdk-js/playwright-report


### PR DESCRIPTION
## Summary & Motivation

Addresses the last deprecation warning about using node 20 actions seen in an [annotation here](https://github.com/tkhq/sdk/actions/runs/26905563773/job/79369676536)

## How I Tested These Changes

CI

## Did you add a changeset?

I WOULD NEVER