### PR TITLE
react-wallet-kit: Add error message, expiry message and reset, remove extra otp captcha

### DIFF
--- a/packages/react-wallet-kit/src/components/auth/OTP.tsx
+++ b/packages/react-wallet-kit/src/components/auth/OTP.tsx
@@ -8,8 +8,7 @@ import { OtpType, TurnkeyError, TurnkeyErrorCodes } from "@turnkey/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope, faPhone } from "@fortawesome/free-solid-svg-icons";
 import clsx from "clsx";
-import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
-import { consumeCaptchaToken } from "../../utils/captcha";
+import { useTurnstile } from "./TurnstileWidget";
 
 interface OtpVerificationProps {
   contact: string;
@@ -32,8 +31,7 @@ export function OtpVerification(props: OtpVerificationProps) {
     sessionKey,
     onContinue = null, // Default to null if not provided
   } = props;
-  const { initOtp, completeOtp, config, getTurnstileToken, setTurnstileToken } =
-    useTurnkey();
+  const { initOtp, completeOtp } = useTurnkey();
   const { closeModal, isMobile } = useModal();
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [resending, setResending] = useState<boolean>(false);
@@ -44,11 +42,7 @@ export function OtpVerification(props: OtpVerificationProps) {
   const [error, setError] = useState<string | null>(null);
   const [shaking, setShaking] = useState(false);
 
-  const turnstileRef = useRef<TurnstileInstance>(null);
-  const [showTurnstilePrompt, setShowTurnstilePrompt] = useState(false);
-
-  const consumeToken = () =>
-    consumeCaptchaToken(getTurnstileToken, setTurnstileToken, turnstileRef);
+  const { turnstile, consumeToken } = useTurnstile({ visible: !submitting });
 
   const shakeInput = () => {
     setShaking(true);
@@ -68,7 +62,6 @@ export function OtpVerification(props: OtpVerificationProps) {
           contact,
           otpType,
           ...(sessionKey && { sessionKey }),
-          ...(await consumeToken()),
         });
         closeModal();
       }
@@ -166,37 +159,7 @@ export function OtpVerification(props: OtpVerificationProps) {
           <Spinner strokeWidth={1} className="size-1/2" />
         </div>
       )}
-      {config?.turnstileSiteKey && !submitting && (
-        <div className="mt-3 flex flex-col text-left w-full">
-          {showTurnstilePrompt && (
-            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
-              Let us know you're human
-            </p>
-          )}
-          <Turnstile
-            ref={turnstileRef}
-            siteKey={config.turnstileSiteKey}
-            className="!w-full !block [&>iframe]:!w-full"
-            onSuccess={(token) => {
-              setTurnstileToken(token);
-            }}
-            onError={() => {
-              setTurnstileToken(null);
-            }}
-            onExpire={() => {
-              setTurnstileToken(null);
-            }}
-            onBeforeInteractive={() => {
-              setShowTurnstilePrompt(true);
-            }}
-            options={{
-              theme: config.ui?.darkMode ? "dark" : "light",
-              appearance: "interaction-only",
-              size: "flexible",
-            }}
-          />
-        </div>
-      )}
+      {turnstile}
     </div>
   );
 }

--- a/packages/react-wallet-kit/src/components/auth/TurnstileWidget.tsx
+++ b/packages/react-wallet-kit/src/components/auth/TurnstileWidget.tsx
@@ -1,0 +1,107 @@
+import { useRef, useState } from "react";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
+import { useTurnkey } from "../../providers/client/Hook";
+import { consumeCaptchaToken } from "../../utils/captcha";
+
+interface UseTurnstileOptions {
+  // Allows the caller to hide the widget while it's busy (e.g. while a request
+  // is in flight). The widget is still subject to its own visibility rules.
+  visible?: boolean;
+}
+
+/**
+ * Encapsulates all Cloudflare Turnstile state and behaviour shared across the
+ * auth flows (the main auth modal and the OTP verification screen).
+ *
+ * Returns a ready-to-render `turnstile` element (or `null` when it shouldn't be
+ * shown) plus the pieces callers need to gate their UI:
+ * - `authEnabled`: `false` until a token is available (or immediately `true`
+ *   when no turnstile is configured / a token already existed on mount).
+ * - `consumeToken`: waits for and consumes the current token before a request.
+ */
+export function useTurnstile(options?: UseTurnstileOptions) {
+  const { visible = true } = options ?? {};
+  const { config, getTurnstileToken, setTurnstileToken } = useTurnkey();
+
+  const turnstileRef = useRef<TurnstileInstance>(null);
+  const [showTurnstilePrompt, setShowTurnstilePrompt] = useState(false);
+  // If a token already existed when the component mounted, we don't need to show the widget at all
+  const [hadTokenOnMount] = useState(() => !!getTurnstileToken());
+  const [showTurnstileError, setShowTurnstileError] = useState(false);
+  const [showTurnstileExpired, setShowTurnstileExpired] = useState(false);
+  // Auth is enabled immediately if no turnstile is configured, or if the Provider already has a token
+  const [authEnabled, setAuthEnabled] = useState(
+    !config?.turnstileSiteKey || hadTokenOnMount,
+  );
+  const [turnstileErrorMessage, setTurnstileErrorMessage] = useState<
+    string | null
+  >(null);
+
+  const consumeToken = () =>
+    consumeCaptchaToken(getTurnstileToken, setTurnstileToken, turnstileRef);
+
+  const shouldRender =
+    !!config?.turnstileSiteKey &&
+    visible &&
+    (!hadTokenOnMount || showTurnstileError);
+
+  const onSuccess = (token: string) => {
+    setTurnstileToken(token);
+    setAuthEnabled(true);
+    setTurnstileErrorMessage(null);
+  };
+
+  const onError = () => {
+    setTurnstileToken(null);
+    setShowTurnstileError(true);
+    setTurnstileErrorMessage("Verification failed. Please try again.");
+  };
+
+  const onExpire = () => {
+    setTurnstileToken(null);
+    setAuthEnabled(false);
+    setShowTurnstileExpired(true);
+    turnstileRef.current?.reset();
+  };
+
+  const turnstile =
+    shouldRender && config?.turnstileSiteKey ? (
+      <>
+        <div className="mt-3 flex flex-col text-left w-full">
+          {showTurnstileExpired ? (
+            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
+              Verification expired - retrying...
+            </p>
+          ) : showTurnstilePrompt ? (
+            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
+              Let us know you're human
+            </p>
+          ) : null}
+          <Turnstile
+            ref={turnstileRef}
+            id="auth-component-turnstile"
+            siteKey={config.turnstileSiteKey}
+            className="!w-full !block [&>iframe]:!w-full [&>iframe]:!bg-transparent"
+            onSuccess={onSuccess}
+            onError={onError}
+            onExpire={onExpire}
+            onBeforeInteractive={() => {
+              setShowTurnstilePrompt(true);
+            }}
+            options={{
+              theme: config.ui?.darkMode ? "dark" : "light",
+              appearance: "interaction-only",
+              size: "flexible",
+            }}
+          />
+        </div>
+        {turnstileErrorMessage && (
+          <p className="text-red-500 dark:text-red-400 text-sm mt-2 text-center">
+            {turnstileErrorMessage}
+          </p>
+        )}
+      </>
+    ) : null;
+
+  return { turnstile, consumeToken, authEnabled };
+}

--- a/packages/react-wallet-kit/src/components/auth/index.tsx
+++ b/packages/react-wallet-kit/src/components/auth/index.tsx
@@ -26,9 +26,7 @@ import {
   ExternalWalletSelector,
   WalletSelectorMode,
 } from "./wallet/ExternalWalletSelector";
-import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
-import { useRef, useState } from "react";
-import { consumeCaptchaToken } from "../../utils/captcha";
+import { useTurnstile } from "./TurnstileWidget";
 
 type AuthComponentProps = {
   sessionKey?: string | undefined;
@@ -54,21 +52,10 @@ export function AuthComponent({
     initOtp,
     loginWithPasskey,
     signUpWithPasskey,
-    getTurnstileToken,
-    setTurnstileToken,
   } = useTurnkey();
   const { pushPage, isMobile, openSheet } = useModal();
 
-  const turnstileRef = useRef<TurnstileInstance>(null);
-  const [showTurnstilePrompt, setShowTurnstilePrompt] = useState(false);
-  // If a token already existed when the component mounted, we don't need to show the widget at all
-  const [hadTokenOnMount] = useState(() => !!getTurnstileToken());
-  // Auth is enabled immediately if no turnstile is configured, or if the Provider already has a token
-
-  const [showTurnstileError, setShowTurnstileError] = useState(false);
-  const [authEnabled, setAuthEnabled] = useState(
-    !config?.turnstileSiteKey || hadTokenOnMount,
-  );
+  const { turnstile, consumeToken, authEnabled } = useTurnstile();
 
   if (!config || clientState === ClientState.Loading) {
     // Don't check ClientState.Error here. We already check in the modal root
@@ -84,9 +71,6 @@ export function AuthComponent({
     methodOrder = [],
     oauthOrder = [],
   } = config.ui?.authModal || {};
-
-  const consumeToken = () =>
-    consumeCaptchaToken(getTurnstileToken, setTurnstileToken, turnstileRef);
 
   const handleEmailSubmit = async (email: string) => {
     try {
@@ -484,42 +468,7 @@ export function AuthComponent({
         />
       )}
 
-      {config.turnstileSiteKey && (!hadTokenOnMount || showTurnstileError) && (
-        <div className="mt-3 flex flex-col text-left w-full">
-          {showTurnstilePrompt && (
-            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
-              Let us know you're human
-            </p>
-          )}
-          <Turnstile
-            ref={turnstileRef}
-            id="auth-component-turnstile"
-            siteKey={config.turnstileSiteKey}
-            className="!w-full !block [&>iframe]:!w-full [&>iframe]:!bg-transparent"
-            onSuccess={(token) => {
-              setTurnstileToken(token);
-              setAuthEnabled(true);
-            }}
-            onError={() => {
-              console.error("Turnstile error occurred");
-              setTurnstileToken(null);
-              setShowTurnstileError(true);
-            }}
-            onExpire={() => {
-              setTurnstileToken(null);
-              setAuthEnabled(false);
-            }}
-            onBeforeInteractive={() => {
-              setShowTurnstilePrompt(true);
-            }}
-            options={{
-              theme: config.ui?.darkMode ? "dark" : "light",
-              appearance: "interaction-only",
-              size: "flexible",
-            }}
-          />
-        </div>
-      )}
+      {turnstile}
 
       <div className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-xs mt-4 text-center">
         <span>


### PR DESCRIPTION
## Summary

Three issues this PR solves

### No error message
Currently, when the Cloudflare Turnstile captcha widget errors or expires, the auth buttons get disabled with no explanation to the user, they see a grayed-out form with no indication of why they cannot proceed. We added an error message.

### No expiry handling
When a captcha token expires, nothing happened. We now show a message, and reset the turnstile widget.

### Double captcha
**Current Behavior**
1. User enters email → clicks submit → handleEmailSubmit in index.tsx calls initOtp with consumeToken() → CAPTCHA 1 - (Turnstile widget in index.tsx)
2. User gets OTP code → enters it → handleContinue in OTP.tsx calls completeOtp which internally calls signup → backend requires captcha again → CAPTCHA 2 - (Turnstile widget in OTP.tsx)
**New Behavior**
User enters email → clicks submit → handleEmailSubmit calls initOtp with consumeToken() → CAPTCHA 1 - (Turnstile widget in index.tsx)
User gets OTP code → enters it → handleContinue calls completeOtp which gets a verificationToken from verifyOtp, then passes it to signup → backend sees the verificationToken + email/phone → skips captcha [mono PR #6940](https://github.com/tkhq/mono/pull/6940)

## Changes

1. Extracted <Turnstile> widget into separate component that is shared between auth/index.tsx and OTP.tsx.
2. Added expiry and error message
    a. Error (e.g. network issue, widget failure): shows "Verification failed. Please try again."
    b. Expiry (token timed out): shows "Verification expired — retrying..."
4. Added `turnstileRef.current?.reset()` in onExpire to immediately re-run the challenge. Clears when onSuccess receives new token.
5. Removed `consumeToken` from `handleContinue ` in `OTP.tsx`. With the companion [backend change](https://github.com/tkhq/mono/pull/6940), the captcha check is skipped for email/phone signups when a valid verificationToken is present. Since completeOtp calls verifyOtp internally to obtain a verificationToken before signing up, the backend never validates the captcha token passed through that path. Consuming a captcha token in handleContinue (which calls completeOtp → verifyOtp → signUpWithOtp) is not needed.
