### PR TITLE
Spark support: Support withdrawals

### DIFF
--- a/.changeset/true-carrots-sort.md
+++ b/.changeset/true-carrots-sort.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/spark": minor
+---
+
+Add support for withdrawals

--- a/packages/spark/src/__tests__/wallet.test.ts
+++ b/packages/spark/src/__tests__/wallet.test.ts
@@ -4,7 +4,10 @@ import {
   v1WalletAccount,
 } from "@turnkey/sdk-server";
 import { SparkReadonlyClient, SparkWalletEvent } from "@buildonspark/spark-sdk";
-import type { WalletTransfer } from "@buildonspark/spark-sdk/dist/types";
+import type {
+  ExitSpeed,
+  WalletTransfer,
+} from "@buildonspark/spark-sdk/dist/types";
 import assert from "node:assert";
 import { Curve } from "@turnkey/core";
 import { SPARK_DEPOSIT_SUFFIX, SPARK_IDENTITY_SUFFIX } from "../constants";
@@ -141,25 +144,8 @@ describe("TurnkeySparkWallet", () => {
     // Since these tests can run in parallel, we want to wrap this in try/catch
     // to avoid race conditions between tests tearing down the suite
     try {
-      let transfer: WalletTransfer | undefined;
-      const receiverSparkAddress = await senderWallet.getSparkAddress();
-      const {
-        satsBalance: { available },
-      } = await receiverWallet.getBalance();
-
-      // We need to setup the event listeners before creating the transfer, otherwise we might miss the events
-      const claimed = waitForTransferToBeClaimed(
-        senderWallet,
-        (id) => id === transfer?.id,
-      );
-
-      transfer = await receiverWallet.transfer({
-        amountSats: Number(available),
-        receiverSparkAddress,
-      });
-
-      await claimed;
-    } catch (error: unknown) {
+      recoverAllFunds(receiverWallet, senderWallet);
+    } catch (error) {
       await warn(`Failed to recover funds from receiver wallet:\n\n${error}`);
     }
 
@@ -170,7 +156,7 @@ describe("TurnkeySparkWallet", () => {
   it(
     "should be able to transfer",
     async () => {
-      let transfer: WalletTransfer | undefined;
+      let transfer: WalletTransfer | undefined = undefined;
       const receiverSparkAddress = await receiverWallet.getSparkAddress();
 
       // We need to setup the event listeners before creating the transfer, otherwise we might miss the events
@@ -187,6 +173,42 @@ describe("TurnkeySparkWallet", () => {
       expect(transfer).toBeDefined();
 
       return claimed;
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "should be able to withdraw a specific amount",
+    async () => {
+      const amountSats = 1000;
+      const withdrawalAddress = receiverAccounts.btcAccount.address;
+
+      const feeQuote = await senderWallet.getWithdrawalFeeQuote({
+        amountSats,
+        withdrawalAddress,
+      });
+
+      expect(feeQuote).not.toBeNull();
+
+      const feeAmountSats =
+        (feeQuote!.l1BroadcastFeeFast?.originalValue || 0) +
+        (feeQuote!.userFeeFast?.originalValue || 0);
+
+      const coopExitRequest = await senderWallet.withdraw({
+        amountSats,
+        onchainAddress: withdrawalAddress,
+        deductFeeFromWithdrawalAmount: false,
+        feeQuoteId: feeQuote?.id!,
+        feeAmountSats,
+        exitSpeed: "FAST" as ExitSpeed,
+      });
+
+      expect(coopExitRequest).toBeDefined();
+      expect(coopExitRequest!.coopExitTxid).toBeDefined();
+
+      await warn(`Sent withdrawal request with txid ${coopExitRequest!.coopExitTxid}.
+            
+At the moment, withdrawal requests are leaking test funds into the BTC wallet ${withdrawalAddress}`);
     },
     TEST_TIMEOUT,
   );
@@ -363,6 +385,36 @@ const createGetWalletAccounts =
       btcAccount,
     };
   };
+
+const recoverAllFunds = async (
+  fromWallet: TurnekySparkWalletTest,
+  toWallet: TurnekySparkWalletTest,
+) => {
+  const {
+    satsBalance: { available },
+  } = await fromWallet.getBalance();
+
+  // Don't do anything if there is nothing to recover
+  if (available === BigInt(0)) {
+    return;
+  }
+
+  const toAddress = await toWallet.getSparkAddress();
+
+  // We need to setup the event listeners before creating the transfer, otherwise we might miss the events
+  let transfer: WalletTransfer | undefined = undefined;
+  const claimed = waitForTransferToBeClaimed(
+    toWallet,
+    (id) => id === transfer?.id,
+  );
+
+  transfer = await fromWallet.transfer({
+    amountSats: Number(available),
+    receiverSparkAddress: toAddress,
+  });
+
+  await claimed;
+};
 
 const createFaucetMessage = (address: string) =>
   `You can use the regtest faucet at https://app.lightspark.com/regtest-faucet 

--- a/packages/spark/src/__tests__/wallet.test.ts
+++ b/packages/spark/src/__tests__/wallet.test.ts
@@ -144,7 +144,7 @@ describe("TurnkeySparkWallet", () => {
     // Since these tests can run in parallel, we want to wrap this in try/catch
     // to avoid race conditions between tests tearing down the suite
     try {
-      recoverAllFunds(receiverWallet, senderWallet);
+      await recoverAllFunds(receiverWallet, senderWallet);
     } catch (error) {
       await warn(`Failed to recover funds from receiver wallet:\n\n${error}`);
     }
@@ -387,8 +387,8 @@ const createGetWalletAccounts =
   };
 
 const recoverAllFunds = async (
-  fromWallet: TurnekySparkWalletTest,
-  toWallet: TurnekySparkWalletTest,
+  fromWallet: TurnkeySparkWalletTest,
+  toWallet: TurnkeySparkWalletTest,
 ) => {
   const {
     satsBalance: { available },

--- a/packages/spark/src/services/index.ts
+++ b/packages/spark/src/services/index.ts
@@ -1,1 +1,1 @@
-export * from "./transfer";
+export { TurnkeyTransferService } from "./transfer";

--- a/packages/spark/src/services/transfer.ts
+++ b/packages/spark/src/services/transfer.ts
@@ -178,9 +178,7 @@ export class TurnkeyTransferService extends TransferService {
 
     const ownerIdentityPublicKey = await signer.getIdentityPublicKey();
     const receiverPublicKey = leaves[0]!.receiverIdentityPublicKey;
-    const receiverPublicKeyHex = uint8ArrayToHexString(
-      leaves[0]!.receiverIdentityPublicKey,
-    );
+    const receiverPublicKeyHex = uint8ArrayToHexString(receiverPublicKey);
     const operatorRecipients = operatorsToOperatorRecipients(
       this.config.getSigningOperators(),
     );

--- a/packages/spark/src/services/transfer.ts
+++ b/packages/spark/src/services/transfer.ts
@@ -368,7 +368,7 @@ const isLeafWithTreeNode = (
   value: TransferLeaf,
 ): value is TransferLeafWithTreeNode => value.leaf != null;
 
-const leafKeyTweakToTransferInputLeaf = (
+export const leafKeyTweakToTransferInputLeaf = (
   leaf: LeafKeyTweak,
 ): TransferLeafInput => ({
   leafId: leaf.leaf.id,
@@ -376,7 +376,7 @@ const leafKeyTweakToTransferInputLeaf = (
   newLeafDerivation: leaf.newKeyDerivation,
 });
 
-const normalizeTransferLeafKeyTweak = (
+export const normalizeTransferLeafKeyTweak = (
   leafKeyTweak: LeafKeyTweak,
 ): LeafKeyTweak => ({
   ...leafKeyTweak,
@@ -393,7 +393,7 @@ const normalizeTransferLeafKeyTweak = (
  * Pre-sort, `Object.values()` insertion order would scramble the assignment and
  * operators couldn't reconstruct. See commit 558d66361 for the original incident.
  */
-const operatorsToOperatorRecipients = (
+export const operatorsToOperatorRecipients = (
   operators: Readonly<Record<string, SigningOperator>>,
 ): OperatorRecipientInput[] =>
   Object.values(operators)
@@ -410,7 +410,7 @@ interface LeafKeyTweak {
   receiverIdentityPublicKey: Uint8Array;
 }
 
-interface TransferPackageWithSelfCommitments extends TransferPackage {
+export interface TransferPackageWithSelfCommitments extends TransferPackage {
   leavesToSend: UserSignedTxSigningJobWithSelfCommitment[];
   directLeavesToSend: UserSignedTxSigningJobWithSelfCommitment[];
   directFromCpfpLeavesToSend: UserSignedTxSigningJobWithSelfCommitment[];
@@ -419,7 +419,7 @@ interface TransferPackageWithSelfCommitments extends TransferPackage {
 /**
  * Assemble a TransferPackage from a Turnkey enclave result + signed refund jobs.
  * */
-const transferResultToTransferPackage = (
+export const transferResultToTransferPackage = (
   transferResult: TransferResult,
   signRefundsResult: SignRefundsResult,
 ): TransferPackageWithSelfCommitments => {
@@ -437,7 +437,7 @@ const transferResultToTransferPackage = (
   };
 };
 
-const operatorPackagesToKeyTweakPackage = (
+export const operatorPackagesToKeyTweakPackage = (
   operatorPackages: OperatorPackage[],
 ): Record<string, Uint8Array> =>
   Object.fromEntries(

--- a/packages/spark/src/wallet.ts
+++ b/packages/spark/src/wallet.ts
@@ -1,9 +1,23 @@
 import {
   type ConfigOptions,
+  getTransferPackageSigningPayload,
+  Network,
+  SparkRequestError,
   SparkSigner,
+  SparkValidationError,
   SparkWallet,
 } from "@buildonspark/spark-sdk";
-import { TurnkeyTransferService } from "./services/transfer";
+import {
+  leafKeyTweakToTransferInputLeaf,
+  normalizeTransferLeafKeyTweak,
+  operatorsToOperatorRecipients,
+  transferResultToTransferPackage,
+  TurnkeyTransferService,
+} from "./services/transfer";
+import { v7 as uuidv7 } from "uuid";
+import type { CooperativeExitResponse } from "@buildonspark/spark-sdk/dist/proto/spark";
+import { uint8ArrayToHexString } from "@turnkey/encoding";
+import type { ConnectorOutput, TurnkeySparkSigner } from "./signer";
 
 export class TurnkeySparkWallet extends SparkWallet {
   constructor(options?: ConfigOptions, signerArg?: SparkSigner) {
@@ -30,5 +44,129 @@ export class TurnkeySparkWallet extends SparkWallet {
     });
 
     Object.assign(this.swapService, { transferService: this.transferService });
+
+    Object.assign(this.coopExitService, {
+      getConnectorRefundSignatures: this.createGetConnectorRefundSignatures(),
+    });
+  }
+
+  /**
+   * Temporary hack before CoopExitService gets exported from spark SDK
+   */
+  private createGetConnectorRefundSignatures() {
+    type GetConnectorRefundSignatures =
+      typeof this.coopExitService.getConnectorRefundSignatures;
+
+    const signer = this.config.signer as TurnkeySparkSigner;
+
+    const getConnectorRefundSignatures: GetConnectorRefundSignatures = async ({
+      leaves,
+      exitTxId,
+      connectorOutputs,
+      receiverPubKey,
+      transferId,
+      connectorTx,
+    }) => {
+      if (leaves.length !== connectorOutputs.length) {
+        throw new SparkValidationError(
+          "Mismatch between leaves and connector outputs",
+          {
+            field: "leaves/connectorOutputs",
+            value: {
+              leavesCount: leaves.length,
+              outputsCount: connectorOutputs.length,
+            },
+            expected: "Equal length",
+          },
+        );
+      }
+
+      const receiverPublicKeyHex = uint8ArrayToHexString(receiverPubKey);
+      const normalizedLeaves = leaves.map(normalizeTransferLeafKeyTweak);
+      const operatorRecipients = operatorsToOperatorRecipients(
+        this.config.getSigningOperators(),
+      );
+      const transferLeafInputs = normalizedLeaves.map(
+        leafKeyTweakToTransferInputLeaf,
+      );
+
+      const transferResult = await signer.prepareTransfer({
+        transferId,
+        leaves: transferLeafInputs,
+        threshold: this.config.getThreshold(),
+        operatorRecipients,
+        receiverPublicKey: receiverPublicKeyHex,
+      });
+
+      // 2. Get SO signing commitments (3 per leaf: cpfp, direct, directFromCpfp)
+      const sparkClient = await this.connectionManager.createSparkClient(
+        this.config.getCoordinatorAddress(),
+      );
+
+      const { signingCommitments: commitments } =
+        await sparkClient.get_signing_commitments({
+          nodeIds: leaves.map(({ leaf }) => leaf.id),
+          count: 3,
+        });
+
+      const signRefundsResult = await signer.signRefundsBatchedCoopExit({
+        leaves: normalizedLeaves,
+        network: this.config.getNetwork(),
+        commitments,
+        connectorOutputs: connectorOutputs as ConnectorOutput[],
+        connectorTx,
+      });
+
+      const transferPackage = transferResultToTransferPackage(
+        transferResult,
+        signRefundsResult,
+      );
+
+      const transferPackageSigningPayload = getTransferPackageSigningPayload(
+        transferId,
+        transferPackage,
+      );
+      const signature = await signer.signMessageWithIdentityKey(
+        transferPackageSigningPayload,
+      );
+      transferPackage.userSignature = new Uint8Array(signature);
+
+      // 5. Call cooperative_exit_v2 with TransferPackage
+      let response: CooperativeExitResponse;
+      try {
+        response = await sparkClient.cooperative_exit_v2({
+          transfer: {
+            transferId,
+            ownerIdentityPublicKey:
+              await this.config.signer.getIdentityPublicKey(),
+            receiverIdentityPublicKey: receiverPubKey,
+            transferPackage,
+            expiryTime:
+              this.config.getNetwork() == Network.MAINNET
+                ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 5 * 60 * 1000)
+                : new Date(Date.now() + 35 * 60 * 1000),
+          },
+          exitId: uuidv7(),
+          exitTxid: exitTxId,
+          connectorTx: connectorTx,
+        });
+      } catch (error) {
+        throw new SparkRequestError("Failed to initiate cooperative exit", {
+          operation: "cooperative_exit_v2",
+          error,
+        });
+      }
+
+      if (!response.transfer) {
+        throw new SparkRequestError("Failed to initiate cooperative exit", {
+          operation: "cooperative_exit_v2",
+          error: new Error("No transfer in response"),
+        });
+      }
+
+      return { transfer: response.transfer };
+    };
+
+    return getConnectorRefundSignatures;
   }
 }

--- a/packages/spark/src/wallet.ts
+++ b/packages/spark/src/wallet.ts
@@ -142,7 +142,7 @@ export class TurnkeySparkWallet extends SparkWallet {
             receiverIdentityPublicKey: receiverPubKey,
             transferPackage,
             expiryTime:
-              this.config.getNetwork() == Network.MAINNET
+              this.config.getNetwork() === Network.MAINNET
                 ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 5 * 60 * 1000)
                 : new Date(Date.now() + 35 * 60 * 1000),
           },


### PR DESCRIPTION
## Summary & Motivation

Adds (albeit a bit hacked, waiting for `@buildonspark/spark-sdk` to be published) support for withdraw from Spark.

At the moment, the funds withdrawn in the tests end up in the receiver BTC wallet and are not being recycled back to the sender wallet using deposit.

## How I Tested These Changes

Unit test added

## Did you add a changeset?

Indeed