### PR TITLE
Fix: Pass permissions to publish workflow

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -45,5 +45,9 @@ jobs:
     needs: version
     uses: ./.github/workflows/reusable-publish.yml
     secrets: inherit
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     with:
       version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/publish-release-branch.yml
+++ b/.github/workflows/publish-release-branch.yml
@@ -36,5 +36,9 @@ jobs:
     needs: version
     uses: ./.github/workflows/reusable-publish.yml
     secrets: inherit
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     with:
       version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
## Summary & Motivation

See failed workflow [here](https://github.com/tkhq/sdk/actions/runs/27217767690/job/80366364476#step:7:101). The permissions were not being passed to the reusable workflow

## How I Tested These Changes

Nohow

## Did you add a changeset?

Dev changes only