### PR TITLE
Sync SDK generated API output

### DIFF
--- a/examples/chain-integrations/with-bitcoin/src/requests/createUser.ts
+++ b/examples/chain-integrations/with-bitcoin/src/requests/createUser.ts
@@ -11,8 +11,8 @@ export default async function createUser(
 ): Promise<string> {
   let userTags: string[] = new Array();
   try {
-    const { userIds } = await turnkeyClient.createApiOnlyUsers({
-      apiOnlyUsers: [
+    const { userIds } = await turnkeyClient.createUsers({
+      users: [
         {
           userName,
           userTags,
@@ -20,8 +20,11 @@ export default async function createUser(
             {
               apiKeyName,
               publicKey,
+              curveType: "API_KEY_CURVE_P256",
             },
           ],
+          authenticators: [],
+          oauthProviders: [],
         },
       ],
     });

--- a/examples/chain-integrations/with-solana/src/requests/createUser.ts
+++ b/examples/chain-integrations/with-solana/src/requests/createUser.ts
@@ -13,8 +13,8 @@ export default async function createUser(
 ): Promise<string> {
   let userTags: string[] = new Array();
   try {
-    const { userIds } = await turnkeyClient.createApiOnlyUsers({
-      apiOnlyUsers: [
+    const { userIds } = await turnkeyClient.createUsers({
+      users: [
         {
           userName,
           userTags,
@@ -22,8 +22,11 @@ export default async function createUser(
             {
               apiKeyName,
               publicKey,
+              curveType: "API_KEY_CURVE_P256",
             },
           ],
+          authenticators: [],
+          oauthProviders: [],
         },
       ],
     });

--- a/examples/chain-integrations/with-tron/src/requests/createUser.ts
+++ b/examples/chain-integrations/with-tron/src/requests/createUser.ts
@@ -11,8 +11,8 @@ export default async function createUser(
 ): Promise<string> {
   let userTags: string[] = new Array();
   try {
-    const { userIds } = await turnkeyClient.createApiOnlyUsers({
-      apiOnlyUsers: [
+    const { userIds } = await turnkeyClient.createUsers({
+      users: [
         {
           userName,
           userTags,
@@ -20,8 +20,11 @@ export default async function createUser(
             {
               apiKeyName,
               publicKey,
+              curveType: "API_KEY_CURVE_P256",
             },
           ],
+          authenticators: [],
+          oauthProviders: [],
         },
       ],
     });

--- a/examples/defi/trading-runner/src/requests/createUser.ts
+++ b/examples/defi/trading-runner/src/requests/createUser.ts
@@ -13,8 +13,8 @@ export default async function createUser(
   publicKey: string,
 ): Promise<string> {
   try {
-    const { userIds } = await turnkeyClient.createApiOnlyUsers({
-      apiOnlyUsers: [
+    const { userIds } = await turnkeyClient.createUsers({
+      users: [
         {
           userName,
           userTags,
@@ -22,8 +22,11 @@ export default async function createUser(
             {
               apiKeyName,
               publicKey,
+              curveType: "API_KEY_CURVE_P256",
             },
           ],
+          authenticators: [],
+          oauthProviders: [],
         },
       ],
     });

--- a/examples/demos/kitchen-sink/src/http/createUser.ts
+++ b/examples/demos/kitchen-sink/src/http/createUser.ts
@@ -24,11 +24,11 @@ async function main() {
   const apiKeyName = "<API key name>";
   const publicKey = "<API public key>";
 
-  const { activity } = await turnkeyClient.createApiOnlyUsers({
-    type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS",
+  const { activity } = await turnkeyClient.createUsers({
+    type: "ACTIVITY_TYPE_CREATE_USERS_V4",
     organizationId: process.env.ORGANIZATION_ID!,
     parameters: {
-      apiOnlyUsers: [
+      users: [
         {
           userName,
           userTags,
@@ -36,17 +36,18 @@ async function main() {
             {
               apiKeyName,
               publicKey,
+              curveType: "API_KEY_CURVE_P256",
             },
           ],
+          authenticators: [],
+          oauthProviders: [],
         },
       ],
     },
     timestampMs: String(Date.now()), // millisecond timestamp
   });
 
-  const userId = refineNonNull(
-    activity.result.createApiOnlyUsersResult?.userIds?.[0],
-  );
+  const userId = refineNonNull(activity.result.createUsersResult?.userIds?.[0]);
 
   // Success!
   console.log(

--- a/examples/demos/kitchen-sink/src/http/with-poller/createUser.ts
+++ b/examples/demos/kitchen-sink/src/http/with-poller/createUser.ts
@@ -24,11 +24,11 @@ async function main() {
   const apiKeyName = "<API key name>";
   const publicKey = "<API public key>";
 
-  const { activity } = await turnkeyClient.createApiOnlyUsers({
-    type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS",
+  const { activity } = await turnkeyClient.createUsers({
+    type: "ACTIVITY_TYPE_CREATE_USERS_V4",
     organizationId: process.env.ORGANIZATION_ID!,
     parameters: {
-      apiOnlyUsers: [
+      users: [
         {
           userName,
           userTags,
@@ -36,17 +36,18 @@ async function main() {
             {
               apiKeyName,
               publicKey,
+              curveType: "API_KEY_CURVE_P256",
             },
           ],
+          authenticators: [],
+          oauthProviders: [],
         },
       ],
     },
     timestampMs: String(Date.now()), // millisecond timestamp
   });
 
-  const userId = refineNonNull(
-    activity.result.createApiOnlyUsersResult?.userIds?.[0],
-  );
+  const userId = refineNonNull(activity.result.createUsersResult?.userIds?.[0]);
 
   // Success!
   console.log(

--- a/examples/demos/kitchen-sink/src/sdk-server/createUser.ts
+++ b/examples/demos/kitchen-sink/src/sdk-server/createUser.ts
@@ -22,8 +22,8 @@ async function main() {
   const apiKeyName = "<API key name>";
   const publicKey = "<API public key>";
 
-  const { userIds } = await turnkeyClient.apiClient().createApiOnlyUsers({
-    apiOnlyUsers: [
+  const { userIds } = await turnkeyClient.apiClient().createUsers({
+    users: [
       {
         userName,
         userTags,
@@ -31,8 +31,11 @@ async function main() {
           {
             apiKeyName,
             publicKey,
+            curveType: "API_KEY_CURVE_P256",
           },
         ],
+        authenticators: [],
+        oauthProviders: [],
       },
     ],
   });

--- a/examples/transaction-management/rebalancer/src/requests/createUser.ts
+++ b/examples/transaction-management/rebalancer/src/requests/createUser.ts
@@ -10,8 +10,8 @@ export default async function createUser(
   publicKey: string,
 ): Promise<string> {
   try {
-    const activity = await turnkeyClient.apiClient().createApiOnlyUsers({
-      apiOnlyUsers: [
+    const activity = await turnkeyClient.apiClient().createUsers({
+      users: [
         {
           userName,
           userTags,
@@ -19,8 +19,11 @@ export default async function createUser(
             {
               apiKeyName,
               publicKey,
+              curveType: "API_KEY_CURVE_P256",
             },
           ],
+          authenticators: [],
+          oauthProviders: [],
         },
       ],
     });

--- a/packages/core/src/__generated__/sdk-client-base.ts
+++ b/packages/core/src/__generated__/sdk-client-base.ts
@@ -806,6 +806,145 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getMfaPolicies = async (
+    input: SdkTypes.TGetMfaPoliciesBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetMfaPoliciesResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_mfa_policies",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetMfaPolicies = async (
+    input: SdkTypes.TGetMfaPoliciesBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_mfa_policies";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getMfaPolicy = async (
+    input: SdkTypes.TGetMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetMfaPolicyResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_mfa_policy",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetMfaPolicy = async (
+    input: SdkTypes.TGetMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_mfa_policy";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getMfaStatus = async (
+    input: SdkTypes.TGetMfaStatusBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetMfaStatusResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_mfa_status",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetMfaStatus = async (
+    input: SdkTypes.TGetMfaStatusBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_mfa_status";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getNonces = async (
     input: SdkTypes.TGetNoncesBody,
     stampWith?: StamperType,
@@ -1226,6 +1365,100 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getSessionProfile = async (
+    input: SdkTypes.TGetSessionProfileBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetSessionProfileResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_session_profile",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetSessionProfile = async (
+    input: SdkTypes.TGetSessionProfileBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_session_profile";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getSessionProfiles = async (
+    input: SdkTypes.TGetSessionProfilesBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetSessionProfilesResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_session_profiles",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetSessionProfiles = async (
+    input: SdkTypes.TGetSessionProfilesBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_session_profiles";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getSmartContractInterface = async (
     input: SdkTypes.TGetSmartContractInterfaceBody,
     stampWith?: StamperType,
@@ -1349,6 +1582,53 @@ export class TurnkeySDKClientBase {
     const session = await this.storageManager?.getActiveSession();
     const fullUrl =
       this.config.apiBaseUrl + "/public/v1/query/get_tvc_deployment";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getTvcDeploymentDebugLogs = async (
+    input: SdkTypes.TGetTvcDeploymentDebugLogsBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetTvcDeploymentDebugLogsResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_tvc_deployment_debug_logs",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetTvcDeploymentDebugLogs = async (
+    input: SdkTypes.TGetTvcDeploymentDebugLogsBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_tvc_deployment_debug_logs";
     const body = {
       ...input,
       organizationId:
@@ -2771,6 +3051,64 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  createMfaPolicy = async (
+    input: SdkTypes.TCreateMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TCreateMfaPolicyResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/create_mfa_policy",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+      },
+      "createMfaPolicyResult",
+      stampWith,
+    );
+  };
+
+  stampCreateMfaPolicy = async (
+    input: SdkTypes.TCreateMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   createOauth2Credential = async (
     input: SdkTypes.TCreateOauth2CredentialBody,
     stampWith?: StamperType,
@@ -3223,6 +3561,64 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION_V2",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  createSessionProfile = async (
+    input: SdkTypes.TCreateSessionProfileBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TCreateSessionProfileResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/create_session_profile",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+      },
+      "createSessionProfileResult",
+      stampWith,
+    );
+  };
+
+  stampCreateSessionProfile = async (
+    input: SdkTypes.TCreateSessionProfileBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_session_profile";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4035,6 +4431,64 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_INVITATION",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  deleteMfaPolicy = async (
+    input: SdkTypes.TDeleteMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TDeleteMfaPolicyResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/delete_mfa_policy",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+      },
+      "deleteMfaPolicyResult",
+      stampWith,
+    );
+  };
+
+  stampDeleteMfaPolicy = async (
+    input: SdkTypes.TDeleteMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/delete_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_DELETE_MFA_POLICY",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4994,7 +5448,7 @@ export class TurnkeySDKClientBase {
         generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
       },
-      "ethSendTransactionResult",
+      "ethSendTransactionResultV2",
       stampWith,
     );
   };
@@ -6979,6 +7433,64 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_FIAT_ON_RAMP_CREDENTIAL",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateMfaPolicy = async (
+    input: SdkTypes.TUpdateMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TUpdateMfaPolicyResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/update_mfa_policy",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+      },
+      "updateMfaPolicyResult",
+      stampWith,
+    );
+  };
+
+  stampUpdateMfaPolicy = async (
+    input: SdkTypes.TUpdateMfaPolicyBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/core/src/__inputs__/auth_proxy.swagger.json
+++ b/packages/core/src/__inputs__/auth_proxy.swagger.json
@@ -1207,6 +1207,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/core/src/__inputs__/public_api.swagger.json
+++ b/packages/core/src/__inputs__/public_api.swagger.json
@@ -392,6 +392,102 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_mfa_policies": {
+      "post": {
+        "summary": "Get MFA policies",
+        "description": "Get all MFA policies for a user.",
+        "operationId": "PublicApiService_GetMfaPolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_policy": {
+      "post": {
+        "summary": "Get MFA policy",
+        "description": "Get a single MFA policy for a user.",
+        "operationId": "PublicApiService_GetMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_status": {
+      "post": {
+        "summary": "Get MFA status",
+        "description": "Get the MFA status of an activity for a specific user or all voting users.",
+        "operationId": "PublicApiService_GetMfaStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/query/get_nonces": {
       "post": {
         "summary": "Get nonces",
@@ -680,6 +776,70 @@
         "tags": ["Send Transactions"]
       }
     },
+    "/public/v1/query/get_session_profile": {
+      "post": {
+        "summary": "Get session profile",
+        "description": "Get a single session profile for an organization.",
+        "operationId": "PublicApiService_GetSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
+    "/public/v1/query/get_session_profiles": {
+      "post": {
+        "summary": "Get session profiles",
+        "description": "Get all session profiles for an organization.",
+        "operationId": "PublicApiService_GetSessionProfiles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
     "/public/v1/query/get_smart_contract_interface": {
       "post": {
         "summary": "Get smart contract interface",
@@ -770,6 +930,38 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1GetTvcDeploymentRequest"
+            }
+          }
+        ],
+        "tags": ["TVC"]
+      }
+    },
+    "/public/v1/query/get_tvc_deployment_debug_logs": {
+      "post": {
+        "summary": "Get TVC Deployment debug logs",
+        "description": "Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp.",
+        "operationId": "PublicApiService_GetTvcDeploymentDebugLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsRequest"
             }
           }
         ],
@@ -875,7 +1067,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1387,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -1704,6 +1896,38 @@
         "tags": ["Invitations"]
       }
     },
+    "/public/v1/submit/create_mfa_policy": {
+      "post": {
+        "summary": "Create MFA policy",
+        "description": "Create a new MFA policy for a user.",
+        "operationId": "PublicApiService_CreateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/create_oauth2_credential": {
       "post": {
         "summary": "Create an OAuth 2.0 Credential",
@@ -1958,6 +2182,38 @@
           }
         ],
         "tags": ["Sessions"]
+      }
+    },
+    "/public/v1/submit/create_session_profile": {
+      "post": {
+        "summary": "Create session profile",
+        "description": "Create a new session profile for an organization.",
+        "operationId": "PublicApiService_CreateSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
       }
     },
     "/public/v1/submit/create_smart_contract_interface": {
@@ -2406,6 +2662,38 @@
           }
         ],
         "tags": ["Invitations"]
+      }
+    },
+    "/public/v1/submit/delete_mfa_policy": {
+      "post": {
+        "summary": "Delete MFA policy",
+        "description": "Delete an MFA policy for a user.",
+        "operationId": "PublicApiService_DeleteMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
       }
     },
     "/public/v1/submit/delete_oauth2_credential": {
@@ -4040,6 +4328,38 @@
         "tags": ["On Ramp"]
       }
     },
+    "/public/v1/submit/update_mfa_policy": {
+      "post": {
+        "summary": "Update MFA policy",
+        "description": "Update an MFA policy for a user.",
+        "operationId": "PublicApiService_UpdateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/update_oauth2_credential": {
       "post": {
         "summary": "Update an OAuth 2.0 Credential",
@@ -4695,6 +5015,10 @@
         },
         "type": {
           "$ref": "#/definitions/v1CredentialType"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN."
         }
       },
       "required": ["publicKey", "type"]
@@ -4984,7 +5308,8 @@
         "ACTIVITY_STATUS_COMPLETED",
         "ACTIVITY_STATUS_FAILED",
         "ACTIVITY_STATUS_CONSENSUS_NEEDED",
-        "ACTIVITY_STATUS_REJECTED"
+        "ACTIVITY_STATUS_REJECTED",
+        "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED"
       ]
     },
     "v1ActivityType": {
@@ -5127,7 +5452,16 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2",
+        "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+        "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+        "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+        "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+        "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER",
+        "ACTIVITY_TYPE_EARN_DEPOSIT",
+        "ACTIVITY_TYPE_EARN_WITHDRAW",
+        "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG"
       ]
     },
     "v1AddressFormat": {
@@ -5444,6 +5778,45 @@
         "transports"
       ]
     },
+    "v1AuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., for requiring a specific session profile id)"
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication)."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used."
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationType": {
+      "type": "string",
+      "enum": [
+        "AUTHENTICATION_TYPE_EMAIL_OTP",
+        "AUTHENTICATION_TYPE_SMS_OTP",
+        "AUTHENTICATION_TYPE_PASSKEY",
+        "AUTHENTICATION_TYPE_API_KEY",
+        "AUTHENTICATION_TYPE_OAUTH",
+        "AUTHENTICATION_TYPE_SESSION"
+      ]
+    },
     "v1Authenticator": {
       "type": "object",
       "properties": {
@@ -5586,11 +5959,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5979,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -5960,6 +6337,78 @@
         }
       },
       "required": ["invitationIds"]
+    },
+    "v1CreateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to add the MFA Policy to."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": [
+        "userId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order"
+      ]
+    },
+    "v1CreateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1CreateOauth2CredentialIntent": {
       "type": "object",
@@ -6662,6 +7111,59 @@
         "credentialBundle"
       ]
     },
+    "v1CreateSessionProfileIntent": {
+      "type": "object",
+      "properties": {
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope string that defines the permissions for this Session Profile."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for a Session Profile."
+        }
+      },
+      "required": ["sessionProfileName", "scope"]
+    },
+    "v1CreateSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_SESSION_PROFILE"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateSessionProfileResult": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        }
+      },
+      "required": ["sessionProfileId"]
+    },
     "v1CreateSmartContractInterfaceIntent": {
       "type": "object",
       "properties": {
@@ -7188,6 +7690,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -7971,6 +8477,51 @@
         }
       },
       "required": ["invitationId"]
+    },
+    "v1DeleteMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to delete the MFA Policy from."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1DeleteMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1DeleteOauth2CredentialIntent": {
       "type": "object",
@@ -8784,6 +9335,179 @@
       },
       "required": ["privateKeyId"]
     },
+    "v1EarnDeployWrapperIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to wrap (from the EarnVaults catalog)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        }
+      },
+      "required": ["vaultAddress", "chainCaip2"]
+    },
+    "v1EarnDeployWrapperResult": {
+      "type": "object",
+      "properties": {
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee wrapper (the deposit target)."
+        },
+        "splitterAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave)."
+        },
+        "deployTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the wrapper deployment."
+        }
+      },
+      "required": ["wrapperAddress", "splitterAddress", "deployTxHash"]
+    },
+    "v1EarnDepositIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "assets": {
+          "type": "string",
+          "description": "Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        }
+      },
+      "required": ["vaultAddress", "signWith", "assets", "chainCaip2"]
+    },
+    "v1EarnDepositResult": {
+      "type": "object",
+      "properties": {
+        "depositTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the deposit."
+        },
+        "sharesMinted": {
+          "type": "string",
+          "description": "Number of wrapper shares minted to the depositor, in raw on-chain units."
+        },
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the fee wrapper the deposit was routed to."
+        },
+        "depositRequestId": {
+          "type": "string",
+          "description": "Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path)."
+        }
+      },
+      "required": [
+        "depositTxHash",
+        "sharesMinted",
+        "wrapperAddress",
+        "depositRequestId"
+      ]
+    },
+    "v1EarnWithdrawIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        },
+        "amountType": {
+          "type": "string",
+          "enum": ["SHARES", "ASSETS"],
+          "description": "Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims)."
+        },
+        "amountValue": {
+          "type": "string",
+          "description": "The amount to withdraw, in raw on-chain units, interpreted according to amount_type."
+        }
+      },
+      "required": [
+        "vaultAddress",
+        "signWith",
+        "chainCaip2",
+        "amountType",
+        "amountValue"
+      ]
+    },
+    "v1EarnWithdrawResult": {
+      "type": "object",
+      "properties": {
+        "withdrawTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the withdrawal."
+        },
+        "withdrawRequestId": {
+          "type": "string",
+          "description": "Identifier to poll withdrawal status via EarnWithdrawStatus."
+        },
+        "assetsReceived": {
+          "type": "string",
+          "description": "Amount of the underlying asset received, in raw on-chain units."
+        },
+        "sharesBurned": {
+          "type": "string",
+          "description": "Number of wrapper shares burned, in raw on-chain units."
+        }
+      },
+      "required": [
+        "withdrawTxHash",
+        "withdrawRequestId",
+        "assetsReceived",
+        "sharesBurned"
+      ]
+    },
     "v1Effect": {
       "type": "string",
       "enum": ["EFFECT_ALLOW", "EFFECT_DENY"]
@@ -9037,6 +9761,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9807,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9845,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9890,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9966,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9975,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9797,6 +10613,94 @@
       },
       "required": ["organizationId", "appName"]
     },
+    "v1GetMfaPoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        }
+      },
+      "required": ["organizationId", "userId"]
+    },
+    "v1GetMfaPoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of multi-factor authentication policies for a user."
+        }
+      },
+      "required": ["mfaPolicies"]
+    },
+    "v1GetMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA policy."
+        }
+      },
+      "required": ["organizationId", "userId", "mfaPolicyId"]
+    },
+    "v1GetMfaPolicyResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicy": {
+          "$ref": "#/definitions/v1MfaPolicy",
+          "description": "Multi-factor authentication policy for a user."
+        }
+      },
+      "required": ["mfaPolicy"]
+    },
+    "v1GetMfaStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "activityId": {
+          "type": "string",
+          "description": "The unique identifier of the activity to get MFA status for."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Optional user ID to filter MFA status for a specific user."
+        }
+      },
+      "required": ["organizationId", "activityId"]
+    },
+    "v1GetMfaStatusResponse": {
+      "type": "object",
+      "properties": {
+        "mfaStatuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaStatus"
+          },
+          "description": "A list of MFA statuses for the activity's votes."
+        }
+      },
+      "required": ["mfaStatuses"]
+    },
     "v1GetNoncesRequest": {
       "type": "object",
       "properties": {
@@ -9816,7 +10720,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10108,6 +11014,54 @@
       },
       "required": ["txStatus"]
     },
+    "v1GetSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a session profile."
+        }
+      },
+      "required": ["organizationId", "sessionProfileId"]
+    },
+    "v1GetSessionProfileResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfile": {
+          "$ref": "#/definitions/v1SessionProfile",
+          "description": "Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies."
+        }
+      },
+      "required": ["sessionProfile"]
+    },
+    "v1GetSessionProfilesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetSessionProfilesResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SessionProfile"
+          },
+          "description": "A list of session profiles for users in the organization."
+        }
+      },
+      "required": ["sessionProfiles"]
+    },
     "v1GetSmartContractInterfaceRequest": {
       "type": "object",
       "properties": {
@@ -10266,6 +11220,44 @@
         }
       },
       "required": ["tvcApps"]
+    },
+    "v1GetTvcDeploymentDebugLogsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "Unique identifier for a given TVC Deployment. The deployment must be running in debug mode."
+        },
+        "tailLines": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied."
+        },
+        "sinceSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs."
+        }
+      },
+      "required": ["organizationId", "deploymentId"]
+    },
+    "v1GetTvcDeploymentDebugLogsResponse": {
+      "type": "object",
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TvcDeploymentDebugLogEntry"
+          },
+          "description": "Application log entries sorted by platform timestamp."
+        }
+      },
+      "required": ["entries"]
     },
     "v1GetTvcDeploymentRequest": {
       "type": "object",
@@ -10462,6 +11454,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +12810,33 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
+        },
+        "createMfaPolicyIntent": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        },
+        "updateMfaPolicyIntent": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        },
+        "deleteMfaPolicyIntent": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        },
+        "createSessionProfileIntent": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        },
+        "earnDeployWrapperIntent": {
+          "$ref": "#/definitions/v1EarnDeployWrapperIntent"
+        },
+        "earnDepositIntent": {
+          "$ref": "#/definitions/v1EarnDepositIntent"
+        },
+        "earnWithdrawIntent": {
+          "$ref": "#/definitions/v1EarnWithdrawIntent"
+        },
+        "upsertEarnClientFeeConfigIntent": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigIntent"
         }
       }
     },
@@ -11998,6 +13023,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -12066,6 +13097,20 @@
       },
       "required": ["webhookEndpoints"]
     },
+    "v1LogLine": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "One log line, exactly as the application printed it (without the trailing newline)"
+        },
+        "ts": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "When the line was logged. Stable across replays, so lines can be chronologically merged across pods"
+        }
+      },
+      "required": ["content"]
+    },
     "v1LoginUsage": {
       "type": "object",
       "properties": {
@@ -12075,6 +13120,95 @@
         }
       },
       "required": ["publicKey"]
+    },
+    "v1MfaPolicy": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for an MFA Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this policy is evaluated relative to other MFA policies."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular MFA policy."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "v1MfaStatus": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "satisfied": {
+          "type": "boolean",
+          "description": "Whether the MFA policy requirements are currently satisfied."
+        },
+        "satisfiedMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods already satisfied for this MFA policy."
+        },
+        "requiredMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements needed to satisfy this MFA policy."
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "userId",
+        "satisfied",
+        "satisfiedMethods",
+        "requiredMethods"
+      ]
     },
     "v1MnemonicLanguage": {
       "type": "string",
@@ -12278,6 +13412,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["oidcToken", "publicKey"]
@@ -12558,6 +13696,10 @@
         "clientSignature": {
           "$ref": "#/definitions/v1ClientSignature",
           "description": "Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey"]
@@ -12584,6 +13726,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login sessions"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey", "clientSignature"]
@@ -12630,7 +13776,8 @@
         "OUTCOME_DENY_IMPLICIT",
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
-        "OUTCOME_ERROR"
+        "OUTCOME_ERROR",
+        "OUTCOME_REQUIRES_AUTHENTICATORS"
       ]
     },
     "v1Pagination": {
@@ -13064,6 +14211,34 @@
       },
       "required": ["features"]
     },
+    "v1RequiredAuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
+    "v1RequiredAuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethodParams"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
     "v1RestoreTvcDeploymentIntent": {
       "type": "object",
       "properties": {
@@ -13458,6 +14633,33 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
+        },
+        "createMfaPolicyResult": {
+          "$ref": "#/definitions/v1CreateMfaPolicyResult"
+        },
+        "updateMfaPolicyResult": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyResult"
+        },
+        "deleteMfaPolicyResult": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyResult"
+        },
+        "createSessionProfileResult": {
+          "$ref": "#/definitions/v1CreateSessionProfileResult"
+        },
+        "earnDeployWrapperResult": {
+          "$ref": "#/definitions/v1EarnDeployWrapperResult"
+        },
+        "earnDepositResult": {
+          "$ref": "#/definitions/v1EarnDepositResult"
+        },
+        "earnWithdrawResult": {
+          "$ref": "#/definitions/v1EarnWithdrawResult"
+        },
+        "upsertEarnClientFeeConfigResult": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigResult"
         }
       }
     },
@@ -13710,6 +14912,44 @@
           }
         }
       }
+    },
+    "v1SessionProfile": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        },
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The specific scope that a session created with this profile is limited to."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "Optional window (in seconds) indicating how long sessions created with this profile should last."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular Session Profile."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "sessionProfileId",
+        "sessionProfileName",
+        "scope",
+        "createdAt",
+        "updatedAt"
+      ]
     },
     "v1SetIpAllowlistIntent": {
       "type": "object",
@@ -14806,6 +16046,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["publicKey"]
@@ -14925,6 +16169,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +16185,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15055,6 +16304,20 @@
         "updatedAt",
         "delete"
       ]
+    },
+    "v1TvcDeploymentDebugLogEntry": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "$ref": "#/definitions/v1LogLine",
+          "description": "Application log line with its platform timestamp."
+        },
+        "replicaLabel": {
+          "type": "string",
+          "description": "Public replica label that produced this log line, for example 'replica 2/3'."
+        }
+      },
+      "required": ["line", "replicaLabel"]
     },
     "v1TvcHealthCheckType": {
       "type": "string",
@@ -15461,6 +16724,76 @@
         }
       },
       "required": ["fiatOnRampCredentialId"]
+    },
+    "v1UpdateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to update the MFA Policy for."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1UpdateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1UpdateOauth2CredentialIntent": {
       "type": "object",
@@ -16204,6 +17537,30 @@
       },
       "required": ["endpointId", "webhookEndpoint"]
     },
+    "v1UpsertEarnClientFeeConfigIntent": {
+      "type": "object",
+      "properties": {
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address."
+        }
+      },
+      "required": ["clientFeeBps", "clientFeeWallet"]
+    },
+    "v1UpsertEarnClientFeeConfigResult": {
+      "type": "object",
+      "properties": {
+        "feeUpdateTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee configuration update."
+        }
+      },
+      "required": ["feeUpdateTxHash"]
+    },
     "v1UpsertGasUsageConfigIntent": {
       "type": "object",
       "properties": {
@@ -16303,6 +17660,14 @@
         },
         "updatedAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of MFA Policies that define multi-factor authentication requirements for this user."
         }
       },
       "required": [
@@ -16313,7 +17678,8 @@
         "userTags",
         "oauthProviders",
         "createdAt",
-        "updatedAt"
+        "updatedAt",
+        "mfaPolicies"
       ]
     },
     "v1UserParams": {
@@ -16749,6 +18115,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +18152,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -46,6 +46,18 @@ import type {
   TGetLatestBootProofBody,
   TGetLatestBootProofResponse,
 } from "./public_api.fetcher";
+import type {
+  TGetMfaPoliciesBody,
+  TGetMfaPoliciesResponse,
+} from "./public_api.fetcher";
+import type {
+  TGetMfaPolicyBody,
+  TGetMfaPolicyResponse,
+} from "./public_api.fetcher";
+import type {
+  TGetMfaStatusBody,
+  TGetMfaStatusResponse,
+} from "./public_api.fetcher";
 import type { TGetNoncesBody, TGetNoncesResponse } from "./public_api.fetcher";
 import type {
   TGetOauth2CredentialBody,
@@ -58,10 +70,6 @@ import type {
 import type {
   TGetOnRampTransactionStatusBody,
   TGetOnRampTransactionStatusResponse,
-} from "./public_api.fetcher";
-import type {
-  TGetOrganizationBody,
-  TGetOrganizationResponse,
 } from "./public_api.fetcher";
 import type {
   TGetOrganizationConfigsBody,
@@ -81,6 +89,14 @@ import type {
   TGetSendTransactionStatusResponse,
 } from "./public_api.fetcher";
 import type {
+  TGetSessionProfileBody,
+  TGetSessionProfileResponse,
+} from "./public_api.fetcher";
+import type {
+  TGetSessionProfilesBody,
+  TGetSessionProfilesResponse,
+} from "./public_api.fetcher";
+import type {
   TGetSmartContractInterfaceBody,
   TGetSmartContractInterfaceResponse,
 } from "./public_api.fetcher";
@@ -90,8 +106,8 @@ import type {
   TGetTvcDeploymentResponse,
 } from "./public_api.fetcher";
 import type {
-  TGetTvcDeploymentProvisioningDetailsBody,
-  TGetTvcDeploymentProvisioningDetailsResponse,
+  TGetTvcDeploymentDebugLogsBody,
+  TGetTvcDeploymentDebugLogsResponse,
 } from "./public_api.fetcher";
 import type { TGetUserBody, TGetUserResponse } from "./public_api.fetcher";
 import type { TGetWalletBody, TGetWalletResponse } from "./public_api.fetcher";
@@ -186,10 +202,6 @@ import type {
   TCreateApiKeysResponse,
 } from "./public_api.fetcher";
 import type {
-  TCreateApiOnlyUsersBody,
-  TCreateApiOnlyUsersResponse,
-} from "./public_api.fetcher";
-import type {
   TCreateAuthenticatorsBody,
   TCreateAuthenticatorsResponse,
 } from "./public_api.fetcher";
@@ -200,6 +212,10 @@ import type {
 import type {
   TCreateInvitationsBody,
   TCreateInvitationsResponse,
+} from "./public_api.fetcher";
+import type {
+  TCreateMfaPolicyBody,
+  TCreateMfaPolicyResponse,
 } from "./public_api.fetcher";
 import type {
   TCreateOauth2CredentialBody,
@@ -232,6 +248,10 @@ import type {
 import type {
   TCreateReadWriteSessionBody,
   TCreateReadWriteSessionResponse,
+} from "./public_api.fetcher";
+import type {
+  TCreateSessionProfileBody,
+  TCreateSessionProfileResponse,
 } from "./public_api.fetcher";
 import type {
   TCreateSmartContractInterfaceBody,
@@ -288,6 +308,10 @@ import type {
 import type {
   TDeleteInvitationBody,
   TDeleteInvitationResponse,
+} from "./public_api.fetcher";
+import type {
+  TDeleteMfaPolicyBody,
+  TDeleteMfaPolicyResponse,
 } from "./public_api.fetcher";
 import type {
   TDeleteOauth2CredentialBody,
@@ -351,10 +375,6 @@ import type {
 } from "./public_api.fetcher";
 import type { TEmailAuthBody, TEmailAuthResponse } from "./public_api.fetcher";
 import type {
-  TEthSendRawTransactionBody,
-  TEthSendRawTransactionResponse,
-} from "./public_api.fetcher";
-import type {
   TEthSendTransactionBody,
   TEthSendTransactionResponse,
 } from "./public_api.fetcher";
@@ -410,10 +430,6 @@ import type {
 } from "./public_api.fetcher";
 import type { TOtpAuthBody, TOtpAuthResponse } from "./public_api.fetcher";
 import type { TOtpLoginBody, TOtpLoginResponse } from "./public_api.fetcher";
-import type {
-  TPostTvcQuorumKeyShareBody,
-  TPostTvcQuorumKeyShareResponse,
-} from "./public_api.fetcher";
 import type {
   TRecoverUserBody,
   TRecoverUserResponse,
@@ -487,6 +503,10 @@ import type {
   TUpdateFiatOnRampCredentialResponse,
 } from "./public_api.fetcher";
 import type {
+  TUpdateMfaPolicyBody,
+  TUpdateMfaPolicyResponse,
+} from "./public_api.fetcher";
+import type {
   TUpdateOauth2CredentialBody,
   TUpdateOauth2CredentialResponse,
 } from "./public_api.fetcher";
@@ -535,14 +555,6 @@ import type {
   TUpdateWebhookEndpointResponse,
 } from "./public_api.fetcher";
 import type { TVerifyOtpBody, TVerifyOtpResponse } from "./public_api.fetcher";
-import type {
-  TRefreshFeatureFlagsBody,
-  TRefreshFeatureFlagsResponse,
-} from "./public_api.fetcher";
-import type {
-  TTestRateLimitsBody,
-  TTestRateLimitsResponse,
-} from "./public_api.fetcher";
 
 export class TurnkeyClient {
   config: THttpConfig;
@@ -895,6 +907,99 @@ export class TurnkeyClient {
   };
 
   /**
+   * Get all MFA policies for a user.
+   *
+   * Sign the provided `TGetMfaPoliciesBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_mfa_policies).
+   *
+   * See also {@link stampGetMfaPolicies}.
+   */
+  getMfaPolicies = async (
+    input: TGetMfaPoliciesBody,
+  ): Promise<TGetMfaPoliciesResponse> => {
+    return this.request("/public/v1/query/get_mfa_policies", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetMfaPoliciesBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetMfaPolicies}.
+   */
+  stampGetMfaPolicies = async (
+    input: TGetMfaPoliciesBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/query/get_mfa_policies";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Get a single MFA policy for a user.
+   *
+   * Sign the provided `TGetMfaPolicyBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_mfa_policy).
+   *
+   * See also {@link stampGetMfaPolicy}.
+   */
+  getMfaPolicy = async (
+    input: TGetMfaPolicyBody,
+  ): Promise<TGetMfaPolicyResponse> => {
+    return this.request("/public/v1/query/get_mfa_policy", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetMfaPolicyBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetMfaPolicy}.
+   */
+  stampGetMfaPolicy = async (
+    input: TGetMfaPolicyBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/query/get_mfa_policy";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Get the MFA status of an activity for a specific user or all voting users.
+   *
+   * Sign the provided `TGetMfaStatusBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_mfa_status).
+   *
+   * See also {@link stampGetMfaStatus}.
+   */
+  getMfaStatus = async (
+    input: TGetMfaStatusBody,
+  ): Promise<TGetMfaStatusResponse> => {
+    return this.request("/public/v1/query/get_mfa_status", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetMfaStatusBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetMfaStatus}.
+   */
+  stampGetMfaStatus = async (
+    input: TGetMfaStatusBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/query/get_mfa_status";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions.
    *
    * Sign the provided `TGetNoncesBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_nonces).
@@ -1011,37 +1116,6 @@ export class TurnkeyClient {
   ): Promise<TSignedRequest> => {
     const fullUrl =
       this.config.baseUrl + "/public/v1/query/get_onramp_transaction_status";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
-   * Get details about an organization.
-   *
-   * Sign the provided `TGetOrganizationBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_organization).
-   *
-   * See also {@link stampGetOrganization}.
-   */
-  getOrganization = async (
-    input: TGetOrganizationBody,
-  ): Promise<TGetOrganizationResponse> => {
-    return this.request("/public/v1/query/get_organization", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TGetOrganizationBody` by using the client's `stamp` function.
-   *
-   * See also {@link GetOrganization}.
-   */
-  stampGetOrganization = async (
-    input: TGetOrganizationBody,
-  ): Promise<TSignedRequest> => {
-    const fullUrl = this.config.baseUrl + "/public/v1/query/get_organization";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {
@@ -1206,6 +1280,70 @@ export class TurnkeyClient {
   };
 
   /**
+   * Get a single session profile for an organization.
+   *
+   * Sign the provided `TGetSessionProfileBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_session_profile).
+   *
+   * See also {@link stampGetSessionProfile}.
+   */
+  getSessionProfile = async (
+    input: TGetSessionProfileBody,
+  ): Promise<TGetSessionProfileResponse> => {
+    return this.request("/public/v1/query/get_session_profile", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetSessionProfileBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetSessionProfile}.
+   */
+  stampGetSessionProfile = async (
+    input: TGetSessionProfileBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/query/get_session_profile";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Get all session profiles for an organization.
+   *
+   * Sign the provided `TGetSessionProfilesBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_session_profiles).
+   *
+   * See also {@link stampGetSessionProfiles}.
+   */
+  getSessionProfiles = async (
+    input: TGetSessionProfilesBody,
+  ): Promise<TGetSessionProfilesResponse> => {
+    return this.request("/public/v1/query/get_session_profiles", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetSessionProfilesBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetSessionProfiles}.
+   */
+  stampGetSessionProfiles = async (
+    input: TGetSessionProfilesBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/query/get_session_profiles";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * Get details about a smart contract interface.
    *
    * Sign the provided `TGetSmartContractInterfaceBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_smart_contract_interface).
@@ -1296,32 +1434,31 @@ export class TurnkeyClient {
   };
 
   /**
-   * Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment
+   * Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp.
    *
-   * Sign the provided `TGetTvcDeploymentProvisioningDetailsBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_tvc_deployment_provisioning_details).
+   * Sign the provided `TGetTvcDeploymentDebugLogsBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_tvc_deployment_debug_logs).
    *
-   * See also {@link stampGetTvcDeploymentProvisioningDetails}.
+   * See also {@link stampGetTvcDeploymentDebugLogs}.
    */
-  getTvcDeploymentProvisioningDetails = async (
-    input: TGetTvcDeploymentProvisioningDetailsBody,
-  ): Promise<TGetTvcDeploymentProvisioningDetailsResponse> => {
+  getTvcDeploymentDebugLogs = async (
+    input: TGetTvcDeploymentDebugLogsBody,
+  ): Promise<TGetTvcDeploymentDebugLogsResponse> => {
     return this.request(
-      "/public/v1/query/get_tvc_deployment_provisioning_details",
+      "/public/v1/query/get_tvc_deployment_debug_logs",
       input,
     );
   };
 
   /**
-   * Produce a `SignedRequest` from `TGetTvcDeploymentProvisioningDetailsBody` by using the client's `stamp` function.
+   * Produce a `SignedRequest` from `TGetTvcDeploymentDebugLogsBody` by using the client's `stamp` function.
    *
-   * See also {@link GetTvcDeploymentProvisioningDetails}.
+   * See also {@link GetTvcDeploymentDebugLogs}.
    */
-  stampGetTvcDeploymentProvisioningDetails = async (
-    input: TGetTvcDeploymentProvisioningDetailsBody,
+  stampGetTvcDeploymentDebugLogs = async (
+    input: TGetTvcDeploymentDebugLogsBody,
   ): Promise<TSignedRequest> => {
     const fullUrl =
-      this.config.baseUrl +
-      "/public/v1/query/get_tvc_deployment_provisioning_details";
+      this.config.baseUrl + "/public/v1/query/get_tvc_deployment_debug_logs";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {
@@ -1417,7 +1554,7 @@ export class TurnkeyClient {
   };
 
   /**
-   * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.
+   * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.
    *
    * Sign the provided `TGetWalletAddressBalancesBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_wallet_address_balances).
    *
@@ -1738,7 +1875,7 @@ export class TurnkeyClient {
   };
 
   /**
-   * List supported assets for the specified network. This feature is in beta - please contact support for access.
+   * List supported assets for the specified network.
    *
    * Sign the provided `TListSupportedAssetsBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/list_supported_assets).
    *
@@ -2130,38 +2267,6 @@ export class TurnkeyClient {
   };
 
   /**
-   * Create API-only users in an existing organization.
-   *
-   * Sign the provided `TCreateApiOnlyUsersBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_api_only_users).
-   *
-   * See also {@link stampCreateApiOnlyUsers}.
-   */
-  createApiOnlyUsers = async (
-    input: TCreateApiOnlyUsersBody,
-  ): Promise<TCreateApiOnlyUsersResponse> => {
-    return this.request("/public/v1/submit/create_api_only_users", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TCreateApiOnlyUsersBody` by using the client's `stamp` function.
-   *
-   * See also {@link CreateApiOnlyUsers}.
-   */
-  stampCreateApiOnlyUsers = async (
-    input: TCreateApiOnlyUsersBody,
-  ): Promise<TSignedRequest> => {
-    const fullUrl =
-      this.config.baseUrl + "/public/v1/submit/create_api_only_users";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
    * Create authenticators to authenticate requests to Turnkey.
    *
    * Sign the provided `TCreateAuthenticatorsBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_authenticators).
@@ -2251,6 +2356,37 @@ export class TurnkeyClient {
   ): Promise<TSignedRequest> => {
     const fullUrl =
       this.config.baseUrl + "/public/v1/submit/create_invitations";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Create a new MFA policy for a user.
+   *
+   * Sign the provided `TCreateMfaPolicyBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_mfa_policy).
+   *
+   * See also {@link stampCreateMfaPolicy}.
+   */
+  createMfaPolicy = async (
+    input: TCreateMfaPolicyBody,
+  ): Promise<TCreateMfaPolicyResponse> => {
+    return this.request("/public/v1/submit/create_mfa_policy", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TCreateMfaPolicyBody` by using the client's `stamp` function.
+   *
+   * See also {@link CreateMfaPolicy}.
+   */
+  stampCreateMfaPolicy = async (
+    input: TCreateMfaPolicyBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/submit/create_mfa_policy";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {
@@ -2505,6 +2641,38 @@ export class TurnkeyClient {
   ): Promise<TSignedRequest> => {
     const fullUrl =
       this.config.baseUrl + "/public/v1/submit/create_read_write_session";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Create a new session profile for an organization.
+   *
+   * Sign the provided `TCreateSessionProfileBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_session_profile).
+   *
+   * See also {@link stampCreateSessionProfile}.
+   */
+  createSessionProfile = async (
+    input: TCreateSessionProfileBody,
+  ): Promise<TCreateSessionProfileResponse> => {
+    return this.request("/public/v1/submit/create_session_profile", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TCreateSessionProfileBody` by using the client's `stamp` function.
+   *
+   * See also {@link CreateSessionProfile}.
+   */
+  stampCreateSessionProfile = async (
+    input: TCreateSessionProfileBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/submit/create_session_profile";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {
@@ -2956,6 +3124,37 @@ export class TurnkeyClient {
     input: TDeleteInvitationBody,
   ): Promise<TSignedRequest> => {
     const fullUrl = this.config.baseUrl + "/public/v1/submit/delete_invitation";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Delete an MFA policy for a user.
+   *
+   * Sign the provided `TDeleteMfaPolicyBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/delete_mfa_policy).
+   *
+   * See also {@link stampDeleteMfaPolicy}.
+   */
+  deleteMfaPolicy = async (
+    input: TDeleteMfaPolicyBody,
+  ): Promise<TDeleteMfaPolicyResponse> => {
+    return this.request("/public/v1/submit/delete_mfa_policy", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TDeleteMfaPolicyBody` by using the client's `stamp` function.
+   *
+   * See also {@link DeleteMfaPolicy}.
+   */
+  stampDeleteMfaPolicy = async (
+    input: TDeleteMfaPolicyBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/submit/delete_mfa_policy";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {
@@ -3474,38 +3673,6 @@ export class TurnkeyClient {
   };
 
   /**
-   * Submit a raw transaction (serialized and signed) for broadcasting to the network.
-   *
-   * Sign the provided `TEthSendRawTransactionBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/eth_send_raw_transaction).
-   *
-   * See also {@link stampEthSendRawTransaction}.
-   */
-  ethSendRawTransaction = async (
-    input: TEthSendRawTransactionBody,
-  ): Promise<TEthSendRawTransactionResponse> => {
-    return this.request("/public/v1/submit/eth_send_raw_transaction", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TEthSendRawTransactionBody` by using the client's `stamp` function.
-   *
-   * See also {@link EthSendRawTransaction}.
-   */
-  stampEthSendRawTransaction = async (
-    input: TEthSendRawTransactionBody,
-  ): Promise<TSignedRequest> => {
-    const fullUrl =
-      this.config.baseUrl + "/public/v1/submit/eth_send_raw_transaction";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
    * Submit a transaction intent describing an EVM transaction you would like to broadcast.
    *
    * Sign the provided `TEthSendTransactionBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/eth_send_transaction).
@@ -4011,38 +4178,6 @@ export class TurnkeyClient {
    */
   stampOtpLogin = async (input: TOtpLoginBody): Promise<TSignedRequest> => {
     const fullUrl = this.config.baseUrl + "/public/v1/submit/otp_login";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
-   * Post re-encrypted quorum key share for a TVC deployment.
-   *
-   * Sign the provided `TPostTvcQuorumKeyShareBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/post_tvc_quorum_key_share).
-   *
-   * See also {@link stampPostTvcQuorumKeyShare}.
-   */
-  postTvcQuorumKeyShare = async (
-    input: TPostTvcQuorumKeyShareBody,
-  ): Promise<TPostTvcQuorumKeyShareResponse> => {
-    return this.request("/public/v1/submit/post_tvc_quorum_key_share", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TPostTvcQuorumKeyShareBody` by using the client's `stamp` function.
-   *
-   * See also {@link PostTvcQuorumKeyShare}.
-   */
-  stampPostTvcQuorumKeyShare = async (
-    input: TPostTvcQuorumKeyShareBody,
-  ): Promise<TSignedRequest> => {
-    const fullUrl =
-      this.config.baseUrl + "/public/v1/submit/post_tvc_quorum_key_share";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {
@@ -4623,6 +4758,37 @@ export class TurnkeyClient {
   };
 
   /**
+   * Update an MFA policy for a user.
+   *
+   * Sign the provided `TUpdateMfaPolicyBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/update_mfa_policy).
+   *
+   * See also {@link stampUpdateMfaPolicy}.
+   */
+  updateMfaPolicy = async (
+    input: TUpdateMfaPolicyBody,
+  ): Promise<TUpdateMfaPolicyResponse> => {
+    return this.request("/public/v1/submit/update_mfa_policy", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TUpdateMfaPolicyBody` by using the client's `stamp` function.
+   *
+   * See also {@link UpdateMfaPolicy}.
+   */
+  stampUpdateMfaPolicy = async (
+    input: TUpdateMfaPolicyBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/submit/update_mfa_policy";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * Update an OAuth 2.0 provider credential
    *
    * Sign the provided `TUpdateOauth2CredentialBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/update_oauth2_credential).
@@ -5014,68 +5180,6 @@ export class TurnkeyClient {
    */
   stampVerifyOtp = async (input: TVerifyOtpBody): Promise<TSignedRequest> => {
     const fullUrl = this.config.baseUrl + "/public/v1/submit/verify_otp";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
-   * Refresh feature flags by triggering a DB read to flush the in-memory cache.
-   *
-   * Sign the provided `TRefreshFeatureFlagsBody` with the client's `stamp` function, and submit the request (POST /tkhq/api/v1/refresh_feature_flags).
-   *
-   * See also {@link stampRefreshFeatureFlags}.
-   */
-  refreshFeatureFlags = async (
-    input: TRefreshFeatureFlagsBody,
-  ): Promise<TRefreshFeatureFlagsResponse> => {
-    return this.request("/tkhq/api/v1/refresh_feature_flags", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TRefreshFeatureFlagsBody` by using the client's `stamp` function.
-   *
-   * See also {@link RefreshFeatureFlags}.
-   */
-  stampRefreshFeatureFlags = async (
-    input: TRefreshFeatureFlagsBody,
-  ): Promise<TSignedRequest> => {
-    const fullUrl = this.config.baseUrl + "/tkhq/api/v1/refresh_feature_flags";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
-   * Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite.
-   *
-   * Sign the provided `TTestRateLimitsBody` with the client's `stamp` function, and submit the request (POST /tkhq/api/v1/test_rate_limits).
-   *
-   * See also {@link stampTestRateLimits}.
-   */
-  testRateLimits = async (
-    input: TTestRateLimitsBody,
-  ): Promise<TTestRateLimitsResponse> => {
-    return this.request("/tkhq/api/v1/test_rate_limits", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TTestRateLimitsBody` by using the client's `stamp` function.
-   *
-   * See also {@link TestRateLimits}.
-   */
-  stampTestRateLimits = async (
-    input: TTestRateLimitsBody,
-  ): Promise<TSignedRequest> => {
-    const fullUrl = this.config.baseUrl + "/tkhq/api/v1/test_rate_limits";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -486,6 +486,144 @@ export const signGetLatestBootProof = (
   });
 
 /**
+ * `POST /public/v1/query/get_mfa_policies`
+ */
+export type TGetMfaPoliciesResponse =
+  operations["PublicApiService_GetMfaPolicies"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_mfa_policies`
+ */
+export type TGetMfaPoliciesInput = { body: TGetMfaPoliciesBody };
+
+/**
+ * `POST /public/v1/query/get_mfa_policies`
+ */
+export type TGetMfaPoliciesBody =
+  operations["PublicApiService_GetMfaPolicies"]["parameters"]["body"]["body"];
+
+/**
+ * Get MFA policies
+ *
+ * Get all MFA policies for a user.
+ *
+ * `POST /public/v1/query/get_mfa_policies`
+ */
+export const getMfaPolicies = (input: TGetMfaPoliciesInput) =>
+  request<TGetMfaPoliciesResponse, TGetMfaPoliciesBody, never, never, never>({
+    uri: "/public/v1/query/get_mfa_policies",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetMfaPolicies` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetMfaPolicies}
+ */
+export const signGetMfaPolicies = (
+  input: TGetMfaPoliciesInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetMfaPoliciesBody, never, never>({
+    uri: "/public/v1/query/get_mfa_policies",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/query/get_mfa_policy`
+ */
+export type TGetMfaPolicyResponse =
+  operations["PublicApiService_GetMfaPolicy"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_mfa_policy`
+ */
+export type TGetMfaPolicyInput = { body: TGetMfaPolicyBody };
+
+/**
+ * `POST /public/v1/query/get_mfa_policy`
+ */
+export type TGetMfaPolicyBody =
+  operations["PublicApiService_GetMfaPolicy"]["parameters"]["body"]["body"];
+
+/**
+ * Get MFA policy
+ *
+ * Get a single MFA policy for a user.
+ *
+ * `POST /public/v1/query/get_mfa_policy`
+ */
+export const getMfaPolicy = (input: TGetMfaPolicyInput) =>
+  request<TGetMfaPolicyResponse, TGetMfaPolicyBody, never, never, never>({
+    uri: "/public/v1/query/get_mfa_policy",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetMfaPolicy` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetMfaPolicy}
+ */
+export const signGetMfaPolicy = (
+  input: TGetMfaPolicyInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetMfaPolicyBody, never, never>({
+    uri: "/public/v1/query/get_mfa_policy",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/query/get_mfa_status`
+ */
+export type TGetMfaStatusResponse =
+  operations["PublicApiService_GetMfaStatus"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_mfa_status`
+ */
+export type TGetMfaStatusInput = { body: TGetMfaStatusBody };
+
+/**
+ * `POST /public/v1/query/get_mfa_status`
+ */
+export type TGetMfaStatusBody =
+  operations["PublicApiService_GetMfaStatus"]["parameters"]["body"]["body"];
+
+/**
+ * Get MFA status
+ *
+ * Get the MFA status of an activity for a specific user or all voting users.
+ *
+ * `POST /public/v1/query/get_mfa_status`
+ */
+export const getMfaStatus = (input: TGetMfaStatusInput) =>
+  request<TGetMfaStatusResponse, TGetMfaStatusBody, never, never, never>({
+    uri: "/public/v1/query/get_mfa_status",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetMfaStatus` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetMfaStatus}
+ */
+export const signGetMfaStatus = (
+  input: TGetMfaStatusInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetMfaStatusBody, never, never>({
+    uri: "/public/v1/query/get_mfa_status",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/query/get_nonces`
  */
 export type TGetNoncesResponse =
@@ -687,52 +825,6 @@ export const signGetOnRampTransactionStatus = (
 ) =>
   signedRequest<TGetOnRampTransactionStatusBody, never, never>({
     uri: "/public/v1/query/get_onramp_transaction_status",
-    body: input.body,
-    options,
-  });
-
-/**
- * `POST /public/v1/query/get_organization`
- */
-export type TGetOrganizationResponse =
-  operations["PublicApiService_GetOrganization"]["responses"]["200"]["schema"];
-
-/**
- * `POST /public/v1/query/get_organization`
- */
-export type TGetOrganizationInput = { body: TGetOrganizationBody };
-
-/**
- * `POST /public/v1/query/get_organization`
- */
-export type TGetOrganizationBody =
-  operations["PublicApiService_GetOrganization"]["parameters"]["body"]["body"];
-
-/**
- * Get organization
- *
- * Get details about an organization.
- *
- * `POST /public/v1/query/get_organization`
- */
-export const getOrganization = (input: TGetOrganizationInput) =>
-  request<TGetOrganizationResponse, TGetOrganizationBody, never, never, never>({
-    uri: "/public/v1/query/get_organization",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `GetOrganization` request, ready to be POSTed to Turnkey.
- *
- * See {@link GetOrganization}
- */
-export const signGetOrganization = (
-  input: TGetOrganizationInput,
-  options?: TurnkeyCredentialRequestOptions,
-) =>
-  signedRequest<TGetOrganizationBody, never, never>({
-    uri: "/public/v1/query/get_organization",
     body: input.body,
     options,
   });
@@ -992,6 +1084,110 @@ export const signGetSendTransactionStatus = (
   });
 
 /**
+ * `POST /public/v1/query/get_session_profile`
+ */
+export type TGetSessionProfileResponse =
+  operations["PublicApiService_GetSessionProfile"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_session_profile`
+ */
+export type TGetSessionProfileInput = { body: TGetSessionProfileBody };
+
+/**
+ * `POST /public/v1/query/get_session_profile`
+ */
+export type TGetSessionProfileBody =
+  operations["PublicApiService_GetSessionProfile"]["parameters"]["body"]["body"];
+
+/**
+ * Get session profile
+ *
+ * Get a single session profile for an organization.
+ *
+ * `POST /public/v1/query/get_session_profile`
+ */
+export const getSessionProfile = (input: TGetSessionProfileInput) =>
+  request<
+    TGetSessionProfileResponse,
+    TGetSessionProfileBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/query/get_session_profile",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetSessionProfile` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetSessionProfile}
+ */
+export const signGetSessionProfile = (
+  input: TGetSessionProfileInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetSessionProfileBody, never, never>({
+    uri: "/public/v1/query/get_session_profile",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/query/get_session_profiles`
+ */
+export type TGetSessionProfilesResponse =
+  operations["PublicApiService_GetSessionProfiles"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_session_profiles`
+ */
+export type TGetSessionProfilesInput = { body: TGetSessionProfilesBody };
+
+/**
+ * `POST /public/v1/query/get_session_profiles`
+ */
+export type TGetSessionProfilesBody =
+  operations["PublicApiService_GetSessionProfiles"]["parameters"]["body"]["body"];
+
+/**
+ * Get session profiles
+ *
+ * Get all session profiles for an organization.
+ *
+ * `POST /public/v1/query/get_session_profiles`
+ */
+export const getSessionProfiles = (input: TGetSessionProfilesInput) =>
+  request<
+    TGetSessionProfilesResponse,
+    TGetSessionProfilesBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/query/get_session_profiles",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetSessionProfiles` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetSessionProfiles}
+ */
+export const signGetSessionProfiles = (
+  input: TGetSessionProfilesInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetSessionProfilesBody, never, never>({
+    uri: "/public/v1/query/get_session_profiles",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/query/get_smart_contract_interface`
  */
 export type TGetSmartContractInterfaceResponse =
@@ -1146,57 +1342,57 @@ export const signGetTvcDeployment = (
   });
 
 /**
- * `POST /public/v1/query/get_tvc_deployment_provisioning_details`
+ * `POST /public/v1/query/get_tvc_deployment_debug_logs`
  */
-export type TGetTvcDeploymentProvisioningDetailsResponse =
-  operations["PublicApiService_GetTvcDeploymentProvisioningDetails"]["responses"]["200"]["schema"];
+export type TGetTvcDeploymentDebugLogsResponse =
+  operations["PublicApiService_GetTvcDeploymentDebugLogs"]["responses"]["200"]["schema"];
 
 /**
- * `POST /public/v1/query/get_tvc_deployment_provisioning_details`
+ * `POST /public/v1/query/get_tvc_deployment_debug_logs`
  */
-export type TGetTvcDeploymentProvisioningDetailsInput = {
-  body: TGetTvcDeploymentProvisioningDetailsBody;
+export type TGetTvcDeploymentDebugLogsInput = {
+  body: TGetTvcDeploymentDebugLogsBody;
 };
 
 /**
- * `POST /public/v1/query/get_tvc_deployment_provisioning_details`
+ * `POST /public/v1/query/get_tvc_deployment_debug_logs`
  */
-export type TGetTvcDeploymentProvisioningDetailsBody =
-  operations["PublicApiService_GetTvcDeploymentProvisioningDetails"]["parameters"]["body"]["body"];
+export type TGetTvcDeploymentDebugLogsBody =
+  operations["PublicApiService_GetTvcDeploymentDebugLogs"]["parameters"]["body"]["body"];
 
 /**
- * Get TVC Deployment's Provisioning Details
+ * Get TVC Deployment debug logs
  *
- * Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment
+ * Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp.
  *
- * `POST /public/v1/query/get_tvc_deployment_provisioning_details`
+ * `POST /public/v1/query/get_tvc_deployment_debug_logs`
  */
-export const getTvcDeploymentProvisioningDetails = (
-  input: TGetTvcDeploymentProvisioningDetailsInput,
+export const getTvcDeploymentDebugLogs = (
+  input: TGetTvcDeploymentDebugLogsInput,
 ) =>
   request<
-    TGetTvcDeploymentProvisioningDetailsResponse,
-    TGetTvcDeploymentProvisioningDetailsBody,
+    TGetTvcDeploymentDebugLogsResponse,
+    TGetTvcDeploymentDebugLogsBody,
     never,
     never,
     never
   >({
-    uri: "/public/v1/query/get_tvc_deployment_provisioning_details",
+    uri: "/public/v1/query/get_tvc_deployment_debug_logs",
     method: "POST",
     body: input.body,
   });
 
 /**
- * Request a WebAuthn assertion and return a signed `GetTvcDeploymentProvisioningDetails` request, ready to be POSTed to Turnkey.
+ * Request a WebAuthn assertion and return a signed `GetTvcDeploymentDebugLogs` request, ready to be POSTed to Turnkey.
  *
- * See {@link GetTvcDeploymentProvisioningDetails}
+ * See {@link GetTvcDeploymentDebugLogs}
  */
-export const signGetTvcDeploymentProvisioningDetails = (
-  input: TGetTvcDeploymentProvisioningDetailsInput,
+export const signGetTvcDeploymentDebugLogs = (
+  input: TGetTvcDeploymentDebugLogsInput,
   options?: TurnkeyCredentialRequestOptions,
 ) =>
-  signedRequest<TGetTvcDeploymentProvisioningDetailsBody, never, never>({
-    uri: "/public/v1/query/get_tvc_deployment_provisioning_details",
+  signedRequest<TGetTvcDeploymentDebugLogsBody, never, never>({
+    uri: "/public/v1/query/get_tvc_deployment_debug_logs",
     body: input.body,
     options,
   });
@@ -1367,7 +1563,7 @@ export type TGetWalletAddressBalancesBody =
 /**
  * Get balances
  *
- * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.
+ * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.
  *
  * `POST /public/v1/query/get_wallet_address_balances`
  */
@@ -1867,7 +2063,7 @@ export type TListSupportedAssetsBody =
 /**
  * List supported assets
  *
- * List supported assets for the specified network. This feature is in beta - please contact support for access.
+ * List supported assets for the specified network.
  *
  * `POST /public/v1/query/list_supported_assets`
  */
@@ -2482,58 +2678,6 @@ export const signCreateApiKeys = (
   });
 
 /**
- * `POST /public/v1/submit/create_api_only_users`
- */
-export type TCreateApiOnlyUsersResponse =
-  operations["PublicApiService_CreateApiOnlyUsers"]["responses"]["200"]["schema"];
-
-/**
- * `POST /public/v1/submit/create_api_only_users`
- */
-export type TCreateApiOnlyUsersInput = { body: TCreateApiOnlyUsersBody };
-
-/**
- * `POST /public/v1/submit/create_api_only_users`
- */
-export type TCreateApiOnlyUsersBody =
-  operations["PublicApiService_CreateApiOnlyUsers"]["parameters"]["body"]["body"];
-
-/**
- * Create API-only users
- *
- * Create API-only users in an existing organization.
- *
- * `POST /public/v1/submit/create_api_only_users`
- */
-export const createApiOnlyUsers = (input: TCreateApiOnlyUsersInput) =>
-  request<
-    TCreateApiOnlyUsersResponse,
-    TCreateApiOnlyUsersBody,
-    never,
-    never,
-    never
-  >({
-    uri: "/public/v1/submit/create_api_only_users",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `CreateApiOnlyUsers` request, ready to be POSTed to Turnkey.
- *
- * See {@link CreateApiOnlyUsers}
- */
-export const signCreateApiOnlyUsers = (
-  input: TCreateApiOnlyUsersInput,
-  options?: TurnkeyCredentialRequestOptions,
-) =>
-  signedRequest<TCreateApiOnlyUsersBody, never, never>({
-    uri: "/public/v1/submit/create_api_only_users",
-    body: input.body,
-    options,
-  });
-
-/**
  * `POST /public/v1/submit/create_authenticators`
  */
 export type TCreateAuthenticatorsResponse =
@@ -2689,6 +2833,52 @@ export const signCreateInvitations = (
 ) =>
   signedRequest<TCreateInvitationsBody, never, never>({
     uri: "/public/v1/submit/create_invitations",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/submit/create_mfa_policy`
+ */
+export type TCreateMfaPolicyResponse =
+  operations["PublicApiService_CreateMfaPolicy"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/create_mfa_policy`
+ */
+export type TCreateMfaPolicyInput = { body: TCreateMfaPolicyBody };
+
+/**
+ * `POST /public/v1/submit/create_mfa_policy`
+ */
+export type TCreateMfaPolicyBody =
+  operations["PublicApiService_CreateMfaPolicy"]["parameters"]["body"]["body"];
+
+/**
+ * Create MFA policy
+ *
+ * Create a new MFA policy for a user.
+ *
+ * `POST /public/v1/submit/create_mfa_policy`
+ */
+export const createMfaPolicy = (input: TCreateMfaPolicyInput) =>
+  request<TCreateMfaPolicyResponse, TCreateMfaPolicyBody, never, never, never>({
+    uri: "/public/v1/submit/create_mfa_policy",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `CreateMfaPolicy` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link CreateMfaPolicy}
+ */
+export const signCreateMfaPolicy = (
+  input: TCreateMfaPolicyInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TCreateMfaPolicyBody, never, never>({
+    uri: "/public/v1/submit/create_mfa_policy",
     body: input.body,
     options,
   });
@@ -3097,6 +3287,58 @@ export const signCreateReadWriteSession = (
 ) =>
   signedRequest<TCreateReadWriteSessionBody, never, never>({
     uri: "/public/v1/submit/create_read_write_session",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/submit/create_session_profile`
+ */
+export type TCreateSessionProfileResponse =
+  operations["PublicApiService_CreateSessionProfile"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/create_session_profile`
+ */
+export type TCreateSessionProfileInput = { body: TCreateSessionProfileBody };
+
+/**
+ * `POST /public/v1/submit/create_session_profile`
+ */
+export type TCreateSessionProfileBody =
+  operations["PublicApiService_CreateSessionProfile"]["parameters"]["body"]["body"];
+
+/**
+ * Create session profile
+ *
+ * Create a new session profile for an organization.
+ *
+ * `POST /public/v1/submit/create_session_profile`
+ */
+export const createSessionProfile = (input: TCreateSessionProfileInput) =>
+  request<
+    TCreateSessionProfileResponse,
+    TCreateSessionProfileBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/submit/create_session_profile",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `CreateSessionProfile` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link CreateSessionProfile}
+ */
+export const signCreateSessionProfile = (
+  input: TCreateSessionProfileInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TCreateSessionProfileBody, never, never>({
+    uri: "/public/v1/submit/create_session_profile",
     body: input.body,
     options,
   });
@@ -3807,6 +4049,52 @@ export const signDeleteInvitation = (
 ) =>
   signedRequest<TDeleteInvitationBody, never, never>({
     uri: "/public/v1/submit/delete_invitation",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/submit/delete_mfa_policy`
+ */
+export type TDeleteMfaPolicyResponse =
+  operations["PublicApiService_DeleteMfaPolicy"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/delete_mfa_policy`
+ */
+export type TDeleteMfaPolicyInput = { body: TDeleteMfaPolicyBody };
+
+/**
+ * `POST /public/v1/submit/delete_mfa_policy`
+ */
+export type TDeleteMfaPolicyBody =
+  operations["PublicApiService_DeleteMfaPolicy"]["parameters"]["body"]["body"];
+
+/**
+ * Delete MFA policy
+ *
+ * Delete an MFA policy for a user.
+ *
+ * `POST /public/v1/submit/delete_mfa_policy`
+ */
+export const deleteMfaPolicy = (input: TDeleteMfaPolicyInput) =>
+  request<TDeleteMfaPolicyResponse, TDeleteMfaPolicyBody, never, never, never>({
+    uri: "/public/v1/submit/delete_mfa_policy",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `DeleteMfaPolicy` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link DeleteMfaPolicy}
+ */
+export const signDeleteMfaPolicy = (
+  input: TDeleteMfaPolicyInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TDeleteMfaPolicyBody, never, never>({
+    uri: "/public/v1/submit/delete_mfa_policy",
     body: input.body,
     options,
   });
@@ -4613,58 +4901,6 @@ export const signEmailAuth = (
 ) =>
   signedRequest<TEmailAuthBody, never, never>({
     uri: "/public/v1/submit/email_auth",
-    body: input.body,
-    options,
-  });
-
-/**
- * `POST /public/v1/submit/eth_send_raw_transaction`
- */
-export type TEthSendRawTransactionResponse =
-  operations["PublicApiService_EthSendRawTransaction"]["responses"]["200"]["schema"];
-
-/**
- * `POST /public/v1/submit/eth_send_raw_transaction`
- */
-export type TEthSendRawTransactionInput = { body: TEthSendRawTransactionBody };
-
-/**
- * `POST /public/v1/submit/eth_send_raw_transaction`
- */
-export type TEthSendRawTransactionBody =
-  operations["PublicApiService_EthSendRawTransaction"]["parameters"]["body"]["body"];
-
-/**
- * Submit a raw transaction for broadcasting.
- *
- * Submit a raw transaction (serialized and signed) for broadcasting to the network.
- *
- * `POST /public/v1/submit/eth_send_raw_transaction`
- */
-export const ethSendRawTransaction = (input: TEthSendRawTransactionInput) =>
-  request<
-    TEthSendRawTransactionResponse,
-    TEthSendRawTransactionBody,
-    never,
-    never,
-    never
-  >({
-    uri: "/public/v1/submit/eth_send_raw_transaction",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `EthSendRawTransaction` request, ready to be POSTed to Turnkey.
- *
- * See {@link EthSendRawTransaction}
- */
-export const signEthSendRawTransaction = (
-  input: TEthSendRawTransactionInput,
-  options?: TurnkeyCredentialRequestOptions,
-) =>
-  signedRequest<TEthSendRawTransactionBody, never, never>({
-    uri: "/public/v1/submit/eth_send_raw_transaction",
     body: input.body,
     options,
   });
@@ -5495,58 +5731,6 @@ export const signOtpLogin = (
 ) =>
   signedRequest<TOtpLoginBody, never, never>({
     uri: "/public/v1/submit/otp_login",
-    body: input.body,
-    options,
-  });
-
-/**
- * `POST /public/v1/submit/post_tvc_quorum_key_share`
- */
-export type TPostTvcQuorumKeyShareResponse =
-  operations["PublicApiService_PostTvcQuorumKeyShare"]["responses"]["200"]["schema"];
-
-/**
- * `POST /public/v1/submit/post_tvc_quorum_key_share`
- */
-export type TPostTvcQuorumKeyShareInput = { body: TPostTvcQuorumKeyShareBody };
-
-/**
- * `POST /public/v1/submit/post_tvc_quorum_key_share`
- */
-export type TPostTvcQuorumKeyShareBody =
-  operations["PublicApiService_PostTvcQuorumKeyShare"]["parameters"]["body"]["body"];
-
-/**
- * Post TVC Quorum Key Share
- *
- * Post re-encrypted quorum key share for a TVC deployment.
- *
- * `POST /public/v1/submit/post_tvc_quorum_key_share`
- */
-export const postTvcQuorumKeyShare = (input: TPostTvcQuorumKeyShareInput) =>
-  request<
-    TPostTvcQuorumKeyShareResponse,
-    TPostTvcQuorumKeyShareBody,
-    never,
-    never,
-    never
-  >({
-    uri: "/public/v1/submit/post_tvc_quorum_key_share",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `PostTvcQuorumKeyShare` request, ready to be POSTed to Turnkey.
- *
- * See {@link PostTvcQuorumKeyShare}
- */
-export const signPostTvcQuorumKeyShare = (
-  input: TPostTvcQuorumKeyShareInput,
-  options?: TurnkeyCredentialRequestOptions,
-) =>
-  signedRequest<TPostTvcQuorumKeyShareBody, never, never>({
-    uri: "/public/v1/submit/post_tvc_quorum_key_share",
     body: input.body,
     options,
   });
@@ -6458,6 +6642,52 @@ export const signUpdateFiatOnRampCredential = (
   });
 
 /**
+ * `POST /public/v1/submit/update_mfa_policy`
+ */
+export type TUpdateMfaPolicyResponse =
+  operations["PublicApiService_UpdateMfaPolicy"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/update_mfa_policy`
+ */
+export type TUpdateMfaPolicyInput = { body: TUpdateMfaPolicyBody };
+
+/**
+ * `POST /public/v1/submit/update_mfa_policy`
+ */
+export type TUpdateMfaPolicyBody =
+  operations["PublicApiService_UpdateMfaPolicy"]["parameters"]["body"]["body"];
+
+/**
+ * Update MFA policy
+ *
+ * Update an MFA policy for a user.
+ *
+ * `POST /public/v1/submit/update_mfa_policy`
+ */
+export const updateMfaPolicy = (input: TUpdateMfaPolicyInput) =>
+  request<TUpdateMfaPolicyResponse, TUpdateMfaPolicyBody, never, never, never>({
+    uri: "/public/v1/submit/update_mfa_policy",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `UpdateMfaPolicy` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link UpdateMfaPolicy}
+ */
+export const signUpdateMfaPolicy = (
+  input: TUpdateMfaPolicyInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TUpdateMfaPolicyBody, never, never>({
+    uri: "/public/v1/submit/update_mfa_policy",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/submit/update_oauth2_credential`
  */
 export type TUpdateOauth2CredentialResponse =
@@ -7118,102 +7348,4 @@ export const nOOPCodegenAnchor = () =>
 export const signNOOPCodegenAnchor = () =>
   signedRequest<never, never, never>({
     uri: "/tkhq/api/v1/noop-codegen-anchor",
-  });
-
-/**
- * `POST /tkhq/api/v1/refresh_feature_flags`
- */
-export type TRefreshFeatureFlagsResponse =
-  operations["PublicApiService_RefreshFeatureFlags"]["responses"]["200"]["schema"];
-
-/**
- * `POST /tkhq/api/v1/refresh_feature_flags`
- */
-export type TRefreshFeatureFlagsInput = { body: TRefreshFeatureFlagsBody };
-
-/**
- * `POST /tkhq/api/v1/refresh_feature_flags`
- */
-export type TRefreshFeatureFlagsBody =
-  operations["PublicApiService_RefreshFeatureFlags"]["parameters"]["body"]["body"];
-
-/**
- * Refresh feature flags
- *
- * Refresh feature flags by triggering a DB read to flush the in-memory cache.
- *
- * `POST /tkhq/api/v1/refresh_feature_flags`
- */
-export const refreshFeatureFlags = (input: TRefreshFeatureFlagsInput) =>
-  request<
-    TRefreshFeatureFlagsResponse,
-    TRefreshFeatureFlagsBody,
-    never,
-    never,
-    never
-  >({
-    uri: "/tkhq/api/v1/refresh_feature_flags",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `RefreshFeatureFlags` request, ready to be POSTed to Turnkey.
- *
- * See {@link RefreshFeatureFlags}
- */
-export const signRefreshFeatureFlags = (
-  input: TRefreshFeatureFlagsInput,
-  options?: TurnkeyCredentialRequestOptions,
-) =>
-  signedRequest<TRefreshFeatureFlagsBody, never, never>({
-    uri: "/tkhq/api/v1/refresh_feature_flags",
-    body: input.body,
-    options,
-  });
-
-/**
- * `POST /tkhq/api/v1/test_rate_limits`
- */
-export type TTestRateLimitsResponse =
-  operations["PublicApiService_TestRateLimits"]["responses"]["200"]["schema"];
-
-/**
- * `POST /tkhq/api/v1/test_rate_limits`
- */
-export type TTestRateLimitsInput = { body: TTestRateLimitsBody };
-
-/**
- * `POST /tkhq/api/v1/test_rate_limits`
- */
-export type TTestRateLimitsBody =
-  operations["PublicApiService_TestRateLimits"]["parameters"]["body"]["body"];
-
-/**
- * Test rate limit
- *
- * Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite.
- *
- * `POST /tkhq/api/v1/test_rate_limits`
- */
-export const testRateLimits = (input: TTestRateLimitsInput) =>
-  request<TTestRateLimitsResponse, TTestRateLimitsBody, never, never, never>({
-    uri: "/tkhq/api/v1/test_rate_limits",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `TestRateLimits` request, ready to be POSTed to Turnkey.
- *
- * See {@link TestRateLimits}
- */
-export const signTestRateLimits = (
-  input: TTestRateLimitsInput,
-  options?: TurnkeyCredentialRequestOptions,
-) =>
-  signedRequest<TTestRateLimitsBody, never, never>({
-    uri: "/tkhq/api/v1/test_rate_limits",
-    body: input.body,
-    options,
   });

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -392,6 +392,102 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_mfa_policies": {
+      "post": {
+        "summary": "Get MFA policies",
+        "description": "Get all MFA policies for a user.",
+        "operationId": "PublicApiService_GetMfaPolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_policy": {
+      "post": {
+        "summary": "Get MFA policy",
+        "description": "Get a single MFA policy for a user.",
+        "operationId": "PublicApiService_GetMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_status": {
+      "post": {
+        "summary": "Get MFA status",
+        "description": "Get the MFA status of an activity for a specific user or all voting users.",
+        "operationId": "PublicApiService_GetMfaStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/query/get_nonces": {
       "post": {
         "summary": "Get nonces",
@@ -518,38 +614,6 @@
           }
         ],
         "tags": ["On Ramp"]
-      }
-    },
-    "/public/v1/query/get_organization": {
-      "post": {
-        "summary": "Get organization",
-        "description": "Get details about an organization.",
-        "operationId": "PublicApiService_GetOrganization",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1GetOrganizationResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1GetOrganizationRequest"
-            }
-          }
-        ],
-        "tags": ["Organizations"]
       }
     },
     "/public/v1/query/get_organization_configs": {
@@ -712,6 +776,70 @@
         "tags": ["Send Transactions"]
       }
     },
+    "/public/v1/query/get_session_profile": {
+      "post": {
+        "summary": "Get session profile",
+        "description": "Get a single session profile for an organization.",
+        "operationId": "PublicApiService_GetSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
+    "/public/v1/query/get_session_profiles": {
+      "post": {
+        "summary": "Get session profiles",
+        "description": "Get all session profiles for an organization.",
+        "operationId": "PublicApiService_GetSessionProfiles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
     "/public/v1/query/get_smart_contract_interface": {
       "post": {
         "summary": "Get smart contract interface",
@@ -808,16 +936,16 @@
         "tags": ["TVC"]
       }
     },
-    "/public/v1/query/get_tvc_deployment_provisioning_details": {
+    "/public/v1/query/get_tvc_deployment_debug_logs": {
       "post": {
-        "summary": "Get TVC Deployment's Provisioning Details",
-        "description": "Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment",
-        "operationId": "PublicApiService_GetTvcDeploymentProvisioningDetails",
+        "summary": "Get TVC Deployment debug logs",
+        "description": "Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp.",
+        "operationId": "PublicApiService_GetTvcDeploymentDebugLogs",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1GetTvcDeploymentProvisioningDetailsResponse"
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsResponse"
             }
           },
           "default": {
@@ -833,7 +961,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1GetTvcDeploymentProvisioningDetailsRequest"
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsRequest"
             }
           }
         ],
@@ -939,7 +1067,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1259,7 +1387,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -1672,38 +1800,6 @@
         "tags": ["API Keys"]
       }
     },
-    "/public/v1/submit/create_api_only_users": {
-      "post": {
-        "summary": "Create API-only users",
-        "description": "Create API-only users in an existing organization.",
-        "operationId": "PublicApiService_CreateApiOnlyUsers",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ActivityResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1CreateApiOnlyUsersRequest"
-            }
-          }
-        ],
-        "tags": ["Users"]
-      }
-    },
     "/public/v1/submit/create_authenticators": {
       "post": {
         "summary": "Create authenticators",
@@ -1798,6 +1894,38 @@
           }
         ],
         "tags": ["Invitations"]
+      }
+    },
+    "/public/v1/submit/create_mfa_policy": {
+      "post": {
+        "summary": "Create MFA policy",
+        "description": "Create a new MFA policy for a user.",
+        "operationId": "PublicApiService_CreateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
       }
     },
     "/public/v1/submit/create_oauth2_credential": {
@@ -2054,6 +2182,38 @@
           }
         ],
         "tags": ["Sessions"]
+      }
+    },
+    "/public/v1/submit/create_session_profile": {
+      "post": {
+        "summary": "Create session profile",
+        "description": "Create a new session profile for an organization.",
+        "operationId": "PublicApiService_CreateSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
       }
     },
     "/public/v1/submit/create_smart_contract_interface": {
@@ -2502,6 +2662,38 @@
           }
         ],
         "tags": ["Invitations"]
+      }
+    },
+    "/public/v1/submit/delete_mfa_policy": {
+      "post": {
+        "summary": "Delete MFA policy",
+        "description": "Delete an MFA policy for a user.",
+        "operationId": "PublicApiService_DeleteMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
       }
     },
     "/public/v1/submit/delete_oauth2_credential": {
@@ -3014,38 +3206,6 @@
           }
         ],
         "tags": ["User Auth"]
-      }
-    },
-    "/public/v1/submit/eth_send_raw_transaction": {
-      "post": {
-        "summary": "Submit a raw transaction for broadcasting.",
-        "description": "Submit a raw transaction (serialized and signed) for broadcasting to the network.",
-        "operationId": "PublicApiService_EthSendRawTransaction",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ActivityResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1EthSendRawTransactionRequest"
-            }
-          }
-        ],
-        "tags": ["Broadcasting"]
       }
     },
     "/public/v1/submit/eth_send_transaction": {
@@ -3590,38 +3750,6 @@
           }
         ],
         "tags": ["Sessions"]
-      }
-    },
-    "/public/v1/submit/post_tvc_quorum_key_share": {
-      "post": {
-        "summary": "Post TVC Quorum Key Share",
-        "description": "Post re-encrypted quorum key share for a TVC deployment.",
-        "operationId": "PublicApiService_PostTvcQuorumKeyShare",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ActivityResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1PostTvcQuorumKeyShareRequest"
-            }
-          }
-        ],
-        "tags": ["TVC"]
       }
     },
     "/public/v1/submit/recover_user": {
@@ -4200,6 +4328,38 @@
         "tags": ["On Ramp"]
       }
     },
+    "/public/v1/submit/update_mfa_policy": {
+      "post": {
+        "summary": "Update MFA policy",
+        "description": "Update an MFA policy for a user.",
+        "operationId": "PublicApiService_UpdateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/update_oauth2_credential": {
       "post": {
         "summary": "Update an OAuth 2.0 Credential",
@@ -4635,70 +4795,6 @@
         },
         "tags": ["PublicApiService"]
       }
-    },
-    "/tkhq/api/v1/refresh_feature_flags": {
-      "post": {
-        "summary": "Refresh feature flags",
-        "description": "Refresh feature flags by triggering a DB read to flush the in-memory cache.",
-        "operationId": "PublicApiService_RefreshFeatureFlags",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RefreshFeatureFlagsResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1RefreshFeatureFlagsRequest"
-            }
-          }
-        ],
-        "tags": ["FeatureFlags"]
-      }
-    },
-    "/tkhq/api/v1/test_rate_limits": {
-      "post": {
-        "summary": "Test rate limit",
-        "description": "Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite.",
-        "operationId": "PublicApiService_TestRateLimits",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1TestRateLimitsResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1TestRateLimitsRequest"
-            }
-          }
-        ],
-        "tags": ["RateLimit"]
-      }
     }
   },
   "definitions": {
@@ -4919,6 +5015,10 @@
         },
         "type": {
           "$ref": "#/definitions/v1CredentialType"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN."
         }
       },
       "required": ["publicKey", "type"]
@@ -5208,7 +5308,8 @@
         "ACTIVITY_STATUS_COMPLETED",
         "ACTIVITY_STATUS_FAILED",
         "ACTIVITY_STATUS_CONSENSUS_NEEDED",
-        "ACTIVITY_STATUS_REJECTED"
+        "ACTIVITY_STATUS_REJECTED",
+        "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED"
       ]
     },
     "v1ActivityType": {
@@ -5351,7 +5452,16 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2",
+        "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+        "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+        "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+        "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+        "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER",
+        "ACTIVITY_TYPE_EARN_DEPOSIT",
+        "ACTIVITY_TYPE_EARN_WITHDRAW",
+        "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG"
       ]
     },
     "v1AddressFormat": {
@@ -5668,6 +5778,45 @@
         "transports"
       ]
     },
+    "v1AuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., for requiring a specific session profile id)"
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication)."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used."
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationType": {
+      "type": "string",
+      "enum": [
+        "AUTHENTICATION_TYPE_EMAIL_OTP",
+        "AUTHENTICATION_TYPE_SMS_OTP",
+        "AUTHENTICATION_TYPE_PASSKEY",
+        "AUTHENTICATION_TYPE_API_KEY",
+        "AUTHENTICATION_TYPE_OAUTH",
+        "AUTHENTICATION_TYPE_SESSION"
+      ]
+    },
     "v1Authenticator": {
       "type": "object",
       "properties": {
@@ -5810,11 +5959,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5830,6 +5979,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -5979,30 +6132,6 @@
         }
       },
       "required": ["apiOnlyUsers"]
-    },
-    "v1CreateApiOnlyUsersRequest": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["ACTIVITY_TYPE_CREATE_API_ONLY_USERS"]
-        },
-        "timestampMs": {
-          "type": "string",
-          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
-        },
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given Organization."
-        },
-        "parameters": {
-          "$ref": "#/definitions/v1CreateApiOnlyUsersIntent"
-        },
-        "generateAppProofs": {
-          "type": "boolean"
-        }
-      },
-      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1CreateApiOnlyUsersResult": {
       "type": "object",
@@ -6208,6 +6337,78 @@
         }
       },
       "required": ["invitationIds"]
+    },
+    "v1CreateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to add the MFA Policy to."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": [
+        "userId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order"
+      ]
+    },
+    "v1CreateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1CreateOauth2CredentialIntent": {
       "type": "object",
@@ -6910,6 +7111,59 @@
         "credentialBundle"
       ]
     },
+    "v1CreateSessionProfileIntent": {
+      "type": "object",
+      "properties": {
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope string that defines the permissions for this Session Profile."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for a Session Profile."
+        }
+      },
+      "required": ["sessionProfileName", "scope"]
+    },
+    "v1CreateSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_SESSION_PROFILE"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateSessionProfileResult": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        }
+      },
+      "required": ["sessionProfileId"]
+    },
     "v1CreateSmartContractInterfaceIntent": {
       "type": "object",
       "properties": {
@@ -7436,6 +7690,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -8219,6 +8477,51 @@
         }
       },
       "required": ["invitationId"]
+    },
+    "v1DeleteMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to delete the MFA Policy from."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1DeleteMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1DeleteOauth2CredentialIntent": {
       "type": "object",
@@ -9032,6 +9335,179 @@
       },
       "required": ["privateKeyId"]
     },
+    "v1EarnDeployWrapperIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to wrap (from the EarnVaults catalog)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        }
+      },
+      "required": ["vaultAddress", "chainCaip2"]
+    },
+    "v1EarnDeployWrapperResult": {
+      "type": "object",
+      "properties": {
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee wrapper (the deposit target)."
+        },
+        "splitterAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave)."
+        },
+        "deployTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the wrapper deployment."
+        }
+      },
+      "required": ["wrapperAddress", "splitterAddress", "deployTxHash"]
+    },
+    "v1EarnDepositIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "assets": {
+          "type": "string",
+          "description": "Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        }
+      },
+      "required": ["vaultAddress", "signWith", "assets", "chainCaip2"]
+    },
+    "v1EarnDepositResult": {
+      "type": "object",
+      "properties": {
+        "depositTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the deposit."
+        },
+        "sharesMinted": {
+          "type": "string",
+          "description": "Number of wrapper shares minted to the depositor, in raw on-chain units."
+        },
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the fee wrapper the deposit was routed to."
+        },
+        "depositRequestId": {
+          "type": "string",
+          "description": "Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path)."
+        }
+      },
+      "required": [
+        "depositTxHash",
+        "sharesMinted",
+        "wrapperAddress",
+        "depositRequestId"
+      ]
+    },
+    "v1EarnWithdrawIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        },
+        "amountType": {
+          "type": "string",
+          "enum": ["SHARES", "ASSETS"],
+          "description": "Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims)."
+        },
+        "amountValue": {
+          "type": "string",
+          "description": "The amount to withdraw, in raw on-chain units, interpreted according to amount_type."
+        }
+      },
+      "required": [
+        "vaultAddress",
+        "signWith",
+        "chainCaip2",
+        "amountType",
+        "amountValue"
+      ]
+    },
+    "v1EarnWithdrawResult": {
+      "type": "object",
+      "properties": {
+        "withdrawTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the withdrawal."
+        },
+        "withdrawRequestId": {
+          "type": "string",
+          "description": "Identifier to poll withdrawal status via EarnWithdrawStatus."
+        },
+        "assetsReceived": {
+          "type": "string",
+          "description": "Amount of the underlying asset received, in raw on-chain units."
+        },
+        "sharesBurned": {
+          "type": "string",
+          "description": "Number of wrapper shares burned, in raw on-chain units."
+        }
+      },
+      "required": [
+        "withdrawTxHash",
+        "withdrawRequestId",
+        "assetsReceived",
+        "sharesBurned"
+      ]
+    },
     "v1Effect": {
       "type": "string",
       "enum": ["EFFECT_ALLOW", "EFFECT_DENY"]
@@ -9285,6 +9761,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9313,36 +9807,14 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
       },
       "required": ["signedTransaction", "caip2"]
-    },
-    "v1EthSendRawTransactionRequest": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_RAW_TRANSACTION"]
-        },
-        "timestampMs": {
-          "type": "string",
-          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
-        },
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given Organization."
-        },
-        "parameters": {
-          "$ref": "#/definitions/v1EthSendRawTransactionIntent"
-        },
-        "generateAppProofs": {
-          "type": "boolean"
-        }
-      },
-      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendRawTransactionResult": {
       "type": "object",
@@ -9373,7 +9845,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9416,12 +9890,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9432,7 +9966,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9441,6 +9975,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -10069,6 +10613,94 @@
       },
       "required": ["organizationId", "appName"]
     },
+    "v1GetMfaPoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        }
+      },
+      "required": ["organizationId", "userId"]
+    },
+    "v1GetMfaPoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of multi-factor authentication policies for a user."
+        }
+      },
+      "required": ["mfaPolicies"]
+    },
+    "v1GetMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA policy."
+        }
+      },
+      "required": ["organizationId", "userId", "mfaPolicyId"]
+    },
+    "v1GetMfaPolicyResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicy": {
+          "$ref": "#/definitions/v1MfaPolicy",
+          "description": "Multi-factor authentication policy for a user."
+        }
+      },
+      "required": ["mfaPolicy"]
+    },
+    "v1GetMfaStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "activityId": {
+          "type": "string",
+          "description": "The unique identifier of the activity to get MFA status for."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Optional user ID to filter MFA status for a specific user."
+        }
+      },
+      "required": ["organizationId", "activityId"]
+    },
+    "v1GetMfaStatusResponse": {
+      "type": "object",
+      "properties": {
+        "mfaStatuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaStatus"
+          },
+          "description": "A list of MFA statuses for the activity's votes."
+        }
+      },
+      "required": ["mfaStatuses"]
+    },
     "v1GetNoncesRequest": {
       "type": "object",
       "properties": {
@@ -10088,7 +10720,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10216,26 +10850,6 @@
         }
       },
       "required": ["configs"]
-    },
-    "v1GetOrganizationRequest": {
-      "type": "object",
-      "properties": {
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given organization."
-        }
-      },
-      "required": ["organizationId"]
-    },
-    "v1GetOrganizationResponse": {
-      "type": "object",
-      "properties": {
-        "organizationData": {
-          "$ref": "#/definitions/v1OrganizationData",
-          "description": "Object representing the full current and deleted / disabled collection of users, policies, private keys, and invitations attributable to a particular organization."
-        }
-      },
-      "required": ["organizationData"]
     },
     "v1GetPoliciesRequest": {
       "type": "object",
@@ -10400,6 +11014,54 @@
       },
       "required": ["txStatus"]
     },
+    "v1GetSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a session profile."
+        }
+      },
+      "required": ["organizationId", "sessionProfileId"]
+    },
+    "v1GetSessionProfileResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfile": {
+          "$ref": "#/definitions/v1SessionProfile",
+          "description": "Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies."
+        }
+      },
+      "required": ["sessionProfile"]
+    },
+    "v1GetSessionProfilesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetSessionProfilesResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SessionProfile"
+          },
+          "description": "A list of session profiles for users in the organization."
+        }
+      },
+      "required": ["sessionProfiles"]
+    },
     "v1GetSmartContractInterfaceRequest": {
       "type": "object",
       "properties": {
@@ -10559,7 +11221,7 @@
       },
       "required": ["tvcApps"]
     },
-    "v1GetTvcDeploymentProvisioningDetailsRequest": {
+    "v1GetTvcDeploymentDebugLogsRequest": {
       "type": "object",
       "properties": {
         "organizationId": {
@@ -10568,26 +11230,34 @@
         },
         "deploymentId": {
           "type": "string",
-          "description": "Unique identifier for a given TVC Deployment."
+          "description": "Unique identifier for a given TVC Deployment. The deployment must be running in debug mode."
+        },
+        "tailLines": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied."
+        },
+        "sinceSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs."
         }
       },
       "required": ["organizationId", "deploymentId"]
     },
-    "v1GetTvcDeploymentProvisioningDetailsResponse": {
+    "v1GetTvcDeploymentDebugLogsResponse": {
       "type": "object",
       "properties": {
-        "attestationDocument": {
-          "type": "string",
-          "format": "byte",
-          "description": "The attestation document of the provisioning enclave in a TVC deployment."
-        },
-        "manifestEnvelope": {
-          "type": "string",
-          "format": "byte",
-          "description": "The manifest envelope containing the TVC deployment's manifest and signatures."
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TvcDeploymentDebugLogEntry"
+          },
+          "description": "Application log entries sorted by platform timestamp."
         }
       },
-      "required": ["attestationDocument", "manifestEnvelope"]
+      "required": ["entries"]
     },
     "v1GetTvcDeploymentRequest": {
       "type": "object",
@@ -10784,6 +11454,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -12134,61 +12810,35 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
+        },
+        "createMfaPolicyIntent": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        },
+        "updateMfaPolicyIntent": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        },
+        "deleteMfaPolicyIntent": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        },
+        "createSessionProfileIntent": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        },
+        "earnDeployWrapperIntent": {
+          "$ref": "#/definitions/v1EarnDeployWrapperIntent"
+        },
+        "earnDepositIntent": {
+          "$ref": "#/definitions/v1EarnDepositIntent"
+        },
+        "earnWithdrawIntent": {
+          "$ref": "#/definitions/v1EarnWithdrawIntent"
+        },
+        "upsertEarnClientFeeConfigIntent": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigIntent"
         }
       }
-    },
-    "v1Invitation": {
-      "type": "object",
-      "properties": {
-        "invitationId": {
-          "type": "string",
-          "description": "Unique identifier for a given Invitation object."
-        },
-        "receiverUserName": {
-          "type": "string",
-          "description": "The name of the intended Invitation recipient."
-        },
-        "receiverEmail": {
-          "type": "string",
-          "description": "The email address of the intended Invitation recipient."
-        },
-        "receiverUserTags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "A list of tags assigned to the Invitation recipient."
-        },
-        "accessType": {
-          "$ref": "#/definitions/v1AccessType",
-          "description": "The User's permissible access method(s)."
-        },
-        "status": {
-          "$ref": "#/definitions/v1InvitationStatus",
-          "description": "The current processing status of a specified Invitation."
-        },
-        "createdAt": {
-          "$ref": "#/definitions/externaldatav1Timestamp"
-        },
-        "updatedAt": {
-          "$ref": "#/definitions/externaldatav1Timestamp"
-        },
-        "senderUserId": {
-          "type": "string",
-          "description": "Unique identifier for the Sender of an Invitation."
-        }
-      },
-      "required": [
-        "invitationId",
-        "receiverUserName",
-        "receiverEmail",
-        "receiverUserTags",
-        "accessType",
-        "status",
-        "createdAt",
-        "updatedAt",
-        "senderUserId"
-      ]
     },
     "v1InvitationParams": {
       "type": "object",
@@ -12223,14 +12873,6 @@
         "receiverUserTags",
         "accessType",
         "senderUserId"
-      ]
-    },
-    "v1InvitationStatus": {
-      "type": "string",
-      "enum": [
-        "INVITATION_STATUS_CREATED",
-        "INVITATION_STATUS_ACCEPTED",
-        "INVITATION_STATUS_REVOKED"
       ]
     },
     "v1IpAllowlist": {
@@ -12381,6 +13023,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -12449,6 +13097,20 @@
       },
       "required": ["webhookEndpoints"]
     },
+    "v1LogLine": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "One log line, exactly as the application printed it (without the trailing newline)"
+        },
+        "ts": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "When the line was logged. Stable across replays, so lines can be chronologically merged across pods"
+        }
+      },
+      "required": ["content"]
+    },
     "v1LoginUsage": {
       "type": "object",
       "properties": {
@@ -12458,6 +13120,95 @@
         }
       },
       "required": ["publicKey"]
+    },
+    "v1MfaPolicy": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for an MFA Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this policy is evaluated relative to other MFA policies."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular MFA policy."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "v1MfaStatus": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "satisfied": {
+          "type": "boolean",
+          "description": "Whether the MFA policy requirements are currently satisfied."
+        },
+        "satisfiedMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods already satisfied for this MFA policy."
+        },
+        "requiredMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements needed to satisfy this MFA policy."
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "userId",
+        "satisfied",
+        "satisfiedMethods",
+        "requiredMethods"
+      ]
     },
     "v1MnemonicLanguage": {
       "type": "string",
@@ -12661,6 +13412,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["oidcToken", "publicKey"]
@@ -12847,76 +13602,6 @@
         "OPERATOR_CONTAINS_ALL"
       ]
     },
-    "v1OrganizationData": {
-      "type": "object",
-      "properties": {
-        "organizationId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1User"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1Policy"
-          }
-        },
-        "privateKeys": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1PrivateKey"
-          }
-        },
-        "invitations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1Invitation"
-          }
-        },
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/datav1Tag"
-          }
-        },
-        "rootQuorum": {
-          "$ref": "#/definitions/externaldatav1Quorum"
-        },
-        "features": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1Feature"
-          }
-        },
-        "wallets": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1Wallet"
-          }
-        },
-        "smartContractInterfaceReferences": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1SmartContractInterfaceReference"
-          }
-        }
-      }
-    },
     "v1OtpAuthIntent": {
       "type": "object",
       "properties": {
@@ -13011,6 +13696,10 @@
         "clientSignature": {
           "$ref": "#/definitions/v1ClientSignature",
           "description": "Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey"]
@@ -13037,6 +13726,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login sessions"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey", "clientSignature"]
@@ -13083,7 +13776,8 @@
         "OUTCOME_DENY_IMPLICIT",
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
-        "OUTCOME_ERROR"
+        "OUTCOME_ERROR",
+        "OUTCOME_REQUIRES_AUTHENTICATORS"
       ]
     },
     "v1Pagination": {
@@ -13182,27 +13876,6 @@
         "ephemeralPublicKeyHex",
         "shareApprovalBundle"
       ]
-    },
-    "v1PostTvcQuorumKeyShareRequest": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"]
-        },
-        "timestampMs": {
-          "type": "string",
-          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
-        },
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given Organization."
-        },
-        "parameters": {
-          "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
-        }
-      },
-      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1PostTvcQuorumKeyShareResult": {
       "type": "object",
@@ -13420,12 +14093,6 @@
       },
       "required": ["authenticatorId"]
     },
-    "v1RefreshFeatureFlagsRequest": {
-      "type": "object"
-    },
-    "v1RefreshFeatureFlagsResponse": {
-      "type": "object"
-    },
     "v1RejectActivityIntent": {
       "type": "object",
       "properties": {
@@ -13543,6 +14210,34 @@
         }
       },
       "required": ["features"]
+    },
+    "v1RequiredAuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
+    "v1RequiredAuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethodParams"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
     },
     "v1RestoreTvcDeploymentIntent": {
       "type": "object",
@@ -13938,6 +14633,33 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
+        },
+        "createMfaPolicyResult": {
+          "$ref": "#/definitions/v1CreateMfaPolicyResult"
+        },
+        "updateMfaPolicyResult": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyResult"
+        },
+        "deleteMfaPolicyResult": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyResult"
+        },
+        "createSessionProfileResult": {
+          "$ref": "#/definitions/v1CreateSessionProfileResult"
+        },
+        "earnDeployWrapperResult": {
+          "$ref": "#/definitions/v1EarnDeployWrapperResult"
+        },
+        "earnDepositResult": {
+          "$ref": "#/definitions/v1EarnDepositResult"
+        },
+        "earnWithdrawResult": {
+          "$ref": "#/definitions/v1EarnWithdrawResult"
+        },
+        "upsertEarnClientFeeConfigResult": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigResult"
         }
       }
     },
@@ -14190,6 +14912,44 @@
           }
         }
       }
+    },
+    "v1SessionProfile": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        },
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The specific scope that a session created with this profile is limited to."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "Optional window (in seconds) indicating how long sessions created with this profile should last."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular Session Profile."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "sessionProfileId",
+        "sessionProfileName",
+        "scope",
+        "createdAt",
+        "updatedAt"
+      ]
     },
     "v1SetIpAllowlistIntent": {
       "type": "object",
@@ -14584,20 +15344,6 @@
         },
         "credProps": {
           "$ref": "#/definitions/v1CredPropsAuthenticationExtensionsClientOutputs"
-        }
-      }
-    },
-    "v1SmartContractInterfaceReference": {
-      "type": "object",
-      "properties": {
-        "smartContractInterfaceId": {
-          "type": "string"
-        },
-        "smartContractAddress": {
-          "type": "string"
-        },
-        "digest": {
-          "type": "string"
         }
       }
     },
@@ -15300,6 +16046,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["publicKey"]
@@ -15341,28 +16091,6 @@
     "v1TagType": {
       "type": "string",
       "enum": ["TAG_TYPE_USER", "TAG_TYPE_PRIVATE_KEY"]
-    },
-    "v1TestRateLimitsRequest": {
-      "type": "object",
-      "properties": {
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given organization. If the request is being made by a WebAuthN user and their sub-organization ID is unknown, this can be the parent organization ID; using the sub-organization ID when possible is preferred due to performance reasons."
-        },
-        "isSetLimit": {
-          "type": "boolean",
-          "description": "Whether or not to set a limit on this request."
-        },
-        "limit": {
-          "type": "integer",
-          "format": "int64",
-          "description": "Rate limit to set for org, if is_set_limit is set to true."
-        }
-      },
-      "required": ["organizationId", "isSetLimit", "limit"]
-    },
-    "v1TestRateLimitsResponse": {
-      "type": "object"
     },
     "v1TokenUsage": {
       "type": "object",
@@ -15441,6 +16169,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -15453,7 +16185,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15571,6 +16304,20 @@
         "updatedAt",
         "delete"
       ]
+    },
+    "v1TvcDeploymentDebugLogEntry": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "$ref": "#/definitions/v1LogLine",
+          "description": "Application log line with its platform timestamp."
+        },
+        "replicaLabel": {
+          "type": "string",
+          "description": "Public replica label that produced this log line, for example 'replica 2/3'."
+        }
+      },
+      "required": ["line", "replicaLabel"]
     },
     "v1TvcHealthCheckType": {
       "type": "string",
@@ -15977,6 +16724,76 @@
         }
       },
       "required": ["fiatOnRampCredentialId"]
+    },
+    "v1UpdateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to update the MFA Policy for."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1UpdateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1UpdateOauth2CredentialIntent": {
       "type": "object",
@@ -16720,6 +17537,30 @@
       },
       "required": ["endpointId", "webhookEndpoint"]
     },
+    "v1UpsertEarnClientFeeConfigIntent": {
+      "type": "object",
+      "properties": {
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address."
+        }
+      },
+      "required": ["clientFeeBps", "clientFeeWallet"]
+    },
+    "v1UpsertEarnClientFeeConfigResult": {
+      "type": "object",
+      "properties": {
+        "feeUpdateTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee configuration update."
+        }
+      },
+      "required": ["feeUpdateTxHash"]
+    },
     "v1UpsertGasUsageConfigIntent": {
       "type": "object",
       "properties": {
@@ -16819,6 +17660,14 @@
         },
         "updatedAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of MFA Policies that define multi-factor authentication requirements for this user."
         }
       },
       "required": [
@@ -16829,7 +17678,8 @@
         "userTags",
         "oauthProviders",
         "createdAt",
-        "updatedAt"
+        "updatedAt",
+        "mfaPolicies"
       ]
     },
     "v1UserParams": {
@@ -17265,6 +18115,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -17298,6 +18152,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -44,6 +44,18 @@ export type paths = {
     /** Get the latest boot proof for a given enclave app name. */
     post: operations["PublicApiService_GetLatestBootProof"];
   };
+  "/public/v1/query/get_mfa_policies": {
+    /** Get all MFA policies for a user. */
+    post: operations["PublicApiService_GetMfaPolicies"];
+  };
+  "/public/v1/query/get_mfa_policy": {
+    /** Get a single MFA policy for a user. */
+    post: operations["PublicApiService_GetMfaPolicy"];
+  };
+  "/public/v1/query/get_mfa_status": {
+    /** Get the MFA status of an activity for a specific user or all voting users. */
+    post: operations["PublicApiService_GetMfaStatus"];
+  };
   "/public/v1/query/get_nonces": {
     /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
     post: operations["PublicApiService_GetNonces"];
@@ -59,10 +71,6 @@ export type paths = {
   "/public/v1/query/get_onramp_transaction_status": {
     /** Get the status of an on ramp transaction. */
     post: operations["PublicApiService_GetOnRampTransactionStatus"];
-  };
-  "/public/v1/query/get_organization": {
-    /** Get details about an organization. */
-    post: operations["PublicApiService_GetOrganization"];
   };
   "/public/v1/query/get_organization_configs": {
     /** Get quorum settings and features for an organization. */
@@ -84,6 +92,14 @@ export type paths = {
     /** Get the status of a send transaction request. */
     post: operations["PublicApiService_GetSendTransactionStatus"];
   };
+  "/public/v1/query/get_session_profile": {
+    /** Get a single session profile for an organization. */
+    post: operations["PublicApiService_GetSessionProfile"];
+  };
+  "/public/v1/query/get_session_profiles": {
+    /** Get all session profiles for an organization. */
+    post: operations["PublicApiService_GetSessionProfiles"];
+  };
   "/public/v1/query/get_smart_contract_interface": {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
@@ -96,9 +112,9 @@ export type paths = {
     /** Get details about a single TVC Deployment */
     post: operations["PublicApiService_GetTvcDeployment"];
   };
-  "/public/v1/query/get_tvc_deployment_provisioning_details": {
-    /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-    post: operations["PublicApiService_GetTvcDeploymentProvisioningDetails"];
+  "/public/v1/query/get_tvc_deployment_debug_logs": {
+    /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+    post: operations["PublicApiService_GetTvcDeploymentDebugLogs"];
   };
   "/public/v1/query/get_user": {
     /** Get details about a user. */
@@ -113,7 +129,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +169,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -204,10 +220,6 @@ export type paths = {
     /** Add API keys to an existing user. */
     post: operations["PublicApiService_CreateApiKeys"];
   };
-  "/public/v1/submit/create_api_only_users": {
-    /** Create API-only users in an existing organization. */
-    post: operations["PublicApiService_CreateApiOnlyUsers"];
-  };
   "/public/v1/submit/create_authenticators": {
     /** Create authenticators to authenticate requests to Turnkey. */
     post: operations["PublicApiService_CreateAuthenticators"];
@@ -219,6 +231,10 @@ export type paths = {
   "/public/v1/submit/create_invitations": {
     /** Create invitations to join an existing organization. */
     post: operations["PublicApiService_CreateInvitations"];
+  };
+  "/public/v1/submit/create_mfa_policy": {
+    /** Create a new MFA policy for a user. */
+    post: operations["PublicApiService_CreateMfaPolicy"];
   };
   "/public/v1/submit/create_oauth2_credential": {
     /** Enable authentication for end users with an OAuth 2.0 provider */
@@ -251,6 +267,10 @@ export type paths = {
   "/public/v1/submit/create_read_write_session": {
     /** Create a read write session for a user. */
     post: operations["PublicApiService_CreateReadWriteSession"];
+  };
+  "/public/v1/submit/create_session_profile": {
+    /** Create a new session profile for an organization. */
+    post: operations["PublicApiService_CreateSessionProfile"];
   };
   "/public/v1/submit/create_smart_contract_interface": {
     /** Create an ABI/IDL in JSON. */
@@ -307,6 +327,10 @@ export type paths = {
   "/public/v1/submit/delete_invitation": {
     /** Delete an existing invitation. */
     post: operations["PublicApiService_DeleteInvitation"];
+  };
+  "/public/v1/submit/delete_mfa_policy": {
+    /** Delete an MFA policy for a user. */
+    post: operations["PublicApiService_DeleteMfaPolicy"];
   };
   "/public/v1/submit/delete_oauth2_credential": {
     /** Disable authentication for end users with an OAuth 2.0 provider */
@@ -371,10 +395,6 @@ export type paths = {
   "/public/v1/submit/email_auth": {
     /** Authenticate a user via email. */
     post: operations["PublicApiService_EmailAuth"];
-  };
-  "/public/v1/submit/eth_send_raw_transaction": {
-    /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-    post: operations["PublicApiService_EthSendRawTransaction"];
   };
   "/public/v1/submit/eth_send_transaction": {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
@@ -443,10 +463,6 @@ export type paths = {
   "/public/v1/submit/otp_login": {
     /** Create an OTP session for a user. */
     post: operations["PublicApiService_OtpLogin"];
-  };
-  "/public/v1/submit/post_tvc_quorum_key_share": {
-    /** Post re-encrypted quorum key share for a TVC deployment. */
-    post: operations["PublicApiService_PostTvcQuorumKeyShare"];
   };
   "/public/v1/submit/recover_user": {
     /** Complete the process of recovering a user by adding an authenticator. */
@@ -520,6 +536,10 @@ export type paths = {
     /** Update a fiat on ramp provider credential */
     post: operations["PublicApiService_UpdateFiatOnRampCredential"];
   };
+  "/public/v1/submit/update_mfa_policy": {
+    /** Update an MFA policy for a user. */
+    post: operations["PublicApiService_UpdateMfaPolicy"];
+  };
   "/public/v1/submit/update_oauth2_credential": {
     /** Update an OAuth 2.0 provider credential */
     post: operations["PublicApiService_UpdateOauth2Credential"];
@@ -574,14 +594,6 @@ export type paths = {
   };
   "/tkhq/api/v1/noop-codegen-anchor": {
     post: operations["PublicApiService_NOOPCodegenAnchor"];
-  };
-  "/tkhq/api/v1/refresh_feature_flags": {
-    /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-    post: operations["PublicApiService_RefreshFeatureFlags"];
-  };
-  "/tkhq/api/v1/test_rate_limits": {
-    /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-    post: operations["PublicApiService_TestRateLimits"];
   };
 };
 
@@ -671,6 +683,8 @@ export type definitions = {
     /** @description The public component of a cryptographic key pair used to sign messages and transactions. */
     publicKey: string;
     type: definitions["v1CredentialType"];
+    /** @description The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN. */
+    sessionProfileId?: string;
   };
   externaldatav1Quorum: {
     /**
@@ -783,7 +797,8 @@ export type definitions = {
     | "ACTIVITY_STATUS_COMPLETED"
     | "ACTIVITY_STATUS_FAILED"
     | "ACTIVITY_STATUS_CONSENSUS_NEEDED"
-    | "ACTIVITY_STATUS_REJECTED";
+    | "ACTIVITY_STATUS_REJECTED"
+    | "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED";
   /** @enum {string} */
   v1ActivityType:
     | "ACTIVITY_TYPE_CREATE_API_KEYS"
@@ -923,7 +938,16 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
+    | "ACTIVITY_TYPE_CREATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_UPDATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_DELETE_MFA_POLICY"
+    | "ACTIVITY_TYPE_CREATE_SESSION_PROFILE"
+    | "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER"
+    | "ACTIVITY_TYPE_EARN_DEPOSIT"
+    | "ACTIVITY_TYPE_EARN_WITHDRAW"
+    | "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1084,6 +1108,26 @@ export type definitions = {
     /** @description The type of authenticator transports. */
     transports: definitions["v1AuthenticatorTransport"][];
   };
+  v1AuthenticationMethod: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step. */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., for requiring a specific session profile id) */
+    id?: string;
+  };
+  v1AuthenticationMethodParams: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication). */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used. */
+    id?: string;
+  };
+  /** @enum {string} */
+  v1AuthenticationType:
+    | "AUTHENTICATION_TYPE_EMAIL_OTP"
+    | "AUTHENTICATION_TYPE_SMS_OTP"
+    | "AUTHENTICATION_TYPE_PASSKEY"
+    | "AUTHENTICATION_TYPE_API_KEY"
+    | "AUTHENTICATION_TYPE_OAUTH"
+    | "AUTHENTICATION_TYPE_SESSION";
   v1Authenticator: {
     /** @description Types of transports that may be used by an Authenticator (e.g., USB, NFC, BLE). */
     transports: definitions["v1AuthenticatorTransport"][];
@@ -1139,9 +1183,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1194,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1199,16 +1245,6 @@ export type definitions = {
   v1CreateApiOnlyUsersIntent: {
     /** @description A list of API-only Users to create. */
     apiOnlyUsers: definitions["v1ApiOnlyUserParams"][];
-  };
-  v1CreateApiOnlyUsersRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1CreateApiOnlyUsersIntent"];
-    generateAppProofs?: boolean;
   };
   v1CreateApiOnlyUsersResult: {
     /** @description A list of API-only User IDs. */
@@ -1285,6 +1321,36 @@ export type definitions = {
   v1CreateInvitationsResult: {
     /** @description A list of Invitation IDs */
     invitationIds: string[];
+  };
+  v1CreateMfaPolicyIntent: {
+    /** @description The ID of the User to add the MFA Policy to. */
+    userId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1CreateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateMfaPolicyIntent"];
+  };
+  v1CreateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1CreateOauth2CredentialIntent: {
     /** @description The OAuth 2.0 provider */
@@ -1560,6 +1626,29 @@ export type definitions = {
     /** @description HPKE encrypted credential bundle */
     credentialBundle: string;
   };
+  v1CreateSessionProfileIntent: {
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The scope string that defines the permissions for this Session Profile. */
+    scope: string;
+    /** @description The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities. */
+    expirationSeconds?: string;
+    /** @description Notes for a Session Profile. */
+    notes?: string;
+  };
+  v1CreateSessionProfileRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSessionProfileIntent"];
+  };
+  v1CreateSessionProfileResult: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+  };
   v1CreateSmartContractInterfaceIntent: {
     /** @description Corresponding contract address or program ID */
     smartContractAddress: string;
@@ -1776,6 +1865,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2091,6 +2182,25 @@ export type definitions = {
   v1DeleteInvitationResult: {
     /** @description Unique identifier for a given Invitation. */
     invitationId: string;
+  };
+  v1DeleteMfaPolicyIntent: {
+    /** @description The ID of the User to delete the MFA Policy from. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+  };
+  v1DeleteMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteMfaPolicyIntent"];
+  };
+  v1DeleteMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1DeleteOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to delete */
@@ -2408,6 +2518,96 @@ export type definitions = {
     /** @description Unique identifier for a given Private Key. */
     privateKeyId: string;
   };
+  v1EarnDeployWrapperIntent: {
+    /** @description Address of the underlying yield vault to wrap (from the EarnVaults catalog). */
+    vaultAddress: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+  };
+  v1EarnDeployWrapperResult: {
+    /** @description Address of the deployed fee wrapper (the deposit target). */
+    wrapperAddress: string;
+    /** @description Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave). */
+    splitterAddress: string;
+    /** @description Transaction hash of the wrapper deployment. */
+    deployTxHash: string;
+  };
+  v1EarnDepositIntent: {
+    /** @description Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals). */
+    assets: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+  };
+  v1EarnDepositResult: {
+    /** @description Transaction hash of the deposit. */
+    depositTxHash: string;
+    /** @description Number of wrapper shares minted to the depositor, in raw on-chain units. */
+    sharesMinted: string;
+    /** @description Address of the fee wrapper the deposit was routed to. */
+    wrapperAddress: string;
+    /** @description Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path). */
+    depositRequestId: string;
+  };
+  v1EarnWithdrawIntent: {
+    /** @description Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+    /**
+     * @description Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims).
+     * @enum {string}
+     */
+    amountType: "SHARES" | "ASSETS";
+    /** @description The amount to withdraw, in raw on-chain units, interpreted according to amount_type. */
+    amountValue: string;
+  };
+  v1EarnWithdrawResult: {
+    /** @description Transaction hash of the withdrawal. */
+    withdrawTxHash: string;
+    /** @description Identifier to poll withdrawal status via EarnWithdrawStatus. */
+    withdrawRequestId: string;
+    /** @description Amount of the underlying asset received, in raw on-chain units. */
+    assetsReceived: string;
+    /** @description Number of wrapper shares burned, in raw on-chain units. */
+    sharesBurned: string;
+  };
   /** @enum {string} */
   v1Effect: "EFFECT_ALLOW" | "EFFECT_DENY";
   v1EmailAuthCustomizationParams: {
@@ -2525,6 +2725,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,17 +2750,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
-  };
-  v1EthSendRawTransactionRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_RAW_TRANSACTION";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1EthSendRawTransactionIntent"];
-    generateAppProofs?: boolean;
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionResult: {
     /** @description The transaction hash of the sent transaction */
@@ -2573,7 +2773,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2795,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2896,6 +3135,40 @@ export type definitions = {
     /** @description Name of enclave app. */
     appName: string;
   };
+  v1GetMfaPoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+  };
+  v1GetMfaPoliciesResponse: {
+    /** @description A list of multi-factor authentication policies for a user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
+  };
+  v1GetMfaPolicyRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+    /** @description Unique identifier for a given MFA policy. */
+    mfaPolicyId: string;
+  };
+  v1GetMfaPolicyResponse: {
+    /** @description Multi-factor authentication policy for a user. */
+    mfaPolicy: definitions["v1MfaPolicy"];
+  };
+  v1GetMfaStatusRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description The unique identifier of the activity to get MFA status for. */
+    activityId: string;
+    /** @description Optional user ID to filter MFA status for a specific user. */
+    userId?: string;
+  };
+  v1GetMfaStatusResponse: {
+    /** @description A list of MFA statuses for the activity's votes. */
+    mfaStatuses: definitions["v1MfaStatus"][];
+  };
   v1GetNoncesRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -2911,7 +3184,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -2967,14 +3242,6 @@ export type definitions = {
   v1GetOrganizationConfigsResponse: {
     /** @description Organization configs including quorum settings and organization features. */
     configs: definitions["v1Config"];
-  };
-  v1GetOrganizationRequest: {
-    /** @description Unique identifier for a given organization. */
-    organizationId: string;
-  };
-  v1GetOrganizationResponse: {
-    /** @description Object representing the full current and deleted / disabled collection of users, policies, private keys, and invitations attributable to a particular organization. */
-    organizationData: definitions["v1OrganizationData"];
   };
   v1GetPoliciesRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3039,6 +3306,24 @@ export type definitions = {
     /** @description Structured error information including revert details, if available. */
     error?: definitions["v1TxError"];
   };
+  v1GetSessionProfileRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a session profile. */
+    sessionProfileId: string;
+  };
+  v1GetSessionProfileResponse: {
+    /** @description Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies. */
+    sessionProfile: definitions["v1SessionProfile"];
+  };
+  v1GetSessionProfilesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetSessionProfilesResponse: {
+    /** @description A list of session profiles for users in the organization. */
+    sessionProfiles: definitions["v1SessionProfile"][];
+  };
   v1GetSmartContractInterfaceRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3099,23 +3384,25 @@ export type definitions = {
     /** @description A list of TVC Apps. */
     tvcApps: definitions["v1TvcApp"][];
   };
-  v1GetTvcDeploymentProvisioningDetailsRequest: {
+  v1GetTvcDeploymentDebugLogsRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Unique identifier for a given TVC Deployment. */
+    /** @description Unique identifier for a given TVC Deployment. The deployment must be running in debug mode. */
     deploymentId: string;
+    /**
+     * Format: int32
+     * @description Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied.
+     */
+    tailLines?: number;
+    /**
+     * Format: int64
+     * @description Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs.
+     */
+    sinceSeconds?: string;
   };
-  v1GetTvcDeploymentProvisioningDetailsResponse: {
-    /**
-     * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
-     */
-    attestationDocument: string;
-    /**
-     * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
-     */
-    manifestEnvelope: string;
+  v1GetTvcDeploymentDebugLogsResponse: {
+    /** @description Application log entries sorted by platform timestamp. */
+    entries: definitions["v1TvcDeploymentDebugLogEntry"][];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3203,6 +3490,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,24 +4053,15 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
-  };
-  v1Invitation: {
-    /** @description Unique identifier for a given Invitation object. */
-    invitationId: string;
-    /** @description The name of the intended Invitation recipient. */
-    receiverUserName: string;
-    /** @description The email address of the intended Invitation recipient. */
-    receiverEmail: string;
-    /** @description A list of tags assigned to the Invitation recipient. */
-    receiverUserTags: string[];
-    /** @description The User's permissible access method(s). */
-    accessType: definitions["v1AccessType"];
-    /** @description The current processing status of a specified Invitation. */
-    status: definitions["v1InvitationStatus"];
-    createdAt: definitions["externaldatav1Timestamp"];
-    updatedAt: definitions["externaldatav1Timestamp"];
-    /** @description Unique identifier for the Sender of an Invitation. */
-    senderUserId: string;
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
+    createMfaPolicyIntent?: definitions["v1CreateMfaPolicyIntent"];
+    updateMfaPolicyIntent?: definitions["v1UpdateMfaPolicyIntent"];
+    deleteMfaPolicyIntent?: definitions["v1DeleteMfaPolicyIntent"];
+    createSessionProfileIntent?: definitions["v1CreateSessionProfileIntent"];
+    earnDeployWrapperIntent?: definitions["v1EarnDeployWrapperIntent"];
+    earnDepositIntent?: definitions["v1EarnDepositIntent"];
+    earnWithdrawIntent?: definitions["v1EarnWithdrawIntent"];
+    upsertEarnClientFeeConfigIntent?: definitions["v1UpsertEarnClientFeeConfigIntent"];
   };
   v1InvitationParams: {
     /** @description The name of the intended Invitation recipient. */
@@ -3791,11 +4075,6 @@ export type definitions = {
     /** @description Unique identifier for the Sender of an Invitation. */
     senderUserId: string;
   };
-  /** @enum {string} */
-  v1InvitationStatus:
-    | "INVITATION_STATUS_CREATED"
-    | "INVITATION_STATUS_ACCEPTED"
-    | "INVITATION_STATUS_REVOKED";
   v1IpAllowlist: {
     /** @description Unique identifier for the organization this allowlist belongs to. */
     organizationId: string;
@@ -3858,6 +4137,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3880,9 +4165,46 @@ export type definitions = {
   v1ListWebhookEndpointsResponse: {
     webhookEndpoints: definitions["v1WebhookEndpointData"][];
   };
+  v1LogLine: {
+    /** @description One log line, exactly as the application printed it (without the trailing newline) */
+    content: string;
+    /** @description When the line was logged. Stable across replays, so lines can be chronologically merged across pods */
+    ts?: definitions["externaldatav1Timestamp"];
+  };
   v1LoginUsage: {
     /** @description Public key for authentication */
     publicKey: string;
+  };
+  v1MfaPolicy: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for an MFA Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethod"][];
+    /**
+     * Format: int64
+     * @description The order in which this policy is evaluated relative to other MFA policies.
+     */
+    order: number;
+    /** @description Optional human-readable notes added by a User to describe a particular MFA policy. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
+  };
+  v1MfaStatus: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Whether the MFA policy requirements are currently satisfied. */
+    satisfied: boolean;
+    /** @description A list of authentication methods already satisfied for this MFA policy. */
+    satisfiedMethods: definitions["v1AuthenticationMethod"][];
+    /** @description An ordered list of authentication requirements needed to satisfy this MFA policy. */
+    requiredMethods: definitions["v1RequiredAuthenticationMethod"][];
   };
   /** @enum {string} */
   v1MnemonicLanguage:
@@ -3975,6 +4297,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OauthLoginRequest: {
     /** @enum {string} */
@@ -4057,19 +4381,6 @@ export type definitions = {
     | "OPERATOR_NOT_IN"
     | "OPERATOR_CONTAINS_ONE"
     | "OPERATOR_CONTAINS_ALL";
-  v1OrganizationData: {
-    organizationId?: string;
-    name?: string;
-    users?: definitions["v1User"][];
-    policies?: definitions["v1Policy"][];
-    privateKeys?: definitions["v1PrivateKey"][];
-    invitations?: definitions["v1Invitation"][];
-    tags?: definitions["datav1Tag"][];
-    rootQuorum?: definitions["externaldatav1Quorum"];
-    features?: definitions["v1Feature"][];
-    wallets?: definitions["v1Wallet"][];
-    smartContractInterfaceReferences?: definitions["v1SmartContractInterfaceReference"][];
-  };
   v1OtpAuthIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -4113,6 +4424,8 @@ export type definitions = {
     invalidateExisting?: boolean;
     /** @description Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step. */
     clientSignature?: definitions["v1ClientSignature"];
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginIntentV2: {
     /** @description Signed Verification Token containing a unique id, expiry, verification type, contact */
@@ -4125,6 +4438,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login sessions */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginRequest: {
     /** @enum {string} */
@@ -4147,7 +4462,8 @@ export type definitions = {
     | "OUTCOME_DENY_IMPLICIT"
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
-    | "OUTCOME_ERROR";
+    | "OUTCOME_ERROR"
+    | "OUTCOME_REQUIRES_AUTHENTICATORS";
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -4187,15 +4503,6 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description Re-encrypted quorum key share and approval */
     shareApprovalBundle: definitions["v1QuorumKeyShareApprovalBundle"];
-  };
-  v1PostTvcQuorumKeyShareRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1PostTvcQuorumKeyShareIntent"];
   };
   v1PostTvcQuorumKeyShareResult: {
     /** @description The unique identifier for the provisioning quorum key share */
@@ -4273,8 +4580,6 @@ export type definitions = {
     /** @description ID of the authenticator created. */
     authenticatorId: string[];
   };
-  v1RefreshFeatureFlagsRequest: { [key: string]: unknown };
-  v1RefreshFeatureFlagsResponse: { [key: string]: unknown };
   v1RejectActivityIntent: {
     /** @description An artifact verifying a User's action. */
     fingerprint: string;
@@ -4321,6 +4626,14 @@ export type definitions = {
   v1RemoveOrganizationFeatureResult: {
     /** @description Resulting list of organization features. */
     features: definitions["v1Feature"][];
+  };
+  v1RequiredAuthenticationMethod: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethod"][];
+  };
+  v1RequiredAuthenticationMethodParams: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethodParams"][];
   };
   v1RestoreTvcDeploymentIntent: {
     /** @description The unique identifier of the TVC deployment to restore. */
@@ -4457,6 +4770,15 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
+    createMfaPolicyResult?: definitions["v1CreateMfaPolicyResult"];
+    updateMfaPolicyResult?: definitions["v1UpdateMfaPolicyResult"];
+    deleteMfaPolicyResult?: definitions["v1DeleteMfaPolicyResult"];
+    createSessionProfileResult?: definitions["v1CreateSessionProfileResult"];
+    earnDeployWrapperResult?: definitions["v1EarnDeployWrapperResult"];
+    earnDepositResult?: definitions["v1EarnDepositResult"];
+    earnWithdrawResult?: definitions["v1EarnWithdrawResult"];
+    upsertEarnClientFeeConfigResult?: definitions["v1UpsertEarnClientFeeConfigResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -4543,6 +4865,20 @@ export type definitions = {
     subject?: string;
     operator?: definitions["v1Operator"];
     targets?: string[];
+  };
+  v1SessionProfile: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The specific scope that a session created with this profile is limited to. */
+    scope: string;
+    /** @description Optional window (in seconds) indicating how long sessions created with this profile should last. */
+    expirationSeconds?: string;
+    /** @description Optional human-readable notes added by a User to describe a particular Session Profile. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
   };
   v1SetIpAllowlistIntent: {
     /** @description The public component of an API key. If null, the IP allowlist applies at the organization level. If set, it applies only to this specific API key. */
@@ -4691,11 +5027,6 @@ export type definitions = {
     appid?: boolean;
     appidExclude?: boolean;
     credProps?: definitions["v1CredPropsAuthenticationExtensionsClientOutputs"];
-  };
-  v1SmartContractInterfaceReference: {
-    smartContractInterfaceId?: string;
-    smartContractAddress?: string;
-    digest?: string;
   };
   /** @enum {string} */
   v1SmartContractInterfaceType:
@@ -4994,6 +5325,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1StampLoginRequest: {
     /** @enum {string} */
@@ -5011,18 +5344,6 @@ export type definitions = {
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
-  v1TestRateLimitsRequest: {
-    /** @description Unique identifier for a given organization. If the request is being made by a WebAuthN user and their sub-organization ID is unknown, this can be the parent organization ID; using the sub-organization ID when possible is preferred due to performance reasons. */
-    organizationId: string;
-    /** @description Whether or not to set a limit on this request. */
-    isSetLimit: boolean;
-    /**
-     * Format: int64
-     * @description Rate limit to set for org, if is_set_limit is set to true.
-     */
-    limit: number;
-  };
-  v1TestRateLimitsResponse: { [key: string]: unknown };
   v1TokenUsage: {
     /** @description Type of token usage */
     type: definitions["v1UsageType"];
@@ -5060,6 +5381,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5106,6 +5429,12 @@ export type definitions = {
     updatedAt: definitions["externaldatav1Timestamp"];
     /** @description Whether or not the user wants this deployment deleted from the cluster. */
     delete: boolean;
+  };
+  v1TvcDeploymentDebugLogEntry: {
+    /** @description Application log line with its platform timestamp. */
+    line: definitions["v1LogLine"];
+    /** @description Public replica label that produced this log line, for example 'replica 2/3'. */
+    replicaLabel: string;
   };
   /** @enum {string} */
   v1TvcHealthCheckType:
@@ -5289,6 +5618,38 @@ export type definitions = {
   v1UpdateFiatOnRampCredentialResult: {
     /** @description Unique identifier of the Fiat On-Ramp credential that was updated */
     fiatOnRampCredentialId: string;
+  };
+  v1UpdateMfaPolicyIntent: {
+    /** @description The ID of the User to update the MFA Policy for. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName?: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition?: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods?: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order?: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1UpdateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateMfaPolicyIntent"];
+  };
+  v1UpdateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1UpdateOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to update */
@@ -5599,6 +5960,16 @@ export type definitions = {
     /** @description The updated webhook endpoint data. */
     webhookEndpoint: definitions["v1WebhookEndpointData"];
   };
+  v1UpsertEarnClientFeeConfigIntent: {
+    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    clientFeeBps: string;
+    /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
+    clientFeeWallet: string;
+  };
+  v1UpsertEarnClientFeeConfigResult: {
+    /** @description Transaction hash of the fee configuration update. */
+    feeUpdateTxHash: string;
+  };
   v1UpsertGasUsageConfigIntent: {
     /** @description Gas sponsorship USD limit for the billing organization window. */
     orgWindowLimitUsd: string;
@@ -5636,6 +6007,8 @@ export type definitions = {
     oauthProviders: definitions["v1OauthProvider"][];
     createdAt: definitions["externaldatav1Timestamp"];
     updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description A list of MFA Policies that define multi-factor authentication requirements for this user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
   };
   v1UserParams: {
     /** @description Human-readable name for a User. */
@@ -5794,6 +6167,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +6179,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6053,6 +6430,60 @@ export type operations = {
       };
     };
   };
+  /** Get all MFA policies for a user. */
+  PublicApiService_GetMfaPolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get a single MFA policy for a user. */
+  PublicApiService_GetMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPolicyResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get the MFA status of an activity for a specific user or all voting users. */
+  PublicApiService_GetMfaStatus: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaStatusRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaStatusResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
   PublicApiService_GetNonces: {
     parameters: {
@@ -6118,24 +6549,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetOnRampTransactionStatusResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get details about an organization. */
-  PublicApiService_GetOrganization: {
-    parameters: {
-      body: {
-        body: definitions["v1GetOrganizationRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetOrganizationResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6233,6 +6646,42 @@ export type operations = {
       };
     };
   };
+  /** Get a single session profile for an organization. */
+  PublicApiService_GetSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfileRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfileResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get all session profiles for an organization. */
+  PublicApiService_GetSessionProfiles: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfilesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfilesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a smart contract interface. */
   PublicApiService_GetSmartContractInterface: {
     parameters: {
@@ -6287,17 +6736,17 @@ export type operations = {
       };
     };
   };
-  /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-  PublicApiService_GetTvcDeploymentProvisioningDetails: {
+  /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+  PublicApiService_GetTvcDeploymentDebugLogs: {
     parameters: {
       body: {
-        body: definitions["v1GetTvcDeploymentProvisioningDetailsRequest"];
+        body: definitions["v1GetTvcDeploymentDebugLogsRequest"];
       };
     };
     responses: {
       /** A successful response. */
       200: {
-        schema: definitions["v1GetTvcDeploymentProvisioningDetailsResponse"];
+        schema: definitions["v1GetTvcDeploymentDebugLogsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6359,7 +6808,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6988,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {
@@ -6773,24 +7222,6 @@ export type operations = {
       };
     };
   };
-  /** Create API-only users in an existing organization. */
-  PublicApiService_CreateApiOnlyUsers: {
-    parameters: {
-      body: {
-        body: definitions["v1CreateApiOnlyUsersRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
   /** Create authenticators to authenticate requests to Turnkey. */
   PublicApiService_CreateAuthenticators: {
     parameters: {
@@ -6832,6 +7263,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateInvitationsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new MFA policy for a user. */
+  PublicApiService_CreateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateMfaPolicyRequest"];
       };
     };
     responses: {
@@ -6976,6 +7425,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateReadWriteSessionRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new session profile for an organization. */
+  PublicApiService_CreateSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSessionProfileRequest"];
       };
     };
     responses: {
@@ -7228,6 +7695,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteInvitationRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an MFA policy for a user. */
+  PublicApiService_DeleteMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteMfaPolicyRequest"];
       };
     };
     responses: {
@@ -7516,24 +8001,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1EmailAuthRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-  PublicApiService_EthSendRawTransaction: {
-    parameters: {
-      body: {
-        body: definitions["v1EthSendRawTransactionRequest"];
       };
     };
     responses: {
@@ -7840,24 +8307,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1OtpLoginRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Post re-encrypted quorum key share for a TVC deployment. */
-  PublicApiService_PostTvcQuorumKeyShare: {
-    parameters: {
-      body: {
-        body: definitions["v1PostTvcQuorumKeyShareRequest"];
       };
     };
     responses: {
@@ -8195,6 +8644,24 @@ export type operations = {
       };
     };
   };
+  /** Update an MFA policy for a user. */
+  PublicApiService_UpdateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Update an OAuth 2.0 provider credential */
   PublicApiService_UpdateOauth2Credential: {
     parameters: {
@@ -8434,42 +8901,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1NOOPCodegenAnchorResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-  PublicApiService_RefreshFeatureFlags: {
-    parameters: {
-      body: {
-        body: definitions["v1RefreshFeatureFlagsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1RefreshFeatureFlagsResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-  PublicApiService_TestRateLimits: {
-    parameters: {
-      body: {
-        body: definitions["v1TestRateLimitsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1TestRateLimitsResponse"];
       };
       /** An unexpected error response. */
       default: {

--- a/packages/http/src/__tests__/async-test.ts
+++ b/packages/http/src/__tests__/async-test.ts
@@ -4,6 +4,7 @@ import {
   TurnkeyApi,
   init,
   withAsyncPolling,
+  createActivityPoller,
   TurnkeyActivityError,
 } from "../index";
 import { readFixture } from "../__fixtures__/shared";
@@ -128,6 +129,101 @@ test("`withAsyncPolling` should throw a rich error when activity requires consen
   }
 
   expect(fetch).toHaveBeenCalledTimes(expectedCallCount);
+});
+
+test("`withAsyncPolling` should throw a rich error when activity needs authenticators", async () => {
+  const mutation = withAsyncPolling({
+    request: TurnkeyApi.createPrivateKeys,
+  });
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+  const { expectedCallCount } = chainMockResponseSequence(mockedFetch, [
+    {
+      activity: {
+        status: "ACTIVITY_STATUS_PENDING",
+        type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+        id: "ee916c38-8151-460d-91c0-8bdbf5a9b20e",
+      },
+    },
+    {
+      activity: {
+        status: "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED",
+        type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+        id: "ee916c38-8151-460d-91c0-8bdbf5a9b20e",
+      },
+    },
+  ]);
+
+  try {
+    await mutation(sampleCreatePrivateKeysInput);
+
+    expect("the mutation above must throw").toEqual("an error");
+  } catch (error) {
+    expect(error).toBeInstanceOf(TurnkeyActivityError);
+    const richError = error as TurnkeyActivityError;
+    const { message, activityId, activityStatus, activityType } = richError;
+
+    expect({
+      message,
+      activityId,
+      activityStatus,
+      activityType,
+    }).toMatchInlineSnapshot(`
+      {
+        "activityId": "ee916c38-8151-460d-91c0-8bdbf5a9b20e",
+        "activityStatus": "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED",
+        "activityType": "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+        "message": "Authenticators needed for activity ee916c38-8151-460d-91c0-8bdbf5a9b20e",
+      }
+    `);
+  }
+
+  expect(fetch).toHaveBeenCalledTimes(expectedCallCount);
+});
+
+test("`createActivityPoller` should throw a rich error when activity needs authenticators", async () => {
+  const requestFn = jest.fn(async () => ({
+    activity: createActivityFixture({
+      status: "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED",
+      type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+      id: "ee916c38-8151-460d-91c0-8bdbf5a9b20e",
+    }),
+  }));
+  const client = {
+    getActivity: jest.fn(),
+  };
+  const mutation = createActivityPoller({
+    client: client as any,
+    requestFn,
+  });
+
+  try {
+    await mutation(sampleCreatePrivateKeysInput.body);
+
+    expect("the mutation above must throw").toEqual("an error");
+  } catch (error) {
+    expect(error).toBeInstanceOf(TurnkeyActivityError);
+    const richError = error as TurnkeyActivityError;
+    const { message, activityId, activityStatus, activityType } = richError;
+
+    expect({
+      message,
+      activityId,
+      activityStatus,
+      activityType,
+    }).toMatchInlineSnapshot(`
+      {
+        "activityId": "ee916c38-8151-460d-91c0-8bdbf5a9b20e",
+        "activityStatus": "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED",
+        "activityType": "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+        "message": "Authenticators needed for activity ee916c38-8151-460d-91c0-8bdbf5a9b20e",
+      }
+    `);
+  }
+
+  expect(requestFn).toHaveBeenCalledTimes(1);
+  expect(client.getActivity).not.toHaveBeenCalled();
 });
 
 test("`withAsyncPolling` should throw a rich error when activity is rejected", async () => {
@@ -311,6 +407,30 @@ function createMockResponse(result: { activity: Partial<TActivity> }) {
   response.ok = true;
   response.json = async () => result;
   return Promise.resolve(response);
+}
+
+function createActivityFixture(overrides: Partial<TActivity> = {}): TActivity {
+  return {
+    id: "activity-id",
+    organizationId: "organization-id",
+    status: "ACTIVITY_STATUS_PENDING",
+    type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+    intent: {},
+    result: {},
+    votes: [],
+    fingerprint: "fingerprint",
+    canApprove: false,
+    canReject: false,
+    createdAt: {
+      seconds: "0",
+      nanos: "0",
+    },
+    updatedAt: {
+      seconds: "0",
+      nanos: "0",
+    },
+    ...overrides,
+  };
 }
 
 function chainMockResponseSequence(

--- a/packages/http/src/async.ts
+++ b/packages/http/src/async.ts
@@ -48,6 +48,14 @@ export function withAsyncPolling<
             activityType: activity.type,
           });
         }
+        case "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED": {
+          throw new TurnkeyActivityError({
+            message: `Authenticators needed for activity ${activity.id}`,
+            activityId: activity.id,
+            activityStatus: activity.status,
+            activityType: activity.type,
+          });
+        }
         case "ACTIVITY_STATUS_FAILED": {
           // Activity failed
           throw new TurnkeyActivityError({
@@ -136,6 +144,14 @@ export function createActivityPoller<
           // when the required approvals/rejections are in place.
           throw new TurnkeyActivityError({
             message: `Consensus needed for activity ${activity.id}`,
+            activityId: activity.id,
+            activityStatus: activity.status,
+            activityType: activity.type,
+          });
+        }
+        case "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED": {
+          throw new TurnkeyActivityError({
+            message: `Authenticators needed for activity ${activity.id}`,
             activityId: activity.id,
             activityStatus: activity.status,
             activityType: activity.type,

--- a/packages/sdk-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-browser/src/__generated__/sdk-client-base.ts
@@ -567,6 +567,130 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getMfaPolicies = async (
+    input: SdkApiTypes.TGetMfaPoliciesBody,
+  ): Promise<SdkApiTypes.TGetMfaPoliciesResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_mfa_policies", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetMfaPolicies = async (
+    input: SdkApiTypes.TGetMfaPoliciesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_mfa_policies";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getMfaPolicy = async (
+    input: SdkApiTypes.TGetMfaPolicyBody,
+  ): Promise<SdkApiTypes.TGetMfaPolicyResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_mfa_policy", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetMfaPolicy = async (
+    input: SdkApiTypes.TGetMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_mfa_policy";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getMfaStatus = async (
+    input: SdkApiTypes.TGetMfaStatusBody,
+  ): Promise<SdkApiTypes.TGetMfaStatusResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_mfa_status", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetMfaStatus = async (
+    input: SdkApiTypes.TGetMfaStatusBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_mfa_status";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getNonces = async (
     input: SdkApiTypes.TGetNoncesBody,
   ): Promise<SdkApiTypes.TGetNoncesResponse> => {
@@ -942,6 +1066,90 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getSessionProfile = async (
+    input: SdkApiTypes.TGetSessionProfileBody,
+  ): Promise<SdkApiTypes.TGetSessionProfileResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_session_profile", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetSessionProfile = async (
+    input: SdkApiTypes.TGetSessionProfileBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_session_profile";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getSessionProfiles = async (
+    input: SdkApiTypes.TGetSessionProfilesBody,
+  ): Promise<SdkApiTypes.TGetSessionProfilesResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_session_profiles", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetSessionProfiles = async (
+    input: SdkApiTypes.TGetSessionProfilesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_session_profiles";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getSmartContractInterface = async (
     input: SdkApiTypes.TGetSmartContractInterfaceBody,
   ): Promise<SdkApiTypes.TGetSmartContractInterfaceResponse> => {
@@ -1050,6 +1258,48 @@ export class TurnkeySDKClientBase {
     const session = sessionData ? parseSession(sessionData) : null;
     const fullUrl =
       this.config.apiBaseUrl + "/public/v1/query/get_tvc_deployment";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getTvcDeploymentDebugLogs = async (
+    input: SdkApiTypes.TGetTvcDeploymentDebugLogsBody,
+  ): Promise<SdkApiTypes.TGetTvcDeploymentDebugLogsResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_tvc_deployment_debug_logs", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetTvcDeploymentDebugLogs = async (
+    input: SdkApiTypes.TGetTvcDeploymentDebugLogsBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_tvc_deployment_debug_logs";
     const body = {
       ...input,
       organizationId:
@@ -2320,6 +2570,58 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  createMfaPolicy = async (
+    input: SdkApiTypes.TCreateMfaPolicyBody,
+  ): Promise<SdkApiTypes.TCreateMfaPolicyResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/create_mfa_policy",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+      },
+      "createMfaPolicyResult",
+    );
+  };
+
+  stampCreateMfaPolicy = async (
+    input: SdkApiTypes.TCreateMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   createOauth2Credential = async (
     input: SdkApiTypes.TCreateOauth2CredentialBody,
   ): Promise<SdkApiTypes.TCreateOauth2CredentialResponse> => {
@@ -2724,6 +3026,58 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION_V2",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  createSessionProfile = async (
+    input: SdkApiTypes.TCreateSessionProfileBody,
+  ): Promise<SdkApiTypes.TCreateSessionProfileResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/create_session_profile",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+      },
+      "createSessionProfileResult",
+    );
+  };
+
+  stampCreateSessionProfile = async (
+    input: SdkApiTypes.TCreateSessionProfileBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_session_profile";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -3452,6 +3806,58 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_INVITATION",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  deleteMfaPolicy = async (
+    input: SdkApiTypes.TDeleteMfaPolicyBody,
+  ): Promise<SdkApiTypes.TDeleteMfaPolicyResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/delete_mfa_policy",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+      },
+      "deleteMfaPolicyResult",
+    );
+  };
+
+  stampDeleteMfaPolicy = async (
+    input: SdkApiTypes.TDeleteMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/delete_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_DELETE_MFA_POLICY",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4311,7 +4717,7 @@ export class TurnkeySDKClientBase {
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
       },
-      "ethSendTransactionResult",
+      "ethSendTransactionResultV2",
     );
   };
 
@@ -6088,6 +6494,58 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_FIAT_ON_RAMP_CREDENTIAL",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateMfaPolicy = async (
+    input: SdkApiTypes.TUpdateMfaPolicyBody,
+  ): Promise<SdkApiTypes.TUpdateMfaPolicyResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/update_mfa_policy",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+      },
+      "updateMfaPolicyResult",
+    );
+  };
+
+  stampUpdateMfaPolicy = async (
+    input: SdkApiTypes.TUpdateMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/sdk-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-browser/src/__generated__/sdk_api_types.ts
@@ -117,6 +117,39 @@ export type TGetLatestBootProofBody = Omit<
 > &
   queryOverrideParams;
 
+export type TGetMfaPoliciesResponse =
+  operations["PublicApiService_GetMfaPolicies"]["responses"]["200"]["schema"];
+
+export type TGetMfaPoliciesInput = { body: TGetMfaPoliciesBody };
+
+export type TGetMfaPoliciesBody = Omit<
+  operations["PublicApiService_GetMfaPolicies"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
+export type TGetMfaPolicyResponse =
+  operations["PublicApiService_GetMfaPolicy"]["responses"]["200"]["schema"];
+
+export type TGetMfaPolicyInput = { body: TGetMfaPolicyBody };
+
+export type TGetMfaPolicyBody = Omit<
+  operations["PublicApiService_GetMfaPolicy"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
+export type TGetMfaStatusResponse =
+  operations["PublicApiService_GetMfaStatus"]["responses"]["200"]["schema"];
+
+export type TGetMfaStatusInput = { body: TGetMfaStatusBody };
+
+export type TGetMfaStatusBody = Omit<
+  operations["PublicApiService_GetMfaStatus"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetNoncesResponse =
   operations["PublicApiService_GetNonces"]["responses"]["200"]["schema"];
 
@@ -222,6 +255,28 @@ export type TGetSendTransactionStatusBody = Omit<
 > &
   queryOverrideParams;
 
+export type TGetSessionProfileResponse =
+  operations["PublicApiService_GetSessionProfile"]["responses"]["200"]["schema"];
+
+export type TGetSessionProfileInput = { body: TGetSessionProfileBody };
+
+export type TGetSessionProfileBody = Omit<
+  operations["PublicApiService_GetSessionProfile"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
+export type TGetSessionProfilesResponse =
+  operations["PublicApiService_GetSessionProfiles"]["responses"]["200"]["schema"];
+
+export type TGetSessionProfilesInput = { body: TGetSessionProfilesBody };
+
+export type TGetSessionProfilesBody = Omit<
+  operations["PublicApiService_GetSessionProfiles"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetSmartContractInterfaceResponse =
   operations["PublicApiService_GetSmartContractInterface"]["responses"]["200"]["schema"];
 
@@ -253,6 +308,19 @@ export type TGetTvcDeploymentInput = { body: TGetTvcDeploymentBody };
 
 export type TGetTvcDeploymentBody = Omit<
   operations["PublicApiService_GetTvcDeployment"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
+export type TGetTvcDeploymentDebugLogsResponse =
+  operations["PublicApiService_GetTvcDeploymentDebugLogs"]["responses"]["200"]["schema"];
+
+export type TGetTvcDeploymentDebugLogsInput = {
+  body: TGetTvcDeploymentDebugLogsBody;
+};
+
+export type TGetTvcDeploymentDebugLogsBody = Omit<
+  operations["PublicApiService_GetTvcDeploymentDebugLogs"]["parameters"]["body"]["body"],
   "organizationId"
 > &
   queryOverrideParams;
@@ -579,6 +647,16 @@ export type TCreateInvitationsBody =
   operations["PublicApiService_CreateInvitations"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
+export type TCreateMfaPolicyResponse =
+  operations["PublicApiService_CreateMfaPolicy"]["responses"]["200"]["schema"]["activity"]["result"]["createMfaPolicyResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TCreateMfaPolicyInput = { body: TCreateMfaPolicyBody };
+
+export type TCreateMfaPolicyBody =
+  operations["PublicApiService_CreateMfaPolicy"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
 export type TCreateOauth2CredentialResponse =
   operations["PublicApiService_CreateOauth2Credential"]["responses"]["200"]["schema"]["activity"]["result"]["createOauth2CredentialResult"] &
     definitions["v1ActivityResponse"];
@@ -661,6 +739,16 @@ export type TCreateReadWriteSessionInput = {
 
 export type TCreateReadWriteSessionBody =
   operations["PublicApiService_CreateReadWriteSession"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TCreateSessionProfileResponse =
+  operations["PublicApiService_CreateSessionProfile"]["responses"]["200"]["schema"]["activity"]["result"]["createSessionProfileResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TCreateSessionProfileInput = { body: TCreateSessionProfileBody };
+
+export type TCreateSessionProfileBody =
+  operations["PublicApiService_CreateSessionProfile"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TCreateSmartContractInterfaceResponse =
@@ -807,6 +895,16 @@ export type TDeleteInvitationInput = { body: TDeleteInvitationBody };
 
 export type TDeleteInvitationBody =
   operations["PublicApiService_DeleteInvitation"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TDeleteMfaPolicyResponse =
+  operations["PublicApiService_DeleteMfaPolicy"]["responses"]["200"]["schema"]["activity"]["result"]["deleteMfaPolicyResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TDeleteMfaPolicyInput = { body: TDeleteMfaPolicyBody };
+
+export type TDeleteMfaPolicyBody =
+  operations["PublicApiService_DeleteMfaPolicy"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TDeleteOauth2CredentialResponse =
@@ -976,7 +1074,7 @@ export type TEmailAuthBody =
     commandOverrideParams;
 
 export type TEthSendTransactionResponse =
-  operations["PublicApiService_EthSendTransaction"]["responses"]["200"]["schema"]["activity"]["result"]["ethSendTransactionResult"] &
+  operations["PublicApiService_EthSendTransaction"]["responses"]["200"]["schema"]["activity"]["result"]["ethSendTransactionResultV2"] &
     definitions["v1ActivityResponse"];
 
 export type TEthSendTransactionInput = { body: TEthSendTransactionBody };
@@ -1333,6 +1431,16 @@ export type TUpdateFiatOnRampCredentialInput = {
 
 export type TUpdateFiatOnRampCredentialBody =
   operations["PublicApiService_UpdateFiatOnRampCredential"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpdateMfaPolicyResponse =
+  operations["PublicApiService_UpdateMfaPolicy"]["responses"]["200"]["schema"]["activity"]["result"]["updateMfaPolicyResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpdateMfaPolicyInput = { body: TUpdateMfaPolicyBody };
+
+export type TUpdateMfaPolicyBody =
+  operations["PublicApiService_UpdateMfaPolicy"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TUpdateOauth2CredentialResponse =

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -392,6 +392,102 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_mfa_policies": {
+      "post": {
+        "summary": "Get MFA policies",
+        "description": "Get all MFA policies for a user.",
+        "operationId": "PublicApiService_GetMfaPolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_policy": {
+      "post": {
+        "summary": "Get MFA policy",
+        "description": "Get a single MFA policy for a user.",
+        "operationId": "PublicApiService_GetMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_status": {
+      "post": {
+        "summary": "Get MFA status",
+        "description": "Get the MFA status of an activity for a specific user or all voting users.",
+        "operationId": "PublicApiService_GetMfaStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/query/get_nonces": {
       "post": {
         "summary": "Get nonces",
@@ -680,6 +776,70 @@
         "tags": ["Send Transactions"]
       }
     },
+    "/public/v1/query/get_session_profile": {
+      "post": {
+        "summary": "Get session profile",
+        "description": "Get a single session profile for an organization.",
+        "operationId": "PublicApiService_GetSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
+    "/public/v1/query/get_session_profiles": {
+      "post": {
+        "summary": "Get session profiles",
+        "description": "Get all session profiles for an organization.",
+        "operationId": "PublicApiService_GetSessionProfiles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
     "/public/v1/query/get_smart_contract_interface": {
       "post": {
         "summary": "Get smart contract interface",
@@ -770,6 +930,38 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1GetTvcDeploymentRequest"
+            }
+          }
+        ],
+        "tags": ["TVC"]
+      }
+    },
+    "/public/v1/query/get_tvc_deployment_debug_logs": {
+      "post": {
+        "summary": "Get TVC Deployment debug logs",
+        "description": "Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp.",
+        "operationId": "PublicApiService_GetTvcDeploymentDebugLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsRequest"
             }
           }
         ],
@@ -875,7 +1067,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1387,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -1704,6 +1896,38 @@
         "tags": ["Invitations"]
       }
     },
+    "/public/v1/submit/create_mfa_policy": {
+      "post": {
+        "summary": "Create MFA policy",
+        "description": "Create a new MFA policy for a user.",
+        "operationId": "PublicApiService_CreateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/create_oauth2_credential": {
       "post": {
         "summary": "Create an OAuth 2.0 Credential",
@@ -1958,6 +2182,38 @@
           }
         ],
         "tags": ["Sessions"]
+      }
+    },
+    "/public/v1/submit/create_session_profile": {
+      "post": {
+        "summary": "Create session profile",
+        "description": "Create a new session profile for an organization.",
+        "operationId": "PublicApiService_CreateSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
       }
     },
     "/public/v1/submit/create_smart_contract_interface": {
@@ -2406,6 +2662,38 @@
           }
         ],
         "tags": ["Invitations"]
+      }
+    },
+    "/public/v1/submit/delete_mfa_policy": {
+      "post": {
+        "summary": "Delete MFA policy",
+        "description": "Delete an MFA policy for a user.",
+        "operationId": "PublicApiService_DeleteMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
       }
     },
     "/public/v1/submit/delete_oauth2_credential": {
@@ -4040,6 +4328,38 @@
         "tags": ["On Ramp"]
       }
     },
+    "/public/v1/submit/update_mfa_policy": {
+      "post": {
+        "summary": "Update MFA policy",
+        "description": "Update an MFA policy for a user.",
+        "operationId": "PublicApiService_UpdateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/update_oauth2_credential": {
       "post": {
         "summary": "Update an OAuth 2.0 Credential",
@@ -4695,6 +5015,10 @@
         },
         "type": {
           "$ref": "#/definitions/v1CredentialType"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN."
         }
       },
       "required": ["publicKey", "type"]
@@ -4984,7 +5308,8 @@
         "ACTIVITY_STATUS_COMPLETED",
         "ACTIVITY_STATUS_FAILED",
         "ACTIVITY_STATUS_CONSENSUS_NEEDED",
-        "ACTIVITY_STATUS_REJECTED"
+        "ACTIVITY_STATUS_REJECTED",
+        "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED"
       ]
     },
     "v1ActivityType": {
@@ -5127,7 +5452,16 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2",
+        "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+        "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+        "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+        "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+        "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER",
+        "ACTIVITY_TYPE_EARN_DEPOSIT",
+        "ACTIVITY_TYPE_EARN_WITHDRAW",
+        "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG"
       ]
     },
     "v1AddressFormat": {
@@ -5444,6 +5778,45 @@
         "transports"
       ]
     },
+    "v1AuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., for requiring a specific session profile id)"
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication)."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used."
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationType": {
+      "type": "string",
+      "enum": [
+        "AUTHENTICATION_TYPE_EMAIL_OTP",
+        "AUTHENTICATION_TYPE_SMS_OTP",
+        "AUTHENTICATION_TYPE_PASSKEY",
+        "AUTHENTICATION_TYPE_API_KEY",
+        "AUTHENTICATION_TYPE_OAUTH",
+        "AUTHENTICATION_TYPE_SESSION"
+      ]
+    },
     "v1Authenticator": {
       "type": "object",
       "properties": {
@@ -5586,11 +5959,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5979,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -5960,6 +6337,78 @@
         }
       },
       "required": ["invitationIds"]
+    },
+    "v1CreateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to add the MFA Policy to."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": [
+        "userId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order"
+      ]
+    },
+    "v1CreateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1CreateOauth2CredentialIntent": {
       "type": "object",
@@ -6662,6 +7111,59 @@
         "credentialBundle"
       ]
     },
+    "v1CreateSessionProfileIntent": {
+      "type": "object",
+      "properties": {
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope string that defines the permissions for this Session Profile."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for a Session Profile."
+        }
+      },
+      "required": ["sessionProfileName", "scope"]
+    },
+    "v1CreateSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_SESSION_PROFILE"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateSessionProfileResult": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        }
+      },
+      "required": ["sessionProfileId"]
+    },
     "v1CreateSmartContractInterfaceIntent": {
       "type": "object",
       "properties": {
@@ -7188,6 +7690,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -7971,6 +8477,51 @@
         }
       },
       "required": ["invitationId"]
+    },
+    "v1DeleteMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to delete the MFA Policy from."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1DeleteMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1DeleteOauth2CredentialIntent": {
       "type": "object",
@@ -8784,6 +9335,179 @@
       },
       "required": ["privateKeyId"]
     },
+    "v1EarnDeployWrapperIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to wrap (from the EarnVaults catalog)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        }
+      },
+      "required": ["vaultAddress", "chainCaip2"]
+    },
+    "v1EarnDeployWrapperResult": {
+      "type": "object",
+      "properties": {
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee wrapper (the deposit target)."
+        },
+        "splitterAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave)."
+        },
+        "deployTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the wrapper deployment."
+        }
+      },
+      "required": ["wrapperAddress", "splitterAddress", "deployTxHash"]
+    },
+    "v1EarnDepositIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "assets": {
+          "type": "string",
+          "description": "Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        }
+      },
+      "required": ["vaultAddress", "signWith", "assets", "chainCaip2"]
+    },
+    "v1EarnDepositResult": {
+      "type": "object",
+      "properties": {
+        "depositTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the deposit."
+        },
+        "sharesMinted": {
+          "type": "string",
+          "description": "Number of wrapper shares minted to the depositor, in raw on-chain units."
+        },
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the fee wrapper the deposit was routed to."
+        },
+        "depositRequestId": {
+          "type": "string",
+          "description": "Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path)."
+        }
+      },
+      "required": [
+        "depositTxHash",
+        "sharesMinted",
+        "wrapperAddress",
+        "depositRequestId"
+      ]
+    },
+    "v1EarnWithdrawIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        },
+        "amountType": {
+          "type": "string",
+          "enum": ["SHARES", "ASSETS"],
+          "description": "Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims)."
+        },
+        "amountValue": {
+          "type": "string",
+          "description": "The amount to withdraw, in raw on-chain units, interpreted according to amount_type."
+        }
+      },
+      "required": [
+        "vaultAddress",
+        "signWith",
+        "chainCaip2",
+        "amountType",
+        "amountValue"
+      ]
+    },
+    "v1EarnWithdrawResult": {
+      "type": "object",
+      "properties": {
+        "withdrawTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the withdrawal."
+        },
+        "withdrawRequestId": {
+          "type": "string",
+          "description": "Identifier to poll withdrawal status via EarnWithdrawStatus."
+        },
+        "assetsReceived": {
+          "type": "string",
+          "description": "Amount of the underlying asset received, in raw on-chain units."
+        },
+        "sharesBurned": {
+          "type": "string",
+          "description": "Number of wrapper shares burned, in raw on-chain units."
+        }
+      },
+      "required": [
+        "withdrawTxHash",
+        "withdrawRequestId",
+        "assetsReceived",
+        "sharesBurned"
+      ]
+    },
     "v1Effect": {
       "type": "string",
       "enum": ["EFFECT_ALLOW", "EFFECT_DENY"]
@@ -9037,6 +9761,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9807,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9845,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9890,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9966,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9975,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9797,6 +10613,94 @@
       },
       "required": ["organizationId", "appName"]
     },
+    "v1GetMfaPoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        }
+      },
+      "required": ["organizationId", "userId"]
+    },
+    "v1GetMfaPoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of multi-factor authentication policies for a user."
+        }
+      },
+      "required": ["mfaPolicies"]
+    },
+    "v1GetMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA policy."
+        }
+      },
+      "required": ["organizationId", "userId", "mfaPolicyId"]
+    },
+    "v1GetMfaPolicyResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicy": {
+          "$ref": "#/definitions/v1MfaPolicy",
+          "description": "Multi-factor authentication policy for a user."
+        }
+      },
+      "required": ["mfaPolicy"]
+    },
+    "v1GetMfaStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "activityId": {
+          "type": "string",
+          "description": "The unique identifier of the activity to get MFA status for."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Optional user ID to filter MFA status for a specific user."
+        }
+      },
+      "required": ["organizationId", "activityId"]
+    },
+    "v1GetMfaStatusResponse": {
+      "type": "object",
+      "properties": {
+        "mfaStatuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaStatus"
+          },
+          "description": "A list of MFA statuses for the activity's votes."
+        }
+      },
+      "required": ["mfaStatuses"]
+    },
     "v1GetNoncesRequest": {
       "type": "object",
       "properties": {
@@ -9816,7 +10720,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10108,6 +11014,54 @@
       },
       "required": ["txStatus"]
     },
+    "v1GetSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a session profile."
+        }
+      },
+      "required": ["organizationId", "sessionProfileId"]
+    },
+    "v1GetSessionProfileResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfile": {
+          "$ref": "#/definitions/v1SessionProfile",
+          "description": "Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies."
+        }
+      },
+      "required": ["sessionProfile"]
+    },
+    "v1GetSessionProfilesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetSessionProfilesResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SessionProfile"
+          },
+          "description": "A list of session profiles for users in the organization."
+        }
+      },
+      "required": ["sessionProfiles"]
+    },
     "v1GetSmartContractInterfaceRequest": {
       "type": "object",
       "properties": {
@@ -10266,6 +11220,44 @@
         }
       },
       "required": ["tvcApps"]
+    },
+    "v1GetTvcDeploymentDebugLogsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "Unique identifier for a given TVC Deployment. The deployment must be running in debug mode."
+        },
+        "tailLines": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied."
+        },
+        "sinceSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs."
+        }
+      },
+      "required": ["organizationId", "deploymentId"]
+    },
+    "v1GetTvcDeploymentDebugLogsResponse": {
+      "type": "object",
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TvcDeploymentDebugLogEntry"
+          },
+          "description": "Application log entries sorted by platform timestamp."
+        }
+      },
+      "required": ["entries"]
     },
     "v1GetTvcDeploymentRequest": {
       "type": "object",
@@ -10462,6 +11454,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +12810,33 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
+        },
+        "createMfaPolicyIntent": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        },
+        "updateMfaPolicyIntent": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        },
+        "deleteMfaPolicyIntent": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        },
+        "createSessionProfileIntent": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        },
+        "earnDeployWrapperIntent": {
+          "$ref": "#/definitions/v1EarnDeployWrapperIntent"
+        },
+        "earnDepositIntent": {
+          "$ref": "#/definitions/v1EarnDepositIntent"
+        },
+        "earnWithdrawIntent": {
+          "$ref": "#/definitions/v1EarnWithdrawIntent"
+        },
+        "upsertEarnClientFeeConfigIntent": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigIntent"
         }
       }
     },
@@ -11998,6 +13023,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -12066,6 +13097,20 @@
       },
       "required": ["webhookEndpoints"]
     },
+    "v1LogLine": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "One log line, exactly as the application printed it (without the trailing newline)"
+        },
+        "ts": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "When the line was logged. Stable across replays, so lines can be chronologically merged across pods"
+        }
+      },
+      "required": ["content"]
+    },
     "v1LoginUsage": {
       "type": "object",
       "properties": {
@@ -12075,6 +13120,95 @@
         }
       },
       "required": ["publicKey"]
+    },
+    "v1MfaPolicy": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for an MFA Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this policy is evaluated relative to other MFA policies."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular MFA policy."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "v1MfaStatus": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "satisfied": {
+          "type": "boolean",
+          "description": "Whether the MFA policy requirements are currently satisfied."
+        },
+        "satisfiedMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods already satisfied for this MFA policy."
+        },
+        "requiredMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements needed to satisfy this MFA policy."
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "userId",
+        "satisfied",
+        "satisfiedMethods",
+        "requiredMethods"
+      ]
     },
     "v1MnemonicLanguage": {
       "type": "string",
@@ -12278,6 +13412,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["oidcToken", "publicKey"]
@@ -12558,6 +13696,10 @@
         "clientSignature": {
           "$ref": "#/definitions/v1ClientSignature",
           "description": "Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey"]
@@ -12584,6 +13726,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login sessions"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey", "clientSignature"]
@@ -12630,7 +13776,8 @@
         "OUTCOME_DENY_IMPLICIT",
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
-        "OUTCOME_ERROR"
+        "OUTCOME_ERROR",
+        "OUTCOME_REQUIRES_AUTHENTICATORS"
       ]
     },
     "v1Pagination": {
@@ -13064,6 +14211,34 @@
       },
       "required": ["features"]
     },
+    "v1RequiredAuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
+    "v1RequiredAuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethodParams"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
     "v1RestoreTvcDeploymentIntent": {
       "type": "object",
       "properties": {
@@ -13458,6 +14633,33 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
+        },
+        "createMfaPolicyResult": {
+          "$ref": "#/definitions/v1CreateMfaPolicyResult"
+        },
+        "updateMfaPolicyResult": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyResult"
+        },
+        "deleteMfaPolicyResult": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyResult"
+        },
+        "createSessionProfileResult": {
+          "$ref": "#/definitions/v1CreateSessionProfileResult"
+        },
+        "earnDeployWrapperResult": {
+          "$ref": "#/definitions/v1EarnDeployWrapperResult"
+        },
+        "earnDepositResult": {
+          "$ref": "#/definitions/v1EarnDepositResult"
+        },
+        "earnWithdrawResult": {
+          "$ref": "#/definitions/v1EarnWithdrawResult"
+        },
+        "upsertEarnClientFeeConfigResult": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigResult"
         }
       }
     },
@@ -13710,6 +14912,44 @@
           }
         }
       }
+    },
+    "v1SessionProfile": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        },
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The specific scope that a session created with this profile is limited to."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "Optional window (in seconds) indicating how long sessions created with this profile should last."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular Session Profile."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "sessionProfileId",
+        "sessionProfileName",
+        "scope",
+        "createdAt",
+        "updatedAt"
+      ]
     },
     "v1SetIpAllowlistIntent": {
       "type": "object",
@@ -14806,6 +16046,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["publicKey"]
@@ -14925,6 +16169,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +16185,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15055,6 +16304,20 @@
         "updatedAt",
         "delete"
       ]
+    },
+    "v1TvcDeploymentDebugLogEntry": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "$ref": "#/definitions/v1LogLine",
+          "description": "Application log line with its platform timestamp."
+        },
+        "replicaLabel": {
+          "type": "string",
+          "description": "Public replica label that produced this log line, for example 'replica 2/3'."
+        }
+      },
+      "required": ["line", "replicaLabel"]
     },
     "v1TvcHealthCheckType": {
       "type": "string",
@@ -15461,6 +16724,76 @@
         }
       },
       "required": ["fiatOnRampCredentialId"]
+    },
+    "v1UpdateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to update the MFA Policy for."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1UpdateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1UpdateOauth2CredentialIntent": {
       "type": "object",
@@ -16204,6 +17537,30 @@
       },
       "required": ["endpointId", "webhookEndpoint"]
     },
+    "v1UpsertEarnClientFeeConfigIntent": {
+      "type": "object",
+      "properties": {
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address."
+        }
+      },
+      "required": ["clientFeeBps", "clientFeeWallet"]
+    },
+    "v1UpsertEarnClientFeeConfigResult": {
+      "type": "object",
+      "properties": {
+        "feeUpdateTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee configuration update."
+        }
+      },
+      "required": ["feeUpdateTxHash"]
+    },
     "v1UpsertGasUsageConfigIntent": {
       "type": "object",
       "properties": {
@@ -16303,6 +17660,14 @@
         },
         "updatedAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of MFA Policies that define multi-factor authentication requirements for this user."
         }
       },
       "required": [
@@ -16313,7 +17678,8 @@
         "userTags",
         "oauthProviders",
         "createdAt",
-        "updatedAt"
+        "updatedAt",
+        "mfaPolicies"
       ]
     },
     "v1UserParams": {
@@ -16749,6 +18115,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +18152,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -44,6 +44,18 @@ export type paths = {
     /** Get the latest boot proof for a given enclave app name. */
     post: operations["PublicApiService_GetLatestBootProof"];
   };
+  "/public/v1/query/get_mfa_policies": {
+    /** Get all MFA policies for a user. */
+    post: operations["PublicApiService_GetMfaPolicies"];
+  };
+  "/public/v1/query/get_mfa_policy": {
+    /** Get a single MFA policy for a user. */
+    post: operations["PublicApiService_GetMfaPolicy"];
+  };
+  "/public/v1/query/get_mfa_status": {
+    /** Get the MFA status of an activity for a specific user or all voting users. */
+    post: operations["PublicApiService_GetMfaStatus"];
+  };
   "/public/v1/query/get_nonces": {
     /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
     post: operations["PublicApiService_GetNonces"];
@@ -59,10 +71,6 @@ export type paths = {
   "/public/v1/query/get_onramp_transaction_status": {
     /** Get the status of an on ramp transaction. */
     post: operations["PublicApiService_GetOnRampTransactionStatus"];
-  };
-  "/public/v1/query/get_organization": {
-    /** Get details about an organization. */
-    post: operations["PublicApiService_GetOrganization"];
   };
   "/public/v1/query/get_organization_configs": {
     /** Get quorum settings and features for an organization. */
@@ -84,6 +92,14 @@ export type paths = {
     /** Get the status of a send transaction request. */
     post: operations["PublicApiService_GetSendTransactionStatus"];
   };
+  "/public/v1/query/get_session_profile": {
+    /** Get a single session profile for an organization. */
+    post: operations["PublicApiService_GetSessionProfile"];
+  };
+  "/public/v1/query/get_session_profiles": {
+    /** Get all session profiles for an organization. */
+    post: operations["PublicApiService_GetSessionProfiles"];
+  };
   "/public/v1/query/get_smart_contract_interface": {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
@@ -96,9 +112,9 @@ export type paths = {
     /** Get details about a single TVC Deployment */
     post: operations["PublicApiService_GetTvcDeployment"];
   };
-  "/public/v1/query/get_tvc_deployment_provisioning_details": {
-    /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-    post: operations["PublicApiService_GetTvcDeploymentProvisioningDetails"];
+  "/public/v1/query/get_tvc_deployment_debug_logs": {
+    /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+    post: operations["PublicApiService_GetTvcDeploymentDebugLogs"];
   };
   "/public/v1/query/get_user": {
     /** Get details about a user. */
@@ -113,7 +129,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +169,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -204,10 +220,6 @@ export type paths = {
     /** Add API keys to an existing user. */
     post: operations["PublicApiService_CreateApiKeys"];
   };
-  "/public/v1/submit/create_api_only_users": {
-    /** Create API-only users in an existing organization. */
-    post: operations["PublicApiService_CreateApiOnlyUsers"];
-  };
   "/public/v1/submit/create_authenticators": {
     /** Create authenticators to authenticate requests to Turnkey. */
     post: operations["PublicApiService_CreateAuthenticators"];
@@ -219,6 +231,10 @@ export type paths = {
   "/public/v1/submit/create_invitations": {
     /** Create invitations to join an existing organization. */
     post: operations["PublicApiService_CreateInvitations"];
+  };
+  "/public/v1/submit/create_mfa_policy": {
+    /** Create a new MFA policy for a user. */
+    post: operations["PublicApiService_CreateMfaPolicy"];
   };
   "/public/v1/submit/create_oauth2_credential": {
     /** Enable authentication for end users with an OAuth 2.0 provider */
@@ -251,6 +267,10 @@ export type paths = {
   "/public/v1/submit/create_read_write_session": {
     /** Create a read write session for a user. */
     post: operations["PublicApiService_CreateReadWriteSession"];
+  };
+  "/public/v1/submit/create_session_profile": {
+    /** Create a new session profile for an organization. */
+    post: operations["PublicApiService_CreateSessionProfile"];
   };
   "/public/v1/submit/create_smart_contract_interface": {
     /** Create an ABI/IDL in JSON. */
@@ -307,6 +327,10 @@ export type paths = {
   "/public/v1/submit/delete_invitation": {
     /** Delete an existing invitation. */
     post: operations["PublicApiService_DeleteInvitation"];
+  };
+  "/public/v1/submit/delete_mfa_policy": {
+    /** Delete an MFA policy for a user. */
+    post: operations["PublicApiService_DeleteMfaPolicy"];
   };
   "/public/v1/submit/delete_oauth2_credential": {
     /** Disable authentication for end users with an OAuth 2.0 provider */
@@ -371,10 +395,6 @@ export type paths = {
   "/public/v1/submit/email_auth": {
     /** Authenticate a user via email. */
     post: operations["PublicApiService_EmailAuth"];
-  };
-  "/public/v1/submit/eth_send_raw_transaction": {
-    /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-    post: operations["PublicApiService_EthSendRawTransaction"];
   };
   "/public/v1/submit/eth_send_transaction": {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
@@ -443,10 +463,6 @@ export type paths = {
   "/public/v1/submit/otp_login": {
     /** Create an OTP session for a user. */
     post: operations["PublicApiService_OtpLogin"];
-  };
-  "/public/v1/submit/post_tvc_quorum_key_share": {
-    /** Post re-encrypted quorum key share for a TVC deployment. */
-    post: operations["PublicApiService_PostTvcQuorumKeyShare"];
   };
   "/public/v1/submit/recover_user": {
     /** Complete the process of recovering a user by adding an authenticator. */
@@ -520,6 +536,10 @@ export type paths = {
     /** Update a fiat on ramp provider credential */
     post: operations["PublicApiService_UpdateFiatOnRampCredential"];
   };
+  "/public/v1/submit/update_mfa_policy": {
+    /** Update an MFA policy for a user. */
+    post: operations["PublicApiService_UpdateMfaPolicy"];
+  };
   "/public/v1/submit/update_oauth2_credential": {
     /** Update an OAuth 2.0 provider credential */
     post: operations["PublicApiService_UpdateOauth2Credential"];
@@ -574,14 +594,6 @@ export type paths = {
   };
   "/tkhq/api/v1/noop-codegen-anchor": {
     post: operations["PublicApiService_NOOPCodegenAnchor"];
-  };
-  "/tkhq/api/v1/refresh_feature_flags": {
-    /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-    post: operations["PublicApiService_RefreshFeatureFlags"];
-  };
-  "/tkhq/api/v1/test_rate_limits": {
-    /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-    post: operations["PublicApiService_TestRateLimits"];
   };
 };
 
@@ -671,6 +683,8 @@ export type definitions = {
     /** @description The public component of a cryptographic key pair used to sign messages and transactions. */
     publicKey: string;
     type: definitions["v1CredentialType"];
+    /** @description The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN. */
+    sessionProfileId?: string;
   };
   externaldatav1Quorum: {
     /**
@@ -783,7 +797,8 @@ export type definitions = {
     | "ACTIVITY_STATUS_COMPLETED"
     | "ACTIVITY_STATUS_FAILED"
     | "ACTIVITY_STATUS_CONSENSUS_NEEDED"
-    | "ACTIVITY_STATUS_REJECTED";
+    | "ACTIVITY_STATUS_REJECTED"
+    | "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED";
   /** @enum {string} */
   v1ActivityType:
     | "ACTIVITY_TYPE_CREATE_API_KEYS"
@@ -923,7 +938,16 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
+    | "ACTIVITY_TYPE_CREATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_UPDATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_DELETE_MFA_POLICY"
+    | "ACTIVITY_TYPE_CREATE_SESSION_PROFILE"
+    | "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER"
+    | "ACTIVITY_TYPE_EARN_DEPOSIT"
+    | "ACTIVITY_TYPE_EARN_WITHDRAW"
+    | "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1084,6 +1108,26 @@ export type definitions = {
     /** @description The type of authenticator transports. */
     transports: definitions["v1AuthenticatorTransport"][];
   };
+  v1AuthenticationMethod: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step. */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., for requiring a specific session profile id) */
+    id?: string;
+  };
+  v1AuthenticationMethodParams: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication). */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used. */
+    id?: string;
+  };
+  /** @enum {string} */
+  v1AuthenticationType:
+    | "AUTHENTICATION_TYPE_EMAIL_OTP"
+    | "AUTHENTICATION_TYPE_SMS_OTP"
+    | "AUTHENTICATION_TYPE_PASSKEY"
+    | "AUTHENTICATION_TYPE_API_KEY"
+    | "AUTHENTICATION_TYPE_OAUTH"
+    | "AUTHENTICATION_TYPE_SESSION";
   v1Authenticator: {
     /** @description Types of transports that may be used by an Authenticator (e.g., USB, NFC, BLE). */
     transports: definitions["v1AuthenticatorTransport"][];
@@ -1139,9 +1183,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1194,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1199,16 +1245,6 @@ export type definitions = {
   v1CreateApiOnlyUsersIntent: {
     /** @description A list of API-only Users to create. */
     apiOnlyUsers: definitions["v1ApiOnlyUserParams"][];
-  };
-  v1CreateApiOnlyUsersRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1CreateApiOnlyUsersIntent"];
-    generateAppProofs?: boolean;
   };
   v1CreateApiOnlyUsersResult: {
     /** @description A list of API-only User IDs. */
@@ -1285,6 +1321,36 @@ export type definitions = {
   v1CreateInvitationsResult: {
     /** @description A list of Invitation IDs */
     invitationIds: string[];
+  };
+  v1CreateMfaPolicyIntent: {
+    /** @description The ID of the User to add the MFA Policy to. */
+    userId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1CreateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateMfaPolicyIntent"];
+  };
+  v1CreateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1CreateOauth2CredentialIntent: {
     /** @description The OAuth 2.0 provider */
@@ -1560,6 +1626,29 @@ export type definitions = {
     /** @description HPKE encrypted credential bundle */
     credentialBundle: string;
   };
+  v1CreateSessionProfileIntent: {
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The scope string that defines the permissions for this Session Profile. */
+    scope: string;
+    /** @description The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities. */
+    expirationSeconds?: string;
+    /** @description Notes for a Session Profile. */
+    notes?: string;
+  };
+  v1CreateSessionProfileRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSessionProfileIntent"];
+  };
+  v1CreateSessionProfileResult: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+  };
   v1CreateSmartContractInterfaceIntent: {
     /** @description Corresponding contract address or program ID */
     smartContractAddress: string;
@@ -1776,6 +1865,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2091,6 +2182,25 @@ export type definitions = {
   v1DeleteInvitationResult: {
     /** @description Unique identifier for a given Invitation. */
     invitationId: string;
+  };
+  v1DeleteMfaPolicyIntent: {
+    /** @description The ID of the User to delete the MFA Policy from. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+  };
+  v1DeleteMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteMfaPolicyIntent"];
+  };
+  v1DeleteMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1DeleteOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to delete */
@@ -2408,6 +2518,96 @@ export type definitions = {
     /** @description Unique identifier for a given Private Key. */
     privateKeyId: string;
   };
+  v1EarnDeployWrapperIntent: {
+    /** @description Address of the underlying yield vault to wrap (from the EarnVaults catalog). */
+    vaultAddress: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+  };
+  v1EarnDeployWrapperResult: {
+    /** @description Address of the deployed fee wrapper (the deposit target). */
+    wrapperAddress: string;
+    /** @description Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave). */
+    splitterAddress: string;
+    /** @description Transaction hash of the wrapper deployment. */
+    deployTxHash: string;
+  };
+  v1EarnDepositIntent: {
+    /** @description Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals). */
+    assets: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+  };
+  v1EarnDepositResult: {
+    /** @description Transaction hash of the deposit. */
+    depositTxHash: string;
+    /** @description Number of wrapper shares minted to the depositor, in raw on-chain units. */
+    sharesMinted: string;
+    /** @description Address of the fee wrapper the deposit was routed to. */
+    wrapperAddress: string;
+    /** @description Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path). */
+    depositRequestId: string;
+  };
+  v1EarnWithdrawIntent: {
+    /** @description Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+    /**
+     * @description Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims).
+     * @enum {string}
+     */
+    amountType: "SHARES" | "ASSETS";
+    /** @description The amount to withdraw, in raw on-chain units, interpreted according to amount_type. */
+    amountValue: string;
+  };
+  v1EarnWithdrawResult: {
+    /** @description Transaction hash of the withdrawal. */
+    withdrawTxHash: string;
+    /** @description Identifier to poll withdrawal status via EarnWithdrawStatus. */
+    withdrawRequestId: string;
+    /** @description Amount of the underlying asset received, in raw on-chain units. */
+    assetsReceived: string;
+    /** @description Number of wrapper shares burned, in raw on-chain units. */
+    sharesBurned: string;
+  };
   /** @enum {string} */
   v1Effect: "EFFECT_ALLOW" | "EFFECT_DENY";
   v1EmailAuthCustomizationParams: {
@@ -2525,6 +2725,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,17 +2750,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
-  };
-  v1EthSendRawTransactionRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_RAW_TRANSACTION";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1EthSendRawTransactionIntent"];
-    generateAppProofs?: boolean;
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionResult: {
     /** @description The transaction hash of the sent transaction */
@@ -2573,7 +2773,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2795,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2896,6 +3135,40 @@ export type definitions = {
     /** @description Name of enclave app. */
     appName: string;
   };
+  v1GetMfaPoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+  };
+  v1GetMfaPoliciesResponse: {
+    /** @description A list of multi-factor authentication policies for a user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
+  };
+  v1GetMfaPolicyRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+    /** @description Unique identifier for a given MFA policy. */
+    mfaPolicyId: string;
+  };
+  v1GetMfaPolicyResponse: {
+    /** @description Multi-factor authentication policy for a user. */
+    mfaPolicy: definitions["v1MfaPolicy"];
+  };
+  v1GetMfaStatusRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description The unique identifier of the activity to get MFA status for. */
+    activityId: string;
+    /** @description Optional user ID to filter MFA status for a specific user. */
+    userId?: string;
+  };
+  v1GetMfaStatusResponse: {
+    /** @description A list of MFA statuses for the activity's votes. */
+    mfaStatuses: definitions["v1MfaStatus"][];
+  };
   v1GetNoncesRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -2911,7 +3184,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -2967,14 +3242,6 @@ export type definitions = {
   v1GetOrganizationConfigsResponse: {
     /** @description Organization configs including quorum settings and organization features. */
     configs: definitions["v1Config"];
-  };
-  v1GetOrganizationRequest: {
-    /** @description Unique identifier for a given organization. */
-    organizationId: string;
-  };
-  v1GetOrganizationResponse: {
-    /** @description Object representing the full current and deleted / disabled collection of users, policies, private keys, and invitations attributable to a particular organization. */
-    organizationData: definitions["v1OrganizationData"];
   };
   v1GetPoliciesRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3039,6 +3306,24 @@ export type definitions = {
     /** @description Structured error information including revert details, if available. */
     error?: definitions["v1TxError"];
   };
+  v1GetSessionProfileRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a session profile. */
+    sessionProfileId: string;
+  };
+  v1GetSessionProfileResponse: {
+    /** @description Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies. */
+    sessionProfile: definitions["v1SessionProfile"];
+  };
+  v1GetSessionProfilesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetSessionProfilesResponse: {
+    /** @description A list of session profiles for users in the organization. */
+    sessionProfiles: definitions["v1SessionProfile"][];
+  };
   v1GetSmartContractInterfaceRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3099,23 +3384,25 @@ export type definitions = {
     /** @description A list of TVC Apps. */
     tvcApps: definitions["v1TvcApp"][];
   };
-  v1GetTvcDeploymentProvisioningDetailsRequest: {
+  v1GetTvcDeploymentDebugLogsRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Unique identifier for a given TVC Deployment. */
+    /** @description Unique identifier for a given TVC Deployment. The deployment must be running in debug mode. */
     deploymentId: string;
+    /**
+     * Format: int32
+     * @description Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied.
+     */
+    tailLines?: number;
+    /**
+     * Format: int64
+     * @description Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs.
+     */
+    sinceSeconds?: string;
   };
-  v1GetTvcDeploymentProvisioningDetailsResponse: {
-    /**
-     * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
-     */
-    attestationDocument: string;
-    /**
-     * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
-     */
-    manifestEnvelope: string;
+  v1GetTvcDeploymentDebugLogsResponse: {
+    /** @description Application log entries sorted by platform timestamp. */
+    entries: definitions["v1TvcDeploymentDebugLogEntry"][];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3203,6 +3490,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,24 +4053,15 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
-  };
-  v1Invitation: {
-    /** @description Unique identifier for a given Invitation object. */
-    invitationId: string;
-    /** @description The name of the intended Invitation recipient. */
-    receiverUserName: string;
-    /** @description The email address of the intended Invitation recipient. */
-    receiverEmail: string;
-    /** @description A list of tags assigned to the Invitation recipient. */
-    receiverUserTags: string[];
-    /** @description The User's permissible access method(s). */
-    accessType: definitions["v1AccessType"];
-    /** @description The current processing status of a specified Invitation. */
-    status: definitions["v1InvitationStatus"];
-    createdAt: definitions["externaldatav1Timestamp"];
-    updatedAt: definitions["externaldatav1Timestamp"];
-    /** @description Unique identifier for the Sender of an Invitation. */
-    senderUserId: string;
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
+    createMfaPolicyIntent?: definitions["v1CreateMfaPolicyIntent"];
+    updateMfaPolicyIntent?: definitions["v1UpdateMfaPolicyIntent"];
+    deleteMfaPolicyIntent?: definitions["v1DeleteMfaPolicyIntent"];
+    createSessionProfileIntent?: definitions["v1CreateSessionProfileIntent"];
+    earnDeployWrapperIntent?: definitions["v1EarnDeployWrapperIntent"];
+    earnDepositIntent?: definitions["v1EarnDepositIntent"];
+    earnWithdrawIntent?: definitions["v1EarnWithdrawIntent"];
+    upsertEarnClientFeeConfigIntent?: definitions["v1UpsertEarnClientFeeConfigIntent"];
   };
   v1InvitationParams: {
     /** @description The name of the intended Invitation recipient. */
@@ -3791,11 +4075,6 @@ export type definitions = {
     /** @description Unique identifier for the Sender of an Invitation. */
     senderUserId: string;
   };
-  /** @enum {string} */
-  v1InvitationStatus:
-    | "INVITATION_STATUS_CREATED"
-    | "INVITATION_STATUS_ACCEPTED"
-    | "INVITATION_STATUS_REVOKED";
   v1IpAllowlist: {
     /** @description Unique identifier for the organization this allowlist belongs to. */
     organizationId: string;
@@ -3858,6 +4137,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3880,9 +4165,46 @@ export type definitions = {
   v1ListWebhookEndpointsResponse: {
     webhookEndpoints: definitions["v1WebhookEndpointData"][];
   };
+  v1LogLine: {
+    /** @description One log line, exactly as the application printed it (without the trailing newline) */
+    content: string;
+    /** @description When the line was logged. Stable across replays, so lines can be chronologically merged across pods */
+    ts?: definitions["externaldatav1Timestamp"];
+  };
   v1LoginUsage: {
     /** @description Public key for authentication */
     publicKey: string;
+  };
+  v1MfaPolicy: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for an MFA Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethod"][];
+    /**
+     * Format: int64
+     * @description The order in which this policy is evaluated relative to other MFA policies.
+     */
+    order: number;
+    /** @description Optional human-readable notes added by a User to describe a particular MFA policy. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
+  };
+  v1MfaStatus: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Whether the MFA policy requirements are currently satisfied. */
+    satisfied: boolean;
+    /** @description A list of authentication methods already satisfied for this MFA policy. */
+    satisfiedMethods: definitions["v1AuthenticationMethod"][];
+    /** @description An ordered list of authentication requirements needed to satisfy this MFA policy. */
+    requiredMethods: definitions["v1RequiredAuthenticationMethod"][];
   };
   /** @enum {string} */
   v1MnemonicLanguage:
@@ -3975,6 +4297,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OauthLoginRequest: {
     /** @enum {string} */
@@ -4057,19 +4381,6 @@ export type definitions = {
     | "OPERATOR_NOT_IN"
     | "OPERATOR_CONTAINS_ONE"
     | "OPERATOR_CONTAINS_ALL";
-  v1OrganizationData: {
-    organizationId?: string;
-    name?: string;
-    users?: definitions["v1User"][];
-    policies?: definitions["v1Policy"][];
-    privateKeys?: definitions["v1PrivateKey"][];
-    invitations?: definitions["v1Invitation"][];
-    tags?: definitions["datav1Tag"][];
-    rootQuorum?: definitions["externaldatav1Quorum"];
-    features?: definitions["v1Feature"][];
-    wallets?: definitions["v1Wallet"][];
-    smartContractInterfaceReferences?: definitions["v1SmartContractInterfaceReference"][];
-  };
   v1OtpAuthIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -4113,6 +4424,8 @@ export type definitions = {
     invalidateExisting?: boolean;
     /** @description Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step. */
     clientSignature?: definitions["v1ClientSignature"];
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginIntentV2: {
     /** @description Signed Verification Token containing a unique id, expiry, verification type, contact */
@@ -4125,6 +4438,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login sessions */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginRequest: {
     /** @enum {string} */
@@ -4147,7 +4462,8 @@ export type definitions = {
     | "OUTCOME_DENY_IMPLICIT"
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
-    | "OUTCOME_ERROR";
+    | "OUTCOME_ERROR"
+    | "OUTCOME_REQUIRES_AUTHENTICATORS";
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -4187,15 +4503,6 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description Re-encrypted quorum key share and approval */
     shareApprovalBundle: definitions["v1QuorumKeyShareApprovalBundle"];
-  };
-  v1PostTvcQuorumKeyShareRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1PostTvcQuorumKeyShareIntent"];
   };
   v1PostTvcQuorumKeyShareResult: {
     /** @description The unique identifier for the provisioning quorum key share */
@@ -4273,8 +4580,6 @@ export type definitions = {
     /** @description ID of the authenticator created. */
     authenticatorId: string[];
   };
-  v1RefreshFeatureFlagsRequest: { [key: string]: unknown };
-  v1RefreshFeatureFlagsResponse: { [key: string]: unknown };
   v1RejectActivityIntent: {
     /** @description An artifact verifying a User's action. */
     fingerprint: string;
@@ -4321,6 +4626,14 @@ export type definitions = {
   v1RemoveOrganizationFeatureResult: {
     /** @description Resulting list of organization features. */
     features: definitions["v1Feature"][];
+  };
+  v1RequiredAuthenticationMethod: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethod"][];
+  };
+  v1RequiredAuthenticationMethodParams: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethodParams"][];
   };
   v1RestoreTvcDeploymentIntent: {
     /** @description The unique identifier of the TVC deployment to restore. */
@@ -4457,6 +4770,15 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
+    createMfaPolicyResult?: definitions["v1CreateMfaPolicyResult"];
+    updateMfaPolicyResult?: definitions["v1UpdateMfaPolicyResult"];
+    deleteMfaPolicyResult?: definitions["v1DeleteMfaPolicyResult"];
+    createSessionProfileResult?: definitions["v1CreateSessionProfileResult"];
+    earnDeployWrapperResult?: definitions["v1EarnDeployWrapperResult"];
+    earnDepositResult?: definitions["v1EarnDepositResult"];
+    earnWithdrawResult?: definitions["v1EarnWithdrawResult"];
+    upsertEarnClientFeeConfigResult?: definitions["v1UpsertEarnClientFeeConfigResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -4543,6 +4865,20 @@ export type definitions = {
     subject?: string;
     operator?: definitions["v1Operator"];
     targets?: string[];
+  };
+  v1SessionProfile: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The specific scope that a session created with this profile is limited to. */
+    scope: string;
+    /** @description Optional window (in seconds) indicating how long sessions created with this profile should last. */
+    expirationSeconds?: string;
+    /** @description Optional human-readable notes added by a User to describe a particular Session Profile. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
   };
   v1SetIpAllowlistIntent: {
     /** @description The public component of an API key. If null, the IP allowlist applies at the organization level. If set, it applies only to this specific API key. */
@@ -4691,11 +5027,6 @@ export type definitions = {
     appid?: boolean;
     appidExclude?: boolean;
     credProps?: definitions["v1CredPropsAuthenticationExtensionsClientOutputs"];
-  };
-  v1SmartContractInterfaceReference: {
-    smartContractInterfaceId?: string;
-    smartContractAddress?: string;
-    digest?: string;
   };
   /** @enum {string} */
   v1SmartContractInterfaceType:
@@ -4994,6 +5325,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1StampLoginRequest: {
     /** @enum {string} */
@@ -5011,18 +5344,6 @@ export type definitions = {
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
-  v1TestRateLimitsRequest: {
-    /** @description Unique identifier for a given organization. If the request is being made by a WebAuthN user and their sub-organization ID is unknown, this can be the parent organization ID; using the sub-organization ID when possible is preferred due to performance reasons. */
-    organizationId: string;
-    /** @description Whether or not to set a limit on this request. */
-    isSetLimit: boolean;
-    /**
-     * Format: int64
-     * @description Rate limit to set for org, if is_set_limit is set to true.
-     */
-    limit: number;
-  };
-  v1TestRateLimitsResponse: { [key: string]: unknown };
   v1TokenUsage: {
     /** @description Type of token usage */
     type: definitions["v1UsageType"];
@@ -5060,6 +5381,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5106,6 +5429,12 @@ export type definitions = {
     updatedAt: definitions["externaldatav1Timestamp"];
     /** @description Whether or not the user wants this deployment deleted from the cluster. */
     delete: boolean;
+  };
+  v1TvcDeploymentDebugLogEntry: {
+    /** @description Application log line with its platform timestamp. */
+    line: definitions["v1LogLine"];
+    /** @description Public replica label that produced this log line, for example 'replica 2/3'. */
+    replicaLabel: string;
   };
   /** @enum {string} */
   v1TvcHealthCheckType:
@@ -5289,6 +5618,38 @@ export type definitions = {
   v1UpdateFiatOnRampCredentialResult: {
     /** @description Unique identifier of the Fiat On-Ramp credential that was updated */
     fiatOnRampCredentialId: string;
+  };
+  v1UpdateMfaPolicyIntent: {
+    /** @description The ID of the User to update the MFA Policy for. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName?: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition?: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods?: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order?: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1UpdateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateMfaPolicyIntent"];
+  };
+  v1UpdateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1UpdateOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to update */
@@ -5599,6 +5960,16 @@ export type definitions = {
     /** @description The updated webhook endpoint data. */
     webhookEndpoint: definitions["v1WebhookEndpointData"];
   };
+  v1UpsertEarnClientFeeConfigIntent: {
+    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    clientFeeBps: string;
+    /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
+    clientFeeWallet: string;
+  };
+  v1UpsertEarnClientFeeConfigResult: {
+    /** @description Transaction hash of the fee configuration update. */
+    feeUpdateTxHash: string;
+  };
   v1UpsertGasUsageConfigIntent: {
     /** @description Gas sponsorship USD limit for the billing organization window. */
     orgWindowLimitUsd: string;
@@ -5636,6 +6007,8 @@ export type definitions = {
     oauthProviders: definitions["v1OauthProvider"][];
     createdAt: definitions["externaldatav1Timestamp"];
     updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description A list of MFA Policies that define multi-factor authentication requirements for this user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
   };
   v1UserParams: {
     /** @description Human-readable name for a User. */
@@ -5794,6 +6167,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +6179,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6053,6 +6430,60 @@ export type operations = {
       };
     };
   };
+  /** Get all MFA policies for a user. */
+  PublicApiService_GetMfaPolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get a single MFA policy for a user. */
+  PublicApiService_GetMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPolicyResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get the MFA status of an activity for a specific user or all voting users. */
+  PublicApiService_GetMfaStatus: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaStatusRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaStatusResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
   PublicApiService_GetNonces: {
     parameters: {
@@ -6118,24 +6549,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetOnRampTransactionStatusResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get details about an organization. */
-  PublicApiService_GetOrganization: {
-    parameters: {
-      body: {
-        body: definitions["v1GetOrganizationRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetOrganizationResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6233,6 +6646,42 @@ export type operations = {
       };
     };
   };
+  /** Get a single session profile for an organization. */
+  PublicApiService_GetSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfileRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfileResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get all session profiles for an organization. */
+  PublicApiService_GetSessionProfiles: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfilesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfilesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a smart contract interface. */
   PublicApiService_GetSmartContractInterface: {
     parameters: {
@@ -6287,17 +6736,17 @@ export type operations = {
       };
     };
   };
-  /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-  PublicApiService_GetTvcDeploymentProvisioningDetails: {
+  /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+  PublicApiService_GetTvcDeploymentDebugLogs: {
     parameters: {
       body: {
-        body: definitions["v1GetTvcDeploymentProvisioningDetailsRequest"];
+        body: definitions["v1GetTvcDeploymentDebugLogsRequest"];
       };
     };
     responses: {
       /** A successful response. */
       200: {
-        schema: definitions["v1GetTvcDeploymentProvisioningDetailsResponse"];
+        schema: definitions["v1GetTvcDeploymentDebugLogsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6359,7 +6808,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6988,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {
@@ -6773,24 +7222,6 @@ export type operations = {
       };
     };
   };
-  /** Create API-only users in an existing organization. */
-  PublicApiService_CreateApiOnlyUsers: {
-    parameters: {
-      body: {
-        body: definitions["v1CreateApiOnlyUsersRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
   /** Create authenticators to authenticate requests to Turnkey. */
   PublicApiService_CreateAuthenticators: {
     parameters: {
@@ -6832,6 +7263,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateInvitationsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new MFA policy for a user. */
+  PublicApiService_CreateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateMfaPolicyRequest"];
       };
     };
     responses: {
@@ -6976,6 +7425,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateReadWriteSessionRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new session profile for an organization. */
+  PublicApiService_CreateSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSessionProfileRequest"];
       };
     };
     responses: {
@@ -7228,6 +7695,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteInvitationRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an MFA policy for a user. */
+  PublicApiService_DeleteMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteMfaPolicyRequest"];
       };
     };
     responses: {
@@ -7516,24 +8001,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1EmailAuthRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-  PublicApiService_EthSendRawTransaction: {
-    parameters: {
-      body: {
-        body: definitions["v1EthSendRawTransactionRequest"];
       };
     };
     responses: {
@@ -7840,24 +8307,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1OtpLoginRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Post re-encrypted quorum key share for a TVC deployment. */
-  PublicApiService_PostTvcQuorumKeyShare: {
-    parameters: {
-      body: {
-        body: definitions["v1PostTvcQuorumKeyShareRequest"];
       };
     };
     responses: {
@@ -8195,6 +8644,24 @@ export type operations = {
       };
     };
   };
+  /** Update an MFA policy for a user. */
+  PublicApiService_UpdateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Update an OAuth 2.0 provider credential */
   PublicApiService_UpdateOauth2Credential: {
     parameters: {
@@ -8434,42 +8901,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1NOOPCodegenAnchorResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-  PublicApiService_RefreshFeatureFlags: {
-    parameters: {
-      body: {
-        body: definitions["v1RefreshFeatureFlagsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1RefreshFeatureFlagsResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-  PublicApiService_TestRateLimits: {
-    parameters: {
-      body: {
-        body: definitions["v1TestRateLimitsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1TestRateLimitsResponse"];
       };
       /** An unexpected error response. */
       default: {

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -456,6 +456,100 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getMfaPolicies = async (
+    input: SdkApiTypes.TGetMfaPoliciesBody,
+  ): Promise<SdkApiTypes.TGetMfaPoliciesResponse> => {
+    return this.request("/public/v1/query/get_mfa_policies", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetMfaPolicies = async (
+    input: SdkApiTypes.TGetMfaPoliciesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_mfa_policies";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getMfaPolicy = async (
+    input: SdkApiTypes.TGetMfaPolicyBody,
+  ): Promise<SdkApiTypes.TGetMfaPolicyResponse> => {
+    return this.request("/public/v1/query/get_mfa_policy", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetMfaPolicy = async (
+    input: SdkApiTypes.TGetMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_mfa_policy";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getMfaStatus = async (
+    input: SdkApiTypes.TGetMfaStatusBody,
+  ): Promise<SdkApiTypes.TGetMfaStatusResponse> => {
+    return this.request("/public/v1/query/get_mfa_status", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetMfaStatus = async (
+    input: SdkApiTypes.TGetMfaStatusBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_mfa_status";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getNonces = async (
     input: SdkApiTypes.TGetNoncesBody,
   ): Promise<SdkApiTypes.TGetNoncesResponse> => {
@@ -741,6 +835,70 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getSessionProfile = async (
+    input: SdkApiTypes.TGetSessionProfileBody,
+  ): Promise<SdkApiTypes.TGetSessionProfileResponse> => {
+    return this.request("/public/v1/query/get_session_profile", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetSessionProfile = async (
+    input: SdkApiTypes.TGetSessionProfileBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_session_profile";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getSessionProfiles = async (
+    input: SdkApiTypes.TGetSessionProfilesBody,
+  ): Promise<SdkApiTypes.TGetSessionProfilesResponse> => {
+    return this.request("/public/v1/query/get_session_profiles", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetSessionProfiles = async (
+    input: SdkApiTypes.TGetSessionProfilesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_session_profiles";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getSmartContractInterface = async (
     input: SdkApiTypes.TGetSmartContractInterfaceBody,
   ): Promise<SdkApiTypes.TGetSmartContractInterfaceResponse> => {
@@ -822,6 +980,38 @@ export class TurnkeySDKClientBase {
 
     const fullUrl =
       this.config.apiBaseUrl + "/public/v1/query/get_tvc_deployment";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getTvcDeploymentDebugLogs = async (
+    input: SdkApiTypes.TGetTvcDeploymentDebugLogsBody,
+  ): Promise<SdkApiTypes.TGetTvcDeploymentDebugLogsResponse> => {
+    return this.request("/public/v1/query/get_tvc_deployment_debug_logs", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetTvcDeploymentDebugLogs = async (
+    input: SdkApiTypes.TGetTvcDeploymentDebugLogsBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_tvc_deployment_debug_logs";
     const body = {
       ...input,
       organizationId: input.organizationId ?? this.config.organizationId,
@@ -1801,6 +1991,48 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  createMfaPolicy = async (
+    input: SdkApiTypes.TCreateMfaPolicyBody,
+  ): Promise<SdkApiTypes.TCreateMfaPolicyResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/create_mfa_policy",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+      },
+      "createMfaPolicyResult",
+    );
+  };
+
+  stampCreateMfaPolicy = async (
+    input: SdkApiTypes.TCreateMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   createOauth2Credential = async (
     input: SdkApiTypes.TCreateOauth2CredentialBody,
   ): Promise<SdkApiTypes.TCreateOauth2CredentialResponse> => {
@@ -2125,6 +2357,48 @@ export class TurnkeySDKClientBase {
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION_V2",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  createSessionProfile = async (
+    input: SdkApiTypes.TCreateSessionProfileBody,
+  ): Promise<SdkApiTypes.TCreateSessionProfileResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/create_session_profile",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+      },
+      "createSessionProfileResult",
+    );
+  };
+
+  stampCreateSessionProfile = async (
+    input: SdkApiTypes.TCreateSessionProfileBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_session_profile";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -2713,6 +2987,48 @@ export class TurnkeySDKClientBase {
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_DELETE_INVITATION",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  deleteMfaPolicy = async (
+    input: SdkApiTypes.TDeleteMfaPolicyBody,
+  ): Promise<SdkApiTypes.TDeleteMfaPolicyResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/delete_mfa_policy",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+      },
+      "deleteMfaPolicyResult",
+    );
+  };
+
+  stampDeleteMfaPolicy = async (
+    input: SdkApiTypes.TDeleteMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/delete_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_DELETE_MFA_POLICY",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -3406,7 +3722,7 @@ export class TurnkeySDKClientBase {
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
       },
-      "ethSendTransactionResult",
+      "ethSendTransactionResultV2",
     );
   };
 
@@ -4841,6 +5157,48 @@ export class TurnkeySDKClientBase {
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_FIAT_ON_RAMP_CREDENTIAL",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  updateMfaPolicy = async (
+    input: SdkApiTypes.TUpdateMfaPolicyBody,
+  ): Promise<SdkApiTypes.TUpdateMfaPolicyResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/update_mfa_policy",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+      },
+      "updateMfaPolicyResult",
+    );
+  };
+
+  stampUpdateMfaPolicy = async (
+    input: SdkApiTypes.TUpdateMfaPolicyBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/update_mfa_policy";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -392,6 +392,102 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_mfa_policies": {
+      "post": {
+        "summary": "Get MFA policies",
+        "description": "Get all MFA policies for a user.",
+        "operationId": "PublicApiService_GetMfaPolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_policy": {
+      "post": {
+        "summary": "Get MFA policy",
+        "description": "Get a single MFA policy for a user.",
+        "operationId": "PublicApiService_GetMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_status": {
+      "post": {
+        "summary": "Get MFA status",
+        "description": "Get the MFA status of an activity for a specific user or all voting users.",
+        "operationId": "PublicApiService_GetMfaStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/query/get_nonces": {
       "post": {
         "summary": "Get nonces",
@@ -680,6 +776,70 @@
         "tags": ["Send Transactions"]
       }
     },
+    "/public/v1/query/get_session_profile": {
+      "post": {
+        "summary": "Get session profile",
+        "description": "Get a single session profile for an organization.",
+        "operationId": "PublicApiService_GetSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
+    "/public/v1/query/get_session_profiles": {
+      "post": {
+        "summary": "Get session profiles",
+        "description": "Get all session profiles for an organization.",
+        "operationId": "PublicApiService_GetSessionProfiles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
     "/public/v1/query/get_smart_contract_interface": {
       "post": {
         "summary": "Get smart contract interface",
@@ -770,6 +930,38 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1GetTvcDeploymentRequest"
+            }
+          }
+        ],
+        "tags": ["TVC"]
+      }
+    },
+    "/public/v1/query/get_tvc_deployment_debug_logs": {
+      "post": {
+        "summary": "Get TVC Deployment debug logs",
+        "description": "Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp.",
+        "operationId": "PublicApiService_GetTvcDeploymentDebugLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsRequest"
             }
           }
         ],
@@ -875,7 +1067,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1387,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -1704,6 +1896,38 @@
         "tags": ["Invitations"]
       }
     },
+    "/public/v1/submit/create_mfa_policy": {
+      "post": {
+        "summary": "Create MFA policy",
+        "description": "Create a new MFA policy for a user.",
+        "operationId": "PublicApiService_CreateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/create_oauth2_credential": {
       "post": {
         "summary": "Create an OAuth 2.0 Credential",
@@ -1958,6 +2182,38 @@
           }
         ],
         "tags": ["Sessions"]
+      }
+    },
+    "/public/v1/submit/create_session_profile": {
+      "post": {
+        "summary": "Create session profile",
+        "description": "Create a new session profile for an organization.",
+        "operationId": "PublicApiService_CreateSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
       }
     },
     "/public/v1/submit/create_smart_contract_interface": {
@@ -2406,6 +2662,38 @@
           }
         ],
         "tags": ["Invitations"]
+      }
+    },
+    "/public/v1/submit/delete_mfa_policy": {
+      "post": {
+        "summary": "Delete MFA policy",
+        "description": "Delete an MFA policy for a user.",
+        "operationId": "PublicApiService_DeleteMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
       }
     },
     "/public/v1/submit/delete_oauth2_credential": {
@@ -4040,6 +4328,38 @@
         "tags": ["On Ramp"]
       }
     },
+    "/public/v1/submit/update_mfa_policy": {
+      "post": {
+        "summary": "Update MFA policy",
+        "description": "Update an MFA policy for a user.",
+        "operationId": "PublicApiService_UpdateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/update_oauth2_credential": {
       "post": {
         "summary": "Update an OAuth 2.0 Credential",
@@ -4695,6 +5015,10 @@
         },
         "type": {
           "$ref": "#/definitions/v1CredentialType"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN."
         }
       },
       "required": ["publicKey", "type"]
@@ -4984,7 +5308,8 @@
         "ACTIVITY_STATUS_COMPLETED",
         "ACTIVITY_STATUS_FAILED",
         "ACTIVITY_STATUS_CONSENSUS_NEEDED",
-        "ACTIVITY_STATUS_REJECTED"
+        "ACTIVITY_STATUS_REJECTED",
+        "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED"
       ]
     },
     "v1ActivityType": {
@@ -5127,7 +5452,16 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2",
+        "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+        "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+        "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+        "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+        "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER",
+        "ACTIVITY_TYPE_EARN_DEPOSIT",
+        "ACTIVITY_TYPE_EARN_WITHDRAW",
+        "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG"
       ]
     },
     "v1AddressFormat": {
@@ -5444,6 +5778,45 @@
         "transports"
       ]
     },
+    "v1AuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., for requiring a specific session profile id)"
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication)."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used."
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationType": {
+      "type": "string",
+      "enum": [
+        "AUTHENTICATION_TYPE_EMAIL_OTP",
+        "AUTHENTICATION_TYPE_SMS_OTP",
+        "AUTHENTICATION_TYPE_PASSKEY",
+        "AUTHENTICATION_TYPE_API_KEY",
+        "AUTHENTICATION_TYPE_OAUTH",
+        "AUTHENTICATION_TYPE_SESSION"
+      ]
+    },
     "v1Authenticator": {
       "type": "object",
       "properties": {
@@ -5586,11 +5959,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5979,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -5960,6 +6337,78 @@
         }
       },
       "required": ["invitationIds"]
+    },
+    "v1CreateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to add the MFA Policy to."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": [
+        "userId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order"
+      ]
+    },
+    "v1CreateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1CreateOauth2CredentialIntent": {
       "type": "object",
@@ -6662,6 +7111,59 @@
         "credentialBundle"
       ]
     },
+    "v1CreateSessionProfileIntent": {
+      "type": "object",
+      "properties": {
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope string that defines the permissions for this Session Profile."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for a Session Profile."
+        }
+      },
+      "required": ["sessionProfileName", "scope"]
+    },
+    "v1CreateSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_SESSION_PROFILE"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateSessionProfileResult": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        }
+      },
+      "required": ["sessionProfileId"]
+    },
     "v1CreateSmartContractInterfaceIntent": {
       "type": "object",
       "properties": {
@@ -7188,6 +7690,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -7971,6 +8477,51 @@
         }
       },
       "required": ["invitationId"]
+    },
+    "v1DeleteMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to delete the MFA Policy from."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1DeleteMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1DeleteOauth2CredentialIntent": {
       "type": "object",
@@ -8784,6 +9335,179 @@
       },
       "required": ["privateKeyId"]
     },
+    "v1EarnDeployWrapperIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to wrap (from the EarnVaults catalog)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        }
+      },
+      "required": ["vaultAddress", "chainCaip2"]
+    },
+    "v1EarnDeployWrapperResult": {
+      "type": "object",
+      "properties": {
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee wrapper (the deposit target)."
+        },
+        "splitterAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave)."
+        },
+        "deployTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the wrapper deployment."
+        }
+      },
+      "required": ["wrapperAddress", "splitterAddress", "deployTxHash"]
+    },
+    "v1EarnDepositIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "assets": {
+          "type": "string",
+          "description": "Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        }
+      },
+      "required": ["vaultAddress", "signWith", "assets", "chainCaip2"]
+    },
+    "v1EarnDepositResult": {
+      "type": "object",
+      "properties": {
+        "depositTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the deposit."
+        },
+        "sharesMinted": {
+          "type": "string",
+          "description": "Number of wrapper shares minted to the depositor, in raw on-chain units."
+        },
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the fee wrapper the deposit was routed to."
+        },
+        "depositRequestId": {
+          "type": "string",
+          "description": "Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path)."
+        }
+      },
+      "required": [
+        "depositTxHash",
+        "sharesMinted",
+        "wrapperAddress",
+        "depositRequestId"
+      ]
+    },
+    "v1EarnWithdrawIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        },
+        "amountType": {
+          "type": "string",
+          "enum": ["SHARES", "ASSETS"],
+          "description": "Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims)."
+        },
+        "amountValue": {
+          "type": "string",
+          "description": "The amount to withdraw, in raw on-chain units, interpreted according to amount_type."
+        }
+      },
+      "required": [
+        "vaultAddress",
+        "signWith",
+        "chainCaip2",
+        "amountType",
+        "amountValue"
+      ]
+    },
+    "v1EarnWithdrawResult": {
+      "type": "object",
+      "properties": {
+        "withdrawTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the withdrawal."
+        },
+        "withdrawRequestId": {
+          "type": "string",
+          "description": "Identifier to poll withdrawal status via EarnWithdrawStatus."
+        },
+        "assetsReceived": {
+          "type": "string",
+          "description": "Amount of the underlying asset received, in raw on-chain units."
+        },
+        "sharesBurned": {
+          "type": "string",
+          "description": "Number of wrapper shares burned, in raw on-chain units."
+        }
+      },
+      "required": [
+        "withdrawTxHash",
+        "withdrawRequestId",
+        "assetsReceived",
+        "sharesBurned"
+      ]
+    },
     "v1Effect": {
       "type": "string",
       "enum": ["EFFECT_ALLOW", "EFFECT_DENY"]
@@ -9037,6 +9761,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9807,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9845,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9890,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9966,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9975,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9797,6 +10613,94 @@
       },
       "required": ["organizationId", "appName"]
     },
+    "v1GetMfaPoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        }
+      },
+      "required": ["organizationId", "userId"]
+    },
+    "v1GetMfaPoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of multi-factor authentication policies for a user."
+        }
+      },
+      "required": ["mfaPolicies"]
+    },
+    "v1GetMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA policy."
+        }
+      },
+      "required": ["organizationId", "userId", "mfaPolicyId"]
+    },
+    "v1GetMfaPolicyResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicy": {
+          "$ref": "#/definitions/v1MfaPolicy",
+          "description": "Multi-factor authentication policy for a user."
+        }
+      },
+      "required": ["mfaPolicy"]
+    },
+    "v1GetMfaStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "activityId": {
+          "type": "string",
+          "description": "The unique identifier of the activity to get MFA status for."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Optional user ID to filter MFA status for a specific user."
+        }
+      },
+      "required": ["organizationId", "activityId"]
+    },
+    "v1GetMfaStatusResponse": {
+      "type": "object",
+      "properties": {
+        "mfaStatuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaStatus"
+          },
+          "description": "A list of MFA statuses for the activity's votes."
+        }
+      },
+      "required": ["mfaStatuses"]
+    },
     "v1GetNoncesRequest": {
       "type": "object",
       "properties": {
@@ -9816,7 +10720,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10108,6 +11014,54 @@
       },
       "required": ["txStatus"]
     },
+    "v1GetSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a session profile."
+        }
+      },
+      "required": ["organizationId", "sessionProfileId"]
+    },
+    "v1GetSessionProfileResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfile": {
+          "$ref": "#/definitions/v1SessionProfile",
+          "description": "Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies."
+        }
+      },
+      "required": ["sessionProfile"]
+    },
+    "v1GetSessionProfilesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetSessionProfilesResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SessionProfile"
+          },
+          "description": "A list of session profiles for users in the organization."
+        }
+      },
+      "required": ["sessionProfiles"]
+    },
     "v1GetSmartContractInterfaceRequest": {
       "type": "object",
       "properties": {
@@ -10266,6 +11220,44 @@
         }
       },
       "required": ["tvcApps"]
+    },
+    "v1GetTvcDeploymentDebugLogsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "Unique identifier for a given TVC Deployment. The deployment must be running in debug mode."
+        },
+        "tailLines": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied."
+        },
+        "sinceSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs."
+        }
+      },
+      "required": ["organizationId", "deploymentId"]
+    },
+    "v1GetTvcDeploymentDebugLogsResponse": {
+      "type": "object",
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TvcDeploymentDebugLogEntry"
+          },
+          "description": "Application log entries sorted by platform timestamp."
+        }
+      },
+      "required": ["entries"]
     },
     "v1GetTvcDeploymentRequest": {
       "type": "object",
@@ -10462,6 +11454,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +12810,33 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
+        },
+        "createMfaPolicyIntent": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        },
+        "updateMfaPolicyIntent": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        },
+        "deleteMfaPolicyIntent": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        },
+        "createSessionProfileIntent": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        },
+        "earnDeployWrapperIntent": {
+          "$ref": "#/definitions/v1EarnDeployWrapperIntent"
+        },
+        "earnDepositIntent": {
+          "$ref": "#/definitions/v1EarnDepositIntent"
+        },
+        "earnWithdrawIntent": {
+          "$ref": "#/definitions/v1EarnWithdrawIntent"
+        },
+        "upsertEarnClientFeeConfigIntent": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigIntent"
         }
       }
     },
@@ -11998,6 +13023,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -12066,6 +13097,20 @@
       },
       "required": ["webhookEndpoints"]
     },
+    "v1LogLine": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "One log line, exactly as the application printed it (without the trailing newline)"
+        },
+        "ts": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "When the line was logged. Stable across replays, so lines can be chronologically merged across pods"
+        }
+      },
+      "required": ["content"]
+    },
     "v1LoginUsage": {
       "type": "object",
       "properties": {
@@ -12075,6 +13120,95 @@
         }
       },
       "required": ["publicKey"]
+    },
+    "v1MfaPolicy": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for an MFA Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this policy is evaluated relative to other MFA policies."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular MFA policy."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "v1MfaStatus": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "satisfied": {
+          "type": "boolean",
+          "description": "Whether the MFA policy requirements are currently satisfied."
+        },
+        "satisfiedMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods already satisfied for this MFA policy."
+        },
+        "requiredMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements needed to satisfy this MFA policy."
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "userId",
+        "satisfied",
+        "satisfiedMethods",
+        "requiredMethods"
+      ]
     },
     "v1MnemonicLanguage": {
       "type": "string",
@@ -12278,6 +13412,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["oidcToken", "publicKey"]
@@ -12558,6 +13696,10 @@
         "clientSignature": {
           "$ref": "#/definitions/v1ClientSignature",
           "description": "Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey"]
@@ -12584,6 +13726,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login sessions"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey", "clientSignature"]
@@ -12630,7 +13776,8 @@
         "OUTCOME_DENY_IMPLICIT",
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
-        "OUTCOME_ERROR"
+        "OUTCOME_ERROR",
+        "OUTCOME_REQUIRES_AUTHENTICATORS"
       ]
     },
     "v1Pagination": {
@@ -13064,6 +14211,34 @@
       },
       "required": ["features"]
     },
+    "v1RequiredAuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
+    "v1RequiredAuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethodParams"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
     "v1RestoreTvcDeploymentIntent": {
       "type": "object",
       "properties": {
@@ -13458,6 +14633,33 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
+        },
+        "createMfaPolicyResult": {
+          "$ref": "#/definitions/v1CreateMfaPolicyResult"
+        },
+        "updateMfaPolicyResult": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyResult"
+        },
+        "deleteMfaPolicyResult": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyResult"
+        },
+        "createSessionProfileResult": {
+          "$ref": "#/definitions/v1CreateSessionProfileResult"
+        },
+        "earnDeployWrapperResult": {
+          "$ref": "#/definitions/v1EarnDeployWrapperResult"
+        },
+        "earnDepositResult": {
+          "$ref": "#/definitions/v1EarnDepositResult"
+        },
+        "earnWithdrawResult": {
+          "$ref": "#/definitions/v1EarnWithdrawResult"
+        },
+        "upsertEarnClientFeeConfigResult": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigResult"
         }
       }
     },
@@ -13710,6 +14912,44 @@
           }
         }
       }
+    },
+    "v1SessionProfile": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        },
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The specific scope that a session created with this profile is limited to."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "Optional window (in seconds) indicating how long sessions created with this profile should last."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular Session Profile."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "sessionProfileId",
+        "sessionProfileName",
+        "scope",
+        "createdAt",
+        "updatedAt"
+      ]
     },
     "v1SetIpAllowlistIntent": {
       "type": "object",
@@ -14806,6 +16046,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["publicKey"]
@@ -14925,6 +16169,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +16185,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15055,6 +16304,20 @@
         "updatedAt",
         "delete"
       ]
+    },
+    "v1TvcDeploymentDebugLogEntry": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "$ref": "#/definitions/v1LogLine",
+          "description": "Application log line with its platform timestamp."
+        },
+        "replicaLabel": {
+          "type": "string",
+          "description": "Public replica label that produced this log line, for example 'replica 2/3'."
+        }
+      },
+      "required": ["line", "replicaLabel"]
     },
     "v1TvcHealthCheckType": {
       "type": "string",
@@ -15461,6 +16724,76 @@
         }
       },
       "required": ["fiatOnRampCredentialId"]
+    },
+    "v1UpdateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to update the MFA Policy for."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1UpdateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1UpdateOauth2CredentialIntent": {
       "type": "object",
@@ -16204,6 +17537,30 @@
       },
       "required": ["endpointId", "webhookEndpoint"]
     },
+    "v1UpsertEarnClientFeeConfigIntent": {
+      "type": "object",
+      "properties": {
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address."
+        }
+      },
+      "required": ["clientFeeBps", "clientFeeWallet"]
+    },
+    "v1UpsertEarnClientFeeConfigResult": {
+      "type": "object",
+      "properties": {
+        "feeUpdateTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee configuration update."
+        }
+      },
+      "required": ["feeUpdateTxHash"]
+    },
     "v1UpsertGasUsageConfigIntent": {
       "type": "object",
       "properties": {
@@ -16303,6 +17660,14 @@
         },
         "updatedAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of MFA Policies that define multi-factor authentication requirements for this user."
         }
       },
       "required": [
@@ -16313,7 +17678,8 @@
         "userTags",
         "oauthProviders",
         "createdAt",
-        "updatedAt"
+        "updatedAt",
+        "mfaPolicies"
       ]
     },
     "v1UserParams": {
@@ -16749,6 +18115,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +18152,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -44,6 +44,18 @@ export type paths = {
     /** Get the latest boot proof for a given enclave app name. */
     post: operations["PublicApiService_GetLatestBootProof"];
   };
+  "/public/v1/query/get_mfa_policies": {
+    /** Get all MFA policies for a user. */
+    post: operations["PublicApiService_GetMfaPolicies"];
+  };
+  "/public/v1/query/get_mfa_policy": {
+    /** Get a single MFA policy for a user. */
+    post: operations["PublicApiService_GetMfaPolicy"];
+  };
+  "/public/v1/query/get_mfa_status": {
+    /** Get the MFA status of an activity for a specific user or all voting users. */
+    post: operations["PublicApiService_GetMfaStatus"];
+  };
   "/public/v1/query/get_nonces": {
     /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
     post: operations["PublicApiService_GetNonces"];
@@ -59,10 +71,6 @@ export type paths = {
   "/public/v1/query/get_onramp_transaction_status": {
     /** Get the status of an on ramp transaction. */
     post: operations["PublicApiService_GetOnRampTransactionStatus"];
-  };
-  "/public/v1/query/get_organization": {
-    /** Get details about an organization. */
-    post: operations["PublicApiService_GetOrganization"];
   };
   "/public/v1/query/get_organization_configs": {
     /** Get quorum settings and features for an organization. */
@@ -84,6 +92,14 @@ export type paths = {
     /** Get the status of a send transaction request. */
     post: operations["PublicApiService_GetSendTransactionStatus"];
   };
+  "/public/v1/query/get_session_profile": {
+    /** Get a single session profile for an organization. */
+    post: operations["PublicApiService_GetSessionProfile"];
+  };
+  "/public/v1/query/get_session_profiles": {
+    /** Get all session profiles for an organization. */
+    post: operations["PublicApiService_GetSessionProfiles"];
+  };
   "/public/v1/query/get_smart_contract_interface": {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
@@ -96,9 +112,9 @@ export type paths = {
     /** Get details about a single TVC Deployment */
     post: operations["PublicApiService_GetTvcDeployment"];
   };
-  "/public/v1/query/get_tvc_deployment_provisioning_details": {
-    /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-    post: operations["PublicApiService_GetTvcDeploymentProvisioningDetails"];
+  "/public/v1/query/get_tvc_deployment_debug_logs": {
+    /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+    post: operations["PublicApiService_GetTvcDeploymentDebugLogs"];
   };
   "/public/v1/query/get_user": {
     /** Get details about a user. */
@@ -113,7 +129,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +169,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -204,10 +220,6 @@ export type paths = {
     /** Add API keys to an existing user. */
     post: operations["PublicApiService_CreateApiKeys"];
   };
-  "/public/v1/submit/create_api_only_users": {
-    /** Create API-only users in an existing organization. */
-    post: operations["PublicApiService_CreateApiOnlyUsers"];
-  };
   "/public/v1/submit/create_authenticators": {
     /** Create authenticators to authenticate requests to Turnkey. */
     post: operations["PublicApiService_CreateAuthenticators"];
@@ -219,6 +231,10 @@ export type paths = {
   "/public/v1/submit/create_invitations": {
     /** Create invitations to join an existing organization. */
     post: operations["PublicApiService_CreateInvitations"];
+  };
+  "/public/v1/submit/create_mfa_policy": {
+    /** Create a new MFA policy for a user. */
+    post: operations["PublicApiService_CreateMfaPolicy"];
   };
   "/public/v1/submit/create_oauth2_credential": {
     /** Enable authentication for end users with an OAuth 2.0 provider */
@@ -251,6 +267,10 @@ export type paths = {
   "/public/v1/submit/create_read_write_session": {
     /** Create a read write session for a user. */
     post: operations["PublicApiService_CreateReadWriteSession"];
+  };
+  "/public/v1/submit/create_session_profile": {
+    /** Create a new session profile for an organization. */
+    post: operations["PublicApiService_CreateSessionProfile"];
   };
   "/public/v1/submit/create_smart_contract_interface": {
     /** Create an ABI/IDL in JSON. */
@@ -307,6 +327,10 @@ export type paths = {
   "/public/v1/submit/delete_invitation": {
     /** Delete an existing invitation. */
     post: operations["PublicApiService_DeleteInvitation"];
+  };
+  "/public/v1/submit/delete_mfa_policy": {
+    /** Delete an MFA policy for a user. */
+    post: operations["PublicApiService_DeleteMfaPolicy"];
   };
   "/public/v1/submit/delete_oauth2_credential": {
     /** Disable authentication for end users with an OAuth 2.0 provider */
@@ -371,10 +395,6 @@ export type paths = {
   "/public/v1/submit/email_auth": {
     /** Authenticate a user via email. */
     post: operations["PublicApiService_EmailAuth"];
-  };
-  "/public/v1/submit/eth_send_raw_transaction": {
-    /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-    post: operations["PublicApiService_EthSendRawTransaction"];
   };
   "/public/v1/submit/eth_send_transaction": {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
@@ -443,10 +463,6 @@ export type paths = {
   "/public/v1/submit/otp_login": {
     /** Create an OTP session for a user. */
     post: operations["PublicApiService_OtpLogin"];
-  };
-  "/public/v1/submit/post_tvc_quorum_key_share": {
-    /** Post re-encrypted quorum key share for a TVC deployment. */
-    post: operations["PublicApiService_PostTvcQuorumKeyShare"];
   };
   "/public/v1/submit/recover_user": {
     /** Complete the process of recovering a user by adding an authenticator. */
@@ -520,6 +536,10 @@ export type paths = {
     /** Update a fiat on ramp provider credential */
     post: operations["PublicApiService_UpdateFiatOnRampCredential"];
   };
+  "/public/v1/submit/update_mfa_policy": {
+    /** Update an MFA policy for a user. */
+    post: operations["PublicApiService_UpdateMfaPolicy"];
+  };
   "/public/v1/submit/update_oauth2_credential": {
     /** Update an OAuth 2.0 provider credential */
     post: operations["PublicApiService_UpdateOauth2Credential"];
@@ -574,14 +594,6 @@ export type paths = {
   };
   "/tkhq/api/v1/noop-codegen-anchor": {
     post: operations["PublicApiService_NOOPCodegenAnchor"];
-  };
-  "/tkhq/api/v1/refresh_feature_flags": {
-    /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-    post: operations["PublicApiService_RefreshFeatureFlags"];
-  };
-  "/tkhq/api/v1/test_rate_limits": {
-    /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-    post: operations["PublicApiService_TestRateLimits"];
   };
 };
 
@@ -671,6 +683,8 @@ export type definitions = {
     /** @description The public component of a cryptographic key pair used to sign messages and transactions. */
     publicKey: string;
     type: definitions["v1CredentialType"];
+    /** @description The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN. */
+    sessionProfileId?: string;
   };
   externaldatav1Quorum: {
     /**
@@ -783,7 +797,8 @@ export type definitions = {
     | "ACTIVITY_STATUS_COMPLETED"
     | "ACTIVITY_STATUS_FAILED"
     | "ACTIVITY_STATUS_CONSENSUS_NEEDED"
-    | "ACTIVITY_STATUS_REJECTED";
+    | "ACTIVITY_STATUS_REJECTED"
+    | "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED";
   /** @enum {string} */
   v1ActivityType:
     | "ACTIVITY_TYPE_CREATE_API_KEYS"
@@ -923,7 +938,16 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
+    | "ACTIVITY_TYPE_CREATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_UPDATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_DELETE_MFA_POLICY"
+    | "ACTIVITY_TYPE_CREATE_SESSION_PROFILE"
+    | "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER"
+    | "ACTIVITY_TYPE_EARN_DEPOSIT"
+    | "ACTIVITY_TYPE_EARN_WITHDRAW"
+    | "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1084,6 +1108,26 @@ export type definitions = {
     /** @description The type of authenticator transports. */
     transports: definitions["v1AuthenticatorTransport"][];
   };
+  v1AuthenticationMethod: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step. */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., for requiring a specific session profile id) */
+    id?: string;
+  };
+  v1AuthenticationMethodParams: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication). */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used. */
+    id?: string;
+  };
+  /** @enum {string} */
+  v1AuthenticationType:
+    | "AUTHENTICATION_TYPE_EMAIL_OTP"
+    | "AUTHENTICATION_TYPE_SMS_OTP"
+    | "AUTHENTICATION_TYPE_PASSKEY"
+    | "AUTHENTICATION_TYPE_API_KEY"
+    | "AUTHENTICATION_TYPE_OAUTH"
+    | "AUTHENTICATION_TYPE_SESSION";
   v1Authenticator: {
     /** @description Types of transports that may be used by an Authenticator (e.g., USB, NFC, BLE). */
     transports: definitions["v1AuthenticatorTransport"][];
@@ -1139,9 +1183,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1194,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1199,16 +1245,6 @@ export type definitions = {
   v1CreateApiOnlyUsersIntent: {
     /** @description A list of API-only Users to create. */
     apiOnlyUsers: definitions["v1ApiOnlyUserParams"][];
-  };
-  v1CreateApiOnlyUsersRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1CreateApiOnlyUsersIntent"];
-    generateAppProofs?: boolean;
   };
   v1CreateApiOnlyUsersResult: {
     /** @description A list of API-only User IDs. */
@@ -1285,6 +1321,36 @@ export type definitions = {
   v1CreateInvitationsResult: {
     /** @description A list of Invitation IDs */
     invitationIds: string[];
+  };
+  v1CreateMfaPolicyIntent: {
+    /** @description The ID of the User to add the MFA Policy to. */
+    userId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1CreateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateMfaPolicyIntent"];
+  };
+  v1CreateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1CreateOauth2CredentialIntent: {
     /** @description The OAuth 2.0 provider */
@@ -1560,6 +1626,29 @@ export type definitions = {
     /** @description HPKE encrypted credential bundle */
     credentialBundle: string;
   };
+  v1CreateSessionProfileIntent: {
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The scope string that defines the permissions for this Session Profile. */
+    scope: string;
+    /** @description The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities. */
+    expirationSeconds?: string;
+    /** @description Notes for a Session Profile. */
+    notes?: string;
+  };
+  v1CreateSessionProfileRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSessionProfileIntent"];
+  };
+  v1CreateSessionProfileResult: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+  };
   v1CreateSmartContractInterfaceIntent: {
     /** @description Corresponding contract address or program ID */
     smartContractAddress: string;
@@ -1776,6 +1865,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2091,6 +2182,25 @@ export type definitions = {
   v1DeleteInvitationResult: {
     /** @description Unique identifier for a given Invitation. */
     invitationId: string;
+  };
+  v1DeleteMfaPolicyIntent: {
+    /** @description The ID of the User to delete the MFA Policy from. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+  };
+  v1DeleteMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteMfaPolicyIntent"];
+  };
+  v1DeleteMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1DeleteOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to delete */
@@ -2408,6 +2518,96 @@ export type definitions = {
     /** @description Unique identifier for a given Private Key. */
     privateKeyId: string;
   };
+  v1EarnDeployWrapperIntent: {
+    /** @description Address of the underlying yield vault to wrap (from the EarnVaults catalog). */
+    vaultAddress: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+  };
+  v1EarnDeployWrapperResult: {
+    /** @description Address of the deployed fee wrapper (the deposit target). */
+    wrapperAddress: string;
+    /** @description Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave). */
+    splitterAddress: string;
+    /** @description Transaction hash of the wrapper deployment. */
+    deployTxHash: string;
+  };
+  v1EarnDepositIntent: {
+    /** @description Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals). */
+    assets: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+  };
+  v1EarnDepositResult: {
+    /** @description Transaction hash of the deposit. */
+    depositTxHash: string;
+    /** @description Number of wrapper shares minted to the depositor, in raw on-chain units. */
+    sharesMinted: string;
+    /** @description Address of the fee wrapper the deposit was routed to. */
+    wrapperAddress: string;
+    /** @description Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path). */
+    depositRequestId: string;
+  };
+  v1EarnWithdrawIntent: {
+    /** @description Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+    /**
+     * @description Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims).
+     * @enum {string}
+     */
+    amountType: "SHARES" | "ASSETS";
+    /** @description The amount to withdraw, in raw on-chain units, interpreted according to amount_type. */
+    amountValue: string;
+  };
+  v1EarnWithdrawResult: {
+    /** @description Transaction hash of the withdrawal. */
+    withdrawTxHash: string;
+    /** @description Identifier to poll withdrawal status via EarnWithdrawStatus. */
+    withdrawRequestId: string;
+    /** @description Amount of the underlying asset received, in raw on-chain units. */
+    assetsReceived: string;
+    /** @description Number of wrapper shares burned, in raw on-chain units. */
+    sharesBurned: string;
+  };
   /** @enum {string} */
   v1Effect: "EFFECT_ALLOW" | "EFFECT_DENY";
   v1EmailAuthCustomizationParams: {
@@ -2525,6 +2725,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,17 +2750,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
-  };
-  v1EthSendRawTransactionRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_RAW_TRANSACTION";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1EthSendRawTransactionIntent"];
-    generateAppProofs?: boolean;
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionResult: {
     /** @description The transaction hash of the sent transaction */
@@ -2573,7 +2773,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2795,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2896,6 +3135,40 @@ export type definitions = {
     /** @description Name of enclave app. */
     appName: string;
   };
+  v1GetMfaPoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+  };
+  v1GetMfaPoliciesResponse: {
+    /** @description A list of multi-factor authentication policies for a user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
+  };
+  v1GetMfaPolicyRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+    /** @description Unique identifier for a given MFA policy. */
+    mfaPolicyId: string;
+  };
+  v1GetMfaPolicyResponse: {
+    /** @description Multi-factor authentication policy for a user. */
+    mfaPolicy: definitions["v1MfaPolicy"];
+  };
+  v1GetMfaStatusRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description The unique identifier of the activity to get MFA status for. */
+    activityId: string;
+    /** @description Optional user ID to filter MFA status for a specific user. */
+    userId?: string;
+  };
+  v1GetMfaStatusResponse: {
+    /** @description A list of MFA statuses for the activity's votes. */
+    mfaStatuses: definitions["v1MfaStatus"][];
+  };
   v1GetNoncesRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -2911,7 +3184,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -2967,14 +3242,6 @@ export type definitions = {
   v1GetOrganizationConfigsResponse: {
     /** @description Organization configs including quorum settings and organization features. */
     configs: definitions["v1Config"];
-  };
-  v1GetOrganizationRequest: {
-    /** @description Unique identifier for a given organization. */
-    organizationId: string;
-  };
-  v1GetOrganizationResponse: {
-    /** @description Object representing the full current and deleted / disabled collection of users, policies, private keys, and invitations attributable to a particular organization. */
-    organizationData: definitions["v1OrganizationData"];
   };
   v1GetPoliciesRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3039,6 +3306,24 @@ export type definitions = {
     /** @description Structured error information including revert details, if available. */
     error?: definitions["v1TxError"];
   };
+  v1GetSessionProfileRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a session profile. */
+    sessionProfileId: string;
+  };
+  v1GetSessionProfileResponse: {
+    /** @description Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies. */
+    sessionProfile: definitions["v1SessionProfile"];
+  };
+  v1GetSessionProfilesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetSessionProfilesResponse: {
+    /** @description A list of session profiles for users in the organization. */
+    sessionProfiles: definitions["v1SessionProfile"][];
+  };
   v1GetSmartContractInterfaceRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3099,23 +3384,25 @@ export type definitions = {
     /** @description A list of TVC Apps. */
     tvcApps: definitions["v1TvcApp"][];
   };
-  v1GetTvcDeploymentProvisioningDetailsRequest: {
+  v1GetTvcDeploymentDebugLogsRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Unique identifier for a given TVC Deployment. */
+    /** @description Unique identifier for a given TVC Deployment. The deployment must be running in debug mode. */
     deploymentId: string;
+    /**
+     * Format: int32
+     * @description Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied.
+     */
+    tailLines?: number;
+    /**
+     * Format: int64
+     * @description Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs.
+     */
+    sinceSeconds?: string;
   };
-  v1GetTvcDeploymentProvisioningDetailsResponse: {
-    /**
-     * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
-     */
-    attestationDocument: string;
-    /**
-     * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
-     */
-    manifestEnvelope: string;
+  v1GetTvcDeploymentDebugLogsResponse: {
+    /** @description Application log entries sorted by platform timestamp. */
+    entries: definitions["v1TvcDeploymentDebugLogEntry"][];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3203,6 +3490,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,24 +4053,15 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
-  };
-  v1Invitation: {
-    /** @description Unique identifier for a given Invitation object. */
-    invitationId: string;
-    /** @description The name of the intended Invitation recipient. */
-    receiverUserName: string;
-    /** @description The email address of the intended Invitation recipient. */
-    receiverEmail: string;
-    /** @description A list of tags assigned to the Invitation recipient. */
-    receiverUserTags: string[];
-    /** @description The User's permissible access method(s). */
-    accessType: definitions["v1AccessType"];
-    /** @description The current processing status of a specified Invitation. */
-    status: definitions["v1InvitationStatus"];
-    createdAt: definitions["externaldatav1Timestamp"];
-    updatedAt: definitions["externaldatav1Timestamp"];
-    /** @description Unique identifier for the Sender of an Invitation. */
-    senderUserId: string;
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
+    createMfaPolicyIntent?: definitions["v1CreateMfaPolicyIntent"];
+    updateMfaPolicyIntent?: definitions["v1UpdateMfaPolicyIntent"];
+    deleteMfaPolicyIntent?: definitions["v1DeleteMfaPolicyIntent"];
+    createSessionProfileIntent?: definitions["v1CreateSessionProfileIntent"];
+    earnDeployWrapperIntent?: definitions["v1EarnDeployWrapperIntent"];
+    earnDepositIntent?: definitions["v1EarnDepositIntent"];
+    earnWithdrawIntent?: definitions["v1EarnWithdrawIntent"];
+    upsertEarnClientFeeConfigIntent?: definitions["v1UpsertEarnClientFeeConfigIntent"];
   };
   v1InvitationParams: {
     /** @description The name of the intended Invitation recipient. */
@@ -3791,11 +4075,6 @@ export type definitions = {
     /** @description Unique identifier for the Sender of an Invitation. */
     senderUserId: string;
   };
-  /** @enum {string} */
-  v1InvitationStatus:
-    | "INVITATION_STATUS_CREATED"
-    | "INVITATION_STATUS_ACCEPTED"
-    | "INVITATION_STATUS_REVOKED";
   v1IpAllowlist: {
     /** @description Unique identifier for the organization this allowlist belongs to. */
     organizationId: string;
@@ -3858,6 +4137,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3880,9 +4165,46 @@ export type definitions = {
   v1ListWebhookEndpointsResponse: {
     webhookEndpoints: definitions["v1WebhookEndpointData"][];
   };
+  v1LogLine: {
+    /** @description One log line, exactly as the application printed it (without the trailing newline) */
+    content: string;
+    /** @description When the line was logged. Stable across replays, so lines can be chronologically merged across pods */
+    ts?: definitions["externaldatav1Timestamp"];
+  };
   v1LoginUsage: {
     /** @description Public key for authentication */
     publicKey: string;
+  };
+  v1MfaPolicy: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for an MFA Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethod"][];
+    /**
+     * Format: int64
+     * @description The order in which this policy is evaluated relative to other MFA policies.
+     */
+    order: number;
+    /** @description Optional human-readable notes added by a User to describe a particular MFA policy. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
+  };
+  v1MfaStatus: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Whether the MFA policy requirements are currently satisfied. */
+    satisfied: boolean;
+    /** @description A list of authentication methods already satisfied for this MFA policy. */
+    satisfiedMethods: definitions["v1AuthenticationMethod"][];
+    /** @description An ordered list of authentication requirements needed to satisfy this MFA policy. */
+    requiredMethods: definitions["v1RequiredAuthenticationMethod"][];
   };
   /** @enum {string} */
   v1MnemonicLanguage:
@@ -3975,6 +4297,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OauthLoginRequest: {
     /** @enum {string} */
@@ -4057,19 +4381,6 @@ export type definitions = {
     | "OPERATOR_NOT_IN"
     | "OPERATOR_CONTAINS_ONE"
     | "OPERATOR_CONTAINS_ALL";
-  v1OrganizationData: {
-    organizationId?: string;
-    name?: string;
-    users?: definitions["v1User"][];
-    policies?: definitions["v1Policy"][];
-    privateKeys?: definitions["v1PrivateKey"][];
-    invitations?: definitions["v1Invitation"][];
-    tags?: definitions["datav1Tag"][];
-    rootQuorum?: definitions["externaldatav1Quorum"];
-    features?: definitions["v1Feature"][];
-    wallets?: definitions["v1Wallet"][];
-    smartContractInterfaceReferences?: definitions["v1SmartContractInterfaceReference"][];
-  };
   v1OtpAuthIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -4113,6 +4424,8 @@ export type definitions = {
     invalidateExisting?: boolean;
     /** @description Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step. */
     clientSignature?: definitions["v1ClientSignature"];
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginIntentV2: {
     /** @description Signed Verification Token containing a unique id, expiry, verification type, contact */
@@ -4125,6 +4438,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login sessions */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginRequest: {
     /** @enum {string} */
@@ -4147,7 +4462,8 @@ export type definitions = {
     | "OUTCOME_DENY_IMPLICIT"
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
-    | "OUTCOME_ERROR";
+    | "OUTCOME_ERROR"
+    | "OUTCOME_REQUIRES_AUTHENTICATORS";
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -4187,15 +4503,6 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description Re-encrypted quorum key share and approval */
     shareApprovalBundle: definitions["v1QuorumKeyShareApprovalBundle"];
-  };
-  v1PostTvcQuorumKeyShareRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1PostTvcQuorumKeyShareIntent"];
   };
   v1PostTvcQuorumKeyShareResult: {
     /** @description The unique identifier for the provisioning quorum key share */
@@ -4273,8 +4580,6 @@ export type definitions = {
     /** @description ID of the authenticator created. */
     authenticatorId: string[];
   };
-  v1RefreshFeatureFlagsRequest: { [key: string]: unknown };
-  v1RefreshFeatureFlagsResponse: { [key: string]: unknown };
   v1RejectActivityIntent: {
     /** @description An artifact verifying a User's action. */
     fingerprint: string;
@@ -4321,6 +4626,14 @@ export type definitions = {
   v1RemoveOrganizationFeatureResult: {
     /** @description Resulting list of organization features. */
     features: definitions["v1Feature"][];
+  };
+  v1RequiredAuthenticationMethod: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethod"][];
+  };
+  v1RequiredAuthenticationMethodParams: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethodParams"][];
   };
   v1RestoreTvcDeploymentIntent: {
     /** @description The unique identifier of the TVC deployment to restore. */
@@ -4457,6 +4770,15 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
+    createMfaPolicyResult?: definitions["v1CreateMfaPolicyResult"];
+    updateMfaPolicyResult?: definitions["v1UpdateMfaPolicyResult"];
+    deleteMfaPolicyResult?: definitions["v1DeleteMfaPolicyResult"];
+    createSessionProfileResult?: definitions["v1CreateSessionProfileResult"];
+    earnDeployWrapperResult?: definitions["v1EarnDeployWrapperResult"];
+    earnDepositResult?: definitions["v1EarnDepositResult"];
+    earnWithdrawResult?: definitions["v1EarnWithdrawResult"];
+    upsertEarnClientFeeConfigResult?: definitions["v1UpsertEarnClientFeeConfigResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -4543,6 +4865,20 @@ export type definitions = {
     subject?: string;
     operator?: definitions["v1Operator"];
     targets?: string[];
+  };
+  v1SessionProfile: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The specific scope that a session created with this profile is limited to. */
+    scope: string;
+    /** @description Optional window (in seconds) indicating how long sessions created with this profile should last. */
+    expirationSeconds?: string;
+    /** @description Optional human-readable notes added by a User to describe a particular Session Profile. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
   };
   v1SetIpAllowlistIntent: {
     /** @description The public component of an API key. If null, the IP allowlist applies at the organization level. If set, it applies only to this specific API key. */
@@ -4691,11 +5027,6 @@ export type definitions = {
     appid?: boolean;
     appidExclude?: boolean;
     credProps?: definitions["v1CredPropsAuthenticationExtensionsClientOutputs"];
-  };
-  v1SmartContractInterfaceReference: {
-    smartContractInterfaceId?: string;
-    smartContractAddress?: string;
-    digest?: string;
   };
   /** @enum {string} */
   v1SmartContractInterfaceType:
@@ -4994,6 +5325,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1StampLoginRequest: {
     /** @enum {string} */
@@ -5011,18 +5344,6 @@ export type definitions = {
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
-  v1TestRateLimitsRequest: {
-    /** @description Unique identifier for a given organization. If the request is being made by a WebAuthN user and their sub-organization ID is unknown, this can be the parent organization ID; using the sub-organization ID when possible is preferred due to performance reasons. */
-    organizationId: string;
-    /** @description Whether or not to set a limit on this request. */
-    isSetLimit: boolean;
-    /**
-     * Format: int64
-     * @description Rate limit to set for org, if is_set_limit is set to true.
-     */
-    limit: number;
-  };
-  v1TestRateLimitsResponse: { [key: string]: unknown };
   v1TokenUsage: {
     /** @description Type of token usage */
     type: definitions["v1UsageType"];
@@ -5060,6 +5381,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5106,6 +5429,12 @@ export type definitions = {
     updatedAt: definitions["externaldatav1Timestamp"];
     /** @description Whether or not the user wants this deployment deleted from the cluster. */
     delete: boolean;
+  };
+  v1TvcDeploymentDebugLogEntry: {
+    /** @description Application log line with its platform timestamp. */
+    line: definitions["v1LogLine"];
+    /** @description Public replica label that produced this log line, for example 'replica 2/3'. */
+    replicaLabel: string;
   };
   /** @enum {string} */
   v1TvcHealthCheckType:
@@ -5289,6 +5618,38 @@ export type definitions = {
   v1UpdateFiatOnRampCredentialResult: {
     /** @description Unique identifier of the Fiat On-Ramp credential that was updated */
     fiatOnRampCredentialId: string;
+  };
+  v1UpdateMfaPolicyIntent: {
+    /** @description The ID of the User to update the MFA Policy for. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName?: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition?: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods?: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order?: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1UpdateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateMfaPolicyIntent"];
+  };
+  v1UpdateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1UpdateOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to update */
@@ -5599,6 +5960,16 @@ export type definitions = {
     /** @description The updated webhook endpoint data. */
     webhookEndpoint: definitions["v1WebhookEndpointData"];
   };
+  v1UpsertEarnClientFeeConfigIntent: {
+    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    clientFeeBps: string;
+    /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
+    clientFeeWallet: string;
+  };
+  v1UpsertEarnClientFeeConfigResult: {
+    /** @description Transaction hash of the fee configuration update. */
+    feeUpdateTxHash: string;
+  };
   v1UpsertGasUsageConfigIntent: {
     /** @description Gas sponsorship USD limit for the billing organization window. */
     orgWindowLimitUsd: string;
@@ -5636,6 +6007,8 @@ export type definitions = {
     oauthProviders: definitions["v1OauthProvider"][];
     createdAt: definitions["externaldatav1Timestamp"];
     updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description A list of MFA Policies that define multi-factor authentication requirements for this user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
   };
   v1UserParams: {
     /** @description Human-readable name for a User. */
@@ -5794,6 +6167,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +6179,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6053,6 +6430,60 @@ export type operations = {
       };
     };
   };
+  /** Get all MFA policies for a user. */
+  PublicApiService_GetMfaPolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get a single MFA policy for a user. */
+  PublicApiService_GetMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPolicyResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get the MFA status of an activity for a specific user or all voting users. */
+  PublicApiService_GetMfaStatus: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaStatusRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaStatusResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
   PublicApiService_GetNonces: {
     parameters: {
@@ -6118,24 +6549,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetOnRampTransactionStatusResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get details about an organization. */
-  PublicApiService_GetOrganization: {
-    parameters: {
-      body: {
-        body: definitions["v1GetOrganizationRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetOrganizationResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6233,6 +6646,42 @@ export type operations = {
       };
     };
   };
+  /** Get a single session profile for an organization. */
+  PublicApiService_GetSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfileRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfileResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get all session profiles for an organization. */
+  PublicApiService_GetSessionProfiles: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfilesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfilesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a smart contract interface. */
   PublicApiService_GetSmartContractInterface: {
     parameters: {
@@ -6287,17 +6736,17 @@ export type operations = {
       };
     };
   };
-  /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-  PublicApiService_GetTvcDeploymentProvisioningDetails: {
+  /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+  PublicApiService_GetTvcDeploymentDebugLogs: {
     parameters: {
       body: {
-        body: definitions["v1GetTvcDeploymentProvisioningDetailsRequest"];
+        body: definitions["v1GetTvcDeploymentDebugLogsRequest"];
       };
     };
     responses: {
       /** A successful response. */
       200: {
-        schema: definitions["v1GetTvcDeploymentProvisioningDetailsResponse"];
+        schema: definitions["v1GetTvcDeploymentDebugLogsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6359,7 +6808,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6988,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {
@@ -6773,24 +7222,6 @@ export type operations = {
       };
     };
   };
-  /** Create API-only users in an existing organization. */
-  PublicApiService_CreateApiOnlyUsers: {
-    parameters: {
-      body: {
-        body: definitions["v1CreateApiOnlyUsersRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
   /** Create authenticators to authenticate requests to Turnkey. */
   PublicApiService_CreateAuthenticators: {
     parameters: {
@@ -6832,6 +7263,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateInvitationsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new MFA policy for a user. */
+  PublicApiService_CreateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateMfaPolicyRequest"];
       };
     };
     responses: {
@@ -6976,6 +7425,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateReadWriteSessionRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new session profile for an organization. */
+  PublicApiService_CreateSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSessionProfileRequest"];
       };
     };
     responses: {
@@ -7228,6 +7695,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteInvitationRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an MFA policy for a user. */
+  PublicApiService_DeleteMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteMfaPolicyRequest"];
       };
     };
     responses: {
@@ -7516,24 +8001,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1EmailAuthRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-  PublicApiService_EthSendRawTransaction: {
-    parameters: {
-      body: {
-        body: definitions["v1EthSendRawTransactionRequest"];
       };
     };
     responses: {
@@ -7840,24 +8307,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1OtpLoginRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Post re-encrypted quorum key share for a TVC deployment. */
-  PublicApiService_PostTvcQuorumKeyShare: {
-    parameters: {
-      body: {
-        body: definitions["v1PostTvcQuorumKeyShareRequest"];
       };
     };
     responses: {
@@ -8195,6 +8644,24 @@ export type operations = {
       };
     };
   };
+  /** Update an MFA policy for a user. */
+  PublicApiService_UpdateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Update an OAuth 2.0 provider credential */
   PublicApiService_UpdateOauth2Credential: {
     parameters: {
@@ -8434,42 +8901,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1NOOPCodegenAnchorResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-  PublicApiService_RefreshFeatureFlags: {
-    parameters: {
-      body: {
-        body: definitions["v1RefreshFeatureFlagsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1RefreshFeatureFlagsResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-  PublicApiService_TestRateLimits: {
-    parameters: {
-      body: {
-        body: definitions["v1TestRateLimitsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1TestRateLimitsResponse"];
       };
       /** An unexpected error response. */
       default: {

--- a/packages/sdk-types/src/__generated__/types.ts
+++ b/packages/sdk-types/src/__generated__/types.ts
@@ -384,6 +384,8 @@ export type v1WalletAccountParams = {
   path: string;
   /** Address format used to generate a wallet Acccount. */
   addressFormat: v1AddressFormat;
+  /** Optional human-readable name for the account. */
+  name?: string;
 };
 
 export type v1WalletParams = {
@@ -497,6 +499,8 @@ export type externaldatav1Credential = {
   /** The public component of a cryptographic key pair used to sign messages and transactions. */
   publicKey: string;
   type: v1CredentialType;
+  /** The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN. */
+  sessionProfileId?: string;
 };
 
 export type externaldatav1Quorum = {
@@ -608,7 +612,8 @@ export type v1ActivityStatus =
   | "ACTIVITY_STATUS_COMPLETED"
   | "ACTIVITY_STATUS_FAILED"
   | "ACTIVITY_STATUS_CONSENSUS_NEEDED"
-  | "ACTIVITY_STATUS_REJECTED";
+  | "ACTIVITY_STATUS_REJECTED"
+  | "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED";
 
 export type v1ActivityType =
   | "ACTIVITY_TYPE_CREATE_API_KEYS"
@@ -748,7 +753,16 @@ export type v1ActivityType =
   | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
   | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
   | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-  | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+  | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+  | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
+  | "ACTIVITY_TYPE_CREATE_MFA_POLICY"
+  | "ACTIVITY_TYPE_UPDATE_MFA_POLICY"
+  | "ACTIVITY_TYPE_DELETE_MFA_POLICY"
+  | "ACTIVITY_TYPE_CREATE_SESSION_PROFILE"
+  | "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER"
+  | "ACTIVITY_TYPE_EARN_DEPOSIT"
+  | "ACTIVITY_TYPE_EARN_WITHDRAW"
+  | "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG";
 
 export type v1ApiKey = {
   /** A User credential that can be used to authenticate to Turnkey. */
@@ -833,6 +847,28 @@ export type v1AssetMetadata = {
   name?: string;
 };
 
+export type v1AuthenticationMethod = {
+  /** The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step. */
+  type: v1AuthenticationType;
+  /** Optional specific authenticator ID required (e.g., for requiring a specific session profile id) */
+  id?: string;
+};
+
+export type v1AuthenticationMethodParams = {
+  /** The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication). */
+  type: v1AuthenticationType;
+  /** Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used. */
+  id?: string;
+};
+
+export type v1AuthenticationType =
+  | "AUTHENTICATION_TYPE_EMAIL_OTP"
+  | "AUTHENTICATION_TYPE_SMS_OTP"
+  | "AUTHENTICATION_TYPE_PASSKEY"
+  | "AUTHENTICATION_TYPE_API_KEY"
+  | "AUTHENTICATION_TYPE_OAUTH"
+  | "AUTHENTICATION_TYPE_SESSION";
+
 export type v1Authenticator = {
   /** Types of transports that may be used by an Authenticator (e.g., USB, NFC, BLE). */
   transports: v1AuthenticatorTransport[];
@@ -875,9 +911,9 @@ export type v1BootProof = {
   ephemeralPublicKeyHex: string;
   /** The DER encoded COSE Sign1 struct Attestation doc. */
   awsAttestationDocB64: string;
-  /** The borsch serialized base64 encoded Manifest. */
+  /** The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
   qosManifestB64: string;
-  /** The borsch serialized base64 encoded Manifest Envelope. */
+  /** The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
   qosManifestEnvelopeB64: string;
   /** The label under which the enclave app was deployed. */
   deploymentLabel: string;
@@ -886,6 +922,8 @@ export type v1BootProof = {
   /** Owner of the app i.e. 'tkhq' */
   owner: string;
   createdAt: externaldatav1Timestamp;
+  /** QOS manifest schema version. */
+  qosManifestVersion?: string;
 };
 
 export type v1BootProofResponse = {
@@ -1013,6 +1051,35 @@ export type v1CreateInvitationsRequest = {
 export type v1CreateInvitationsResult = {
   /** A list of Invitation IDs */
   invitationIds: string[];
+};
+
+export type v1CreateMfaPolicyIntent = {
+  /** The ID of the User to add the MFA Policy to. */
+  userId: string;
+  /** Human-readable name for a Policy. */
+  mfaPolicyName: string;
+  /** A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+  condition: string;
+  /** An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+  requiredAuthenticationMethods: v1RequiredAuthenticationMethodParams[];
+  /** The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first. */
+  order: number;
+  /** Notes for an MFA Policy. */
+  notes?: string;
+};
+
+export type v1CreateMfaPolicyRequest = {
+  type: "ACTIVITY_TYPE_CREATE_MFA_POLICY";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1CreateMfaPolicyIntent;
+};
+
+export type v1CreateMfaPolicyResult = {
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
 };
 
 export type v1CreateOauth2CredentialIntent = {
@@ -1312,6 +1379,31 @@ export type v1CreateReadWriteSessionResultV2 = {
   credentialBundle: string;
 };
 
+export type v1CreateSessionProfileIntent = {
+  /** Human-readable name for a Session Profile. */
+  sessionProfileName: string;
+  /** The scope string that defines the permissions for this Session Profile. */
+  scope: string;
+  /** The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities. */
+  expirationSeconds?: string;
+  /** Notes for a Session Profile. */
+  notes?: string;
+};
+
+export type v1CreateSessionProfileRequest = {
+  type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1CreateSessionProfileIntent;
+};
+
+export type v1CreateSessionProfileResult = {
+  /** Unique identifier for a given Session Profile. */
+  sessionProfileId: string;
+};
+
 export type v1CreateSmartContractInterfaceIntent = {
   /** Corresponding contract address or program ID */
   smartContractAddress: string;
@@ -1524,6 +1616,8 @@ export type v1CreateTvcAppIntent = {
   shareSetParams?: v1TvcOperatorSetParams;
   /** Enables network egress for this TVC app. Default if not provided: false. */
   enableEgress?: boolean;
+  /** When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+  enableDebugModeDeployments?: boolean;
 };
 
 export type v1CreateTvcAppRequest = {
@@ -1850,6 +1944,27 @@ export type v1DeleteInvitationRequest = {
 export type v1DeleteInvitationResult = {
   /** Unique identifier for a given Invitation. */
   invitationId: string;
+};
+
+export type v1DeleteMfaPolicyIntent = {
+  /** The ID of the User to delete the MFA Policy from. */
+  userId: string;
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+};
+
+export type v1DeleteMfaPolicyRequest = {
+  type: "ACTIVITY_TYPE_DELETE_MFA_POLICY";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1DeleteMfaPolicyIntent;
+};
+
+export type v1DeleteMfaPolicyResult = {
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
 };
 
 export type v1DeleteOauth2CredentialIntent = {
@@ -2197,6 +2312,90 @@ export type v1DisablePrivateKeyResult = {
   privateKeyId: string;
 };
 
+export type v1EarnDeployWrapperIntent = {
+  /** Address of the underlying yield vault to wrap (from the EarnVaults catalog). */
+  vaultAddress: string;
+  /** CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base). */
+  chainCaip2:
+    | "eip155:1"
+    | "eip155:8453"
+    | "eip155:42161"
+    | "eip155:137"
+    | "eip155:56"
+    | "eip155:4217";
+};
+
+export type v1EarnDeployWrapperResult = {
+  /** Address of the deployed fee wrapper (the deposit target). */
+  wrapperAddress: string;
+  /** Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave). */
+  splitterAddress: string;
+  /** Transaction hash of the wrapper deployment. */
+  deployTxHash: string;
+};
+
+export type v1EarnDepositIntent = {
+  /** Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault. */
+  vaultAddress: string;
+  /** A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+  signWith: string;
+  /** Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals). */
+  assets: string;
+  /** CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base). */
+  chainCaip2:
+    | "eip155:1"
+    | "eip155:8453"
+    | "eip155:42161"
+    | "eip155:137"
+    | "eip155:56"
+    | "eip155:4217";
+  /** Whether to sponsor this transaction via Gas Station. */
+  sponsor?: boolean;
+};
+
+export type v1EarnDepositResult = {
+  /** Transaction hash of the deposit. */
+  depositTxHash: string;
+  /** Number of wrapper shares minted to the depositor, in raw on-chain units. */
+  sharesMinted: string;
+  /** Address of the fee wrapper the deposit was routed to. */
+  wrapperAddress: string;
+  /** Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path). */
+  depositRequestId: string;
+};
+
+export type v1EarnWithdrawIntent = {
+  /** Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault. */
+  vaultAddress: string;
+  /** A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+  signWith: string;
+  /** CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base). */
+  chainCaip2:
+    | "eip155:1"
+    | "eip155:8453"
+    | "eip155:42161"
+    | "eip155:137"
+    | "eip155:56"
+    | "eip155:4217";
+  /** Whether to sponsor this transaction via Gas Station. */
+  sponsor?: boolean;
+  /** Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims). */
+  amountType: "SHARES" | "ASSETS";
+  /** The amount to withdraw, in raw on-chain units, interpreted according to amount_type. */
+  amountValue: string;
+};
+
+export type v1EarnWithdrawResult = {
+  /** Transaction hash of the withdrawal. */
+  withdrawTxHash: string;
+  /** Identifier to poll withdrawal status via EarnWithdrawStatus. */
+  withdrawRequestId: string;
+  /** Amount of the underlying asset received, in raw on-chain units. */
+  assetsReceived: string;
+  /** Number of wrapper shares burned, in raw on-chain units. */
+  sharesBurned: string;
+};
+
 export type v1Effect = "EFFECT_ALLOW" | "EFFECT_DENY";
 
 export type v1EmailAuthCustomizationParams = {
@@ -2322,6 +2521,15 @@ export type v1EnableAuthProxyResult = {
   userId: string;
 };
 
+export type v1EthCallParams = {
+  /** Recipient address as a hex string with 0x prefix. */
+  to: string;
+  /** Amount of native asset to send in wei. */
+  value?: string;
+  /** Hex-encoded call data for contract interactions. */
+  data?: string;
+};
+
 export type v1EthFailureDetails = {
   /** Ethereum revert chain, ordered from outermost to innermost. */
   revertChain?: v1RevertChainEntry[];
@@ -2337,7 +2545,9 @@ export type v1EthSendRawTransactionIntent = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
 };
 
 export type v1EthSendRawTransactionResult = {
@@ -2357,7 +2567,9 @@ export type v1EthSendTransactionIntent = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Recipient address as a hex string with 0x prefix. */
   to: string;
   /** Amount of native asset to send in wei. */
@@ -2378,17 +2590,53 @@ export type v1EthSendTransactionIntent = {
   gasStationNonce?: string;
 };
 
+export type v1EthSendTransactionIntentV2 = {
+  /** A wallet or private key address to sign with. This does not support private key IDs. */
+  from: string;
+  /** CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet). */
+  caip2:
+    | "eip155:1"
+    | "eip155:11155111"
+    | "eip155:8453"
+    | "eip155:84532"
+    | "eip155:137"
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
+  /** Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+  sponsor?: boolean;
+  /** Outer transaction nonce. Omit to auto-fetch. */
+  nonce?: string;
+  /** Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+  gasLimit?: string;
+  /** Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+  maxFeePerGas?: string;
+  /** Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+  maxPriorityFeePerGas?: string;
+  /** Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+  deadline?: string;
+  /** The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+  gasStationNonce?: string;
+  /** Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+  calls: v1EthCallParams[];
+};
+
 export type v1EthSendTransactionRequest = {
-  type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+  type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
   /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
   timestampMs: string;
   /** Unique identifier for a given Organization. */
   organizationId: string;
-  parameters: v1EthSendTransactionIntent;
+  parameters: v1EthSendTransactionIntentV2;
   generateAppProofs?: boolean;
 };
 
 export type v1EthSendTransactionResult = {
+  /** The send_transaction_status ID associated with the transaction submission */
+  sendTransactionStatusId: string;
+};
+
+export type v1EthSendTransactionResultV2 = {
   /** The send_transaction_status ID associated with the transaction submission */
   sendTransactionStatusId: string;
 };
@@ -2709,6 +2957,46 @@ export type v1GetLatestBootProofRequest = {
   appName: string;
 };
 
+export type v1GetMfaPoliciesRequest = {
+  /** Unique identifier for a given organization. */
+  organizationId: string;
+  /** Unique identifier for a given user. */
+  userId: string;
+};
+
+export type v1GetMfaPoliciesResponse = {
+  /** A list of multi-factor authentication policies for a user. */
+  mfaPolicies: v1MfaPolicy[];
+};
+
+export type v1GetMfaPolicyRequest = {
+  /** Unique identifier for a given organization. */
+  organizationId: string;
+  /** Unique identifier for a given user. */
+  userId: string;
+  /** Unique identifier for a given MFA policy. */
+  mfaPolicyId: string;
+};
+
+export type v1GetMfaPolicyResponse = {
+  /** Multi-factor authentication policy for a user. */
+  mfaPolicy: v1MfaPolicy;
+};
+
+export type v1GetMfaStatusRequest = {
+  /** Unique identifier for a given organization. */
+  organizationId: string;
+  /** The unique identifier of the activity to get MFA status for. */
+  activityId: string;
+  /** Optional user ID to filter MFA status for a specific user. */
+  userId?: string;
+};
+
+export type v1GetMfaStatusResponse = {
+  /** A list of MFA statuses for the activity's votes. */
+  mfaStatuses: v1MfaStatus[];
+};
+
 export type v1GetNoncesRequest = {
   /** Unique identifier for a given Organization. */
   organizationId: string;
@@ -2721,7 +3009,9 @@ export type v1GetNoncesRequest = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Whether to fetch the standard on-chain nonce. */
   nonce?: boolean;
   /** Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -2857,6 +3147,28 @@ export type v1GetSendTransactionStatusResponse = {
   error?: v1TxError;
 };
 
+export type v1GetSessionProfileRequest = {
+  /** Unique identifier for a given organization. */
+  organizationId: string;
+  /** Unique identifier for a session profile. */
+  sessionProfileId: string;
+};
+
+export type v1GetSessionProfileResponse = {
+  /** Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies. */
+  sessionProfile: v1SessionProfile;
+};
+
+export type v1GetSessionProfilesRequest = {
+  /** Unique identifier for a given organization. */
+  organizationId: string;
+};
+
+export type v1GetSessionProfilesResponse = {
+  /** A list of session profiles for users in the organization. */
+  sessionProfiles: v1SessionProfile[];
+};
+
 export type v1GetSmartContractInterfaceRequest = {
   /** Unique identifier for a given organization. */
   organizationId: string;
@@ -2927,6 +3239,22 @@ export type v1GetTvcAppsRequest = {
 export type v1GetTvcAppsResponse = {
   /** A list of TVC Apps. */
   tvcApps: v1TvcApp[];
+};
+
+export type v1GetTvcDeploymentDebugLogsRequest = {
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  /** Unique identifier for a given TVC Deployment. The deployment must be running in debug mode. */
+  deploymentId: string;
+  /** Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied. */
+  tailLines?: number;
+  /** Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs. */
+  sinceSeconds?: string;
+};
+
+export type v1GetTvcDeploymentDebugLogsResponse = {
+  /** Application log entries sorted by platform timestamp. */
+  entries: v1TvcDeploymentDebugLogEntry[];
 };
 
 export type v1GetTvcDeploymentRequest = {
@@ -3024,6 +3352,12 @@ export type v1GetWalletAddressBalancesRequest = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -3587,6 +3921,15 @@ export type v1Intent = {
   sparkClaimTransferIntent?: v1SparkClaimTransferIntent;
   sparkPrepareLightningReceiveIntent?: v1SparkPrepareLightningReceiveIntent;
   postTvcQuorumKeyShareIntent?: v1PostTvcQuorumKeyShareIntent;
+  ethSendTransactionIntentV2?: v1EthSendTransactionIntentV2;
+  createMfaPolicyIntent?: v1CreateMfaPolicyIntent;
+  updateMfaPolicyIntent?: v1UpdateMfaPolicyIntent;
+  deleteMfaPolicyIntent?: v1DeleteMfaPolicyIntent;
+  createSessionProfileIntent?: v1CreateSessionProfileIntent;
+  earnDeployWrapperIntent?: v1EarnDeployWrapperIntent;
+  earnDepositIntent?: v1EarnDepositIntent;
+  earnWithdrawIntent?: v1EarnWithdrawIntent;
+  upsertEarnClientFeeConfigIntent?: v1UpsertEarnClientFeeConfigIntent;
 };
 
 export type v1InvitationParams = {
@@ -3670,6 +4013,12 @@ export type v1ListSupportedAssetsRequest = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -3698,9 +4047,46 @@ export type v1ListWebhookEndpointsResponse = {
   webhookEndpoints: v1WebhookEndpointData[];
 };
 
+export type v1LogLine = {
+  /** One log line, exactly as the application printed it (without the trailing newline) */
+  content: string;
+  /** When the line was logged. Stable across replays, so lines can be chronologically merged across pods */
+  ts?: externaldatav1Timestamp;
+};
+
 export type v1LoginUsage = {
   /** Public key for authentication */
   publicKey: string;
+};
+
+export type v1MfaPolicy = {
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+  /** Human-readable name for an MFA Policy. */
+  mfaPolicyName: string;
+  /** A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+  condition: string;
+  /** An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+  requiredAuthenticationMethods: v1RequiredAuthenticationMethod[];
+  /** The order in which this policy is evaluated relative to other MFA policies. */
+  order: number;
+  /** Optional human-readable notes added by a User to describe a particular MFA policy. */
+  notes?: string;
+  createdAt: externaldatav1Timestamp;
+  updatedAt: externaldatav1Timestamp;
+};
+
+export type v1MfaStatus = {
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+  /** Unique identifier for a given User. */
+  userId: string;
+  /** Whether the MFA policy requirements are currently satisfied. */
+  satisfied: boolean;
+  /** A list of authentication methods already satisfied for this MFA policy. */
+  satisfiedMethods: v1AuthenticationMethod[];
+  /** An ordered list of authentication requirements needed to satisfy this MFA policy. */
+  requiredMethods: v1RequiredAuthenticationMethod[];
 };
 
 export type v1MnemonicLanguage =
@@ -3795,6 +4181,8 @@ export type v1OauthLoginIntent = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  /** Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+  sessionProfileId?: string;
 };
 
 export type v1OauthLoginRequest = {
@@ -3904,6 +4292,8 @@ export type v1OtpLoginIntent = {
   invalidateExisting?: boolean;
   /** Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step. */
   clientSignature?: v1ClientSignature;
+  /** Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+  sessionProfileId?: string;
 };
 
 export type v1OtpLoginIntentV2 = {
@@ -3917,6 +4307,8 @@ export type v1OtpLoginIntentV2 = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login sessions */
   invalidateExisting?: boolean;
+  /** Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+  sessionProfileId?: string;
 };
 
 export type v1OtpLoginResult = {
@@ -3930,7 +4322,8 @@ export type v1Outcome =
   | "OUTCOME_DENY_IMPLICIT"
   | "OUTCOME_REQUIRES_CONSENSUS"
   | "OUTCOME_REJECTED"
-  | "OUTCOME_ERROR";
+  | "OUTCOME_ERROR"
+  | "OUTCOME_REQUIRES_AUTHENTICATORS";
 
 export type v1Pagination = {
   /** A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
@@ -4106,6 +4499,16 @@ export type v1RemoveOrganizationFeatureResult = {
   features: v1Feature[];
 };
 
+export type v1RequiredAuthenticationMethod = {
+  /** A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+  any: v1AuthenticationMethod[];
+};
+
+export type v1RequiredAuthenticationMethodParams = {
+  /** A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+  any: v1AuthenticationMethodParams[];
+};
+
 export type v1RestoreTvcDeploymentIntent = {
   /** The unique identifier of the TVC deployment to restore. */
   deploymentId: string;
@@ -4243,6 +4646,15 @@ export type v1Result = {
   sparkClaimTransferResult?: v1SparkClaimTransferResult;
   sparkPrepareLightningReceiveResult?: v1SparkPrepareLightningReceiveResult;
   postTvcQuorumKeyShareResult?: v1PostTvcQuorumKeyShareResult;
+  ethSendTransactionResultV2?: v1EthSendTransactionResultV2;
+  createMfaPolicyResult?: v1CreateMfaPolicyResult;
+  updateMfaPolicyResult?: v1UpdateMfaPolicyResult;
+  deleteMfaPolicyResult?: v1DeleteMfaPolicyResult;
+  createSessionProfileResult?: v1CreateSessionProfileResult;
+  earnDeployWrapperResult?: v1EarnDeployWrapperResult;
+  earnDepositResult?: v1EarnDepositResult;
+  earnWithdrawResult?: v1EarnWithdrawResult;
+  upsertEarnClientFeeConfigResult?: v1UpsertEarnClientFeeConfigResult;
 };
 
 export type v1RevertChainEntry = {
@@ -4337,6 +4749,21 @@ export type v1SelectorV2 = {
   subject?: string;
   operator?: v1Operator;
   targets?: string[];
+};
+
+export type v1SessionProfile = {
+  /** Unique identifier for a given Session Profile. */
+  sessionProfileId: string;
+  /** Human-readable name for a Session Profile. */
+  sessionProfileName: string;
+  /** The specific scope that a session created with this profile is limited to. */
+  scope: string;
+  /** Optional window (in seconds) indicating how long sessions created with this profile should last. */
+  expirationSeconds?: string;
+  /** Optional human-readable notes added by a User to describe a particular Session Profile. */
+  notes?: string;
+  createdAt: externaldatav1Timestamp;
+  updatedAt: externaldatav1Timestamp;
 };
 
 export type v1SetIpAllowlistIntent = {
@@ -4805,6 +5232,8 @@ export type v1StampLoginIntent = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  /** Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+  sessionProfileId?: string;
 };
 
 export type v1StampLoginRequest = {
@@ -4862,6 +5291,8 @@ export type v1TvcApp = {
   liveDeploymentId?: string;
   /** The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
   publicDomain: string;
+  /** Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+  enableDebugModeDeployments: boolean;
 };
 
 export type v1TvcContainerSpec = {
@@ -4904,6 +5335,13 @@ export type v1TvcDeployment = {
   updatedAt: externaldatav1Timestamp;
   /** Whether or not the user wants this deployment deleted from the cluster. */
   delete: boolean;
+};
+
+export type v1TvcDeploymentDebugLogEntry = {
+  /** Application log line with its platform timestamp. */
+  line: v1LogLine;
+  /** Public replica label that produced this log line, for example 'replica 2/3'. */
+  replicaLabel: string;
 };
 
 export type v1TvcHealthCheckType =
@@ -5077,6 +5515,37 @@ export type v1UpdateFiatOnRampCredentialRequest = {
 export type v1UpdateFiatOnRampCredentialResult = {
   /** Unique identifier of the Fiat On-Ramp credential that was updated */
   fiatOnRampCredentialId: string;
+};
+
+export type v1UpdateMfaPolicyIntent = {
+  /** The ID of the User to update the MFA Policy for. */
+  userId: string;
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+  /** Human-readable name for a Policy. */
+  mfaPolicyName?: string;
+  /** A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+  condition?: string;
+  /** An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+  requiredAuthenticationMethods?: v1RequiredAuthenticationMethodParams[];
+  /** The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first. */
+  order?: number;
+  /** Notes for an MFA Policy. */
+  notes?: string;
+};
+
+export type v1UpdateMfaPolicyRequest = {
+  type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1UpdateMfaPolicyIntent;
+};
+
+export type v1UpdateMfaPolicyResult = {
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
 };
 
 export type v1UpdateOauth2CredentialIntent = {
@@ -5411,6 +5880,18 @@ export type v1UpdateWebhookEndpointResult = {
   webhookEndpoint: v1WebhookEndpointData;
 };
 
+export type v1UpsertEarnClientFeeConfigIntent = {
+  /** Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+  clientFeeBps: string;
+  /** The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
+  clientFeeWallet: string;
+};
+
+export type v1UpsertEarnClientFeeConfigResult = {
+  /** Transaction hash of the fee configuration update. */
+  feeUpdateTxHash: string;
+};
+
 export type v1UpsertGasUsageConfigIntent = {
   /** Gas sponsorship USD limit for the billing organization window. */
   orgWindowLimitUsd: string;
@@ -5450,6 +5931,8 @@ export type v1User = {
   oauthProviders: v1OauthProvider[];
   createdAt: externaldatav1Timestamp;
   updatedAt: externaldatav1Timestamp;
+  /** A list of MFA Policies that define multi-factor authentication requirements for this user. */
+  mfaPolicies: v1MfaPolicy[];
 };
 
 export type v1UserParams = {
@@ -5609,6 +6092,8 @@ export type v1WalletAccount = {
   publicKey?: string;
   /** Wallet details for this account. This is only present when include_wallet_details=true. */
   walletDetails?: v1Wallet;
+  /** Human-readable name for this Wallet Account, unique within the organization. */
+  name?: string;
 };
 
 export type v1WalletKitSettingsParams = {
@@ -5785,6 +6270,49 @@ export type TGetLatestBootProofBody = {
 
 export type TGetLatestBootProofInput = { body: TGetLatestBootProofBody };
 
+export type TGetMfaPoliciesResponse = {
+  /** A list of multi-factor authentication policies for a user. */
+  mfaPolicies: v1MfaPolicy[];
+};
+
+export type TGetMfaPoliciesBody = {
+  organizationId?: string;
+  /** Unique identifier for a given user. */
+  userId: string;
+};
+
+export type TGetMfaPoliciesInput = { body: TGetMfaPoliciesBody };
+
+export type TGetMfaPolicyResponse = {
+  /** Multi-factor authentication policy for a user. */
+  mfaPolicy: v1MfaPolicy;
+};
+
+export type TGetMfaPolicyBody = {
+  organizationId?: string;
+  /** Unique identifier for a given user. */
+  userId: string;
+  /** Unique identifier for a given MFA policy. */
+  mfaPolicyId: string;
+};
+
+export type TGetMfaPolicyInput = { body: TGetMfaPolicyBody };
+
+export type TGetMfaStatusResponse = {
+  /** A list of MFA statuses for the activity's votes. */
+  mfaStatuses: v1MfaStatus[];
+};
+
+export type TGetMfaStatusBody = {
+  organizationId?: string;
+  /** The unique identifier of the activity to get MFA status for. */
+  activityId: string;
+  /** Optional user ID to filter MFA status for a specific user. */
+  userId?: string;
+};
+
+export type TGetMfaStatusInput = { body: TGetMfaStatusBody };
+
 export type TGetNoncesResponse = {
   /** The standard on-chain nonce for the address, if requested. */
   nonce?: string;
@@ -5803,7 +6331,9 @@ export type TGetNoncesBody = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Whether to fetch the standard on-chain nonce. */
   nonce?: boolean;
   /** Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -5928,6 +6458,30 @@ export type TGetSendTransactionStatusInput = {
   body: TGetSendTransactionStatusBody;
 };
 
+export type TGetSessionProfileResponse = {
+  /** Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies. */
+  sessionProfile: v1SessionProfile;
+};
+
+export type TGetSessionProfileBody = {
+  organizationId?: string;
+  /** Unique identifier for a session profile. */
+  sessionProfileId: string;
+};
+
+export type TGetSessionProfileInput = { body: TGetSessionProfileBody };
+
+export type TGetSessionProfilesResponse = {
+  /** A list of session profiles for users in the organization. */
+  sessionProfiles: v1SessionProfile[];
+};
+
+export type TGetSessionProfilesBody = {
+  organizationId?: string;
+};
+
+export type TGetSessionProfilesInput = { body: TGetSessionProfilesBody };
+
 export type TGetSmartContractInterfaceResponse = {
   /** Object to be used in conjunction with policies to guard transaction signing. */
   smartContractInterface: externaldatav1SmartContractInterface;
@@ -5968,6 +6522,25 @@ export type TGetTvcDeploymentBody = {
 };
 
 export type TGetTvcDeploymentInput = { body: TGetTvcDeploymentBody };
+
+export type TGetTvcDeploymentDebugLogsResponse = {
+  /** Application log entries sorted by platform timestamp. */
+  entries: v1TvcDeploymentDebugLogEntry[];
+};
+
+export type TGetTvcDeploymentDebugLogsBody = {
+  organizationId?: string;
+  /** Unique identifier for a given TVC Deployment. The deployment must be running in debug mode. */
+  deploymentId: string;
+  /** Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied. */
+  tailLines?: number;
+  /** Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs. */
+  sinceSeconds?: string;
+};
+
+export type TGetTvcDeploymentDebugLogsInput = {
+  body: TGetTvcDeploymentDebugLogsBody;
+};
 
 export type TGetUserResponse = {
   /** Web and/or API user within your organization. */
@@ -6029,6 +6602,12 @@ export type TGetWalletAddressBalancesBody = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -6166,6 +6745,12 @@ export type TListSupportedAssetsBody = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -6399,6 +6984,31 @@ export type TCreateInvitationsBody = {
 
 export type TCreateInvitationsInput = { body: TCreateInvitationsBody };
 
+export type TCreateMfaPolicyResponse = {
+  activity: v1Activity;
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+};
+
+export type TCreateMfaPolicyBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  /** The ID of the User to add the MFA Policy to. */
+  userId: string;
+  /** Human-readable name for a Policy. */
+  mfaPolicyName: string;
+  /** A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+  condition: string;
+  /** An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+  requiredAuthenticationMethods: v1RequiredAuthenticationMethodParams[];
+  /** The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first. */
+  order: number;
+  /** Notes for an MFA Policy. */
+  notes?: string;
+};
+
+export type TCreateMfaPolicyInput = { body: TCreateMfaPolicyBody };
+
 export type TCreateOauth2CredentialResponse = {
   activity: v1Activity;
   /** Unique identifier of the OAuth 2.0 credential that was created */
@@ -6575,6 +7185,27 @@ export type TCreateReadWriteSessionInput = {
   body: TCreateReadWriteSessionBody;
 };
 
+export type TCreateSessionProfileResponse = {
+  activity: v1Activity;
+  /** Unique identifier for a given Session Profile. */
+  sessionProfileId: string;
+};
+
+export type TCreateSessionProfileBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  /** Human-readable name for a Session Profile. */
+  sessionProfileName: string;
+  /** The scope string that defines the permissions for this Session Profile. */
+  scope: string;
+  /** The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities. */
+  expirationSeconds?: string;
+  /** Notes for a Session Profile. */
+  notes?: string;
+};
+
+export type TCreateSessionProfileInput = { body: TCreateSessionProfileBody };
+
 export type TCreateSmartContractInterfaceResponse = {
   activity: v1Activity;
   /** The ID of the created Smart Contract Interface. */
@@ -6664,6 +7295,8 @@ export type TCreateTvcAppBody = {
   shareSetParams?: v1TvcOperatorSetParams;
   /** Enables network egress for this TVC app. Default if not provided: false. */
   enableEgress?: boolean;
+  /** When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+  enableDebugModeDeployments?: boolean;
 };
 
 export type TCreateTvcAppInput = { body: TCreateTvcAppBody };
@@ -6895,6 +7528,23 @@ export type TDeleteInvitationBody = {
 };
 
 export type TDeleteInvitationInput = { body: TDeleteInvitationBody };
+
+export type TDeleteMfaPolicyResponse = {
+  activity: v1Activity;
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+};
+
+export type TDeleteMfaPolicyBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  /** The ID of the User to delete the MFA Policy from. */
+  userId: string;
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+};
+
+export type TDeleteMfaPolicyInput = { body: TDeleteMfaPolicyBody };
 
 export type TDeleteOauth2CredentialResponse = {
   activity: v1Activity;
@@ -7208,7 +7858,9 @@ export type TEthSendTransactionBody = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Recipient address as a hex string with 0x prefix. */
   to: string;
   /** Amount of native asset to send in wei. */
@@ -7593,6 +8245,8 @@ export type TOauthLoginBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  /** Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+  sessionProfileId?: string;
   generateAppProofs?: boolean;
 };
 
@@ -7647,6 +8301,8 @@ export type TOtpLoginBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login sessions */
   invalidateExisting?: boolean;
+  /** Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+  sessionProfileId?: string;
   generateAppProofs?: boolean;
 };
 
@@ -7976,6 +8632,8 @@ export type TStampLoginBody = {
   expirationSeconds?: string;
   /** Invalidate all other previously generated Login API keys */
   invalidateExisting?: boolean;
+  /** Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+  sessionProfileId?: string;
   generateAppProofs?: boolean;
 };
 
@@ -8008,6 +8666,33 @@ export type TUpdateFiatOnRampCredentialBody = {
 export type TUpdateFiatOnRampCredentialInput = {
   body: TUpdateFiatOnRampCredentialBody;
 };
+
+export type TUpdateMfaPolicyResponse = {
+  activity: v1Activity;
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+};
+
+export type TUpdateMfaPolicyBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  /** The ID of the User to update the MFA Policy for. */
+  userId: string;
+  /** Unique identifier for a given MFA Policy. */
+  mfaPolicyId: string;
+  /** Human-readable name for a Policy. */
+  mfaPolicyName?: string;
+  /** A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+  condition?: string;
+  /** An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+  requiredAuthenticationMethods?: v1RequiredAuthenticationMethodParams[];
+  /** The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first. */
+  order?: number;
+  /** Notes for an MFA Policy. */
+  notes?: string;
+};
+
+export type TUpdateMfaPolicyInput = { body: TUpdateMfaPolicyBody };
 
 export type TUpdateOauth2CredentialResponse = {
   activity: v1Activity;

--- a/packages/sdk-types/src/__inputs__/auth_proxy.swagger.json
+++ b/packages/sdk-types/src/__inputs__/auth_proxy.swagger.json
@@ -1207,6 +1207,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-types/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-types/src/__inputs__/public_api.swagger.json
@@ -392,6 +392,102 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_mfa_policies": {
+      "post": {
+        "summary": "Get MFA policies",
+        "description": "Get all MFA policies for a user.",
+        "operationId": "PublicApiService_GetMfaPolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_policy": {
+      "post": {
+        "summary": "Get MFA policy",
+        "description": "Get a single MFA policy for a user.",
+        "operationId": "PublicApiService_GetMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
+    "/public/v1/query/get_mfa_status": {
+      "post": {
+        "summary": "Get MFA status",
+        "description": "Get the MFA status of an activity for a specific user or all voting users.",
+        "operationId": "PublicApiService_GetMfaStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMfaStatusRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/query/get_nonces": {
       "post": {
         "summary": "Get nonces",
@@ -680,6 +776,70 @@
         "tags": ["Send Transactions"]
       }
     },
+    "/public/v1/query/get_session_profile": {
+      "post": {
+        "summary": "Get session profile",
+        "description": "Get a single session profile for an organization.",
+        "operationId": "PublicApiService_GetSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
+    "/public/v1/query/get_session_profiles": {
+      "post": {
+        "summary": "Get session profiles",
+        "description": "Get all session profiles for an organization.",
+        "operationId": "PublicApiService_GetSessionProfiles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSessionProfilesRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
+      }
+    },
     "/public/v1/query/get_smart_contract_interface": {
       "post": {
         "summary": "Get smart contract interface",
@@ -770,6 +930,38 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/v1GetTvcDeploymentRequest"
+            }
+          }
+        ],
+        "tags": ["TVC"]
+      }
+    },
+    "/public/v1/query/get_tvc_deployment_debug_logs": {
+      "post": {
+        "summary": "Get TVC Deployment debug logs",
+        "description": "Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp.",
+        "operationId": "PublicApiService_GetTvcDeploymentDebugLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetTvcDeploymentDebugLogsRequest"
             }
           }
         ],
@@ -875,7 +1067,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1387,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -1704,6 +1896,38 @@
         "tags": ["Invitations"]
       }
     },
+    "/public/v1/submit/create_mfa_policy": {
+      "post": {
+        "summary": "Create MFA policy",
+        "description": "Create a new MFA policy for a user.",
+        "operationId": "PublicApiService_CreateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/create_oauth2_credential": {
       "post": {
         "summary": "Create an OAuth 2.0 Credential",
@@ -1958,6 +2182,38 @@
           }
         ],
         "tags": ["Sessions"]
+      }
+    },
+    "/public/v1/submit/create_session_profile": {
+      "post": {
+        "summary": "Create session profile",
+        "description": "Create a new session profile for an organization.",
+        "operationId": "PublicApiService_CreateSessionProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateSessionProfileRequest"
+            }
+          }
+        ],
+        "tags": ["Session Profiles"]
       }
     },
     "/public/v1/submit/create_smart_contract_interface": {
@@ -2406,6 +2662,38 @@
           }
         ],
         "tags": ["Invitations"]
+      }
+    },
+    "/public/v1/submit/delete_mfa_policy": {
+      "post": {
+        "summary": "Delete MFA policy",
+        "description": "Delete an MFA policy for a user.",
+        "operationId": "PublicApiService_DeleteMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
       }
     },
     "/public/v1/submit/delete_oauth2_credential": {
@@ -4040,6 +4328,38 @@
         "tags": ["On Ramp"]
       }
     },
+    "/public/v1/submit/update_mfa_policy": {
+      "post": {
+        "summary": "Update MFA policy",
+        "description": "Update an MFA policy for a user.",
+        "operationId": "PublicApiService_UpdateMfaPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateMfaPolicyRequest"
+            }
+          }
+        ],
+        "tags": ["MFA Policies"]
+      }
+    },
     "/public/v1/submit/update_oauth2_credential": {
       "post": {
         "summary": "Update an OAuth 2.0 Credential",
@@ -4695,6 +5015,10 @@
         },
         "type": {
           "$ref": "#/definitions/v1CredentialType"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN."
         }
       },
       "required": ["publicKey", "type"]
@@ -4984,7 +5308,8 @@
         "ACTIVITY_STATUS_COMPLETED",
         "ACTIVITY_STATUS_FAILED",
         "ACTIVITY_STATUS_CONSENSUS_NEEDED",
-        "ACTIVITY_STATUS_REJECTED"
+        "ACTIVITY_STATUS_REJECTED",
+        "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED"
       ]
     },
     "v1ActivityType": {
@@ -5127,7 +5452,16 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2",
+        "ACTIVITY_TYPE_CREATE_MFA_POLICY",
+        "ACTIVITY_TYPE_UPDATE_MFA_POLICY",
+        "ACTIVITY_TYPE_DELETE_MFA_POLICY",
+        "ACTIVITY_TYPE_CREATE_SESSION_PROFILE",
+        "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER",
+        "ACTIVITY_TYPE_EARN_DEPOSIT",
+        "ACTIVITY_TYPE_EARN_WITHDRAW",
+        "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG"
       ]
     },
     "v1AddressFormat": {
@@ -5444,6 +5778,45 @@
         "transports"
       ]
     },
+    "v1AuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., for requiring a specific session profile id)"
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1AuthenticationType",
+          "description": "The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication)."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used."
+        }
+      },
+      "required": ["type"]
+    },
+    "v1AuthenticationType": {
+      "type": "string",
+      "enum": [
+        "AUTHENTICATION_TYPE_EMAIL_OTP",
+        "AUTHENTICATION_TYPE_SMS_OTP",
+        "AUTHENTICATION_TYPE_PASSKEY",
+        "AUTHENTICATION_TYPE_API_KEY",
+        "AUTHENTICATION_TYPE_OAUTH",
+        "AUTHENTICATION_TYPE_SESSION"
+      ]
+    },
     "v1Authenticator": {
       "type": "object",
       "properties": {
@@ -5586,11 +5959,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5979,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -5960,6 +6337,78 @@
         }
       },
       "required": ["invitationIds"]
+    },
+    "v1CreateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to add the MFA Policy to."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": [
+        "userId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order"
+      ]
+    },
+    "v1CreateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1CreateOauth2CredentialIntent": {
       "type": "object",
@@ -6662,6 +7111,59 @@
         "credentialBundle"
       ]
     },
+    "v1CreateSessionProfileIntent": {
+      "type": "object",
+      "properties": {
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope string that defines the permissions for this Session Profile."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for a Session Profile."
+        }
+      },
+      "required": ["sessionProfileName", "scope"]
+    },
+    "v1CreateSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_SESSION_PROFILE"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateSessionProfileResult": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        }
+      },
+      "required": ["sessionProfileId"]
+    },
     "v1CreateSmartContractInterfaceIntent": {
       "type": "object",
       "properties": {
@@ -7188,6 +7690,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -7971,6 +8477,51 @@
         }
       },
       "required": ["invitationId"]
+    },
+    "v1DeleteMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to delete the MFA Policy from."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1DeleteMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1DeleteOauth2CredentialIntent": {
       "type": "object",
@@ -8784,6 +9335,179 @@
       },
       "required": ["privateKeyId"]
     },
+    "v1EarnDeployWrapperIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to wrap (from the EarnVaults catalog)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        }
+      },
+      "required": ["vaultAddress", "chainCaip2"]
+    },
+    "v1EarnDeployWrapperResult": {
+      "type": "object",
+      "properties": {
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee wrapper (the deposit target)."
+        },
+        "splitterAddress": {
+          "type": "string",
+          "description": "Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave)."
+        },
+        "deployTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the wrapper deployment."
+        }
+      },
+      "required": ["wrapperAddress", "splitterAddress", "deployTxHash"]
+    },
+    "v1EarnDepositIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "assets": {
+          "type": "string",
+          "description": "Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals)."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        }
+      },
+      "required": ["vaultAddress", "signWith", "assets", "chainCaip2"]
+    },
+    "v1EarnDepositResult": {
+      "type": "object",
+      "properties": {
+        "depositTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the deposit."
+        },
+        "sharesMinted": {
+          "type": "string",
+          "description": "Number of wrapper shares minted to the depositor, in raw on-chain units."
+        },
+        "wrapperAddress": {
+          "type": "string",
+          "description": "Address of the fee wrapper the deposit was routed to."
+        },
+        "depositRequestId": {
+          "type": "string",
+          "description": "Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path)."
+        }
+      },
+      "required": [
+        "depositTxHash",
+        "sharesMinted",
+        "wrapperAddress",
+        "depositRequestId"
+      ]
+    },
+    "v1EarnWithdrawIntent": {
+      "type": "object",
+      "properties": {
+        "vaultAddress": {
+          "type": "string",
+          "description": "Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault."
+        },
+        "signWith": {
+          "type": "string",
+          "description": "A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported."
+        },
+        "chainCaip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:8453",
+            "eip155:42161",
+            "eip155:137",
+            "eip155:56",
+            "eip155:4217"
+          ],
+          "description": "CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station."
+        },
+        "amountType": {
+          "type": "string",
+          "enum": ["SHARES", "ASSETS"],
+          "description": "Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims)."
+        },
+        "amountValue": {
+          "type": "string",
+          "description": "The amount to withdraw, in raw on-chain units, interpreted according to amount_type."
+        }
+      },
+      "required": [
+        "vaultAddress",
+        "signWith",
+        "chainCaip2",
+        "amountType",
+        "amountValue"
+      ]
+    },
+    "v1EarnWithdrawResult": {
+      "type": "object",
+      "properties": {
+        "withdrawTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the withdrawal."
+        },
+        "withdrawRequestId": {
+          "type": "string",
+          "description": "Identifier to poll withdrawal status via EarnWithdrawStatus."
+        },
+        "assetsReceived": {
+          "type": "string",
+          "description": "Amount of the underlying asset received, in raw on-chain units."
+        },
+        "sharesBurned": {
+          "type": "string",
+          "description": "Number of wrapper shares burned, in raw on-chain units."
+        }
+      },
+      "required": [
+        "withdrawTxHash",
+        "withdrawRequestId",
+        "assetsReceived",
+        "sharesBurned"
+      ]
+    },
     "v1Effect": {
       "type": "string",
       "enum": ["EFFECT_ALLOW", "EFFECT_DENY"]
@@ -9037,6 +9761,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9807,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9845,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9890,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9966,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9975,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9797,6 +10613,94 @@
       },
       "required": ["organizationId", "appName"]
     },
+    "v1GetMfaPoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        }
+      },
+      "required": ["organizationId", "userId"]
+    },
+    "v1GetMfaPoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of multi-factor authentication policies for a user."
+        }
+      },
+      "required": ["mfaPolicies"]
+    },
+    "v1GetMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given user."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA policy."
+        }
+      },
+      "required": ["organizationId", "userId", "mfaPolicyId"]
+    },
+    "v1GetMfaPolicyResponse": {
+      "type": "object",
+      "properties": {
+        "mfaPolicy": {
+          "$ref": "#/definitions/v1MfaPolicy",
+          "description": "Multi-factor authentication policy for a user."
+        }
+      },
+      "required": ["mfaPolicy"]
+    },
+    "v1GetMfaStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "activityId": {
+          "type": "string",
+          "description": "The unique identifier of the activity to get MFA status for."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Optional user ID to filter MFA status for a specific user."
+        }
+      },
+      "required": ["organizationId", "activityId"]
+    },
+    "v1GetMfaStatusResponse": {
+      "type": "object",
+      "properties": {
+        "mfaStatuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaStatus"
+          },
+          "description": "A list of MFA statuses for the activity's votes."
+        }
+      },
+      "required": ["mfaStatuses"]
+    },
     "v1GetNoncesRequest": {
       "type": "object",
       "properties": {
@@ -9816,7 +10720,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10108,6 +11014,54 @@
       },
       "required": ["txStatus"]
     },
+    "v1GetSessionProfileRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a session profile."
+        }
+      },
+      "required": ["organizationId", "sessionProfileId"]
+    },
+    "v1GetSessionProfileResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfile": {
+          "$ref": "#/definitions/v1SessionProfile",
+          "description": "Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies."
+        }
+      },
+      "required": ["sessionProfile"]
+    },
+    "v1GetSessionProfilesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetSessionProfilesResponse": {
+      "type": "object",
+      "properties": {
+        "sessionProfiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SessionProfile"
+          },
+          "description": "A list of session profiles for users in the organization."
+        }
+      },
+      "required": ["sessionProfiles"]
+    },
     "v1GetSmartContractInterfaceRequest": {
       "type": "object",
       "properties": {
@@ -10266,6 +11220,44 @@
         }
       },
       "required": ["tvcApps"]
+    },
+    "v1GetTvcDeploymentDebugLogsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "Unique identifier for a given TVC Deployment. The deployment must be running in debug mode."
+        },
+        "tailLines": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied."
+        },
+        "sinceSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs."
+        }
+      },
+      "required": ["organizationId", "deploymentId"]
+    },
+    "v1GetTvcDeploymentDebugLogsResponse": {
+      "type": "object",
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TvcDeploymentDebugLogEntry"
+          },
+          "description": "Application log entries sorted by platform timestamp."
+        }
+      },
+      "required": ["entries"]
     },
     "v1GetTvcDeploymentRequest": {
       "type": "object",
@@ -10462,6 +11454,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +12810,33 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
+        },
+        "createMfaPolicyIntent": {
+          "$ref": "#/definitions/v1CreateMfaPolicyIntent"
+        },
+        "updateMfaPolicyIntent": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        },
+        "deleteMfaPolicyIntent": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyIntent"
+        },
+        "createSessionProfileIntent": {
+          "$ref": "#/definitions/v1CreateSessionProfileIntent"
+        },
+        "earnDeployWrapperIntent": {
+          "$ref": "#/definitions/v1EarnDeployWrapperIntent"
+        },
+        "earnDepositIntent": {
+          "$ref": "#/definitions/v1EarnDepositIntent"
+        },
+        "earnWithdrawIntent": {
+          "$ref": "#/definitions/v1EarnWithdrawIntent"
+        },
+        "upsertEarnClientFeeConfigIntent": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigIntent"
         }
       }
     },
@@ -11998,6 +13023,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -12066,6 +13097,20 @@
       },
       "required": ["webhookEndpoints"]
     },
+    "v1LogLine": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "One log line, exactly as the application printed it (without the trailing newline)"
+        },
+        "ts": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "When the line was logged. Stable across replays, so lines can be chronologically merged across pods"
+        }
+      },
+      "required": ["content"]
+    },
     "v1LoginUsage": {
       "type": "object",
       "properties": {
@@ -12075,6 +13120,95 @@
         }
       },
       "required": ["publicKey"]
+    },
+    "v1MfaPolicy": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for an MFA Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this policy is evaluated relative to other MFA policies."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular MFA policy."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "mfaPolicyName",
+        "condition",
+        "requiredAuthenticationMethods",
+        "order",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "v1MfaStatus": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "userId": {
+          "type": "string",
+          "description": "Unique identifier for a given User."
+        },
+        "satisfied": {
+          "type": "boolean",
+          "description": "Whether the MFA policy requirements are currently satisfied."
+        },
+        "satisfiedMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods already satisfied for this MFA policy."
+        },
+        "requiredMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethod"
+          },
+          "description": "An ordered list of authentication requirements needed to satisfy this MFA policy."
+        }
+      },
+      "required": [
+        "mfaPolicyId",
+        "userId",
+        "satisfied",
+        "satisfiedMethods",
+        "requiredMethods"
+      ]
     },
     "v1MnemonicLanguage": {
       "type": "string",
@@ -12278,6 +13412,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["oidcToken", "publicKey"]
@@ -12558,6 +13696,10 @@
         "clientSignature": {
           "$ref": "#/definitions/v1ClientSignature",
           "description": "Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step."
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey"]
@@ -12584,6 +13726,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login sessions"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["verificationToken", "publicKey", "clientSignature"]
@@ -12630,7 +13776,8 @@
         "OUTCOME_DENY_IMPLICIT",
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
-        "OUTCOME_ERROR"
+        "OUTCOME_ERROR",
+        "OUTCOME_REQUIRES_AUTHENTICATORS"
       ]
     },
     "v1Pagination": {
@@ -13064,6 +14211,34 @@
       },
       "required": ["features"]
     },
+    "v1RequiredAuthenticationMethod": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethod"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
+    "v1RequiredAuthenticationMethodParams": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AuthenticationMethodParams"
+          },
+          "description": "A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them."
+        }
+      },
+      "required": ["any"]
+    },
     "v1RestoreTvcDeploymentIntent": {
       "type": "object",
       "properties": {
@@ -13458,6 +14633,33 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
+        },
+        "createMfaPolicyResult": {
+          "$ref": "#/definitions/v1CreateMfaPolicyResult"
+        },
+        "updateMfaPolicyResult": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyResult"
+        },
+        "deleteMfaPolicyResult": {
+          "$ref": "#/definitions/v1DeleteMfaPolicyResult"
+        },
+        "createSessionProfileResult": {
+          "$ref": "#/definitions/v1CreateSessionProfileResult"
+        },
+        "earnDeployWrapperResult": {
+          "$ref": "#/definitions/v1EarnDeployWrapperResult"
+        },
+        "earnDepositResult": {
+          "$ref": "#/definitions/v1EarnDepositResult"
+        },
+        "earnWithdrawResult": {
+          "$ref": "#/definitions/v1EarnWithdrawResult"
+        },
+        "upsertEarnClientFeeConfigResult": {
+          "$ref": "#/definitions/v1UpsertEarnClientFeeConfigResult"
         }
       }
     },
@@ -13710,6 +14912,44 @@
           }
         }
       }
+    },
+    "v1SessionProfile": {
+      "type": "object",
+      "properties": {
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Unique identifier for a given Session Profile."
+        },
+        "sessionProfileName": {
+          "type": "string",
+          "description": "Human-readable name for a Session Profile."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The specific scope that a session created with this profile is limited to."
+        },
+        "expirationSeconds": {
+          "type": "string",
+          "description": "Optional window (in seconds) indicating how long sessions created with this profile should last."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional human-readable notes added by a User to describe a particular Session Profile."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp"
+        }
+      },
+      "required": [
+        "sessionProfileId",
+        "sessionProfileName",
+        "scope",
+        "createdAt",
+        "updatedAt"
+      ]
     },
     "v1SetIpAllowlistIntent": {
       "type": "object",
@@ -14806,6 +16046,10 @@
         "invalidateExisting": {
           "type": "boolean",
           "description": "Invalidate all other previously generated Login API keys"
+        },
+        "sessionProfileId": {
+          "type": "string",
+          "description": "Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used."
         }
       },
       "required": ["publicKey"]
@@ -14925,6 +16169,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +16185,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15055,6 +16304,20 @@
         "updatedAt",
         "delete"
       ]
+    },
+    "v1TvcDeploymentDebugLogEntry": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "$ref": "#/definitions/v1LogLine",
+          "description": "Application log line with its platform timestamp."
+        },
+        "replicaLabel": {
+          "type": "string",
+          "description": "Public replica label that produced this log line, for example 'replica 2/3'."
+        }
+      },
+      "required": ["line", "replicaLabel"]
     },
     "v1TvcHealthCheckType": {
       "type": "string",
@@ -15461,6 +16724,76 @@
         }
       },
       "required": ["fiatOnRampCredentialId"]
+    },
+    "v1UpdateMfaPolicyIntent": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The ID of the User to update the MFA Policy for."
+        },
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        },
+        "mfaPolicyName": {
+          "type": "string",
+          "description": "Human-readable name for a Policy."
+        },
+        "condition": {
+          "type": "string",
+          "description": "A condition expression that evaluates to true or false, determining when this MFA policy applies."
+        },
+        "requiredAuthenticationMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RequiredAuthenticationMethodParams"
+          },
+          "description": "An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA."
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notes for an MFA Policy."
+        }
+      },
+      "required": ["userId", "mfaPolicyId"]
+    },
+    "v1UpdateMfaPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPDATE_MFA_POLICY"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpdateMfaPolicyIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1UpdateMfaPolicyResult": {
+      "type": "object",
+      "properties": {
+        "mfaPolicyId": {
+          "type": "string",
+          "description": "Unique identifier for a given MFA Policy."
+        }
+      },
+      "required": ["mfaPolicyId"]
     },
     "v1UpdateOauth2CredentialIntent": {
       "type": "object",
@@ -16204,6 +17537,30 @@
       },
       "required": ["endpointId", "webhookEndpoint"]
     },
+    "v1UpsertEarnClientFeeConfigIntent": {
+      "type": "object",
+      "properties": {
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address."
+        }
+      },
+      "required": ["clientFeeBps", "clientFeeWallet"]
+    },
+    "v1UpsertEarnClientFeeConfigResult": {
+      "type": "object",
+      "properties": {
+        "feeUpdateTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee configuration update."
+        }
+      },
+      "required": ["feeUpdateTxHash"]
+    },
     "v1UpsertGasUsageConfigIntent": {
       "type": "object",
       "properties": {
@@ -16303,6 +17660,14 @@
         },
         "updatedAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "mfaPolicies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MfaPolicy"
+          },
+          "description": "A list of MFA Policies that define multi-factor authentication requirements for this user."
         }
       },
       "required": [
@@ -16313,7 +17678,8 @@
         "userTags",
         "oauthProviders",
         "createdAt",
-        "updatedAt"
+        "updatedAt",
+        "mfaPolicies"
       ]
     },
     "v1UserParams": {
@@ -16749,6 +18115,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +18152,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-types/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-types/src/__inputs__/public_api.types.ts
@@ -44,6 +44,18 @@ export type paths = {
     /** Get the latest boot proof for a given enclave app name. */
     post: operations["PublicApiService_GetLatestBootProof"];
   };
+  "/public/v1/query/get_mfa_policies": {
+    /** Get all MFA policies for a user. */
+    post: operations["PublicApiService_GetMfaPolicies"];
+  };
+  "/public/v1/query/get_mfa_policy": {
+    /** Get a single MFA policy for a user. */
+    post: operations["PublicApiService_GetMfaPolicy"];
+  };
+  "/public/v1/query/get_mfa_status": {
+    /** Get the MFA status of an activity for a specific user or all voting users. */
+    post: operations["PublicApiService_GetMfaStatus"];
+  };
   "/public/v1/query/get_nonces": {
     /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
     post: operations["PublicApiService_GetNonces"];
@@ -59,10 +71,6 @@ export type paths = {
   "/public/v1/query/get_onramp_transaction_status": {
     /** Get the status of an on ramp transaction. */
     post: operations["PublicApiService_GetOnRampTransactionStatus"];
-  };
-  "/public/v1/query/get_organization": {
-    /** Get details about an organization. */
-    post: operations["PublicApiService_GetOrganization"];
   };
   "/public/v1/query/get_organization_configs": {
     /** Get quorum settings and features for an organization. */
@@ -84,6 +92,14 @@ export type paths = {
     /** Get the status of a send transaction request. */
     post: operations["PublicApiService_GetSendTransactionStatus"];
   };
+  "/public/v1/query/get_session_profile": {
+    /** Get a single session profile for an organization. */
+    post: operations["PublicApiService_GetSessionProfile"];
+  };
+  "/public/v1/query/get_session_profiles": {
+    /** Get all session profiles for an organization. */
+    post: operations["PublicApiService_GetSessionProfiles"];
+  };
   "/public/v1/query/get_smart_contract_interface": {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
@@ -96,9 +112,9 @@ export type paths = {
     /** Get details about a single TVC Deployment */
     post: operations["PublicApiService_GetTvcDeployment"];
   };
-  "/public/v1/query/get_tvc_deployment_provisioning_details": {
-    /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-    post: operations["PublicApiService_GetTvcDeploymentProvisioningDetails"];
+  "/public/v1/query/get_tvc_deployment_debug_logs": {
+    /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+    post: operations["PublicApiService_GetTvcDeploymentDebugLogs"];
   };
   "/public/v1/query/get_user": {
     /** Get details about a user. */
@@ -113,7 +129,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +169,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -204,10 +220,6 @@ export type paths = {
     /** Add API keys to an existing user. */
     post: operations["PublicApiService_CreateApiKeys"];
   };
-  "/public/v1/submit/create_api_only_users": {
-    /** Create API-only users in an existing organization. */
-    post: operations["PublicApiService_CreateApiOnlyUsers"];
-  };
   "/public/v1/submit/create_authenticators": {
     /** Create authenticators to authenticate requests to Turnkey. */
     post: operations["PublicApiService_CreateAuthenticators"];
@@ -219,6 +231,10 @@ export type paths = {
   "/public/v1/submit/create_invitations": {
     /** Create invitations to join an existing organization. */
     post: operations["PublicApiService_CreateInvitations"];
+  };
+  "/public/v1/submit/create_mfa_policy": {
+    /** Create a new MFA policy for a user. */
+    post: operations["PublicApiService_CreateMfaPolicy"];
   };
   "/public/v1/submit/create_oauth2_credential": {
     /** Enable authentication for end users with an OAuth 2.0 provider */
@@ -251,6 +267,10 @@ export type paths = {
   "/public/v1/submit/create_read_write_session": {
     /** Create a read write session for a user. */
     post: operations["PublicApiService_CreateReadWriteSession"];
+  };
+  "/public/v1/submit/create_session_profile": {
+    /** Create a new session profile for an organization. */
+    post: operations["PublicApiService_CreateSessionProfile"];
   };
   "/public/v1/submit/create_smart_contract_interface": {
     /** Create an ABI/IDL in JSON. */
@@ -307,6 +327,10 @@ export type paths = {
   "/public/v1/submit/delete_invitation": {
     /** Delete an existing invitation. */
     post: operations["PublicApiService_DeleteInvitation"];
+  };
+  "/public/v1/submit/delete_mfa_policy": {
+    /** Delete an MFA policy for a user. */
+    post: operations["PublicApiService_DeleteMfaPolicy"];
   };
   "/public/v1/submit/delete_oauth2_credential": {
     /** Disable authentication for end users with an OAuth 2.0 provider */
@@ -371,10 +395,6 @@ export type paths = {
   "/public/v1/submit/email_auth": {
     /** Authenticate a user via email. */
     post: operations["PublicApiService_EmailAuth"];
-  };
-  "/public/v1/submit/eth_send_raw_transaction": {
-    /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-    post: operations["PublicApiService_EthSendRawTransaction"];
   };
   "/public/v1/submit/eth_send_transaction": {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
@@ -443,10 +463,6 @@ export type paths = {
   "/public/v1/submit/otp_login": {
     /** Create an OTP session for a user. */
     post: operations["PublicApiService_OtpLogin"];
-  };
-  "/public/v1/submit/post_tvc_quorum_key_share": {
-    /** Post re-encrypted quorum key share for a TVC deployment. */
-    post: operations["PublicApiService_PostTvcQuorumKeyShare"];
   };
   "/public/v1/submit/recover_user": {
     /** Complete the process of recovering a user by adding an authenticator. */
@@ -520,6 +536,10 @@ export type paths = {
     /** Update a fiat on ramp provider credential */
     post: operations["PublicApiService_UpdateFiatOnRampCredential"];
   };
+  "/public/v1/submit/update_mfa_policy": {
+    /** Update an MFA policy for a user. */
+    post: operations["PublicApiService_UpdateMfaPolicy"];
+  };
   "/public/v1/submit/update_oauth2_credential": {
     /** Update an OAuth 2.0 provider credential */
     post: operations["PublicApiService_UpdateOauth2Credential"];
@@ -574,14 +594,6 @@ export type paths = {
   };
   "/tkhq/api/v1/noop-codegen-anchor": {
     post: operations["PublicApiService_NOOPCodegenAnchor"];
-  };
-  "/tkhq/api/v1/refresh_feature_flags": {
-    /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-    post: operations["PublicApiService_RefreshFeatureFlags"];
-  };
-  "/tkhq/api/v1/test_rate_limits": {
-    /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-    post: operations["PublicApiService_TestRateLimits"];
   };
 };
 
@@ -671,6 +683,8 @@ export type definitions = {
     /** @description The public component of a cryptographic key pair used to sign messages and transactions. */
     publicKey: string;
     type: definitions["v1CredentialType"];
+    /** @description The session profile associated with this credential, if any. This field is only applicable for credentials of type CREDENTIAL_TYPE_LOGIN. */
+    sessionProfileId?: string;
   };
   externaldatav1Quorum: {
     /**
@@ -783,7 +797,8 @@ export type definitions = {
     | "ACTIVITY_STATUS_COMPLETED"
     | "ACTIVITY_STATUS_FAILED"
     | "ACTIVITY_STATUS_CONSENSUS_NEEDED"
-    | "ACTIVITY_STATUS_REJECTED";
+    | "ACTIVITY_STATUS_REJECTED"
+    | "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED";
   /** @enum {string} */
   v1ActivityType:
     | "ACTIVITY_TYPE_CREATE_API_KEYS"
@@ -923,7 +938,16 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
+    | "ACTIVITY_TYPE_CREATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_UPDATE_MFA_POLICY"
+    | "ACTIVITY_TYPE_DELETE_MFA_POLICY"
+    | "ACTIVITY_TYPE_CREATE_SESSION_PROFILE"
+    | "ACTIVITY_TYPE_EARN_DEPLOY_WRAPPER"
+    | "ACTIVITY_TYPE_EARN_DEPOSIT"
+    | "ACTIVITY_TYPE_EARN_WITHDRAW"
+    | "ACTIVITY_TYPE_UPSERT_EARN_CLIENT_FEE_CONFIG";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1084,6 +1108,26 @@ export type definitions = {
     /** @description The type of authenticator transports. */
     transports: definitions["v1AuthenticatorTransport"][];
   };
+  v1AuthenticationMethod: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_EMAIL, AUTHENTICATION_TYPE_SESSION) required for this MFA step. */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., for requiring a specific session profile id) */
+    id?: string;
+  };
+  v1AuthenticationMethodParams: {
+    /** @description The type of authenticator (e.g., AUTHENTICATION_TYPE_PASSKEY for passkey authentication). */
+    type: definitions["v1AuthenticationType"];
+    /** @description Optional specific authenticator ID required (e.g., UUID of a passkey authenticator). If not provided, any authenticator of the specified type can be used. */
+    id?: string;
+  };
+  /** @enum {string} */
+  v1AuthenticationType:
+    | "AUTHENTICATION_TYPE_EMAIL_OTP"
+    | "AUTHENTICATION_TYPE_SMS_OTP"
+    | "AUTHENTICATION_TYPE_PASSKEY"
+    | "AUTHENTICATION_TYPE_API_KEY"
+    | "AUTHENTICATION_TYPE_OAUTH"
+    | "AUTHENTICATION_TYPE_SESSION";
   v1Authenticator: {
     /** @description Types of transports that may be used by an Authenticator (e.g., USB, NFC, BLE). */
     transports: definitions["v1AuthenticatorTransport"][];
@@ -1139,9 +1183,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1194,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1199,16 +1245,6 @@ export type definitions = {
   v1CreateApiOnlyUsersIntent: {
     /** @description A list of API-only Users to create. */
     apiOnlyUsers: definitions["v1ApiOnlyUserParams"][];
-  };
-  v1CreateApiOnlyUsersRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_CREATE_API_ONLY_USERS";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1CreateApiOnlyUsersIntent"];
-    generateAppProofs?: boolean;
   };
   v1CreateApiOnlyUsersResult: {
     /** @description A list of API-only User IDs. */
@@ -1285,6 +1321,36 @@ export type definitions = {
   v1CreateInvitationsResult: {
     /** @description A list of Invitation IDs */
     invitationIds: string[];
+  };
+  v1CreateMfaPolicyIntent: {
+    /** @description The ID of the User to add the MFA Policy to. */
+    userId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1CreateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateMfaPolicyIntent"];
+  };
+  v1CreateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1CreateOauth2CredentialIntent: {
     /** @description The OAuth 2.0 provider */
@@ -1560,6 +1626,29 @@ export type definitions = {
     /** @description HPKE encrypted credential bundle */
     credentialBundle: string;
   };
+  v1CreateSessionProfileIntent: {
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The scope string that defines the permissions for this Session Profile. */
+    scope: string;
+    /** @description The duration in seconds for which sessions created with this Session Profile are valid. If not set, expiration will be determined by the value passed in to the intent of login activities. */
+    expirationSeconds?: string;
+    /** @description Notes for a Session Profile. */
+    notes?: string;
+  };
+  v1CreateSessionProfileRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SESSION_PROFILE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSessionProfileIntent"];
+  };
+  v1CreateSessionProfileResult: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+  };
   v1CreateSmartContractInterfaceIntent: {
     /** @description Corresponding contract address or program ID */
     smartContractAddress: string;
@@ -1776,6 +1865,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2091,6 +2182,25 @@ export type definitions = {
   v1DeleteInvitationResult: {
     /** @description Unique identifier for a given Invitation. */
     invitationId: string;
+  };
+  v1DeleteMfaPolicyIntent: {
+    /** @description The ID of the User to delete the MFA Policy from. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+  };
+  v1DeleteMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteMfaPolicyIntent"];
+  };
+  v1DeleteMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1DeleteOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to delete */
@@ -2408,6 +2518,96 @@ export type definitions = {
     /** @description Unique identifier for a given Private Key. */
     privateKeyId: string;
   };
+  v1EarnDeployWrapperIntent: {
+    /** @description Address of the underlying yield vault to wrap (from the EarnVaults catalog). */
+    vaultAddress: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+  };
+  v1EarnDeployWrapperResult: {
+    /** @description Address of the deployed fee wrapper (the deposit target). */
+    wrapperAddress: string;
+    /** @description Address of the deployed fee splitter (PaymentSplitter for Morpho, RevenueSplitterOwner for Aave). */
+    splitterAddress: string;
+    /** @description Transaction hash of the wrapper deployment. */
+    deployTxHash: string;
+  };
+  v1EarnDepositIntent: {
+    /** @description Address of the underlying yield vault to deposit into. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to deposit from and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description Amount of the underlying asset to deposit, in raw on-chain units (e.g., '1000000' for 1 USDC at 6 decimals). */
+    assets: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+  };
+  v1EarnDepositResult: {
+    /** @description Transaction hash of the deposit. */
+    depositTxHash: string;
+    /** @description Number of wrapper shares minted to the depositor, in raw on-chain units. */
+    sharesMinted: string;
+    /** @description Address of the fee wrapper the deposit was routed to. */
+    wrapperAddress: string;
+    /** @description Identifier to poll deposit status via EarnDepositStatus (for the async/sponsored path). */
+    depositRequestId: string;
+  };
+  v1EarnWithdrawIntent: {
+    /** @description Address of the underlying yield vault to withdraw from. The org must have an enabled wrapper for this vault. */
+    vaultAddress: string;
+    /** @description A Wallet account address or Private Key address to withdraw to and sign with. Must be an on-chain address; Private Key identifiers are not supported. */
+    signWith: string;
+    /**
+     * @description CAIP-2 chain ID the vault lives on (e.g., 'eip155:8453' for Base).
+     * @enum {string}
+     */
+    chainCaip2:
+      | "eip155:1"
+      | "eip155:8453"
+      | "eip155:42161"
+      | "eip155:137"
+      | "eip155:56"
+      | "eip155:4217";
+    /** @description Whether to sponsor this transaction via Gas Station. */
+    sponsor?: boolean;
+    /**
+     * @description Whether amount_value is denominated in shares or assets. 'SHARES' redeems wrapper shares (calls redeem()); 'ASSETS' withdraws underlying assets (calls withdraw(), enabling yield-only claims).
+     * @enum {string}
+     */
+    amountType: "SHARES" | "ASSETS";
+    /** @description The amount to withdraw, in raw on-chain units, interpreted according to amount_type. */
+    amountValue: string;
+  };
+  v1EarnWithdrawResult: {
+    /** @description Transaction hash of the withdrawal. */
+    withdrawTxHash: string;
+    /** @description Identifier to poll withdrawal status via EarnWithdrawStatus. */
+    withdrawRequestId: string;
+    /** @description Amount of the underlying asset received, in raw on-chain units. */
+    assetsReceived: string;
+    /** @description Number of wrapper shares burned, in raw on-chain units. */
+    sharesBurned: string;
+  };
   /** @enum {string} */
   v1Effect: "EFFECT_ALLOW" | "EFFECT_DENY";
   v1EmailAuthCustomizationParams: {
@@ -2525,6 +2725,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,17 +2750,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
-  };
-  v1EthSendRawTransactionRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_RAW_TRANSACTION";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1EthSendRawTransactionIntent"];
-    generateAppProofs?: boolean;
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionResult: {
     /** @description The transaction hash of the sent transaction */
@@ -2573,7 +2773,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2795,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2896,6 +3135,40 @@ export type definitions = {
     /** @description Name of enclave app. */
     appName: string;
   };
+  v1GetMfaPoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+  };
+  v1GetMfaPoliciesResponse: {
+    /** @description A list of multi-factor authentication policies for a user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
+  };
+  v1GetMfaPolicyRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a given user. */
+    userId: string;
+    /** @description Unique identifier for a given MFA policy. */
+    mfaPolicyId: string;
+  };
+  v1GetMfaPolicyResponse: {
+    /** @description Multi-factor authentication policy for a user. */
+    mfaPolicy: definitions["v1MfaPolicy"];
+  };
+  v1GetMfaStatusRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description The unique identifier of the activity to get MFA status for. */
+    activityId: string;
+    /** @description Optional user ID to filter MFA status for a specific user. */
+    userId?: string;
+  };
+  v1GetMfaStatusResponse: {
+    /** @description A list of MFA statuses for the activity's votes. */
+    mfaStatuses: definitions["v1MfaStatus"][];
+  };
   v1GetNoncesRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
@@ -2911,7 +3184,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -2967,14 +3242,6 @@ export type definitions = {
   v1GetOrganizationConfigsResponse: {
     /** @description Organization configs including quorum settings and organization features. */
     configs: definitions["v1Config"];
-  };
-  v1GetOrganizationRequest: {
-    /** @description Unique identifier for a given organization. */
-    organizationId: string;
-  };
-  v1GetOrganizationResponse: {
-    /** @description Object representing the full current and deleted / disabled collection of users, policies, private keys, and invitations attributable to a particular organization. */
-    organizationData: definitions["v1OrganizationData"];
   };
   v1GetPoliciesRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3039,6 +3306,24 @@ export type definitions = {
     /** @description Structured error information including revert details, if available. */
     error?: definitions["v1TxError"];
   };
+  v1GetSessionProfileRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+    /** @description Unique identifier for a session profile. */
+    sessionProfileId: string;
+  };
+  v1GetSessionProfileResponse: {
+    /** @description Session profile for a user, including details about the user's authenticators, Oauth providers, API keys, and MFA policies. */
+    sessionProfile: definitions["v1SessionProfile"];
+  };
+  v1GetSessionProfilesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetSessionProfilesResponse: {
+    /** @description A list of session profiles for users in the organization. */
+    sessionProfiles: definitions["v1SessionProfile"][];
+  };
   v1GetSmartContractInterfaceRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3099,23 +3384,25 @@ export type definitions = {
     /** @description A list of TVC Apps. */
     tvcApps: definitions["v1TvcApp"][];
   };
-  v1GetTvcDeploymentProvisioningDetailsRequest: {
+  v1GetTvcDeploymentDebugLogsRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Unique identifier for a given TVC Deployment. */
+    /** @description Unique identifier for a given TVC Deployment. The deployment must be running in debug mode. */
     deploymentId: string;
+    /**
+     * Format: int32
+     * @description Limit returned history to the last N lines per replica. If unset or zero, no tail-line limit is applied.
+     */
+    tailLines?: number;
+    /**
+     * Format: int64
+     * @description Return logs newer than this many seconds ago. If unset or zero, no since-time limit is applied. Useful for clients that poll to follow logs.
+     */
+    sinceSeconds?: string;
   };
-  v1GetTvcDeploymentProvisioningDetailsResponse: {
-    /**
-     * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
-     */
-    attestationDocument: string;
-    /**
-     * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
-     */
-    manifestEnvelope: string;
+  v1GetTvcDeploymentDebugLogsResponse: {
+    /** @description Application log entries sorted by platform timestamp. */
+    entries: definitions["v1TvcDeploymentDebugLogEntry"][];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -3203,6 +3490,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,24 +4053,15 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
-  };
-  v1Invitation: {
-    /** @description Unique identifier for a given Invitation object. */
-    invitationId: string;
-    /** @description The name of the intended Invitation recipient. */
-    receiverUserName: string;
-    /** @description The email address of the intended Invitation recipient. */
-    receiverEmail: string;
-    /** @description A list of tags assigned to the Invitation recipient. */
-    receiverUserTags: string[];
-    /** @description The User's permissible access method(s). */
-    accessType: definitions["v1AccessType"];
-    /** @description The current processing status of a specified Invitation. */
-    status: definitions["v1InvitationStatus"];
-    createdAt: definitions["externaldatav1Timestamp"];
-    updatedAt: definitions["externaldatav1Timestamp"];
-    /** @description Unique identifier for the Sender of an Invitation. */
-    senderUserId: string;
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
+    createMfaPolicyIntent?: definitions["v1CreateMfaPolicyIntent"];
+    updateMfaPolicyIntent?: definitions["v1UpdateMfaPolicyIntent"];
+    deleteMfaPolicyIntent?: definitions["v1DeleteMfaPolicyIntent"];
+    createSessionProfileIntent?: definitions["v1CreateSessionProfileIntent"];
+    earnDeployWrapperIntent?: definitions["v1EarnDeployWrapperIntent"];
+    earnDepositIntent?: definitions["v1EarnDepositIntent"];
+    earnWithdrawIntent?: definitions["v1EarnWithdrawIntent"];
+    upsertEarnClientFeeConfigIntent?: definitions["v1UpsertEarnClientFeeConfigIntent"];
   };
   v1InvitationParams: {
     /** @description The name of the intended Invitation recipient. */
@@ -3791,11 +4075,6 @@ export type definitions = {
     /** @description Unique identifier for the Sender of an Invitation. */
     senderUserId: string;
   };
-  /** @enum {string} */
-  v1InvitationStatus:
-    | "INVITATION_STATUS_CREATED"
-    | "INVITATION_STATUS_ACCEPTED"
-    | "INVITATION_STATUS_REVOKED";
   v1IpAllowlist: {
     /** @description Unique identifier for the organization this allowlist belongs to. */
     organizationId: string;
@@ -3858,6 +4137,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3880,9 +4165,46 @@ export type definitions = {
   v1ListWebhookEndpointsResponse: {
     webhookEndpoints: definitions["v1WebhookEndpointData"][];
   };
+  v1LogLine: {
+    /** @description One log line, exactly as the application printed it (without the trailing newline) */
+    content: string;
+    /** @description When the line was logged. Stable across replays, so lines can be chronologically merged across pods */
+    ts?: definitions["externaldatav1Timestamp"];
+  };
   v1LoginUsage: {
     /** @description Public key for authentication */
     publicKey: string;
+  };
+  v1MfaPolicy: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for an MFA Policy. */
+    mfaPolicyName: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods: definitions["v1RequiredAuthenticationMethod"][];
+    /**
+     * Format: int64
+     * @description The order in which this policy is evaluated relative to other MFA policies.
+     */
+    order: number;
+    /** @description Optional human-readable notes added by a User to describe a particular MFA policy. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
+  };
+  v1MfaStatus: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Unique identifier for a given User. */
+    userId: string;
+    /** @description Whether the MFA policy requirements are currently satisfied. */
+    satisfied: boolean;
+    /** @description A list of authentication methods already satisfied for this MFA policy. */
+    satisfiedMethods: definitions["v1AuthenticationMethod"][];
+    /** @description An ordered list of authentication requirements needed to satisfy this MFA policy. */
+    requiredMethods: definitions["v1RequiredAuthenticationMethod"][];
   };
   /** @enum {string} */
   v1MnemonicLanguage:
@@ -3975,6 +4297,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OauthLoginRequest: {
     /** @enum {string} */
@@ -4057,19 +4381,6 @@ export type definitions = {
     | "OPERATOR_NOT_IN"
     | "OPERATOR_CONTAINS_ONE"
     | "OPERATOR_CONTAINS_ALL";
-  v1OrganizationData: {
-    organizationId?: string;
-    name?: string;
-    users?: definitions["v1User"][];
-    policies?: definitions["v1Policy"][];
-    privateKeys?: definitions["v1PrivateKey"][];
-    invitations?: definitions["v1Invitation"][];
-    tags?: definitions["datav1Tag"][];
-    rootQuorum?: definitions["externaldatav1Quorum"];
-    features?: definitions["v1Feature"][];
-    wallets?: definitions["v1Wallet"][];
-    smartContractInterfaceReferences?: definitions["v1SmartContractInterfaceReference"][];
-  };
   v1OtpAuthIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -4113,6 +4424,8 @@ export type definitions = {
     invalidateExisting?: boolean;
     /** @description Optional signature proving authorization for this login. The signature is over the verification token ID and the public key. Only required if a public key was provided during the verification step. */
     clientSignature?: definitions["v1ClientSignature"];
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginIntentV2: {
     /** @description Signed Verification Token containing a unique id, expiry, verification type, contact */
@@ -4125,6 +4438,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login sessions */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1OtpLoginRequest: {
     /** @enum {string} */
@@ -4147,7 +4462,8 @@ export type definitions = {
     | "OUTCOME_DENY_IMPLICIT"
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
-    | "OUTCOME_ERROR";
+    | "OUTCOME_ERROR"
+    | "OUTCOME_REQUIRES_AUTHENTICATORS";
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -4187,15 +4503,6 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description Re-encrypted quorum key share and approval */
     shareApprovalBundle: definitions["v1QuorumKeyShareApprovalBundle"];
-  };
-  v1PostTvcQuorumKeyShareRequest: {
-    /** @enum {string} */
-    type: "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
-    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
-    timestampMs: string;
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    parameters: definitions["v1PostTvcQuorumKeyShareIntent"];
   };
   v1PostTvcQuorumKeyShareResult: {
     /** @description The unique identifier for the provisioning quorum key share */
@@ -4273,8 +4580,6 @@ export type definitions = {
     /** @description ID of the authenticator created. */
     authenticatorId: string[];
   };
-  v1RefreshFeatureFlagsRequest: { [key: string]: unknown };
-  v1RefreshFeatureFlagsResponse: { [key: string]: unknown };
   v1RejectActivityIntent: {
     /** @description An artifact verifying a User's action. */
     fingerprint: string;
@@ -4321,6 +4626,14 @@ export type definitions = {
   v1RemoveOrganizationFeatureResult: {
     /** @description Resulting list of organization features. */
     features: definitions["v1Feature"][];
+  };
+  v1RequiredAuthenticationMethod: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethod"][];
+  };
+  v1RequiredAuthenticationMethodParams: {
+    /** @description A list of authentication methods for this MFA step. If only one method is provided, it is required. If multiple are provided, the user must satisfy ANY one of them. */
+    any: definitions["v1AuthenticationMethodParams"][];
   };
   v1RestoreTvcDeploymentIntent: {
     /** @description The unique identifier of the TVC deployment to restore. */
@@ -4457,6 +4770,15 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
+    createMfaPolicyResult?: definitions["v1CreateMfaPolicyResult"];
+    updateMfaPolicyResult?: definitions["v1UpdateMfaPolicyResult"];
+    deleteMfaPolicyResult?: definitions["v1DeleteMfaPolicyResult"];
+    createSessionProfileResult?: definitions["v1CreateSessionProfileResult"];
+    earnDeployWrapperResult?: definitions["v1EarnDeployWrapperResult"];
+    earnDepositResult?: definitions["v1EarnDepositResult"];
+    earnWithdrawResult?: definitions["v1EarnWithdrawResult"];
+    upsertEarnClientFeeConfigResult?: definitions["v1UpsertEarnClientFeeConfigResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -4543,6 +4865,20 @@ export type definitions = {
     subject?: string;
     operator?: definitions["v1Operator"];
     targets?: string[];
+  };
+  v1SessionProfile: {
+    /** @description Unique identifier for a given Session Profile. */
+    sessionProfileId: string;
+    /** @description Human-readable name for a Session Profile. */
+    sessionProfileName: string;
+    /** @description The specific scope that a session created with this profile is limited to. */
+    scope: string;
+    /** @description Optional window (in seconds) indicating how long sessions created with this profile should last. */
+    expirationSeconds?: string;
+    /** @description Optional human-readable notes added by a User to describe a particular Session Profile. */
+    notes?: string;
+    createdAt: definitions["externaldatav1Timestamp"];
+    updatedAt: definitions["externaldatav1Timestamp"];
   };
   v1SetIpAllowlistIntent: {
     /** @description The public component of an API key. If null, the IP allowlist applies at the organization level. If set, it applies only to this specific API key. */
@@ -4691,11 +5027,6 @@ export type definitions = {
     appid?: boolean;
     appidExclude?: boolean;
     credProps?: definitions["v1CredPropsAuthenticationExtensionsClientOutputs"];
-  };
-  v1SmartContractInterfaceReference: {
-    smartContractInterfaceId?: string;
-    smartContractAddress?: string;
-    digest?: string;
   };
   /** @enum {string} */
   v1SmartContractInterfaceType:
@@ -4994,6 +5325,8 @@ export type definitions = {
     expirationSeconds?: string;
     /** @description Invalidate all other previously generated Login API keys */
     invalidateExisting?: boolean;
+    /** @description Optional session profile ID to specify which Session Profile to use for this login. If not provided, the default read/write session will be used. */
+    sessionProfileId?: string;
   };
   v1StampLoginRequest: {
     /** @enum {string} */
@@ -5011,18 +5344,6 @@ export type definitions = {
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
-  v1TestRateLimitsRequest: {
-    /** @description Unique identifier for a given organization. If the request is being made by a WebAuthN user and their sub-organization ID is unknown, this can be the parent organization ID; using the sub-organization ID when possible is preferred due to performance reasons. */
-    organizationId: string;
-    /** @description Whether or not to set a limit on this request. */
-    isSetLimit: boolean;
-    /**
-     * Format: int64
-     * @description Rate limit to set for org, if is_set_limit is set to true.
-     */
-    limit: number;
-  };
-  v1TestRateLimitsResponse: { [key: string]: unknown };
   v1TokenUsage: {
     /** @description Type of token usage */
     type: definitions["v1UsageType"];
@@ -5060,6 +5381,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5106,6 +5429,12 @@ export type definitions = {
     updatedAt: definitions["externaldatav1Timestamp"];
     /** @description Whether or not the user wants this deployment deleted from the cluster. */
     delete: boolean;
+  };
+  v1TvcDeploymentDebugLogEntry: {
+    /** @description Application log line with its platform timestamp. */
+    line: definitions["v1LogLine"];
+    /** @description Public replica label that produced this log line, for example 'replica 2/3'. */
+    replicaLabel: string;
   };
   /** @enum {string} */
   v1TvcHealthCheckType:
@@ -5289,6 +5618,38 @@ export type definitions = {
   v1UpdateFiatOnRampCredentialResult: {
     /** @description Unique identifier of the Fiat On-Ramp credential that was updated */
     fiatOnRampCredentialId: string;
+  };
+  v1UpdateMfaPolicyIntent: {
+    /** @description The ID of the User to update the MFA Policy for. */
+    userId: string;
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
+    /** @description Human-readable name for a Policy. */
+    mfaPolicyName?: string;
+    /** @description A condition expression that evaluates to true or false, determining when this MFA policy applies. */
+    condition?: string;
+    /** @description An ordered list of authentication requirements. Each requirement must be satisfied sequentially to complete MFA. */
+    requiredAuthenticationMethods?: definitions["v1RequiredAuthenticationMethodParams"][];
+    /**
+     * Format: int64
+     * @description The order in which this MFA policy is evaluated, starting from 0, relative to other MFA policies. Lower order values are evaluated first.
+     */
+    order?: number;
+    /** @description Notes for an MFA Policy. */
+    notes?: string;
+  };
+  v1UpdateMfaPolicyRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_UPDATE_MFA_POLICY";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1UpdateMfaPolicyIntent"];
+  };
+  v1UpdateMfaPolicyResult: {
+    /** @description Unique identifier for a given MFA Policy. */
+    mfaPolicyId: string;
   };
   v1UpdateOauth2CredentialIntent: {
     /** @description The ID of the OAuth 2.0 credential to update */
@@ -5599,6 +5960,16 @@ export type definitions = {
     /** @description The updated webhook endpoint data. */
     webhookEndpoint: definitions["v1WebhookEndpointData"];
   };
+  v1UpsertEarnClientFeeConfigIntent: {
+    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    clientFeeBps: string;
+    /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
+    clientFeeWallet: string;
+  };
+  v1UpsertEarnClientFeeConfigResult: {
+    /** @description Transaction hash of the fee configuration update. */
+    feeUpdateTxHash: string;
+  };
   v1UpsertGasUsageConfigIntent: {
     /** @description Gas sponsorship USD limit for the billing organization window. */
     orgWindowLimitUsd: string;
@@ -5636,6 +6007,8 @@ export type definitions = {
     oauthProviders: definitions["v1OauthProvider"][];
     createdAt: definitions["externaldatav1Timestamp"];
     updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description A list of MFA Policies that define multi-factor authentication requirements for this user. */
+    mfaPolicies: definitions["v1MfaPolicy"][];
   };
   v1UserParams: {
     /** @description Human-readable name for a User. */
@@ -5794,6 +6167,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +6179,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6053,6 +6430,60 @@ export type operations = {
       };
     };
   };
+  /** Get all MFA policies for a user. */
+  PublicApiService_GetMfaPolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get a single MFA policy for a user. */
+  PublicApiService_GetMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaPolicyResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get the MFA status of an activity for a specific user or all voting users. */
+  PublicApiService_GetMfaStatus: {
+    parameters: {
+      body: {
+        body: definitions["v1GetMfaStatusRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetMfaStatusResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get nonce values for an address on a given network. Can fetch the standard on-chain nonce and/or the gas station nonce used for sponsored transactions. */
   PublicApiService_GetNonces: {
     parameters: {
@@ -6118,24 +6549,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetOnRampTransactionStatusResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get details about an organization. */
-  PublicApiService_GetOrganization: {
-    parameters: {
-      body: {
-        body: definitions["v1GetOrganizationRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetOrganizationResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6233,6 +6646,42 @@ export type operations = {
       };
     };
   };
+  /** Get a single session profile for an organization. */
+  PublicApiService_GetSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfileRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfileResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Get all session profiles for an organization. */
+  PublicApiService_GetSessionProfiles: {
+    parameters: {
+      body: {
+        body: definitions["v1GetSessionProfilesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetSessionProfilesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a smart contract interface. */
   PublicApiService_GetSmartContractInterface: {
     parameters: {
@@ -6287,17 +6736,17 @@ export type operations = {
       };
     };
   };
-  /** Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment */
-  PublicApiService_GetTvcDeploymentProvisioningDetails: {
+  /** Get a bounded window of application logs from a debug-mode TVC deployment. Returned lines are collected from every running replica and sorted by platform timestamp. */
+  PublicApiService_GetTvcDeploymentDebugLogs: {
     parameters: {
       body: {
-        body: definitions["v1GetTvcDeploymentProvisioningDetailsRequest"];
+        body: definitions["v1GetTvcDeploymentDebugLogsRequest"];
       };
     };
     responses: {
       /** A successful response. */
       200: {
-        schema: definitions["v1GetTvcDeploymentProvisioningDetailsResponse"];
+        schema: definitions["v1GetTvcDeploymentDebugLogsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -6359,7 +6808,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6988,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {
@@ -6773,24 +7222,6 @@ export type operations = {
       };
     };
   };
-  /** Create API-only users in an existing organization. */
-  PublicApiService_CreateApiOnlyUsers: {
-    parameters: {
-      body: {
-        body: definitions["v1CreateApiOnlyUsersRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
   /** Create authenticators to authenticate requests to Turnkey. */
   PublicApiService_CreateAuthenticators: {
     parameters: {
@@ -6832,6 +7263,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateInvitationsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new MFA policy for a user. */
+  PublicApiService_CreateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateMfaPolicyRequest"];
       };
     };
     responses: {
@@ -6976,6 +7425,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1CreateReadWriteSessionRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Create a new session profile for an organization. */
+  PublicApiService_CreateSessionProfile: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSessionProfileRequest"];
       };
     };
     responses: {
@@ -7228,6 +7695,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteInvitationRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an MFA policy for a user. */
+  PublicApiService_DeleteMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteMfaPolicyRequest"];
       };
     };
     responses: {
@@ -7516,24 +8001,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1EmailAuthRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Submit a raw transaction (serialized and signed) for broadcasting to the network. */
-  PublicApiService_EthSendRawTransaction: {
-    parameters: {
-      body: {
-        body: definitions["v1EthSendRawTransactionRequest"];
       };
     };
     responses: {
@@ -7840,24 +8307,6 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1OtpLoginRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1ActivityResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Post re-encrypted quorum key share for a TVC deployment. */
-  PublicApiService_PostTvcQuorumKeyShare: {
-    parameters: {
-      body: {
-        body: definitions["v1PostTvcQuorumKeyShareRequest"];
       };
     };
     responses: {
@@ -8195,6 +8644,24 @@ export type operations = {
       };
     };
   };
+  /** Update an MFA policy for a user. */
+  PublicApiService_UpdateMfaPolicy: {
+    parameters: {
+      body: {
+        body: definitions["v1UpdateMfaPolicyRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Update an OAuth 2.0 provider credential */
   PublicApiService_UpdateOauth2Credential: {
     parameters: {
@@ -8434,42 +8901,6 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1NOOPCodegenAnchorResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Refresh feature flags by triggering a DB read to flush the in-memory cache. */
-  PublicApiService_RefreshFeatureFlags: {
-    parameters: {
-      body: {
-        body: definitions["v1RefreshFeatureFlagsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1RefreshFeatureFlagsResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Set a rate local rate limit just on the current endpoint, for purposes of testing with Vivosuite. */
-  PublicApiService_TestRateLimits: {
-    parameters: {
-      body: {
-        body: definitions["v1TestRateLimitsRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1TestRateLimitsResponse"];
       };
       /** An unexpected error response. */
       default: {


### PR DESCRIPTION
## Summary

Refresh SDK checked-in public API inputs and generated SDK output from the mono sync path introduced by INT-571.

Also handles `ACTIVITY_STATUS_AUTHENTICATORS_NEEDED` explicitly in HTTP async polling and updates examples that still called the removed `createApiOnlyUsers` endpoint.

Stacked on SDK #1425 until the SDK-local HTTP generator PR lands.

## Validation

- Mono `sync/js-sdk` handoff against SDK #1425
- SDK codegen/version/formatting gates
- `@turnkey/http` async polling tests and typecheck
- Focused changed-example typechecks
- Root SDK typecheck
