### PR TITLE
Chore: Only run affected tests

### DIFF
--- a/.github/scripts/get-turbo-affected.sh
+++ b/.github/scripts/get-turbo-affected.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+BASE=$1
+COMPARE=$2
+
+# If there is no base to compare against, we return an everything filter
+# 
+# This is a scenario for on: push workflow triggers where github.base_ref is empty
+if [[ -z "$BASE" ]]; then
+    echo "*"
+    exit 0
+fi
+
+# Empty compare means the tip of the current branch
+if [[ -z "$COMPARE" ]]; then
+    COMPARE="HEAD"
+fi
+
+# We return a turbo filter for affected packages between the two branches
+# 
+# See https://turborepo.dev/docs/reference/run#--filter-string for more info
+echo "...[$BASE...$COMPARE]"

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -38,6 +38,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # We need the full history to be able to calculate the affected packages with turbo
 
       # Install and cache JS toolchain and dependencies (node_modules)
       - name: Setup JS
@@ -46,8 +48,16 @@ jobs:
       - name: Build
         run: pnpm build --filter='./packages/*'
 
+      - name: Fetch base branch
+        if: ${{ github.base_ref }}
+        run: git fetch origin ${{ github.base_ref }}
+
       - name: Test
-        run: pnpm test --concurrency=1
+        run: |
+          BASE_REF=${{ github.base_ref && format('origin/{0}', github.base_ref) }}
+          FILTER=$(./.github/scripts/get-turbo-affected.sh "$BASE_REF" HEAD)
+
+          pnpm test --concurrency=1 --filter="$FILTER"
         env:
           NODE_ENV: development
           API_PUBLIC_KEY: ${{ secrets.API_PUBLIC_KEY }}


### PR DESCRIPTION
## Summary & Motivation

Since our tests are growing, it's time to optimize a bit. We'll use the git commit filtering available in `turbo` to achieve something like this:

- On `push`, we want to run all tests
- On `pull_request`, we want to run only tests affected by the PR changes

To do this, this PR adds a shell script that creates a turbo filter based on two git refs. Works something like this:

```sh
# Will return a turbo filter "...[main..my-branch]"
.github/scripts/get-turbo-affected.sh main my-branch

# Without the base ref, it will return "*" so that no packages are filtered out
.github/scripts/get-turbo-affected.sh "" my-branch
```

## How I Tested These Changes

- [First I pushed this branch to see that, without changes to any packages, no tests will run](https://github.com/tkhq/sdk/actions/runs/27297997220/job/80636120074#step:7:30)
- [I pushed a temporary change to a README in the Spark package to trigger a test in the affected packages](https://github.com/tkhq/sdk/actions/runs/27298318153/job/80680370867?pr=1395#step:7:25)
- [I created a PR to this branch](https://github.com/tkhq/sdk/pull/1396) and [pushed a change to two packages](https://github.com/tkhq/sdk/actions/runs/27311293603/job/80682447461?pr=1396#step:7:25)
- I temporarily changed the `push` trigger branch and [pushed](https://github.com/tkhq/sdk/actions/runs/27312810321/job/80686922516?pr=1396#step:7:28) to simulate a push to `main` to see that all tests were run

## Did you add a changeset?

Dev changes only