### PR TITLE
fix(react-wallet-kit): match wallet identity in chain selector provider lookup

### DIFF
--- a/.changeset/fix-wallet-chain-selector-identity.md
+++ b/.changeset/fix-wallet-chain-selector-identity.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Fix chain selector picking wrong wallet when multiple EVM wallets are installed. The provider lookup now matches by wallet identity (rdns preferred, name as fallback) in addition to interface type and chain namespace.

--- a/packages/react-wallet-kit/src/components/auth/wallet/ExternalWalletChainSelector.tsx
+++ b/packages/react-wallet-kit/src/components/auth/wallet/ExternalWalletChainSelector.tsx
@@ -27,13 +27,18 @@ export function ExternalWalletChainSelector(
 
   const [loadingProvider, setLoadingProvider] = useState<WalletProvider>();
 
-  // we find matching providers in current state
+  // we find matching providers in current state, matching by wallet identity
+  // (rdns preferred, name as fallback) in addition to interfaceType + namespace
+  // to avoid picking a different wallet that happens to support the same chain
   const currentProviders = providers
     .map((inputProvider) =>
       walletProviders.find(
         (p) =>
           p.interfaceType === inputProvider.interfaceType &&
-          p.chainInfo.namespace === inputProvider.chainInfo.namespace,
+          p.chainInfo.namespace === inputProvider.chainInfo.namespace &&
+          (p.info.rdns && inputProvider.info.rdns
+            ? p.info.rdns === inputProvider.info.rdns
+            : p.info.name === inputProvider.info.name),
       ),
     )
     .filter((p): p is WalletProvider => p !== undefined);


### PR DESCRIPTION
## Summary & Motivation

`ExternalWalletChainSelector` was looking up providers by interfaceType + chainInfo.namespace only, with no wallet identity check. With multiple EVM wallets installed (e.g. MetaMask + Rabby + Phantom), the selector would always resolve the EVM option to whichever EVM wallet happened to appear first in the discovered list — determined by which wallet's eth_accounts call resolved fastest, not by which wallet the user selected.

Concretely: clicking Phantom → EVM would trigger Rabby's connection prompt instead of Phantom's.

The fix adds wallet identity to the lookup: rdns when both providers have it (preferred, since it's unique per extension), falling back to name comparison.

## How I Tested These Changes

Locally with the ewk demo and MM, Phantom, Rabby and Base wallet extensions installed on both Chrome and Brave

## Did you add a changeset?

.changeset/fix-wallet-chain-selector-identity.md
