### PR TITLE
Fix: Make sure we rerun the build when updating tsconfig or pnpm workspace

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -46,6 +46,11 @@
       ]
     }
   },
+  "globalDependencies": [
+    "tsconfig.base.json",
+    "pnpm-workspace.yaml",
+    "rollup.config.base.mjs"
+  ],
   "globalPassThroughEnv": [
     "API_PUBLIC_KEY",
     "API_PRIVATE_KEY",


### PR DESCRIPTION
## Summary & Motivation

As seen in #1407 , changes to `pnpm-workspace.yaml` did not break the cache for the turbo build step. The error only showed up once the cache was broken, in a PR that for example touched a particular package or the lockfile.

## How I Tested These Changes

CI

## Did you add a changeset?

Dev changes only