### PR TITLE
Spark support: Bump required SDK version

### DIFF
--- a/.changeset/stupid-yaks-dress.md
+++ b/.changeset/stupid-yaks-dress.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/spark": patch
+---
+
+Bump required @buildonspark/spark-sdk version

--- a/examples/with-spark/package.json
+++ b/examples/with-spark/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@buildonspark/issuer-sdk": "^0.1.23",
-    "@buildonspark/spark-sdk": "0.8.4",
+    "@buildonspark/spark-sdk": "0.8.6",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.4.0",
     "@scure/bip39": "^1.3.0",

--- a/packages/spark/package.json
+++ b/packages/spark/package.json
@@ -47,7 +47,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@buildonspark/spark-sdk": "^0.8.4",
+    "@buildonspark/spark-sdk": "^0.8.6",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.4.0",
     "@scure/bip39": "^1.3.0",

--- a/packages/spark/src/services/coop-exit.ts
+++ b/packages/spark/src/services/coop-exit.ts
@@ -1,0 +1,139 @@
+import {
+  CoopExitService,
+  getTransferPackageSigningPayload,
+  Network,
+  SparkRequestError,
+  SparkValidationError,
+} from "@buildonspark/spark-sdk";
+import { uint8ArrayToHexString } from "@turnkey/encoding";
+import {
+  leafKeyTweakToTransferInputLeaf,
+  normalizeTransferLeafKeyTweak,
+  operatorsToOperatorRecipients,
+  transferResultToTransferPackage,
+} from "./transfer";
+import type { ConnectorOutput, TurnkeySparkSigner } from "../signer";
+import type { CooperativeExitResponse } from "@buildonspark/spark-sdk/dist/proto/spark";
+import { v7 as uuidv7 } from "uuid";
+
+type GetConnectorRefundSignaturesSignature =
+  typeof CoopExitService.prototype.getConnectorRefundSignatures;
+
+export type GetConnectorRefundSignaturesParams =
+  Parameters<GetConnectorRefundSignaturesSignature>[0];
+
+export type GetConnectorRefundSignaturesReturn = Awaited<
+  ReturnType<GetConnectorRefundSignaturesSignature>
+>;
+
+export class TurnkeyCoopExitService extends CoopExitService {
+  override async getConnectorRefundSignatures({
+    leaves,
+    exitTxId,
+    connectorOutputs,
+    receiverPubKey,
+    transferId,
+    connectorTx,
+  }: GetConnectorRefundSignaturesParams): Promise<GetConnectorRefundSignaturesReturn> {
+    if (leaves.length !== connectorOutputs.length) {
+      throw new SparkValidationError(
+        "Mismatch between leaves and connector outputs",
+        {
+          field: "leaves/connectorOutputs",
+          value: {
+            leavesCount: leaves.length,
+            outputsCount: connectorOutputs.length,
+          },
+          expected: "Equal length",
+        },
+      );
+    }
+
+    const signer = this.config.signer as TurnkeySparkSigner;
+
+    const receiverPublicKeyHex = uint8ArrayToHexString(receiverPubKey);
+    const normalizedLeaves = leaves.map(normalizeTransferLeafKeyTweak);
+    const operatorRecipients = operatorsToOperatorRecipients(
+      this.config.getSigningOperators(),
+    );
+    const transferLeafInputs = normalizedLeaves.map(
+      leafKeyTweakToTransferInputLeaf,
+    );
+
+    const transferResult = await signer.prepareTransfer({
+      transferId,
+      leaves: transferLeafInputs,
+      threshold: this.config.getThreshold(),
+      operatorRecipients,
+      receiverPublicKey: receiverPublicKeyHex,
+    });
+
+    // 2. Get SO signing commitments (3 per leaf: cpfp, direct, directFromCpfp)
+    const sparkClient = await this.connectionManager.createSparkClient(
+      this.config.getCoordinatorAddress(),
+    );
+
+    const { signingCommitments: commitments } =
+      await sparkClient.get_signing_commitments({
+        nodeIds: leaves.map(({ leaf }) => leaf.id),
+        count: 3,
+      });
+
+    const signRefundsResult = await signer.signRefundsBatchedCoopExit({
+      leaves: normalizedLeaves,
+      network: this.config.getNetwork(),
+      commitments,
+      connectorOutputs: connectorOutputs as ConnectorOutput[],
+      connectorTx,
+    });
+
+    const transferPackage = transferResultToTransferPackage(
+      transferResult,
+      signRefundsResult,
+    );
+
+    const transferPackageSigningPayload = getTransferPackageSigningPayload(
+      transferId,
+      transferPackage,
+    );
+    const signature = await signer.signMessageWithIdentityKey(
+      transferPackageSigningPayload,
+    );
+    transferPackage.userSignature = new Uint8Array(signature);
+
+    // 5. Call cooperative_exit_v2 with TransferPackage
+    let response: CooperativeExitResponse;
+    try {
+      response = await sparkClient.cooperative_exit_v2({
+        transfer: {
+          transferId,
+          ownerIdentityPublicKey:
+            await this.config.signer.getIdentityPublicKey(),
+          receiverIdentityPublicKey: receiverPubKey,
+          transferPackage,
+          expiryTime:
+            this.config.getNetwork() === Network.MAINNET
+              ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 5 * 60 * 1000)
+              : new Date(Date.now() + 35 * 60 * 1000),
+        },
+        exitId: uuidv7(),
+        exitTxid: exitTxId,
+        connectorTx: connectorTx,
+      });
+    } catch (error) {
+      throw new SparkRequestError("Failed to initiate cooperative exit", {
+        operation: "cooperative_exit_v2",
+        error,
+      });
+    }
+
+    if (!response.transfer) {
+      throw new SparkRequestError("Failed to initiate cooperative exit", {
+        operation: "cooperative_exit_v2",
+        error: new Error("No transfer in response"),
+      });
+    }
+
+    return { transfer: response.transfer };
+  }
+}

--- a/packages/spark/src/services/index.ts
+++ b/packages/spark/src/services/index.ts
@@ -1,1 +1,6 @@
+export {
+  TurnkeyCoopExitService,
+  type GetConnectorRefundSignaturesParams,
+  type GetConnectorRefundSignaturesReturn,
+} from "./coop-exit";
 export { TurnkeyTransferService } from "./transfer";

--- a/packages/spark/src/signer.ts
+++ b/packages/spark/src/signer.ts
@@ -993,6 +993,11 @@ export class TurnkeySparkSigner implements SparkSigner {
       );
     }
 
+    // The jobs array will hold three items per element:
+    //
+    // - the cpfp job at index 0
+    // - the direct job at index 1
+    // - the directFromCpfp job at index 2
     const jobs: Triple<UserUnsignedTxSigningJob | undefined>[] = [];
 
     for (let i = 0; i < leaves.length; i++) {
@@ -1100,6 +1105,7 @@ export class TurnkeySparkSigner implements SparkSigner {
       jobs.push(jobsForLeaf);
     }
 
+    // Now we flatten the jobs array into SignFrostParams[] for the batch signing call
     const signFrostParamsForLeaves: SignFrostParams[] = jobs.flatMap(
       (jobsForLeaf, index) => {
         const leaf = leaves[index]!;
@@ -1123,6 +1129,15 @@ export class TurnkeySparkSigner implements SparkSigner {
     );
 
     const signatures = await this.signFrostBatch(signFrostParamsForLeaves);
+
+    // Finally we construct the response
+    //
+    // We iterate over the jobs in the same order as when we were flattening.
+    // That way, we can just shift the signatures off the batch signing response,
+    // since the orders of iterations match.
+    //
+    // The resulting signedJobs array will have the same structure as the jobs array,
+    // but with the userSignature field populated.
     const signedJobs = jobs.map((jobsForLeaf, index) => {
       const leaf = leaves[index]!;
 

--- a/packages/spark/src/signer.ts
+++ b/packages/spark/src/signer.ts
@@ -272,6 +272,9 @@ type CreateRefundTxMessage = (
 
 type ModifySignFrostParams = (params: SignFrostParams) => SignFrostParams;
 
+// Helper type for working with [cpfp, direct, directFromCpfp] structures
+type Triple<T> = [cpfp: T, direct: T, directFromCpfp: T];
+
 export interface ClaimLeaf {
   leaf: TreeNode;
   keyDerivation: KeyDerivation;
@@ -919,11 +922,7 @@ export class TurnkeySparkSigner implements SparkSigner {
    */
   protected partitionOperatorCommitments(
     commitments: OperatorSigningCommitment[],
-  ): [
-    cpfp: OperatorSigningCommitment,
-    direct: OperatorSigningCommitment,
-    directFromCpfp: OperatorSigningCommitment,
-  ][] {
+  ): Triple<OperatorSigningCommitment>[] {
     if (commitments.length % 3 !== 0) {
       throw new SparkValidationError(
         `Expected commitments length to be a multiple of 3 (for cpfp, direct, and direct-from-cpfp), got ${commitments.length}`,
@@ -994,7 +993,7 @@ export class TurnkeySparkSigner implements SparkSigner {
       );
     }
 
-    const jobs: UserUnsignedTxSigningJob[][] = [];
+    const jobs: Triple<UserUnsignedTxSigningJob | undefined>[] = [];
 
     for (let i = 0; i < leaves.length; i++) {
       const leaf = leaves[i]!;
@@ -1037,7 +1036,9 @@ export class TurnkeySparkSigner implements SparkSigner {
         i,
       );
 
-      const jobsForLeaf: UserUnsignedTxSigningJob[] = Array.from({ length: 3 });
+      const jobsForLeaf = Array.from({ length: 3 }) as Triple<
+        UserUnsignedTxSigningJob | undefined
+      >;
 
       // cpfp tx
       const cpfpMessage = createMessage(
@@ -1122,20 +1123,15 @@ export class TurnkeySparkSigner implements SparkSigner {
     );
 
     const signatures = await this.signFrostBatch(signFrostParamsForLeaves);
-    const signedJobs: UserSignedTxSigningJobWithSelfCommitment[][] = jobs.map(
-      (jobsForLeaf, index) => {
-        const leaf = leaves[index]!;
+    const signedJobs = jobs.map((jobsForLeaf, index) => {
+      const leaf = leaves[index]!;
 
-        return jobsForLeaf.flatMap(
-          (job): UserSignedTxSigningJobWithSelfCommitment[] => {
-            if (job == null) return [];
-
-            const userSignature = signatures.shift()!;
-
-            return [
-              {
+      return jobsForLeaf.map(
+        (job): UserSignedTxSigningJobWithSelfCommitment | undefined =>
+          job
+            ? {
                 leafId: leaf.leaf.id,
-                userSignature,
+                userSignature: signatures.shift()!,
                 signingPublicKey: job.signingPublicKey,
                 rawTx: job.rawTx,
                 selfCommitment: job.selfCommitment,
@@ -1144,12 +1140,10 @@ export class TurnkeySparkSigner implements SparkSigner {
                   signingCommitments: job.commitment.signingNonceCommitments!,
                 },
                 additionalInputs: [],
-              },
-            ];
-          },
-        );
-      },
-    );
+              }
+            : undefined,
+      ) as Triple<UserSignedTxSigningJobWithSelfCommitment | undefined>;
+    });
 
     return {
       leaves: signedJobs.flatMap(([job]) => (job ? [job] : [])),
@@ -1180,14 +1174,9 @@ export class TurnkeySparkSigner implements SparkSigner {
         });
       }
 
-      const isZeroNode = !getCurrentTimelock(nodeTx.getInput(0).sequence);
-      const effectiveDirectNodeTx = isZeroNode ? undefined : directNodeTx;
-
       return createConnectorRefundTxs({
         nodeTx,
-        ...(effectiveDirectNodeTx
-          ? { directNodeTx: effectiveDirectNodeTx }
-          : {}),
+        directNodeTx: directNodeTx!,
         sequence,
         connectorOutput,
         receivingPubkey,

--- a/packages/spark/src/wallet.ts
+++ b/packages/spark/src/wallet.ts
@@ -1,23 +1,13 @@
 import {
   type ConfigOptions,
-  getTransferPackageSigningPayload,
-  Network,
-  SparkRequestError,
+  LeafManager,
   SparkSigner,
-  SparkValidationError,
   SparkWallet,
+  SparkWalletEvent,
+  SwapService,
 } from "@buildonspark/spark-sdk";
-import {
-  leafKeyTweakToTransferInputLeaf,
-  normalizeTransferLeafKeyTweak,
-  operatorsToOperatorRecipients,
-  transferResultToTransferPackage,
-  TurnkeyTransferService,
-} from "./services/transfer";
-import { v7 as uuidv7 } from "uuid";
-import type { CooperativeExitResponse } from "@buildonspark/spark-sdk/dist/proto/spark";
-import { uint8ArrayToHexString } from "@turnkey/encoding";
-import type { ConnectorOutput, TurnkeySparkSigner } from "./signer";
+import { TurnkeyTransferService } from "./services/transfer";
+import { TurnkeyCoopExitService } from "./services/coop-exit";
 
 export class TurnkeySparkWallet extends SparkWallet {
   constructor(options?: ConfigOptions, signerArg?: SparkSigner) {
@@ -27,6 +17,21 @@ export class TurnkeySparkWallet extends SparkWallet {
       this.config,
       this.connectionManager,
       this.signingService,
+      this.__getLogging__(),
+    );
+
+    this.swapService = new SwapService(
+      this.config,
+      this.transferService,
+      this.sspClient!,
+      this.__getLogging__(),
+    );
+
+    this.coopExitService = new TurnkeyCoopExitService(
+      this.config,
+      this.connectionManager,
+      this.signingService,
+      this.__getLogging__(),
     );
 
     // Disable the SDK's claim-time auto-optimize swap. The optimizer splits a
@@ -38,135 +43,31 @@ export class TurnkeySparkWallet extends SparkWallet {
     // local leaf is SWAP_PENDING. Disabling the auto-optimize keeps the claim's
     // leaf AVAILABLE so the next operation proceeds. Users who want
     // optimization can call wallet.optimizeLeaves() explicitly and await it.
-    Object.assign(this.leafManager, {
-      transferService: this.transferService,
-      onAutoOptimize: async () => undefined,
-    });
-
-    Object.assign(this.swapService, { transferService: this.transferService });
-
-    Object.assign(this.coopExitService, {
-      getConnectorRefundSignatures: this.createGetConnectorRefundSignatures(),
-    });
+    this.leafManager = new LeafManager(
+      this.config,
+      this.swapService,
+      this.transferService,
+      this.connectionManager,
+      (balance) => {
+        this.emit(SparkWalletEvent.BalanceUpdate, {
+          available: BigInt(balance.available),
+          owned: BigInt(balance.owned),
+          incoming: BigInt(balance.incoming),
+        });
+      },
+      undefined,
+      this.__getLogging__(),
+    );
   }
 
   /**
-   * Temporary hack before CoopExitService gets exported from spark SDK
+   * this.logging is not being exposed by SparkWallet so we'll need to work around TypeScript to get it
    */
-  private createGetConnectorRefundSignatures() {
-    type GetConnectorRefundSignatures =
-      typeof this.coopExitService.getConnectorRefundSignatures;
+  private __getLogging__() {
+    // This method seems the fastest way to get the LoggingService type
+    type BuildConnectionManager = typeof this.buildConnectionManager;
+    type LoggingService = Parameters<BuildConnectionManager>[1];
 
-    const signer = this.config.signer as TurnkeySparkSigner;
-
-    const getConnectorRefundSignatures: GetConnectorRefundSignatures = async ({
-      leaves,
-      exitTxId,
-      connectorOutputs,
-      receiverPubKey,
-      transferId,
-      connectorTx,
-    }) => {
-      if (leaves.length !== connectorOutputs.length) {
-        throw new SparkValidationError(
-          "Mismatch between leaves and connector outputs",
-          {
-            field: "leaves/connectorOutputs",
-            value: {
-              leavesCount: leaves.length,
-              outputsCount: connectorOutputs.length,
-            },
-            expected: "Equal length",
-          },
-        );
-      }
-
-      const receiverPublicKeyHex = uint8ArrayToHexString(receiverPubKey);
-      const normalizedLeaves = leaves.map(normalizeTransferLeafKeyTweak);
-      const operatorRecipients = operatorsToOperatorRecipients(
-        this.config.getSigningOperators(),
-      );
-      const transferLeafInputs = normalizedLeaves.map(
-        leafKeyTweakToTransferInputLeaf,
-      );
-
-      const transferResult = await signer.prepareTransfer({
-        transferId,
-        leaves: transferLeafInputs,
-        threshold: this.config.getThreshold(),
-        operatorRecipients,
-        receiverPublicKey: receiverPublicKeyHex,
-      });
-
-      // 2. Get SO signing commitments (3 per leaf: cpfp, direct, directFromCpfp)
-      const sparkClient = await this.connectionManager.createSparkClient(
-        this.config.getCoordinatorAddress(),
-      );
-
-      const { signingCommitments: commitments } =
-        await sparkClient.get_signing_commitments({
-          nodeIds: leaves.map(({ leaf }) => leaf.id),
-          count: 3,
-        });
-
-      const signRefundsResult = await signer.signRefundsBatchedCoopExit({
-        leaves: normalizedLeaves,
-        network: this.config.getNetwork(),
-        commitments,
-        connectorOutputs: connectorOutputs as ConnectorOutput[],
-        connectorTx,
-      });
-
-      const transferPackage = transferResultToTransferPackage(
-        transferResult,
-        signRefundsResult,
-      );
-
-      const transferPackageSigningPayload = getTransferPackageSigningPayload(
-        transferId,
-        transferPackage,
-      );
-      const signature = await signer.signMessageWithIdentityKey(
-        transferPackageSigningPayload,
-      );
-      transferPackage.userSignature = new Uint8Array(signature);
-
-      // 5. Call cooperative_exit_v2 with TransferPackage
-      let response: CooperativeExitResponse;
-      try {
-        response = await sparkClient.cooperative_exit_v2({
-          transfer: {
-            transferId,
-            ownerIdentityPublicKey:
-              await this.config.signer.getIdentityPublicKey(),
-            receiverIdentityPublicKey: receiverPubKey,
-            transferPackage,
-            expiryTime:
-              this.config.getNetwork() === Network.MAINNET
-                ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 5 * 60 * 1000)
-                : new Date(Date.now() + 35 * 60 * 1000),
-          },
-          exitId: uuidv7(),
-          exitTxid: exitTxId,
-          connectorTx: connectorTx,
-        });
-      } catch (error) {
-        throw new SparkRequestError("Failed to initiate cooperative exit", {
-          operation: "cooperative_exit_v2",
-          error,
-        });
-      }
-
-      if (!response.transfer) {
-        throw new SparkRequestError("Failed to initiate cooperative exit", {
-          operation: "cooperative_exit_v2",
-          error: new Error("No transfer in response"),
-        });
-      }
-
-      return { transfer: response.transfer };
-    };
-
-    return getConnectorRefundSignatures;
+    return (this as any).logging as LoggingService | undefined;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3024,8 +3024,8 @@ importers:
         specifier: ^0.1.23
         version: 0.1.23(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native-get-random-values@1.11.0(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10)))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@buildonspark/spark-sdk':
-        specifier: 0.8.4
-        version: 0.8.4(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native-get-random-values@1.11.0(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10)))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: 0.8.6
+        version: 0.8.6(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native-get-random-values@1.11.0(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10)))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@noble/curves':
         specifier: ^1.9.7
         version: 1.9.7
@@ -4355,8 +4355,8 @@ importers:
   packages/spark:
     dependencies:
       '@buildonspark/spark-sdk':
-        specifier: ^0.8.4
-        version: 0.8.4(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native-get-random-values@1.11.0(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10)))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: ^0.8.6
+        version: 0.8.6(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native-get-random-values@1.11.0(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10)))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@noble/curves':
         specifier: ^1.9.7
         version: 1.9.7
@@ -5470,8 +5470,8 @@ packages:
       react-native-get-random-values:
         optional: true
 
-  '@buildonspark/spark-sdk@0.8.4':
-    resolution: {integrity: sha512-Hn/agiPK8RRwy9Si93JCAonjfpqz/vFLxXkejcAWDDu4Zg4yPVr2qWiU//dTfvZs2Z/9TB9dw5HMSRccQcc5fg==}
+  '@buildonspark/spark-sdk@0.8.6':
+    resolution: {integrity: sha512-rpdmeDvGtXzOmRTGuGUH7HK5fJjLUbPmD01agHry/rdpdzLH/F8eHznmqK1YD/m8EvQ5l0FP/UKxfo01ehNcqw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: '>=18.2.0'
@@ -20392,7 +20392,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@buildonspark/spark-sdk@0.8.4(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native-get-random-values@1.11.0(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10)))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@buildonspark/spark-sdk@0.8.6(bare-buffer@3.6.0)(bare-events@2.8.2)(bufferutil@4.0.9)(react-native-get-random-values@1.11.0(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10)))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.4)(bufferutil@4.0.9)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@lightsparkdev/core': 1.5.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)


### PR DESCRIPTION
## Summary & Motivation

We can remove some hacks that have been there because the previous version of the Spark SDK hadn't been published at the moment of merging.

This includes `Object.assign` some of our overriden services and moving patched code from wallet to a new `TurnkeyCoopExitService`.

Once the new version was in, the withdraw test started failing. Turns out there was a problem with how the leaves were paritioned and some `directFromCpfpLeaves` ended up in `directLeaves`. This is a bit strange since the new error comes from the backend and that hasn't changed.

## How I Tested These Changes

Existing tests

## Did you add a changeset?

Yes