### PR TITLE
Spark support: Fix hanging promise in E2E test

### DIFF
--- a/packages/spark/src/__tests__/wallet.test.ts
+++ b/packages/spark/src/__tests__/wallet.test.ts
@@ -784,8 +784,3 @@ const createBailOnUnexpectedTransferError =
       }
     }
   };
-
-// Print out a warning / github annotation if the tests are disabled
-if (DISABLE_SPARK_E2E_TESTS) {
-  warn("Spark E2E tests are disabled");
-}


### PR DESCRIPTION
## Summary & Motivation

There was an unawaited async call in the test which, sporadically, would fail the test run.

## How I Tested These Changes

CI

## Did you add a changeset?

Test changes only
