### PR TITLE
react-wallet-kit: remove unnecessary captcha consumption from OTP verification

### DIFF
--- a/packages/react-wallet-kit/src/components/auth/OTP.tsx
+++ b/packages/react-wallet-kit/src/components/auth/OTP.tsx
@@ -55,6 +55,9 @@ export function OtpVerification(props: OtpVerificationProps) {
     setTimeout(() => setShaking(false), 250);
   };
 
+  // No captchaToken needed here: the backend skips captcha for email/phone
+  // signups that include a verificationToken (which completeOtp obtains from
+  // verifyOtp). The user already passed captcha during initOtp.
   const handleContinue = async (otpCode: string) => {
     try {
       setSubmitting(true);
@@ -68,7 +71,6 @@ export function OtpVerification(props: OtpVerificationProps) {
           contact,
           otpType,
           ...(sessionKey && { sessionKey }),
-          ...(await consumeToken()),
         });
         closeModal();
       }


### PR DESCRIPTION
## Summary

With the companion backend change ([tkhq/mono#6940](https://github.com/tkhq/mono/pull/6940)), the captcha check is skipped for email/phone signups when a valid `verificationToken` is present. Since `completeOtp` calls `verifyOtp` internally to obtain a `verificationToken` before signing up, the backend never validates the captcha token passed through that path.

Consuming a captcha token in `handleContinue` (which calls `completeOtp` → `verifyOtp` → `signUpWithOtp`) is therefore wasteful — and worse, it can introduce a subtle bug:

1. User enters OTP code → `handleContinue` fires → `consumeToken()` drains the Turnstile token
2. User's OTP is rejected (wrong code, expired, etc.)
3. User clicks "Resend Code" → `handleResend` fires → tries `consumeToken()` for `initOtp`, which **always requires captcha**
4. The widget may not have regenerated a fresh token yet, so resend silently sends no captcha token

## Changes

- Removed the `consumeToken()` spread from the `completeOtp` call in `handleContinue`
- Kept `consumeToken()` in `handleResend` unchanged — `initOtp` always requires captcha
- Added a comment above `handleContinue` explaining why captcha is not needed there

## Companion

- Backend: tkhq/mono#6940 — skips captcha check for email/phone signups with a verificationToken