### PR TITLE
set bitcoin package as private for now while we release other packages

### DIFF
--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@turnkey/bitcoin",
   "version": "0.0.2",
+  "private": true,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation

- The `bitcoin` package has not been manually released yet which is blocking the release flow, temporarily setting it as private until the manual release goes through to unblock

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
