### PR TITLE
Stub of @turnkey/bitcoin package

### DIFF
--- a/examples/with-bitcoin/package.json
+++ b/examples/with-bitcoin/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@turnkey/bitcoin": "workspace:*",
     "@turnkey/crypto": "workspace:*",
     "@turnkey/http": "workspace:*",
     "@turnkey/sdk-server": "workspace:*",

--- a/examples/with-bitcoin/src/createBtcTx.ts
+++ b/examples/with-bitcoin/src/createBtcTx.ts
@@ -10,7 +10,7 @@ import * as ecc from "tiny-secp256k1";
 import { ECPairFactory } from "ecpair";
 
 import { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
-import { TurnkeySigner } from "./signer";
+import { TurnkeyBitcoinSigner } from "@turnkey/bitcoin";
 import { getNetwork, isMainnet, parseAddressAgainstPublicKey } from "./util";
 import { estimateFees } from "./fees";
 
@@ -203,17 +203,21 @@ async function main() {
     network,
   } = result;
 
-  var signer: TurnkeySigner;
+  var signer: TurnkeyBitcoinSigner;
   if (addressType === "MainnetP2TR" || addressType === "TestnetP2TR") {
     // For taproot public key needs to be the decoded address, in order to match the output's "public key" (tweaked)
     // See https://github.com/bitcoinjs/bitcoinjs-lib/blob/34e1644b5fb60055793ec3078f2e4f48b2648ca6/ts_src/psbt.ts#L1786
-    signer = new TurnkeySigner(
-      turnkeyClient,
+    signer = new TurnkeyBitcoinSigner(
+      turnkeyClient.apiClient(),
       bitcoinAddress,
       bitcoin.address.fromBech32(bitcoinAddress).data,
     );
   } else {
-    signer = new TurnkeySigner(turnkeyClient, bitcoinAddress, pair.publicKey);
+    signer = new TurnkeyBitcoinSigner(
+      turnkeyClient.apiClient(),
+      bitcoinAddress,
+      pair.publicKey,
+    );
   }
 
   // Sign the transaction inputs

--- a/packages/bitcoin/LICENSE
+++ b/packages/bitcoin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Turnkey
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/bitcoin/LICENSE
+++ b/packages/bitcoin/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Turnkey
+   Copyright 2026 Turnkey
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/bitcoin/README.md
+++ b/packages/bitcoin/README.md
@@ -1,0 +1,21 @@
+# @turnkey/bitcoin
+
+[![npm](https://img.shields.io/npm/v/@turnkey/bitcoin?color=%234C48FF)](https://www.npmjs.com/package/@turnkey/bitcoin)
+
+[Turnkey](https://turnkey.com) Bitcoin signer:
+
+If you need a lower-level, fully typed HTTP client for interacting with Turnkey API, check out [`@turnkey/http`](https://www.npmjs.com/package/@turnkey/http).
+
+API Docs: https://docs.turnkey.com/
+
+## Getting started
+
+```bash
+$ npm install @turnkey/bitcoin
+```
+
+## Examples
+
+| Example                                        | Description                                                             |
+| ---------------------------------------------- | ----------------------------------------------------------------------- |
+| [`with-bitcoin`](../../examples/with-bitcoin/) | Demonstrates Bitcoin operations using **Turnkey as the key custodian**. |

--- a/packages/bitcoin/jest.config.js
+++ b/packages/bitcoin/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@jest/types").Config.InitialOptions} */
+const config = {
+  transform: {
+    "\\.[jt]sx?$": "@turnkey/jest-config/transformer.js",
+  },
+  testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/node_modules/"],
+};
+
+module.exports = config;

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@turnkey/bitcoin",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "license": "Apache-2.0",
+  "description": "Turnkey Bitcoin Signer implementation",
+  "keywords": [
+    "Turnkey",
+    "Bitcoin"
+  ],
+  "author": {
+    "name": "Turnkey",
+    "url": "https://turnkey.com/"
+  },
+  "homepage": "https://github.com/tkhq/sdk",
+  "bugs": {
+    "url": "https://github.com/tkhq/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tkhq/sdk.git",
+    "directory": "packages/bitcoin"
+  },
+  "files": [
+    "dist/",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prepublishOnly": "pnpm run clean && pnpm run build",
+    "build": "rollup -c",
+    "clean": "rimraf ./dist ./.cache",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@turnkey/sdk-server": "workspace:*"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "7.20.2",
+    "@babel/preset-flow": "7.23.3",
+    "@babel/preset-react": "7.18.6",
+    "@babel/preset-typescript": "7.18.6",
+    "@types/jest": "^29.5.3",
+    "@types/node": "~24.13.1",
+    "jest": "29.7.0",
+    "typescript": "5.4.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -47,6 +47,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@turnkey/core": "workspace:*",
     "@turnkey/sdk-browser": "workspace:*",
     "@turnkey/sdk-server": "workspace:*"
   },

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -47,6 +47,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@turnkey/sdk-browser": "workspace:*",
     "@turnkey/sdk-server": "workspace:*"
   },
   "devDependencies": {

--- a/packages/bitcoin/rollup.config.mjs
+++ b/packages/bitcoin/rollup.config.mjs
@@ -1,0 +1,3 @@
+import rollup from "../../rollup.config.base.mjs";
+
+export default (options) => rollup();

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./signer";

--- a/packages/bitcoin/src/signer.ts
+++ b/packages/bitcoin/src/signer.ts
@@ -1,5 +1,6 @@
-import type { TurnkeyBrowserClient as TurnkeyApiClientBrowser } from "@turnkey/sdk-browser";
-import type { TurnkeyApiClient as TurnkeyApiClientServer } from "@turnkey/sdk-server";
+import type { TurnkeySDKClientBase as TurnkeyClientCore } from "@turnkey/core";
+import type { TurnkeyBrowserClient as TurnkeyClientBrowser } from "@turnkey/sdk-browser";
+import type { TurnkeyApiClient as TurnkeyClientServer } from "@turnkey/sdk-server";
 
 /**
  * Signer which supports P2TR and P2WPKH addresses.
@@ -24,7 +25,7 @@ import type { TurnkeyApiClient as TurnkeyApiClientServer } from "@turnkey/sdk-se
  * -------------------------------------------------------
  */
 export class TurnkeyBitcoinSigner<
-  TClient extends TurnkeyApiClientBitcoinSigner = TurnkeyApiClientBitcoinSigner,
+  TClient extends TurnkeyClientBitcoinSigner = TurnkeyClientBitcoinSigner,
 > {
   /**
    * @param client The turnkey API client
@@ -60,8 +61,11 @@ export class TurnkeyBitcoinSigner<
   }
 }
 
-export type TurnkeyApiClientBitcoinSigner<
-  T extends TurnkeyApiClientServer | TurnkeyApiClientBrowser =
-    | TurnkeyApiClientServer
-    | TurnkeyApiClientBrowser,
+type CompatibleTurnkeyClient =
+  | TurnkeyClientServer
+  | TurnkeyClientBrowser
+  | TurnkeyClientCore;
+
+export type TurnkeyClientBitcoinSigner<
+  T extends CompatibleTurnkeyClient = CompatibleTurnkeyClient,
 > = Pick<T, "signRawPayload">;

--- a/packages/bitcoin/src/signer.ts
+++ b/packages/bitcoin/src/signer.ts
@@ -1,4 +1,4 @@
-import type { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
+import type { TurnkeyApiClient } from "@turnkey/sdk-server";
 
 /**
  * Signer which supports P2TR and P2WPKH addresses.
@@ -22,25 +22,21 @@ import type { Turnkey as TurnkeyServerSDK } from "@turnkey/sdk-server";
  * at signing time if the address type is P2TR. See BIP141 for a more thorough explainer on taproot!
  * -------------------------------------------------------
  */
-export class TurnkeySigner {
-  client: TurnkeyServerSDK;
-  publicKey: Buffer;
-  address: string;
-
+export class TurnkeyBitcoinSigner {
   /**
-   * @param client The turnkey SDK client
+   * @param client The turnkey API client
    * @param address The Turnkey-derived address in bech32 format (e.g. bc1pdyzj6qxu6q40jdkcslh0uqmnppx4vtg0l0a7kfdccr5833wfjwqqnp949w)
    * @param publicKey public key buffer. To sign P2TR outputs it needs to be the decoded address (`bitcoin.address.fromBech32(address).data`).
    *                  For P2WPKH it should be the key pair's underlying public key buffer, uncompressed.
    */
-  constructor(client: TurnkeyServerSDK, address: string, publicKey: Buffer) {
-    this.client = client;
-    this.address = address;
-    this.publicKey = publicKey;
-  }
+  constructor(
+    public readonly client: TurnkeyApiClient,
+    public readonly address: string,
+    public readonly publicKey: Buffer,
+  ) {}
 
   async sign(hash: Buffer, _lowrR: boolean): Promise<Buffer> {
-    const { r, s } = await this.client.apiClient().signRawPayload({
+    const { r, s } = await this.client.signRawPayload({
       signWith: this.address,
       encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
       hashFunction: "HASH_FUNCTION_NO_OP",
@@ -50,7 +46,7 @@ export class TurnkeySigner {
   }
 
   async signSchnorr(hash: Buffer): Promise<Buffer> {
-    const { r, s } = await this.client.apiClient().signRawPayload({
+    const { r, s } = await this.client.signRawPayload({
       signWith: this.address,
       encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
       hashFunction: "HASH_FUNCTION_NO_OP",

--- a/packages/bitcoin/src/signer.ts
+++ b/packages/bitcoin/src/signer.ts
@@ -1,4 +1,5 @@
-import type { TurnkeyApiClient } from "@turnkey/sdk-server";
+import type { TurnkeyBrowserClient as TurnkeyApiClientBrowser } from "@turnkey/sdk-browser";
+import type { TurnkeyApiClient as TurnkeyApiClientServer } from "@turnkey/sdk-server";
 
 /**
  * Signer which supports P2TR and P2WPKH addresses.
@@ -22,7 +23,9 @@ import type { TurnkeyApiClient } from "@turnkey/sdk-server";
  * at signing time if the address type is P2TR. See BIP141 for a more thorough explainer on taproot!
  * -------------------------------------------------------
  */
-export class TurnkeyBitcoinSigner {
+export class TurnkeyBitcoinSigner<
+  TClient extends TurnkeyApiClientBitcoinSigner = TurnkeyApiClientBitcoinSigner,
+> {
   /**
    * @param client The turnkey API client
    * @param address The Turnkey-derived address in bech32 format (e.g. bc1pdyzj6qxu6q40jdkcslh0uqmnppx4vtg0l0a7kfdccr5833wfjwqqnp949w)
@@ -30,7 +33,7 @@ export class TurnkeyBitcoinSigner {
    *                  For P2WPKH it should be the key pair's underlying public key buffer, uncompressed.
    */
   constructor(
-    public readonly client: TurnkeyApiClient,
+    public readonly client: TClient,
     public readonly address: string,
     public readonly publicKey: Buffer,
   ) {}
@@ -56,3 +59,9 @@ export class TurnkeyBitcoinSigner {
     return Buffer.from(r + s, "hex");
   }
 }
+
+export type TurnkeyApiClientBitcoinSigner<
+  T extends TurnkeyApiClientServer | TurnkeyApiClientBrowser =
+    | TurnkeyApiClientServer
+    | TurnkeyApiClientBrowser,
+> = Pick<T, "signRawPayload">;

--- a/packages/bitcoin/tsconfig.json
+++ b/packages/bitcoin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo",
+    "types": ["node", "jest"],
+    "lib": ["ESNext"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1669,6 +1669,9 @@ importers:
 
   examples/with-bitcoin:
     dependencies:
+      '@turnkey/bitcoin':
+        specifier: workspace:*
+        version: link:../../packages/bitcoin
       '@turnkey/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -3678,6 +3681,37 @@ importers:
         specifier: ^0.10.7
         version: 0.10.7
 
+  packages/bitcoin:
+    dependencies:
+      '@turnkey/sdk-server':
+        specifier: workspace:*
+        version: link:../sdk-server
+    devDependencies:
+      '@babel/preset-env':
+        specifier: 7.20.2
+        version: 7.20.2(@babel/core@7.28.5)
+      '@babel/preset-flow':
+        specifier: 7.23.3
+        version: 7.23.3(@babel/core@7.28.5)
+      '@babel/preset-react':
+        specifier: 7.18.6
+        version: 7.18.6(@babel/core@7.28.5)
+      '@babel/preset-typescript':
+        specifier: 7.18.6
+        version: 7.18.6(@babel/core@7.28.5)
+      '@types/jest':
+        specifier: ^29.5.3
+        version: 29.5.14
+      '@types/node':
+        specifier: ~24.13.1
+        version: 24.13.1
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.13.1)(typescript@5.4.3))
+      typescript:
+        specifier: 5.4.3
+        version: 5.4.3
+
   packages/core:
     dependencies:
       '@react-native-async-storage/async-storage':
@@ -4560,10 +4594,6 @@ packages:
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.28.4':
-    resolution: {integrity: sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.28.5':
@@ -17535,9 +17565,6 @@ packages:
   undici-types@7.14.0:
     resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
 
-  undici-types@7.15.0:
-    resolution: {integrity: sha512-Xyn5T99wU4kPhLZMm+ElE6M+IoSeG8Se7eG9xoZ82ZgVHJ07wb/IWcDZeXe2GOPkavcJ8ko5oSlXMDRl/QgY9Q==}
-
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -18428,8 +18455,6 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.4': {}
-
   '@babel/compat-data@7.28.5': {}
 
   '@babel/core@7.26.9':
@@ -18502,9 +18527,9 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      '@babel/compat-data': 7.28.4
+      '@babel/compat-data': 7.28.5
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.25.4
+      browserslist: 4.27.0
       lru-cache: 5.1.1
       semver: 7.7.3
 
@@ -27557,7 +27582,7 @@ snapshots:
       '@solana/rpc-spec': 2.3.0(typescript@5.4.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.4.3)
       typescript: 5.4.3
-      undici-types: 7.15.0
+      undici-types: 7.18.2
 
   '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.3)':
     dependencies:
@@ -42666,8 +42691,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.14.0: {}
-
-  undici-types@7.15.0: {}
 
   undici-types@7.18.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3683,6 +3683,9 @@ importers:
 
   packages/bitcoin:
     dependencies:
+      '@turnkey/core':
+        specifier: workspace:*
+        version: link:../core
       '@turnkey/sdk-browser':
         specifier: workspace:*
         version: link:../sdk-browser

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3683,6 +3683,9 @@ importers:
 
   packages/bitcoin:
     dependencies:
+      '@turnkey/sdk-browser':
+        specifier: workspace:*
+        version: link:../sdk-browser
       '@turnkey/sdk-server':
         specifier: workspace:*
         version: link:../sdk-server


### PR DESCRIPTION
## Summary & Motivation

In order to run full E2E tests for Spark, we'll need to be able to send some bitcoin REGTEST transactions. This PR takes the bitcoin signer out of the example for start and puts it into a new `@turnkey/bitcoin` package.

## How I Tested These Changes

Pure copypasta

## Did you add a changeset?

None needed