### PR TITLE
examples(with-ton): update token unit label TON → GRAM (rebrand)

### DIFF
--- a/examples/chain-integrations/with-ton/README.md
+++ b/examples/chain-integrations/with-ton/README.md
@@ -54,7 +54,7 @@ You should see output similar to the following:
 ```
 ? Recipient address: (<recipient_ton_address>)
 
-Sending 0.015 TON to <recipient_ton_address>
+Sending 0.015 GRAM to <recipient_ton_address>
 
 Transaction sent successfully
 ```

--- a/examples/chain-integrations/with-ton/src/index.ts
+++ b/examples/chain-integrations/with-ton/src/index.ts
@@ -138,7 +138,7 @@ async function main() {
     default: "<recipient_ton_address>",
   });
 
-  console.log(`\nSending 0.015 TON to ${recipientAddress}`);
+  console.log(`\nSending 0.015 GRAM to ${recipientAddress}`);
 
   const tonWallet = WalletContractV4.create({
     workchain: 0,


### PR DESCRIPTION
## Summary

This changes **only** the user-facing token unit/ticker in the `with-ton` example output, from `TON` to `GRAM`, as part of the token ticker rebrand. Exactly **2 lines** are changed:

- `examples/chain-integrations/with-ton/src/index.ts` — the `console.log` sample-send line.
- `examples/chain-integrations/with-ton/README.md` — the matching sample-output line.

## Deliberately left unchanged (out of scope per rebrand)

- **Network name** — "TON transaction", "TON mainnet", "Using TON address", and the `<recipient_ton_address>` placeholder remain as-is (the network is still TON).
- **Env/config vars** — `TON_ADDRESS`, `TON_PUBLIC_KEY`, `TON_RPC_URL`, `TON_API_KEY`.
- **Package imports** — `@ton/ton`, `@ton/core`, `@ton/crypto`, `TonClient`, `WalletContractV4`, etc.
- **Directory/package name** — `with-ton` / `@turnkey/example-with-ton`.
- **Protocol identifiers** — `ADDRESS_FORMAT_TON_*` enums and `Ton V3R2/V4R2/V5R1` display labels.

Only the cosmetic unit/ticker label in the example output was updated. Network name unchanged; protocol unchanged. No global find/replace was performed.
