### PR TITLE
fix(react-wallet-kit): auto-reset Turnstile widget on token expiry

### DIFF
--- a/packages/react-wallet-kit/src/components/auth/OTP.tsx
+++ b/packages/react-wallet-kit/src/components/auth/OTP.tsx
@@ -46,6 +46,7 @@ export function OtpVerification(props: OtpVerificationProps) {
 
   const turnstileRef = useRef<TurnstileInstance>(null);
   const [showTurnstilePrompt, setShowTurnstilePrompt] = useState(false);
+  const [showTurnstileExpired, setShowTurnstileExpired] = useState(false);
 
   const consumeToken = () =>
     consumeCaptchaToken(getTurnstileToken, setTurnstileToken, turnstileRef);
@@ -168,23 +169,30 @@ export function OtpVerification(props: OtpVerificationProps) {
       )}
       {config?.turnstileSiteKey && !submitting && (
         <div className="mt-3 flex flex-col text-left w-full">
-          {showTurnstilePrompt && (
+          {showTurnstileExpired ? (
+            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
+              Verification expired — retrying...
+            </p>
+          ) : showTurnstilePrompt ? (
             <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
               Let us know you're human
             </p>
-          )}
+          ) : null}
           <Turnstile
             ref={turnstileRef}
             siteKey={config.turnstileSiteKey}
             className="!w-full !block [&>iframe]:!w-full"
             onSuccess={(token) => {
               setTurnstileToken(token);
+              setShowTurnstileExpired(false);
             }}
             onError={() => {
               setTurnstileToken(null);
             }}
             onExpire={() => {
               setTurnstileToken(null);
+              setShowTurnstileExpired(true);
+              turnstileRef.current?.reset();
             }}
             onBeforeInteractive={() => {
               setShowTurnstilePrompt(true);

--- a/packages/react-wallet-kit/src/components/auth/index.tsx
+++ b/packages/react-wallet-kit/src/components/auth/index.tsx
@@ -66,6 +66,7 @@ export function AuthComponent({
   // Auth is enabled immediately if no turnstile is configured, or if the Provider already has a token
 
   const [showTurnstileError, setShowTurnstileError] = useState(false);
+  const [showTurnstileExpired, setShowTurnstileExpired] = useState(false);
   const [authEnabled, setAuthEnabled] = useState(
     !config?.turnstileSiteKey || hadTokenOnMount,
   );
@@ -486,11 +487,15 @@ export function AuthComponent({
 
       {config.turnstileSiteKey && (!hadTokenOnMount || showTurnstileError) && (
         <div className="mt-3 flex flex-col text-left w-full">
-          {showTurnstilePrompt && (
-            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
-              Let us know you're human
-            </p>
-          )}
+          {showTurnstileExpired ? (
+              <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
+                Verification expired — retrying...
+              </p>
+            ) : showTurnstilePrompt ? (
+              <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
+                Let us know you're human
+              </p>
+            ) : null}
           <Turnstile
             ref={turnstileRef}
             id="auth-component-turnstile"
@@ -499,6 +504,7 @@ export function AuthComponent({
             onSuccess={(token) => {
               setTurnstileToken(token);
               setAuthEnabled(true);
+              setShowTurnstileExpired(false);
             }}
             onError={() => {
               console.error("Turnstile error occurred");
@@ -508,6 +514,8 @@ export function AuthComponent({
             onExpire={() => {
               setTurnstileToken(null);
               setAuthEnabled(false);
+              setShowTurnstileExpired(true);
+              turnstileRef.current?.reset();
             }}
             onBeforeInteractive={() => {
               setShowTurnstilePrompt(true);


### PR DESCRIPTION
## Summary

Fixes the silent failure when a Turnstile token expires: auth buttons were permanently disabled with no recovery path.

## Root cause

In both `AuthComponent` and `OtpVerification`, `onExpire` only cleared state but never called `reset()` on the widget, so no new challenge was ever triggered.

## Fix

Call `turnstileRef.current?.reset()` in `onExpire` to immediately re-run the challenge. Show a brief "Verification expired — retrying..." message while the new challenge runs. Clear it in `onSuccess` when the fresh token arrives.

## Files changed

- `packages/react-wallet-kit/src/components/auth/index.tsx`
- `packages/react-wallet-kit/src/components/auth/OTP.tsx`

Targets `ethan/auth-proxy-captcha` (PR #1237).