### PR TITLE
fix(examples): bump shell-quote

### DIFF
--- a/examples/defi/with-walletconnect-pay/package-lock.json
+++ b/examples/defi/with-walletconnect-pay/package-lock.json
@@ -12902,9 +12902,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/examples/demos/with-react-native-wallet-kit/package-lock.json
+++ b/examples/demos/with-react-native-wallet-kit/package-lock.json
@@ -13340,9 +13340,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Summary

Fixes the `shell-quote` Dependabot alert by updating the transitive lockfile resolution from `1.8.3` to patched `1.8.4` in the affected React Native example package locks.

This covers:
- `examples/defi/with-walletconnect-pay/package-lock.json`
- `examples/demos/with-react-native-wallet-kit/package-lock.json`

## Impact

The vulnerable package is pulled in through `react-native -> react-devtools-core -> shell-quote` in example apps. It is not directly used by Turnkey SDK source code, but keeping the checked-in example lockfiles patched clears the critical advisory surface.

## Validation

- `rg -n 'shell-quote@1\.8\.3|shell-quote-1\.8\.3|"version": "1\.8\.3"|shell-quote: 1\.8\.3' .`
- `npm ls shell-quote --package-lock-only` in `examples/defi/with-walletconnect-pay`
- `npm ls shell-quote --package-lock-only` in `examples/demos/with-react-native-wallet-kit`
- `npm audit --package-lock-only --omit=dev --audit-level=critical --json` in both affected example directories: `critical=0`, `shell-quote=absent`
