### PR TITLE
Am/examples/feat/with tempo/gas sponsorship

### DIFF
--- a/examples/chain-integrations/with-tempo/README.md
+++ b/examples/chain-integrations/with-tempo/README.md
@@ -185,7 +185,7 @@ Send transaction status ID:
         f3a2b1c0-1234-5678-abcd-ef0123456789
 
 Receipt:
-        https://explore.testnet.tempo.xyz/receipt/0x71ab0cbbd90b0774be500da229e81596b9402f90fe8cf91ee49002eec77307ec
+        https://explore.testnet.tempo.xyz/tx/0x71ab0cbbd90b0774be500da229e81596b9402f90fe8cf91ee49002eec77307ec
 
 Sent 1 AlphaUSD to 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7 (gas sponsored by Turnkey)!
         https://docs.turnkey.com/features/transaction-management

--- a/examples/chain-integrations/with-tempo/README.md
+++ b/examples/chain-integrations/with-tempo/README.md
@@ -136,6 +136,55 @@ AlphaUSD balance for destination (0xD91d92a978AC1E8d5F22EcAb787A10c7676D8311):
         7
 ```
 
+#### Turnkey-sponsored transfer (gas abstraction)
+
+```bash
+$ pnpm start-sponsored
+```
+
+The scripts above use Tempo's native fee-payer to sponsor fees. This script instead uses [Turnkey's gas sponsorship](https://docs.turnkey.com/features/transaction-management) (aka gas abstraction / gasless transactions). You pass a minimal payload to a single `ethSendTransaction` call with `sponsor: true`, and Turnkey constructs, signs, broadcasts, and **pays the fees** via its Gas Station — your sender never needs to hold a native gas token. The script then polls `getSendTransactionStatus` until the transaction is included on-chain.
+
+It demonstrates sending a TIP-20 (AlphaUSD) transfer on Tempo Moderato (`caip2: eip155:42431`). The sender still needs the asset being transferred (AlphaUSD), which the faucet provides; only the fees are sponsored.
+
+Notes:
+
+- Gas sponsorship must be enabled in your Turnkey dashboard, and is available on Enterprise plans. See the [docs](https://docs.turnkey.com/features/transaction-management) for spend limits and billing.
+- `SIGN_WITH` must be a wallet account address (`0x...`); `ethSendTransaction` does not support private key IDs.
+- `SPONSOR_WITH` is not used here — Turnkey covers the fees directly.
+
+See the following for a sample output:
+
+```
+Network:
+        Tempo Testnet (Moderato) (chain ID 42431)
+
+Address:
+        0xDC608F098255C89B36da905D9132A9Ee3DD266D9
+
+Token:
+        AlphaUSD (6 decimals)
+
+Gas sponsorship:
+        Turnkey Gas Station (sponsor: true)
+
+✔ Amount to send (atomic units, 6 decimals) … 1000000
+✔ Destination address (default to TKHQ warchest) … 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7
+
+AlphaUSD balance for 0xDC608F098255C89B36da905D9132A9Ee3DD266D9:
+        1000000
+
+Submitting sponsored transaction via Turnkey...
+
+Send transaction status ID:
+        f3a2b1c0-1234-5678-abcd-ef0123456789
+
+Receipt:
+        https://explore.testnet.tempo.xyz/tx/0x71ab0cbbd90b0774be500da229e81596b9402f90fe8cf91ee49002eec77307ec
+
+Sent 1 AlphaUSD to 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7 (gas sponsored by Turnkey)!
+        https://docs.turnkey.com/features/transaction-management
+```
+
 Note: if you have a consensus-related policy resembling the following
 
 ```

--- a/examples/chain-integrations/with-tempo/README.md
+++ b/examples/chain-integrations/with-tempo/README.md
@@ -151,7 +151,7 @@ The script also reports your sponsored gas budget via the [`getGasUsage`](https:
 Notes:
 
 - Gas sponsorship must be enabled in your Turnkey dashboard, and is available on Enterprise plans. See the [docs](https://docs.turnkey.com/features/transaction-management) for spend limits and billing.
-- `SIGN_WITH` must be a wallet account address (`0x...`); `ethSendTransaction` does not support private key IDs.
+- `SIGN_WITH` must be an address (`0x...`) — either a wallet account address or a private key address; `ethSendTransaction` does not support private key IDs.
 - `SPONSOR_WITH` is not used here — Turnkey covers the fees directly.
 - **On testnet the reported limit won't change and usage always shows `$0`.** Usage is denominated in the USD value of fees at broadcast time, and testnet fees are paid in a valueless test token, so there is nothing to meter. The numbers only move on mainnet.
 

--- a/examples/chain-integrations/with-tempo/README.md
+++ b/examples/chain-integrations/with-tempo/README.md
@@ -146,11 +146,14 @@ The scripts above use Tempo's native fee-payer to sponsor fees. This script inst
 
 It demonstrates sending a TIP-20 (AlphaUSD) transfer on Tempo Moderato (`caip2: eip155:42431`). The sender still needs the asset being transferred (AlphaUSD), which the faucet provides; only the fees are sponsored.
 
+The script also reports your sponsored gas budget via the [`getGasUsage`](https://docs.turnkey.com/api-reference/queries/get-gas-usage) query — the remaining budget before sending, and the limit / used / remaining breakdown afterwards.
+
 Notes:
 
 - Gas sponsorship must be enabled in your Turnkey dashboard, and is available on Enterprise plans. See the [docs](https://docs.turnkey.com/features/transaction-management) for spend limits and billing.
 - `SIGN_WITH` must be a wallet account address (`0x...`); `ethSendTransaction` does not support private key IDs.
 - `SPONSOR_WITH` is not used here — Turnkey covers the fees directly.
+- **On testnet the reported limit won't change and usage always shows `$0`.** Usage is denominated in the USD value of fees at broadcast time, and testnet fees are paid in a valueless test token, so there is nothing to meter. The numbers only move on mainnet.
 
 See the following for a sample output:
 
@@ -167,6 +170,9 @@ Token:
 Gas sponsorship:
         Turnkey Gas Station (sponsor: true)
 
+Sponsored gas remaining (last 1440 min window):
+        $10 (of $10.00000000 limit)
+
 ✔ Amount to send (atomic units, 6 decimals) … 1000000
 ✔ Destination address (default to TKHQ warchest) … 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7
 
@@ -179,10 +185,15 @@ Send transaction status ID:
         f3a2b1c0-1234-5678-abcd-ef0123456789
 
 Receipt:
-        https://explore.testnet.tempo.xyz/tx/0x71ab0cbbd90b0774be500da229e81596b9402f90fe8cf91ee49002eec77307ec
+        https://explore.testnet.tempo.xyz/receipt/0x71ab0cbbd90b0774be500da229e81596b9402f90fe8cf91ee49002eec77307ec
 
 Sent 1 AlphaUSD to 0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7 (gas sponsored by Turnkey)!
         https://docs.turnkey.com/features/transaction-management
+
+Sponsored gas usage (last 1440 min window):
+        used      $0
+        limit     $10.00000000
+        remaining $10
 ```
 
 Note: if you have a consensus-related policy resembling the following

--- a/examples/chain-integrations/with-tempo/package.json
+++ b/examples/chain-integrations/with-tempo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "start-multicall": "tsx src/multicall.ts",
+    "start-sponsored": "tsx src/sponsored.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/chain-integrations/with-tempo/src/sponsored.ts
+++ b/examples/chain-integrations/with-tempo/src/sponsored.ts
@@ -116,7 +116,7 @@ async function main() {
   const signWith = process.env.SIGN_WITH;
   if (!isAddress(signWith)) {
     throw new Error(
-      "SIGN_WITH must be a wallet account address (0x...) for the sponsored flow; private key IDs are not supported by ethSendTransaction.",
+      "SIGN_WITH must be an address (0x...) — a wallet account or private key address — for the sponsored flow; private key IDs are not supported by ethSendTransaction.",
     );
   }
 

--- a/examples/chain-integrations/with-tempo/src/sponsored.ts
+++ b/examples/chain-integrations/with-tempo/src/sponsored.ts
@@ -62,9 +62,7 @@ async function ensureFunded(
   print(
     "Receipts:",
     receipts
-      .map(
-        (r) => `https://explore.testnet.tempo.xyz/receipt/${r.transactionHash}`,
-      )
+      .map((r) => `https://explore.testnet.tempo.xyz/tx/${r.transactionHash}`)
       .join("\n\t"),
   );
 }
@@ -221,7 +219,7 @@ async function main() {
     );
   }
 
-  print("Receipt:", `https://explore.testnet.tempo.xyz/receipt/${txHash}`);
+  print("Receipt:", `https://explore.testnet.tempo.xyz/tx/${txHash}`);
   print(
     `Sent ${formatUnits(BigInt(amount), decimals)} ${name} to ${destination} (gas sponsored by Turnkey)!`,
     "https://docs.turnkey.com/features/transaction-management",

--- a/examples/chain-integrations/with-tempo/src/sponsored.ts
+++ b/examples/chain-integrations/with-tempo/src/sponsored.ts
@@ -17,7 +17,7 @@ import {
 } from "viem";
 import { Turnkey as TurnkeySDKServer } from "@turnkey/sdk-server";
 import { createNewWallet } from "./turnkey";
-import { print, sleep } from "./util";
+import { print } from "./util";
 
 // @ts-ignore
 const ALPHA_USD = "0x20c0000000000000000000000000000000000001" as const;
@@ -194,29 +194,17 @@ async function main() {
 
   print("Send transaction status ID:", sendTransactionStatusId);
 
-  // Poll until Turnkey reports an on-chain transaction hash (or a failure).
-  let txHash: string | undefined;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    const status = await apiClient.getSendTransactionStatus({
-      sendTransactionStatusId,
-    });
+  // Poll until Turnkey reports a terminal state (resolves on success, rejects
+  // on failure).
+  const status = await apiClient.pollTransactionStatus({
+    sendTransactionStatusId,
+    pollingIntervalMs: 1000,
+    timeoutMs: 30_000,
+  });
 
-    if (status.eth?.txHash) {
-      txHash = status.eth.txHash;
-      break;
-    }
-
-    if (status.txStatus === "TX_STATUS_FAILED") {
-      throw new Error(status.txError ?? "Sponsored transaction failed");
-    }
-
-    await sleep(1000);
-  }
-
+  const txHash = status.eth?.txHash;
   if (!txHash) {
-    throw new Error(
-      `Timed out waiting for transaction to be included. Check status ID ${sendTransactionStatusId}.`,
-    );
+    throw new Error(`No tx hash in terminal status ${status.txStatus}`);
   }
 
   print("Receipt:", `https://explore.testnet.tempo.xyz/tx/${txHash}`);

--- a/examples/chain-integrations/with-tempo/src/sponsored.ts
+++ b/examples/chain-integrations/with-tempo/src/sponsored.ts
@@ -1,0 +1,191 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+import prompts from "prompts";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { tempoModerato } from "viem/chains";
+import { Actions, tempoActions } from "viem/tempo";
+import {
+  createClient,
+  http,
+  publicActions,
+  encodeFunctionData,
+  erc20Abi,
+  formatUnits,
+  isAddress,
+} from "viem";
+import { Turnkey as TurnkeySDKServer } from "@turnkey/sdk-server";
+import { createNewWallet } from "./turnkey";
+import { print, sleep } from "./util";
+
+// @ts-ignore
+const ALPHA_USD = "0x20c0000000000000000000000000000000000001" as const;
+
+// CAIP-2 identifier for Tempo Moderato. The generated SDK `caip2` union is
+// currently stale and does not yet include Tempo, so we cast when passing it
+// to `ethSendTransaction` (see the `as any` below).
+const TEMPO_MODERATO_CAIP2 = "eip155:42431";
+
+async function ensureFunded(
+  client: ReturnType<typeof createClient>,
+  address: `0x${string}`,
+  token: { address: `0x${string}`; name: string; decimals: number },
+) {
+  const balance = await Actions.token.getBalance(client, {
+    token: token.address,
+    account: address,
+  });
+
+  if (balance > 0n) {
+    print(
+      `${token.name} balance for ${address}:`,
+      formatUnits(balance, token.decimals),
+    );
+    return;
+  }
+
+  print(
+    `${token.name} balance for ${address} is 0! Funding... if unsuccessful, please add funds via the faucet:`,
+    "https://docs.tempo.xyz/guide/use-accounts/add-funds",
+  );
+  const receipts = await Actions.faucet.fundSync(client, { account: address });
+  const newBalance = await Actions.token.getBalance(client, {
+    token: token.address,
+    account: address,
+  });
+
+  print(
+    `${token.name} balance for ${address}:`,
+    formatUnits(newBalance, token.decimals),
+  );
+  print(
+    "Receipts:",
+    receipts
+      .map((r) => `https://explore.testnet.tempo.xyz/receipt/${r.transactionHash}`)
+      .join("\n\t"),
+  );
+}
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    await createNewWallet();
+    return;
+  }
+
+  // Turnkey's gas sponsorship requires a wallet/private-key *address* to sign
+  // with; private key IDs are not supported by `ethSendTransaction`.
+  const signWith = process.env.SIGN_WITH;
+  if (!isAddress(signWith)) {
+    throw new Error(
+      "SIGN_WITH must be a wallet account address (0x...) for the sponsored flow; private key IDs are not supported by ethSendTransaction.",
+    );
+  }
+
+  const apiClient = new TurnkeySDKServer({
+    apiBaseUrl: process.env.BASE_URL!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    defaultOrganizationId: process.env.ORGANIZATION_ID!,
+  }).apiClient();
+
+  // A read-only client for token metadata, balances and faucet funding. The
+  // transaction itself is constructed, signed and broadcast by Turnkey — the
+  // sender never holds native gas tokens.
+  const client = createClient({
+    chain: tempoModerato,
+    transport: http("https://rpc.moderato.tempo.xyz"),
+  })
+    .extend(publicActions)
+    .extend(tempoActions());
+
+  const { name, decimals } = await Actions.token.getMetadata(client, {
+    token: ALPHA_USD,
+  });
+  const token = { address: ALPHA_USD, name, decimals };
+
+  print("Network:", `${client.chain.name} (chain ID ${client.chain.id})`);
+  print("Address:", signWith);
+  print("Token:", `${name} (${decimals} decimals)`);
+  print("Gas sponsorship:", "Turnkey Gas Station (sponsor: true)");
+
+  const { amount, destination } = await prompts([
+    {
+      type: "text",
+      name: "amount",
+      message: `Amount to send (atomic units, ${decimals} decimals)`,
+      initial: "1000000",
+    },
+    {
+      type: "text",
+      name: "destination",
+      message: "Destination address (default to TKHQ warchest)",
+      initial: "0x08d2b0a37F869FF76BACB5Bab3278E26ab7067B7",
+    },
+  ]);
+
+  console.log();
+
+  // The sender still needs the asset being transferred (AlphaUSD). Gas itself
+  // is covered by Turnkey, so no native fee token is required.
+  await ensureFunded(client, signWith, token);
+
+  // Build a standard ERC20 transfer; on Tempo, TIP-20 tokens expose the ERC20
+  // interface, so we encode `transfer(address,uint256)` calldata to the token.
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "transfer",
+    args: [destination as `0x${string}`, BigInt(amount)],
+  });
+
+  console.log("Submitting sponsored transaction via Turnkey...\n");
+
+  // Turnkey constructs, signs, broadcasts and pays the fees. We pass a minimal
+  // payload and omit gas/fee fields — they are unused for sponsored requests.
+  const { sendTransactionStatusId } = await apiClient.ethSendTransaction({
+    from: signWith,
+    to: ALPHA_USD,
+    value: "0",
+    data,
+    caip2: TEMPO_MODERATO_CAIP2 as any,
+    sponsor: true,
+  });
+
+  print("Send transaction status ID:", sendTransactionStatusId);
+
+  // Poll until Turnkey reports an on-chain transaction hash (or a failure).
+  let txHash: string | undefined;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const status = await apiClient.getSendTransactionStatus({
+      sendTransactionStatusId,
+    });
+
+    if (status.eth?.txHash) {
+      txHash = status.eth.txHash;
+      break;
+    }
+
+    if (status.txStatus === "TX_STATUS_FAILED") {
+      throw new Error(status.txError ?? "Sponsored transaction failed");
+    }
+
+    await sleep(1000);
+  }
+
+  if (!txHash) {
+    throw new Error(
+      `Timed out waiting for transaction to be included. Check status ID ${sendTransactionStatusId}.`,
+    );
+  }
+
+  print("Receipt:", `https://explore.testnet.tempo.xyz/receipt/${txHash}`);
+  print(
+    `Sent ${formatUnits(BigInt(amount), decimals)} ${name} to ${destination} (gas sponsored by Turnkey)!`,
+    "https://docs.turnkey.com/features/transaction-management",
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/examples/chain-integrations/with-tempo/src/sponsored.ts
+++ b/examples/chain-integrations/with-tempo/src/sponsored.ts
@@ -62,8 +62,48 @@ async function ensureFunded(
   print(
     "Receipts:",
     receipts
-      .map((r) => `https://explore.testnet.tempo.xyz/receipt/${r.transactionHash}`)
+      .map(
+        (r) => `https://explore.testnet.tempo.xyz/receipt/${r.transactionHash}`,
+      )
       .join("\n\t"),
+  );
+}
+
+// Fetches the sponsored gas budget for the current window via Turnkey's
+// `getGasUsage` query, returning the limit, the amount used and the remainder.
+//
+// Note: on testnet (e.g. Tempo Moderato), the configured limit won't change
+// and usage will always report $0. Usage is denominated in the USD value of
+// fees at broadcast time, and testnet fees are paid in a valueless test token,
+// so there is nothing to meter. The numbers only move on mainnet.
+async function fetchGasUsage(
+  apiClient: ReturnType<TurnkeySDKServer["apiClient"]>,
+) {
+  const { usageUsd, windowLimitUsd, windowDurationMinutes } =
+    await apiClient.getGasUsage({});
+
+  const remainingUsd = Number(windowLimitUsd) - Number(usageUsd);
+
+  return { usageUsd, windowLimitUsd, windowDurationMinutes, remainingUsd };
+}
+
+type GasUsage = Awaited<ReturnType<typeof fetchGasUsage>>;
+
+function printGasRemaining(usage: GasUsage) {
+  print(
+    `Sponsored gas remaining (last ${usage.windowDurationMinutes} min window):`,
+    `$${usage.remainingUsd} (of $${usage.windowLimitUsd} limit)`,
+  );
+}
+
+function printGasUsage(usage: GasUsage) {
+  print(
+    `Sponsored gas usage (last ${usage.windowDurationMinutes} min window):`,
+    [
+      `used      $${usage.usageUsd}`,
+      `limit     $${usage.windowLimitUsd}`,
+      `remaining $${usage.remainingUsd}`,
+    ].join("\n\t"),
   );
 }
 
@@ -108,6 +148,9 @@ async function main() {
   print("Address:", signWith);
   print("Token:", `${name} (${decimals} decimals)`);
   print("Gas sponsorship:", "Turnkey Gas Station (sponsor: true)");
+
+  // Check the remaining sponsored gas budget before spending any of it.
+  printGasRemaining(await fetchGasUsage(apiClient));
 
   const { amount, destination } = await prompts([
     {
@@ -183,6 +226,8 @@ async function main() {
     `Sent ${formatUnits(BigInt(amount), decimals)} ${name} to ${destination} (gas sponsored by Turnkey)!`,
     "https://docs.turnkey.com/features/transaction-management",
   );
+
+  printGasUsage(await fetchGasUsage(apiClient));
 }
 
 main().catch((e) => {

--- a/examples/chain-integrations/with-tempo/src/sponsored.ts
+++ b/examples/chain-integrations/with-tempo/src/sponsored.ts
@@ -14,13 +14,13 @@ import {
   erc20Abi,
   formatUnits,
   isAddress,
+  type Hex,
 } from "viem";
 import { Turnkey as TurnkeySDKServer } from "@turnkey/sdk-server";
 import { createNewWallet } from "./turnkey";
 import { print } from "./util";
 
-// @ts-ignore
-const ALPHA_USD = "0x20c0000000000000000000000000000000000001" as const;
+const ALPHA_USD = "0x20c0000000000000000000000000000000000001" as Hex;
 
 // CAIP-2 identifier for Tempo Moderato. The generated SDK `caip2` union is
 // currently stale and does not yet include Tempo, so we cast when passing it
@@ -29,8 +29,8 @@ const TEMPO_MODERATO_CAIP2 = "eip155:42431";
 
 async function ensureFunded(
   client: ReturnType<typeof createClient>,
-  address: `0x${string}`,
-  token: { address: `0x${string}`; name: string; decimals: number },
+  address: Hex,
+  token: { address: Hex; name: string; decimals: number },
 ) {
   const balance = await Actions.token.getBalance(client, {
     token: token.address,
@@ -176,7 +176,7 @@ async function main() {
   const data = encodeFunctionData({
     abi: erc20Abi,
     functionName: "transfer",
-    args: [destination as `0x${string}`, BigInt(amount)],
+    args: [destination as Hex, BigInt(amount)],
   });
 
   console.log("Submitting sponsored transaction via Turnkey...\n");

--- a/examples/chain-integrations/with-tempo/src/sponsored.ts
+++ b/examples/chain-integrations/with-tempo/src/sponsored.ts
@@ -80,7 +80,7 @@ async function fetchGasUsage(
   const { usageUsd, windowLimitUsd, windowDurationMinutes } =
     await apiClient.getGasUsage({});
 
-  const remainingUsd = Number(windowLimitUsd) - Number(usageUsd);
+  const remainingUsd = (Number(windowLimitUsd) - Number(usageUsd)).toFixed(2);
 
   return { usageUsd, windowLimitUsd, windowDurationMinutes, remainingUsd };
 }


### PR DESCRIPTION
## Summary & Motivation

Adds a Turnkey **gas sponsorship** demo to the `with-tempo` example.

The existing scripts (`pnpm start`, `pnpm start-multicall`) sponsor fees using Tempo's _native_ fee-payer (`withFeePayer` + the public `sponsor.moderato.tempo.xyz` endpoint). This PR adds a new `pnpm start-sponsored` script that instead uses [**Turnkey's gas sponsorship**](https://docs.turnkey.com/features/transaction-management) — a single `ethSendTransaction` call with `sponsor: true`, where Turnkey constructs, signs, broadcasts, and pays the fees via its Gas Station so the sender never holds a native gas token.

What the new script does:

- Sends a TIP-20 (AlphaUSD) transfer on Tempo Moderato (`caip2: eip155:42431`) by encoding standard ERC20 `transfer(address,uint256)` calldata.
- Submits via `apiClient.ethSendTransaction({ ..., sponsor: true })`, then polls `getSendTransactionStatus` until the transaction is included on-chain (or fails).
- Reports the sponsored gas budget via `getGasUsage` — remaining budget before sending, and a limit / used / remaining breakdown afterwards.

Files changed (all under `examples/chain-integrations/with-tempo`):

- `src/sponsored.ts` — new script (the sponsored flow + gas-usage reporting).
- `package.json` — adds the `start-sponsored` script.
- `README.md` — documents the new flow, sample output, and notes.

Closes [CUS-231](https://linear.app/turnkey/issue/CUS-231/add-gas-sponsorship-flow-to-with-tempo-example)

## How I Tested These Changes

- Ran `pnpm start-sponsored` against Tempo Moderato testnet with a funded Turnkey wallet and confirmed the transfer was broadcast and included.
- Verified on-chain via `eth_getTransactionByHash` against `https://rpc.moderato.tempo.xyz` that the transaction was genuinely sponsored — the tx carries a Gas Station `feePayerSignature` and `maxPriorityFeePerGas: 0x0`, confirming fees were paid by Turnkey rather than the sender's wallet.
- Confirmed the `getGasUsage` reporting prints the configured limit and `$0` usage on testnet (expected for valueless testnet fees).
- Typechecked the example (`tsc --noEmit`) with no errors.

## Did you add a changeset?

No changeset needed. This PR only adds to the `with-tempo` example app.