### PR TITLE
fix: address review comments on captcha support in react-wallet-kit

### DIFF
--- a/packages/core/scripts/codegen.js
+++ b/packages/core/scripts/codegen.js
@@ -159,6 +159,13 @@ const METHODS_WITH_ONLY_OPTIONAL_PARAMETERS = [
   "listUserTags",
 ];
 
+const CAPTCHA_PROTECTED_METHODS = [
+  "proxyInitOtp",
+  "proxySignup",
+  "proxyInitOtpV2",
+  "proxySignupV2",
+];
+
 /**
  * @param {string} methodName
  * @returns {string}
@@ -453,6 +460,7 @@ const generateSDKClientFromSwagger = async (
     async authProxyRequest<TBodyType, TResponseType>(
         url: string,
         body: TBodyType,
+        captchaToken?: string
     ): Promise<TResponseType> {
         if (!this.config.authProxyUrl || !this.config.authProxyConfigId) {
         throw new TurnkeyError("Auth Proxy URL or ID is not configured.", TurnkeyErrorCodes.INVALID_CONFIGURATION);
@@ -462,6 +470,10 @@ const generateSDKClientFromSwagger = async (
         var headers: Record<string, string> = {
         "Content-Type": "application/json",
         "X-Auth-Proxy-Config-ID": this.config.authProxyConfigId,
+        }
+
+        if (captchaToken) {
+        headers["X-Captcha-Token"] = captchaToken;
         }
 
         const response = await fetch(fullUrl, {
@@ -725,15 +737,27 @@ const generateSDKClientFromSwagger = async (
     const inputType = `ProxyT${operationNameWithoutNamespace}Body`;
     const responseType = `ProxyT${operationNameWithoutNamespace}Response`;
 
-    codeBuffer.push(
-      `\n\t${methodName} = async (input: SdkTypes.${inputType}${
-        METHODS_WITH_ONLY_OPTIONAL_PARAMETERS.includes(methodName)
-          ? " = {}"
-          : ""
-      }): Promise<SdkTypes.${responseType}> => {
+    if (CAPTCHA_PROTECTED_METHODS.includes(methodName)) {
+      codeBuffer.push(
+        `\n\t${methodName} = async (input: SdkTypes.${inputType}${
+          METHODS_WITH_ONLY_OPTIONAL_PARAMETERS.includes(methodName)
+            ? " = {}"
+            : ""
+        }, captchaToken?: string): Promise<SdkTypes.${responseType}> => {
+      return this.authProxyRequest("${endpointPath}", input, captchaToken);
+    }`,
+      );
+    } else {
+      codeBuffer.push(
+        `\n\t${methodName} = async (input: SdkTypes.${inputType}${
+          METHODS_WITH_ONLY_OPTIONAL_PARAMETERS.includes(methodName)
+            ? " = {}"
+            : ""
+        }): Promise<SdkTypes.${responseType}> => {
       return this.authProxyRequest("${endpointPath}", input);
     }`,
-    );
+      );
+    }
   }
 
   // End of the TurnkeySDKClient Class Definition

--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -1496,6 +1496,7 @@ export class TurnkeyClient {
       invalidateExisting = false,
       organizationId,
       sessionKey = SessionKey.DefaultSessionkey,
+      captchaToken,
     } = params;
 
     return withTurnkeyErrorHandling(
@@ -1525,13 +1526,16 @@ export class TurnkeyClient {
         };
 
         // the verification token's public key is also used as the session public key for login
-        const loginRes = await this.httpClient.proxyOtpLoginV2({
-          verificationToken,
-          publicKey: verificationPublicKey,
-          clientSignature,
-          invalidateExisting,
-          ...(organizationId && { organizationId }),
-        });
+        const loginRes = await this.httpClient.proxyOtpLoginV2(
+          {
+            verificationToken,
+            publicKey: verificationPublicKey,
+            clientSignature,
+            invalidateExisting,
+            ...(organizationId && { organizationId }),
+          },
+          captchaToken,
+        );
 
         if (!loginRes) {
           throw new TurnkeyError(
@@ -1779,6 +1783,7 @@ export class TurnkeyClient {
             verificationToken,
             ...(invalidateExisting && { invalidateExisting }),
             ...(sessionKey && { sessionKey }),
+            ...(captchaToken && { captchaToken }),
           });
 
           return {

--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -645,6 +645,7 @@ export class TurnkeyClient {
    * @param params.expirationSeconds - session expiration time in seconds (defaults to the configured default).
    * @param params.createSubOrgParams - parameters for creating a sub-organization (e.g., authenticators, user metadata).
    * @param params.sessionKey - session key to use for storing the session (defaults to the default session key).
+   * @param params.captchaToken - optional captcha token for bot prevention (must be enabled in the auth proxy config to take effect).
    * @returns A promise that resolves to a {@link PasskeyAuthResult}, which includes:
    *          - `sessionToken`: the signed JWT session token.
    *          - `credentialId`: the credential ID associated with the passkey created.
@@ -659,6 +660,7 @@ export class TurnkeyClient {
       expirationSeconds = DEFAULT_SESSION_EXPIRATION_IN_SECONDS,
       createSubOrgParams,
       sessionKey = SessionKey.DefaultSessionkey,
+      captchaToken,
     } = params || {};
 
     const generatedPublicKey = await this.createApiKeyPair();
@@ -710,7 +712,10 @@ export class TurnkeyClient {
           },
         });
 
-        const res = await this.httpClient.proxySignupV2(signUpBody);
+        const res = await this.httpClient.proxySignupV2(
+          signUpBody,
+          captchaToken,
+        );
 
         if (!res) {
           throw new TurnkeyError(
@@ -1225,6 +1230,7 @@ export class TurnkeyClient {
    * @param params.sessionKey - session key to use for storing the session (defaults to the default session key).
    * @param params.expirationSeconds - session expiration time in seconds (defaults to the configured default).
    * @param params.organizationId - organization ID to target (defaults to the session's organization ID or the parent organization ID).
+   * @param params.captchaToken - optional captcha token for bot prevention during OTP initialization (must be enabled in the auth proxy config to take effect).
    * @returns A promise that resolves to an object containing:
    *          - `sessionToken`: the signed JWT session token.
    *          - `address`: the authenticated wallet address.
@@ -1238,6 +1244,7 @@ export class TurnkeyClient {
       walletProvider,
       createSubOrgParams,
       sessionKey = SessionKey.DefaultSessionkey,
+      captchaToken,
     } = params;
 
     return withTurnkeyErrorHandling(
@@ -1278,7 +1285,10 @@ export class TurnkeyClient {
             },
           });
 
-          signupRes = await this.httpClient.proxySignupV2(signUpBody);
+          signupRes = await this.httpClient.proxySignupV2(
+            signUpBody,
+            captchaToken,
+          );
 
           if (!signupRes) {
             throw new TurnkeyError(
@@ -1336,6 +1346,7 @@ export class TurnkeyClient {
    * @param params.otpType - type of OTP to initialize (OtpType.Email or OtpType.Sms).
    * @param params.contact - contact information for the user (e.g., email address or phone number).
    * @param params.organizationId - optional organization ID to target (defaults to the session's organization ID or the parent organization ID).
+   * @param params.captchaToken - optional captcha token for bot prevention during OTP initialization (must be enabled in the auth proxy config to take effect).
    * @returns A promise that resolves to an {@link InitOtpResult}, which includes:
    *          - `otpId`: the ID of the initiated OTP.
    *          - `otpEncryptionTargetBundle`: the signed encryption target bundle for encrypting the OTP code.
@@ -1344,7 +1355,10 @@ export class TurnkeyClient {
   initOtp = async (params: InitOtpParams): Promise<InitOtpResult> => {
     return withTurnkeyErrorHandling(
       async () => {
-        const initOtpRes = await this.httpClient.proxyInitOtpV2(params);
+        const initOtpRes = await this.httpClient.proxyInitOtpV2(
+          params,
+          params.captchaToken,
+        );
 
         if (
           !initOtpRes ||
@@ -1564,6 +1578,7 @@ export class TurnkeyClient {
    * @param params.createSubOrgParams - parameters for creating a sub-organization (e.g., authenticators, user metadata).
    * @param params.invalidateExisting - flag to invalidate existing session for the user.
    * @param params.sessionKey - session key to use for session creation (defaults to the default session key).
+   * @param params.captchaToken - optional captcha token for bot prevention during OTP initialization (must be enabled in the auth proxy config to take effect).
    * @returns A promise that resolves to a {@link BaseAuthResult}, which includes:
    *          - `sessionToken`: the signed JWT session token.
    * @throws {TurnkeyError} If there is an error during the OTP sign-up process or session storage.
@@ -1578,6 +1593,7 @@ export class TurnkeyClient {
       createSubOrgParams,
       invalidateExisting,
       sessionKey,
+      captchaToken,
     } = params;
 
     // build sign up body without client signature first
@@ -1626,10 +1642,13 @@ export class TurnkeyClient {
           signature: signature,
         };
 
-        const signupRes = await this.httpClient.proxySignupV2({
-          ...signUpBody,
-          clientSignature,
-        });
+        const signupRes = await this.httpClient.proxySignupV2(
+          {
+            ...signUpBody,
+            clientSignature,
+          },
+          captchaToken,
+        );
 
         if (!signupRes) {
           throw new TurnkeyError(
@@ -1675,6 +1694,7 @@ export class TurnkeyClient {
    * @param params.invalidateExisting - flag to invalidate existing sessions for the user.
    * @param params.sessionKey - session key to use for session creation (defaults to the default session key).
    * @param params.createSubOrgParams - parameters for sub-organization creation (e.g., authenticators, user metadata).
+   * @param params.captchaToken - optional captcha token for bot prevention during OTP initialization (must be enabled in the auth proxy config to take effect).
    * @returns A promise that resolves to an object containing:
    *          - `sessionToken`: the signed JWT session token.
    *          - `verificationToken`: the OTP verification token.
@@ -1695,6 +1715,7 @@ export class TurnkeyClient {
       invalidateExisting = false,
       sessionKey,
       createSubOrgParams,
+      captchaToken,
     } = params;
 
     const publicKey = params.publicKey ?? (await this.createApiKeyPair());
@@ -1745,6 +1766,7 @@ export class TurnkeyClient {
             ...(createSubOrgParams && { createSubOrgParams }),
             ...(invalidateExisting && { invalidateExisting }),
             ...(sessionKey && { sessionKey }),
+            ...(captchaToken && { captchaToken }),
           });
 
           return {
@@ -1801,6 +1823,7 @@ export class TurnkeyClient {
    * @param params.createSubOrgParams - parameters for sub-organization creation (e.g., authenticators, user metadata).
    * @param params.invalidateExisting - flag to invalidate existing sessions for the user.
    * @param params.sessionKey - session key to use for session creation (defaults to the default session key).
+   * @param params.captchaToken - optional captcha token for bot prevention during OAuth completion (must be enabled in the auth proxy config to take effect).
    *
    * @returns A promise that resolves to an object containing:
    *          - `sessionToken`: the signed JWT session token.
@@ -1817,6 +1840,7 @@ export class TurnkeyClient {
       createSubOrgParams,
       invalidateExisting,
       sessionKey,
+      captchaToken,
     } = params;
 
     return withTurnkeyErrorHandling(
@@ -1857,6 +1881,7 @@ export class TurnkeyClient {
             }),
             ...(invalidateExisting && { invalidateExisting }),
             ...(sessionKey && { sessionKey }),
+            ...(captchaToken && { captchaToken }),
           });
 
           return {
@@ -1980,6 +2005,7 @@ export class TurnkeyClient {
    * @param params.providerName - name of the OAuth provider (e.g., "Google", "Apple").
    * @param params.createSubOrgParams - parameters for sub-organization creation (e.g., authenticators, user metadata).
    * @param params.sessionKey - session key to use for session creation (defaults to the default session key).
+   * @param params.captchaToken - optional captcha token for bot prevention during OTP initialization (must be enabled in the auth proxy config to take effect).
    * @returns A promise that resolves to a {@link BaseAuthResult}, which includes:
    *          - `sessionToken`: the signed JWT session token.
    * @throws {TurnkeyError} If there is an error during the OAuth sign-up or login process.
@@ -1993,6 +2019,7 @@ export class TurnkeyClient {
       providerName = "OpenID Connect Provider" + " " + Date.now(),
       createSubOrgParams,
       sessionKey,
+      captchaToken,
     } = params;
 
     return withTurnkeyErrorHandling(
@@ -2010,7 +2037,10 @@ export class TurnkeyClient {
           },
         });
 
-        const signupRes = await this.httpClient.proxySignupV2(signUpBody);
+        const signupRes = await this.httpClient.proxySignupV2(
+          signUpBody,
+          captchaToken,
+        );
 
         if (!signupRes) {
           throw new TurnkeyError(

--- a/packages/core/src/__generated__/sdk-client-base.ts
+++ b/packages/core/src/__generated__/sdk-client-base.ts
@@ -7785,8 +7785,9 @@ export class TurnkeySDKClientBase {
 
   proxyOtpLoginV2 = async (
     input: SdkTypes.ProxyTOtpLoginV2Body,
+    captchaToken?: string,
   ): Promise<SdkTypes.ProxyTOtpLoginV2Response> => {
-    return this.authProxyRequest("/v1/otp_login_v2", input);
+    return this.authProxyRequest("/v1/otp_login_v2", input, captchaToken);
   };
 
   proxyVerifyOtp = async (

--- a/packages/core/src/__generated__/sdk-client-base.ts
+++ b/packages/core/src/__generated__/sdk-client-base.ts
@@ -241,6 +241,7 @@ export class TurnkeySDKClientBase {
   async authProxyRequest<TBodyType, TResponseType>(
     url: string,
     body: TBodyType,
+    captchaToken?: string,
   ): Promise<TResponseType> {
     if (!this.config.authProxyUrl || !this.config.authProxyConfigId) {
       throw new TurnkeyError(
@@ -254,6 +255,10 @@ export class TurnkeySDKClientBase {
       "Content-Type": "application/json",
       "X-Auth-Proxy-Config-ID": this.config.authProxyConfigId,
     };
+
+    if (captchaToken) {
+      headers["X-Captcha-Token"] = captchaToken;
+    }
 
     const response = await fetch(fullUrl, {
       method: "POST",
@@ -4994,7 +4999,7 @@ export class TurnkeySDKClientBase {
         generateAppProofs: generateAppProofs ?? false,
         type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
       },
-      "ethSendTransactionResult",
+      "ethSendTransactionResultV2",
       stampWith,
     );
   };
@@ -7760,14 +7765,16 @@ export class TurnkeySDKClientBase {
 
   proxyInitOtp = async (
     input: SdkTypes.ProxyTInitOtpBody,
+    captchaToken?: string,
   ): Promise<SdkTypes.ProxyTInitOtpResponse> => {
-    return this.authProxyRequest("/v1/otp_init", input);
+    return this.authProxyRequest("/v1/otp_init", input, captchaToken);
   };
 
   proxyInitOtpV2 = async (
     input: SdkTypes.ProxyTInitOtpV2Body,
+    captchaToken?: string,
   ): Promise<SdkTypes.ProxyTInitOtpV2Response> => {
-    return this.authProxyRequest("/v1/otp_init_v2", input);
+    return this.authProxyRequest("/v1/otp_init_v2", input, captchaToken);
   };
 
   proxyOtpLogin = async (
@@ -7796,14 +7803,22 @@ export class TurnkeySDKClientBase {
 
   proxySignup = async (
     input: SdkTypes.ProxyTSignupBody,
+    captchaToken?: string,
   ): Promise<SdkTypes.ProxyTSignupResponse> => {
-    return this.authProxyRequest("/v1/signup", input);
+    return this.authProxyRequest("/v1/signup", input, captchaToken);
   };
 
   proxySignupV2 = async (
     input: SdkTypes.ProxyTSignupV2Body,
+    captchaToken?: string,
   ): Promise<SdkTypes.ProxyTSignupV2Response> => {
-    return this.authProxyRequest("/v1/signup_v2", input);
+    return this.authProxyRequest("/v1/signup_v2", input, captchaToken);
+  };
+
+  proxyGetWalletKitClientParams = async (
+    input: SdkTypes.ProxyTGetWalletKitClientParamsBody,
+  ): Promise<SdkTypes.ProxyTGetWalletKitClientParamsResponse> => {
+    return this.authProxyRequest("/v1/wallet_kit_client_params", input);
   };
 
   proxyGetWalletKitConfig = async (

--- a/packages/core/src/__inputs__/auth_proxy.swagger.json
+++ b/packages/core/src/__inputs__/auth_proxy.swagger.json
@@ -364,6 +364,38 @@
         "tags": ["Auth"]
       }
     },
+    "/v1/wallet_kit_client_params": {
+      "post": {
+        "summary": "Get WalletKit Client Params",
+        "description": "Get client parameters needed to initialize WalletKit flows, such as a client token for the calling organization.",
+        "operationId": "AuthProxyService_GetWalletKitClientParams",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletKitClientParamsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletKitClientParamsRequest"
+            }
+          }
+        ],
+        "tags": ["Wallet Kit"]
+      }
+    },
     "/v1/wallet_kit_config": {
       "post": {
         "summary": "Get WalletKit Config",
@@ -640,6 +672,19 @@
       "properties": {
         "organizationId": {
           "type": "string"
+        }
+      }
+    },
+    "v1GetWalletKitClientParamsRequest": {
+      "type": "object"
+    },
+    "v1GetWalletKitClientParamsResponse": {
+      "type": "object",
+      "properties": {
+        "turnstileSiteKey": {
+          "type": "string",
+          "description": "Site key for Turnstile, used to protect WalletKit flows with bot detection.",
+          "title": "Turnstile Site Key"
         }
       }
     },
@@ -1207,6 +1252,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/core/src/__inputs__/public_api.swagger.json
+++ b/packages/core/src/__inputs__/public_api.swagger.json
@@ -875,7 +875,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1195,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -5127,7 +5127,8 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
       ]
     },
     "v1AddressFormat": {
@@ -5586,11 +5587,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5607,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -7188,6 +7193,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -9037,6 +9046,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9092,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9130,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9175,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9251,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9260,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9816,7 +9917,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10462,6 +10565,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +11921,9 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         }
       }
     },
@@ -11998,6 +12110,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -13458,6 +13576,9 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
         }
       }
     },
@@ -14925,6 +15046,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +15062,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15381,6 +15507,10 @@
             "type": "string"
           },
           "description": "Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider."
+        },
+        "captchaEnabled": {
+          "type": "boolean",
+          "description": "Whether captcha verification is required on sign up \u0026 otp init."
         }
       }
     },
@@ -16749,6 +16879,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +16916,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/core/src/__types__/method-types/shared.ts
+++ b/packages/core/src/__types__/method-types/shared.ts
@@ -72,6 +72,7 @@ export type SignUpWithPasskeyParams = {
   passkeyDisplayName?: string;
   expirationSeconds?: string;
   challenge?: string;
+  captchaToken?: string;
 };
 
 export type SwitchWalletAccountChainParams = {
@@ -104,6 +105,7 @@ export type SignUpWithWalletParams = {
   createSubOrgParams?: CreateSubOrgParams;
   sessionKey?: string;
   expirationSeconds?: string;
+  captchaToken?: string;
 };
 
 export type LoginOrSignupWithWalletParams = {
@@ -112,11 +114,13 @@ export type LoginOrSignupWithWalletParams = {
   createSubOrgParams?: CreateSubOrgParams;
   sessionKey?: string;
   expirationSeconds?: string;
+  captchaToken?: string;
 };
 
 export type InitOtpParams = {
   otpType: OtpType;
   contact: string;
+  captchaToken?: string;
 };
 
 export type InitOtpResult = {
@@ -150,6 +154,7 @@ export type SignUpWithOtpParams = {
   createSubOrgParams?: CreateSubOrgParams;
   invalidateExisting?: boolean;
   sessionKey?: string;
+  captchaToken?: string;
 };
 
 export type CompleteOtpParams = {
@@ -162,6 +167,7 @@ export type CompleteOtpParams = {
   invalidateExisting?: boolean;
   sessionKey?: string;
   createSubOrgParams?: CreateSubOrgParams;
+  captchaToken?: string;
 };
 
 export type CompleteOauthParams = {
@@ -171,6 +177,7 @@ export type CompleteOauthParams = {
   sessionKey?: string;
   invalidateExisting?: boolean;
   createSubOrgParams?: CreateSubOrgParams;
+  captchaToken?: string;
 };
 
 export type LoginWithOauthParams = {
@@ -188,6 +195,7 @@ export type SignUpWithOauthParams = {
   invalidateExisting?: boolean;
   createSubOrgParams?: CreateSubOrgParams;
   sessionKey?: string;
+  captchaToken?: string;
 };
 
 export type FetchWalletsParams = {

--- a/packages/core/src/__types__/method-types/shared.ts
+++ b/packages/core/src/__types__/method-types/shared.ts
@@ -145,6 +145,7 @@ export type LoginWithOtpParams = {
   organizationId?: string;
   invalidateExisting?: boolean;
   sessionKey?: string;
+  captchaToken?: string;
 };
 
 export type SignUpWithOtpParams = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export {
   isEthereumProvider,
   isSolanaProvider,
   getAuthProxyConfig,
+  getClientParams,
   decodeVerificationToken,
   getClientSignatureMessageForLogin,
   getClientSignatureMessageForSignup,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -18,6 +18,7 @@ import {
   type v1SignRawPayloadResult,
   type v1TransactionType,
   type ProxyTGetWalletKitConfigResponse,
+  type ProxyTGetWalletKitClientParamsResponse,
   type v1User,
   type v1CreatePolicyIntentV3,
   type VerificationToken,
@@ -1012,6 +1013,40 @@ export async function getAuthProxyConfig(
 
   const data = await response.json();
   return data as ProxyTGetWalletKitConfigResponse;
+}
+
+/**@internal */
+export async function getClientParams(
+  authProxyConfigId: string,
+  authProxyUrl?: string | undefined,
+): Promise<ProxyTGetWalletKitClientParamsResponse> {
+  const fullUrl =
+    (authProxyUrl ?? "https://authproxy.turnkey.com") +
+    "/v1/wallet_kit_client_params";
+
+  var headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Auth-Proxy-Config-ID": authProxyConfigId,
+  };
+
+  const response = await fetch(fullUrl, {
+    method: "POST",
+    headers: headers,
+  });
+
+  if (!response.ok) {
+    let res: GrpcStatus;
+    try {
+      res = await response.json();
+    } catch (_) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+
+    throw new TurnkeyRequestError(res);
+  }
+
+  const data = await response.json();
+  return data as ProxyTGetWalletKitClientParamsResponse;
 }
 
 /**

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -1417,7 +1417,7 @@ export class TurnkeyClient {
   };
 
   /**
-   * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.
+   * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.
    *
    * Sign the provided `TGetWalletAddressBalancesBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_wallet_address_balances).
    *
@@ -1738,7 +1738,7 @@ export class TurnkeyClient {
   };
 
   /**
-   * List supported assets for the specified network. This feature is in beta - please contact support for access.
+   * List supported assets for the specified network.
    *
    * Sign the provided `TListSupportedAssetsBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/list_supported_assets).
    *

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -1367,7 +1367,7 @@ export type TGetWalletAddressBalancesBody =
 /**
  * Get balances
  *
- * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.
+ * Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.
  *
  * `POST /public/v1/query/get_wallet_address_balances`
  */
@@ -1867,7 +1867,7 @@ export type TListSupportedAssetsBody =
 /**
  * List supported assets
  *
- * List supported assets for the specified network. This feature is in beta - please contact support for access.
+ * List supported assets for the specified network.
  *
  * `POST /public/v1/query/list_supported_assets`
  */

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -939,7 +939,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1259,7 +1259,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -5351,7 +5351,8 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
       ]
     },
     "v1AddressFormat": {
@@ -5810,11 +5811,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5830,6 +5831,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -7436,6 +7441,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -9285,6 +9294,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9313,7 +9340,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9373,7 +9402,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9416,12 +9447,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9432,7 +9523,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9441,6 +9532,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -10088,7 +10189,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10784,6 +10887,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -12134,6 +12243,9 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         }
       }
     },
@@ -12381,6 +12493,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -13938,6 +14056,9 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
         }
       }
     },
@@ -15441,6 +15562,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -15453,7 +15578,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15897,6 +16023,10 @@
             "type": "string"
           },
           "description": "Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider."
+        },
+        "captchaEnabled": {
+          "type": "boolean",
+          "description": "Whether captcha verification is required on sign up \u0026 otp init."
         }
       }
     },
@@ -17265,6 +17395,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -17298,6 +17432,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -113,7 +113,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +153,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -923,7 +923,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1139,9 +1140,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1151,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1776,6 +1779,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2525,6 +2530,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,7 +2555,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -2573,7 +2588,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2610,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2911,7 +2965,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -3203,6 +3259,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,6 +3822,7 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -3858,6 +3921,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4457,6 +4526,7 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -5060,6 +5130,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5257,6 +5329,8 @@ export type definitions = {
     verificationTokenRequiredForGetAccountPii?: boolean;
     /** @description Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider. */
     socialLinkingClientIds?: string[];
+    /** @description Whether captcha verification is required on sign up & otp init. */
+    captchaEnabled?: boolean;
   };
   v1UpdateAuthProxyConfigResult: {
     /** @description Unique identifier for a given User. (representing the turnkey signer user id) */
@@ -5794,6 +5868,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +5880,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6359,7 +6437,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6617,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {

--- a/packages/react-wallet-kit/package.json
+++ b/packages/react-wallet-kit/package.json
@@ -48,6 +48,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@headlessui/react": "^2.2.6",
     "@lottiefiles/react-lottie-player": "^3.6.0",
+    "@marsidev/react-turnstile": "^1.4.2",
     "@noble/hashes": "^1.8.0",
     "@turnkey/core": "workspace:*",
     "@turnkey/iframe-stamper": "workspace:^",

--- a/packages/react-wallet-kit/src/components/auth/Email.tsx
+++ b/packages/react-wallet-kit/src/components/auth/Email.tsx
@@ -11,6 +11,7 @@ function isValidEmail(email: string): boolean {
 
 interface EmailInputProps {
   onContinue?: (email: string) => void;
+  disabled?: boolean;
 }
 
 export function EmailInput(props: EmailInputProps) {
@@ -39,7 +40,7 @@ export function EmailInput(props: EmailInputProps) {
     }
   };
 
-  const buttonDisabled = !emailIsValid;
+  const buttonDisabled = !emailIsValid || (props.disabled ?? false);
 
   const buttonClass = clsx(
     "transition-all duration-300",

--- a/packages/react-wallet-kit/src/components/auth/OAuth.tsx
+++ b/packages/react-wallet-kit/src/components/auth/OAuth.tsx
@@ -6,12 +6,13 @@ interface OAuthButtonProps {
   icon: React.ReactNode;
   onClick: () => void;
   className?: string;
+  disabled?: boolean;
 }
 
 export function OAuthButton(props: OAuthButtonProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [showText, setShowText] = useState(false);
-  const { name, icon, onClick, className } = props;
+  const { name, icon, onClick, className, disabled } = props;
 
   useEffect(() => {
     const observer = new ResizeObserver(([entry]) => {
@@ -32,6 +33,7 @@ export function OAuthButton(props: OAuthButtonProps) {
       <ActionButton
         onClick={onClick}
         name={`oauth-${name.toLowerCase()}`}
+        disabled={disabled}
         className={`flex items-center justify-center gap-2 w-full h-full rounded-md bg-button-light dark:bg-button-dark text-inherit ${className || ""}`}
       >
         {icon}

--- a/packages/react-wallet-kit/src/components/auth/OTP.tsx
+++ b/packages/react-wallet-kit/src/components/auth/OTP.tsx
@@ -38,6 +38,9 @@ export function OtpVerification(props: OtpVerificationProps) {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [resending, setResending] = useState<boolean>(false);
   const [resent, setResent] = useState<boolean>(false);
+  const [captchaReady, setCaptchaReady] = useState<boolean>(
+    !config?.turnstileSiteKey,
+  );
   const [otpId, setOtpId] = useState<string>(props.otpId);
   const [otpEncryptionTargetBundle, setOtpEncryptionTargetBundle] =
     useState<string>(props.otpEncryptionTargetBundle);
@@ -87,6 +90,7 @@ export function OtpVerification(props: OtpVerificationProps) {
 
   const handleResend = async () => {
     setResending(true);
+    setCaptchaReady(false);
     try {
       const { otpId, otpEncryptionTargetBundle } = await initOtp({
         otpType,
@@ -146,7 +150,7 @@ export function OtpVerification(props: OtpVerificationProps) {
         )}
         <BaseButton
           onClick={handleResend}
-          disabled={resending || resent}
+          disabled={resending || resent || !captchaReady}
           className={`text-xs text-inherit font-semibold bg-transparent border-none ${resent && "opacity-30"}`}
         >
           {resending ? (
@@ -179,6 +183,7 @@ export function OtpVerification(props: OtpVerificationProps) {
             className="!w-full !block [&>iframe]:!w-full"
             onSuccess={(token) => {
               setTurnstileToken(token);
+              setCaptchaReady(true);
             }}
             onError={() => {
               setTurnstileToken(null);

--- a/packages/react-wallet-kit/src/components/auth/OTP.tsx
+++ b/packages/react-wallet-kit/src/components/auth/OTP.tsx
@@ -8,6 +8,8 @@ import { OtpType, TurnkeyError, TurnkeyErrorCodes } from "@turnkey/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope, faPhone } from "@fortawesome/free-solid-svg-icons";
 import clsx from "clsx";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
+import { consumeCaptchaToken } from "../../utils/captcha";
 
 interface OtpVerificationProps {
   contact: string;
@@ -30,7 +32,8 @@ export function OtpVerification(props: OtpVerificationProps) {
     sessionKey,
     onContinue = null, // Default to null if not provided
   } = props;
-  const { initOtp, completeOtp } = useTurnkey();
+  const { initOtp, completeOtp, config, getTurnstileToken, setTurnstileToken } =
+    useTurnkey();
   const { closeModal, isMobile } = useModal();
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [resending, setResending] = useState<boolean>(false);
@@ -40,6 +43,12 @@ export function OtpVerification(props: OtpVerificationProps) {
     useState<string>(props.otpEncryptionTargetBundle);
   const [error, setError] = useState<string | null>(null);
   const [shaking, setShaking] = useState(false);
+
+  const turnstileRef = useRef<TurnstileInstance>(null);
+  const [showTurnstilePrompt, setShowTurnstilePrompt] = useState(false);
+
+  const consumeToken = () =>
+    consumeCaptchaToken(getTurnstileToken, setTurnstileToken, turnstileRef);
 
   const shakeInput = () => {
     setShaking(true);
@@ -59,6 +68,7 @@ export function OtpVerification(props: OtpVerificationProps) {
           contact,
           otpType,
           ...(sessionKey && { sessionKey }),
+          ...(await consumeToken()),
         });
         closeModal();
       }
@@ -81,6 +91,7 @@ export function OtpVerification(props: OtpVerificationProps) {
       const { otpId, otpEncryptionTargetBundle } = await initOtp({
         otpType,
         contact,
+        ...(await consumeToken()),
       });
       setOtpId(otpId);
       setOtpEncryptionTargetBundle(otpEncryptionTargetBundle);
@@ -95,7 +106,7 @@ export function OtpVerification(props: OtpVerificationProps) {
   return (
     <div
       className={clsx(
-        "flex items-center justify-center py-3",
+        "flex flex-col items-center justify-center py-3",
         isMobile ? "w-full" : "min-w-96",
       )}
     >
@@ -153,6 +164,37 @@ export function OtpVerification(props: OtpVerificationProps) {
       {submitting && (
         <div className="absolute flex w-full h-full justify-center items-center">
           <Spinner strokeWidth={1} className="size-1/2" />
+        </div>
+      )}
+      {config?.turnstileSiteKey && !submitting && (
+        <div className="mt-3 flex flex-col text-left w-full">
+          {showTurnstilePrompt && (
+            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
+              Let us know you're human
+            </p>
+          )}
+          <Turnstile
+            ref={turnstileRef}
+            siteKey={config.turnstileSiteKey}
+            className="!w-full !block [&>iframe]:!w-full"
+            onSuccess={(token) => {
+              setTurnstileToken(token);
+            }}
+            onError={() => {
+              setTurnstileToken(null);
+            }}
+            onExpire={() => {
+              setTurnstileToken(null);
+            }}
+            onBeforeInteractive={() => {
+              setShowTurnstilePrompt(true);
+            }}
+            options={{
+              theme: config.ui?.darkMode ? "dark" : "light",
+              appearance: "interaction-only",
+              size: "flexible",
+            }}
+          />
         </div>
       )}
     </div>

--- a/packages/react-wallet-kit/src/components/auth/Passkey.tsx
+++ b/packages/react-wallet-kit/src/components/auth/Passkey.tsx
@@ -3,6 +3,7 @@ import { ActionButton } from "../design/Buttons";
 interface PasskeyButtonsProps {
   onLogin: () => void;
   onSignUp: () => void;
+  disabled?: boolean;
 }
 
 export function PasskeyButtons(props: PasskeyButtonsProps) {
@@ -13,6 +14,7 @@ export function PasskeyButtons(props: PasskeyButtonsProps) {
         name="passkey-login-button"
         onClick={onLogin}
         className="w-full text-inherit bg-button-light dark:bg-button-dark"
+        disabled={props.disabled ?? false}
       >
         Log in with passkey
       </ActionButton>
@@ -20,6 +22,7 @@ export function PasskeyButtons(props: PasskeyButtonsProps) {
         name="passkey-signup-button"
         onClick={onSignUp}
         className="w-full bg-transparent text-primary-light dark:text-primary-dark border-none"
+        disabled={props.disabled ?? false}
       >
         Sign up with passkey
       </ActionButton>

--- a/packages/react-wallet-kit/src/components/auth/Phone.tsx
+++ b/packages/react-wallet-kit/src/components/auth/Phone.tsx
@@ -7,6 +7,7 @@ import { useTurnkey } from "../../providers/client/Hook";
 
 interface PhoneNumberInputProps {
   onContinue?: (phone: string, formattedPhone: string) => void;
+  disabled?: boolean;
 }
 
 export function PhoneNumberInput(props: PhoneNumberInputProps) {
@@ -29,7 +30,7 @@ export function PhoneNumberInput(props: PhoneNumberInputProps) {
     }
   };
 
-  const buttonDisabled = !isValid;
+  const buttonDisabled = !isValid || (props.disabled ?? false);
 
   const buttonClass = clsx(
     "transition-all duration-300",

--- a/packages/react-wallet-kit/src/components/auth/index.tsx
+++ b/packages/react-wallet-kit/src/components/auth/index.tsx
@@ -322,6 +322,7 @@ export function AuthComponent({
         name="Google"
         icon={<FontAwesomeIcon icon={faGoogle} />}
         onClick={handleGoogle}
+        disabled={!authEnabled}
       />
     ) : null,
     apple: methods.appleOauthEnabled ? (
@@ -330,6 +331,7 @@ export function AuthComponent({
         name="Apple"
         icon={<FontAwesomeIcon icon={faApple} />}
         onClick={handleApple}
+        disabled={!authEnabled}
       />
     ) : null,
     facebook: methods.facebookOauthEnabled ? (
@@ -338,6 +340,7 @@ export function AuthComponent({
         name="Facebook"
         icon={<FontAwesomeIcon icon={faFacebook} />}
         onClick={handleFacebook}
+        disabled={!authEnabled}
       />
     ) : null,
     x: methods.xOauthEnabled ? (
@@ -346,6 +349,7 @@ export function AuthComponent({
         name="X"
         icon={<FontAwesomeIcon icon={faXTwitter} />}
         onClick={handleX}
+        disabled={!authEnabled}
       />
     ) : null,
     discord: methods.discordOauthEnabled ? (
@@ -354,6 +358,7 @@ export function AuthComponent({
         name="Discord"
         icon={<FontAwesomeIcon icon={faDiscord} />}
         onClick={handleDiscord}
+        disabled={!authEnabled}
       />
     ) : null,
   };
@@ -503,6 +508,7 @@ export function AuthComponent({
             onError={() => {
               console.error("Turnstile error occurred");
               setTurnstileToken(null);
+              setAuthEnabled(false);
               setShowTurnstileError(true);
             }}
             onExpire={() => {

--- a/packages/react-wallet-kit/src/components/auth/index.tsx
+++ b/packages/react-wallet-kit/src/components/auth/index.tsx
@@ -26,6 +26,9 @@ import {
   ExternalWalletSelector,
   WalletSelectorMode,
 } from "./wallet/ExternalWalletSelector";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
+import { useRef, useState } from "react";
+import { consumeCaptchaToken } from "../../utils/captcha";
 
 type AuthComponentProps = {
   sessionKey?: string | undefined;
@@ -51,8 +54,21 @@ export function AuthComponent({
     initOtp,
     loginWithPasskey,
     signUpWithPasskey,
+    getTurnstileToken,
+    setTurnstileToken,
   } = useTurnkey();
   const { pushPage, isMobile, openSheet } = useModal();
+
+  const turnstileRef = useRef<TurnstileInstance>(null);
+  const [showTurnstilePrompt, setShowTurnstilePrompt] = useState(false);
+  // If a token already existed when the component mounted, we don't need to show the widget at all
+  const [hadTokenOnMount] = useState(() => !!getTurnstileToken());
+  // Auth is enabled immediately if no turnstile is configured, or if the Provider already has a token
+
+  const [showTurnstileError, setShowTurnstileError] = useState(false);
+  const [authEnabled, setAuthEnabled] = useState(
+    !config?.turnstileSiteKey || hadTokenOnMount,
+  );
 
   if (!config || clientState === ClientState.Loading) {
     // Don't check ClientState.Error here. We already check in the modal root
@@ -69,11 +85,15 @@ export function AuthComponent({
     oauthOrder = [],
   } = config.ui?.authModal || {};
 
+  const consumeToken = () =>
+    consumeCaptchaToken(getTurnstileToken, setTurnstileToken, turnstileRef);
+
   const handleEmailSubmit = async (email: string) => {
     try {
       const { otpId, otpEncryptionTargetBundle } = await initOtp({
         otpType: OtpType.Email,
         contact: email,
+        ...(await consumeToken()),
       });
       pushPage({
         key: "Verify OTP",
@@ -104,6 +124,7 @@ export function AuthComponent({
       const { otpId, otpEncryptionTargetBundle } = await initOtp({
         otpType: OtpType.Sms,
         contact: phone,
+        ...(await consumeToken()),
       });
       pushPage({
         key: "Verify OTP",
@@ -158,6 +179,7 @@ export function AuthComponent({
           action={async () => {
             await signUpWithPasskey({
               ...(sessionKey && { sessionKey: sessionKey }),
+              ...(await consumeToken()),
             });
           }}
           icon={<FontAwesomeIcon size="3x" icon={faFingerprint} />}
@@ -173,12 +195,13 @@ export function AuthComponent({
       content: (
         <ActionPage
           title="Authenticating with Google..."
-          action={() =>
+          action={async () =>
             handleGoogleOauth({
               additionalState: {
                 openModal: "true",
                 ...(sessionKey && { sessionKey }),
               }, // Tell the provider to reopen the auth modal and show the loading state
+              ...(await consumeToken()),
             })
           }
           icon={<FontAwesomeIcon size="3x" icon={faGoogle} />}
@@ -194,12 +217,13 @@ export function AuthComponent({
       content: (
         <ActionPage
           title="Authenticating with Apple..."
-          action={() =>
+          action={async () =>
             handleAppleOauth({
               additionalState: {
                 openModal: "true",
                 ...(sessionKey && { sessionKey }),
               }, // Tell the provider to reopen the auth modal and show the loading state
+              ...(await consumeToken()),
             })
           }
           icon={<FontAwesomeIcon size="3x" icon={faApple} />}
@@ -215,12 +239,13 @@ export function AuthComponent({
       content: (
         <ActionPage
           title="Authenticating with Facebook..."
-          action={() =>
+          action={async () =>
             handleFacebookOauth({
               additionalState: {
                 openModal: "true",
                 ...(sessionKey && { sessionKey }),
               }, // Tell the provider to reopen the auth modal and show the loading state
+              ...(await consumeToken()),
             })
           }
           icon={<FontAwesomeIcon size="3x" icon={faFacebook} />}
@@ -236,12 +261,13 @@ export function AuthComponent({
       content: (
         <ActionPage
           title="Authenticating with X..."
-          action={() =>
+          action={async () =>
             handleXOauth({
               additionalState: {
                 openModal: "true",
                 ...(sessionKey && { sessionKey }),
               }, // Tell the provider to reopen the auth modal and show the loading state
+              ...(await consumeToken()),
             })
           }
           icon={<FontAwesomeIcon size="3x" icon={faXTwitter} />}
@@ -257,12 +283,13 @@ export function AuthComponent({
       content: (
         <ActionPage
           title="Authenticating with Discord..."
-          action={() =>
+          action={async () =>
             handleDiscordOauth({
               additionalState: {
                 openModal: "true",
                 ...(sessionKey && { sessionKey }),
               }, // Tell the provider to reopen the auth modal and show the loading state
+              ...(await consumeToken()),
             })
           }
           icon={<FontAwesomeIcon size="3x" icon={faDiscord} />}
@@ -375,19 +402,26 @@ export function AuthComponent({
   const methodComponents: Record<string, JSX.Element | null> = {
     socials: oauthBlock,
     email: methods.emailOtpAuthEnabled ? (
-      <EmailInput onContinue={handleEmailSubmit} />
+      <EmailInput onContinue={handleEmailSubmit} disabled={!authEnabled} />
     ) : null,
     sms: methods.smsOtpAuthEnabled ? (
-      <PhoneNumberInput onContinue={handlePhoneSubmit} />
+      <PhoneNumberInput
+        onContinue={handlePhoneSubmit}
+        disabled={!authEnabled}
+      />
     ) : null,
     passkey: methods.passkeyAuthEnabled ? (
       <PasskeyButtons
         onLogin={handlePasskeyLogin}
         onSignUp={handlePasskeySignUp}
+        disabled={!authEnabled}
       />
     ) : null,
     wallet: methods.walletAuthEnabled ? (
-      <WalletAuthButton onContinue={handleShowWalletSelector} />
+      <WalletAuthButton
+        onContinue={handleShowWalletSelector}
+        disabled={!authEnabled}
+      />
     ) : null,
   };
 
@@ -448,6 +482,43 @@ export function AuthComponent({
           // Users should never see this message ever. We should give a reward for anyone who does see this.
           userMessages={["You touched fuzzy.... and got dizzy."]}
         />
+      )}
+
+      {config.turnstileSiteKey && (!hadTokenOnMount || showTurnstileError) && (
+        <div className="mt-3 flex flex-col text-left w-full">
+          {showTurnstilePrompt && (
+            <p className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-sm mb-0.5">
+              Let us know you're human
+            </p>
+          )}
+          <Turnstile
+            ref={turnstileRef}
+            id="auth-component-turnstile"
+            siteKey={config.turnstileSiteKey}
+            className="!w-full !block [&>iframe]:!w-full [&>iframe]:!bg-transparent"
+            onSuccess={(token) => {
+              setTurnstileToken(token);
+              setAuthEnabled(true);
+            }}
+            onError={() => {
+              console.error("Turnstile error occurred");
+              setTurnstileToken(null);
+              setShowTurnstileError(true);
+            }}
+            onExpire={() => {
+              setTurnstileToken(null);
+              setAuthEnabled(false);
+            }}
+            onBeforeInteractive={() => {
+              setShowTurnstilePrompt(true);
+            }}
+            options={{
+              theme: config.ui?.darkMode ? "dark" : "light",
+              appearance: "interaction-only",
+              size: "flexible",
+            }}
+          />
+        </div>
       )}
 
       <div className="text-icon-text-light/70 dark:text-icon-text-dark/70 text-xs mt-4 text-center">

--- a/packages/react-wallet-kit/src/components/auth/wallet/WalletAuthButton.tsx
+++ b/packages/react-wallet-kit/src/components/auth/wallet/WalletAuthButton.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 interface WalletAuthButtonProps {
   onContinue: () => Promise<void>;
+  disabled?: boolean;
 }
 export function WalletAuthButton(props: WalletAuthButtonProps) {
   const { onContinue } = props;
@@ -24,6 +25,7 @@ export function WalletAuthButton(props: WalletAuthButtonProps) {
         onClick={handleContinue}
         loading={isLoading}
         className="w-full text-inherit bg-button-light dark:bg-button-dark"
+        disabled={props.disabled ?? false}
       >
         Continue with wallet
       </ActionButton>

--- a/packages/react-wallet-kit/src/providers/client/Provider.tsx
+++ b/packages/react-wallet-kit/src/providers/client/Provider.tsx
@@ -42,6 +42,7 @@ import {
 } from "../../utils/timers";
 import {
   getAuthProxyConfig,
+  getClientParams,
   Chain,
   DEFAULT_SESSION_EXPIRATION_IN_SECONDS,
   OtpType,
@@ -137,6 +138,7 @@ import {
   type TDeleteSubOrganizationResponse,
   type TStampLoginResponse,
   type ProxyTGetWalletKitConfigResponse,
+  type ProxyTGetWalletKitClientParamsResponse,
   type v1SignRawPayloadResult,
   type v1User,
   type v1PrivateKey,
@@ -215,6 +217,7 @@ import { OnRampPage } from "../../components/onramp/OnRamp";
 import { CoinbaseLogo, MoonPayLogo } from "../../components/design/Svg";
 import { SendTransactionPage } from "../../components/send-transaction/SendTransaction";
 import { getChainLogo } from "../../components/send-transaction/helpers";
+import { Turnstile } from "@marsidev/react-turnstile";
 
 /**
  * @inline
@@ -268,6 +271,15 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
     AuthState.Unauthenticated,
   );
 
+  // Turnstile state: pre-warm the challenge in the background
+  const turnstileTokenRef = useRef<string | null>(null);
+
+  const getTurnstileToken = useCallback(() => turnstileTokenRef.current, []);
+
+  const setTurnstileToken = useCallback((token: string | null) => {
+    turnstileTokenRef.current = token;
+  }, []);
+
   // if there is no authProxyConfigId or if autoFetchWalletKitConfig is specifically
   // set to false, we don't need to fetch the config
   const shouldFetchWalletKitConfig =
@@ -279,6 +291,9 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
 
   const expiryTimeoutsRef = useRef<TimerMap>({});
   const proxyAuthConfigRef = useRef<ProxyTGetWalletKitConfigResponse | null>(
+    null,
+  );
+  const clientParamsRef = useRef<ProxyTGetWalletKitClientParamsResponse | null>(
     null,
   );
 
@@ -401,6 +416,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
           sessionKey,
           nonce,
           openModal,
+          captchaToken,
         } = result;
 
         const isAddProvider = oauthIntent === OAUTH_INTENT_ADD_PROVIDER;
@@ -422,6 +438,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                 publicKey,
                 providerName,
                 sessionKey: sessionKey ?? undefined,
+                captchaToken: captchaToken ?? undefined,
                 callbacks,
                 completeOauth: (completionParams) => {
                   const existingCreateSubOrgParams =
@@ -624,6 +641,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
           openModal,
           sessionKey,
           oauthIntent,
+          captchaToken,
         } = result;
 
         const isAddProvider = oauthIntent === OAUTH_INTENT_ADD_PROVIDER;
@@ -645,6 +663,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
             publicKey,
             oidcToken: idToken,
             sessionKey: sessionKey ?? undefined,
+            captchaToken: captchaToken ?? undefined,
             callbacks,
             completeOauth: (completionParams) => {
               const existingCreateSubOrgParams =
@@ -707,6 +726,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
 
   const buildConfig = (
     proxyAuthConfig?: ProxyTGetWalletKitConfigResponse | undefined,
+    clientParams?: ProxyTGetWalletKitClientParamsResponse | undefined,
   ) => {
     // Juggle the local overrides with the values set in the dashboard (proxyAuthConfig).
     const resolvedMethods = {
@@ -893,6 +913,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       },
       importIframeUrl: config.importIframeUrl ?? "https://import.turnkey.com",
       exportIframeUrl: config.exportIframeUrl ?? "https://export.turnkey.com",
+      turnstileSiteKey: clientParams?.turnstileSiteKey,
     } as TurnkeyProviderConfig;
   };
 
@@ -3493,6 +3514,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
           ?.secondaryClientIds ?? [],
         openInPage = masterConfig?.auth?.oauthConfig?.openOauthInPage ?? false,
         additionalState: additionalParameters,
+        captchaToken,
       } = params || {};
       const clientId = primaryClientId;
 
@@ -3540,7 +3562,10 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
         nonce,
         flow,
         codeChallenge,
-        additionalState: additionalParameters,
+        additionalState: {
+          ...additionalParameters,
+          ...(captchaToken && { captchaToken }),
+        },
       });
 
       if (openInPage) {
@@ -3600,6 +3625,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                       }),
                     });
                   },
+                  captchaToken,
                   onOauthSuccess: params?.onOauthSuccess,
                   exchangeCodeForToken: async (codeVerifier) => {
                     const resp =
@@ -3639,6 +3665,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
           ?.secondaryClientIds ?? [],
         openInPage = masterConfig?.auth?.oauthConfig?.openOauthInPage ?? false,
         additionalState: additionalParameters,
+        captchaToken,
       } = params || {};
       const clientId = primaryClientId;
 
@@ -3686,7 +3713,10 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
         nonce,
         flow,
         codeChallenge,
-        additionalState: additionalParameters,
+        additionalState: {
+          ...additionalParameters,
+          ...(captchaToken && { captchaToken }),
+        },
       });
 
       if (openInPage) {
@@ -3746,6 +3776,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                       }),
                     });
                   },
+                  captchaToken,
                   onOauthSuccess: params?.onOauthSuccess,
                   exchangeCodeForToken: async (codeVerifier) => {
                     const resp =
@@ -3786,6 +3817,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
           ?.secondaryClientIds ?? [],
         openInPage = masterConfig?.auth?.oauthConfig?.openOauthInPage ?? false,
         additionalState: additionalParameters,
+        captchaToken,
       } = params || {};
       const clientId = primaryClientId;
 
@@ -3830,7 +3862,10 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
         publicKey,
         nonce,
         flow,
-        additionalState: additionalParameters,
+        additionalState: {
+          ...additionalParameters,
+          ...(captchaToken && { captchaToken }),
+        },
       });
 
       if (openInPage) {
@@ -3890,6 +3925,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                       }),
                     });
                   },
+                  captchaToken,
                   onOauthSuccess: params?.onOauthSuccess,
                 })
                   .then(() => resolve())
@@ -3918,6 +3954,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
           ?.secondaryClientIds ?? [],
         openInPage = masterConfig?.auth?.oauthConfig?.openOauthInPage ?? false,
         additionalState: additionalParameters,
+        captchaToken,
       } = params || {};
       const clientId = primaryClientId;
 
@@ -3961,7 +3998,10 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
         publicKey,
         nonce,
         flow,
-        additionalState: additionalParameters,
+        additionalState: {
+          ...additionalParameters,
+          ...(captchaToken && { captchaToken }),
+        },
       });
 
       if (openInPage) {
@@ -4021,6 +4061,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                       }),
                     });
                   },
+                  captchaToken,
                   onOauthSuccess: params?.onOauthSuccess,
                 })
                   .then(() => resolve())
@@ -4049,6 +4090,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
           ?.secondaryClientIds ?? [],
         openInPage = masterConfig?.auth?.oauthConfig?.openOauthInPage ?? false,
         additionalState: additionalParameters,
+        captchaToken,
       } = params || {};
       const clientId = primaryClientId;
 
@@ -4096,7 +4138,10 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
         nonce,
         flow,
         codeChallenge,
-        additionalState: additionalParameters,
+        additionalState: {
+          ...additionalParameters,
+          ...(captchaToken && { captchaToken }),
+        },
       });
 
       if (openInPage) {
@@ -4156,6 +4201,7 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
                       }),
                     });
                   },
+                  captchaToken,
                   onOauthSuccess: params?.onOauthSuccess,
                   exchangeCodeForToken: async (codeVerifier) => {
                     const tokenData = await exchangeFacebookCodeForToken(
@@ -6156,21 +6202,45 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
   useEffect(() => {
     if (proxyAuthConfigRef.current) return;
 
-    // Only fetch the proxy auth config once. Use that to build the master config.
+    // Fetch proxy auth config and client params once. Use both to build the master config.
     const fetchProxyAuthConfig = async () => {
       try {
         let proxyAuthConfig: ProxyTGetWalletKitConfigResponse | undefined;
+        let clientParams: ProxyTGetWalletKitClientParamsResponse | undefined;
+
+        const promises: Promise<void>[] = [];
 
         if (shouldFetchWalletKitConfig) {
-          // Only fetch the proxy auth config if we have an authProxyId and the autoFetchWalletKitConfig param is enabled or not passed in.
-          proxyAuthConfig = await getAuthProxyConfig(
-            config.authProxyConfigId!, // Can assert safely. See shouldFetchWalletKitConfig definition.
-            config.authProxyUrl,
+          promises.push(
+            getAuthProxyConfig(
+              config.authProxyConfigId!,
+              config.authProxyUrl,
+            ).then((result) => {
+              proxyAuthConfig = result;
+            }),
           );
-          proxyAuthConfigRef.current = proxyAuthConfig;
         }
 
-        setMasterConfig(buildConfig(proxyAuthConfig));
+        if (config.authProxyConfigId) {
+          promises.push(
+            getClientParams(config.authProxyConfigId, config.authProxyUrl).then(
+              (result: ProxyTGetWalletKitClientParamsResponse) => {
+                clientParams = result;
+              },
+            ),
+          );
+        }
+
+        await Promise.all(promises);
+
+        if (proxyAuthConfig) {
+          proxyAuthConfigRef.current = proxyAuthConfig;
+        }
+        if (clientParams) {
+          clientParamsRef.current = clientParams;
+        }
+
+        setMasterConfig(buildConfig(proxyAuthConfig, clientParams));
       } catch {
         setClientState(ClientState.Error);
       }
@@ -6192,7 +6262,12 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
     // If shouldFetchWalletKitConfig is false, we'll never have a proxyAuthConfig to build the master config with, so this useEffect should always run.
     if (!proxyAuthConfigRef.current && shouldFetchWalletKitConfig) return;
 
-    setMasterConfig(buildConfig(proxyAuthConfigRef.current ?? undefined));
+    setMasterConfig(
+      buildConfig(
+        proxyAuthConfigRef.current ?? undefined,
+        clientParamsRef.current ?? undefined,
+      ),
+    );
   }, [config, proxyAuthConfigRef.current]);
 
   /**
@@ -6396,8 +6471,30 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
         handleOnRamp,
         handleSendTransaction,
         handleSendErc20Transfer,
+        getTurnstileToken,
+        setTurnstileToken,
       }}
     >
+      {masterConfig?.turnstileSiteKey &&
+        authState !== AuthState.Authenticated &&
+        !getTurnstileToken() && (
+          <Turnstile
+            siteKey={masterConfig.turnstileSiteKey}
+            onSuccess={(token) => {
+              setTurnstileToken(token);
+            }}
+            onError={() => {
+              setTurnstileToken(null);
+            }}
+            onExpire={() => {
+              setTurnstileToken(null);
+            }}
+            options={{
+              size: "invisible",
+              appearance: "execute",
+            }}
+          />
+        )}
       {children}
     </ClientContext.Provider>
   );

--- a/packages/react-wallet-kit/src/providers/client/Types.tsx
+++ b/packages/react-wallet-kit/src/providers/client/Types.tsx
@@ -820,6 +820,11 @@ export interface ClientContextType
   handleSendErc20Transfer: (
     params: HandleSendErc20TransferParams,
   ) => Promise<void>;
+
+  /** @internal Get the current Turnstile captcha token */
+  getTurnstileToken: () => string | null;
+  /** @internal Set the Turnstile captcha token (used by the auth component when interactive challenge completes) */
+  setTurnstileToken: (token: string | null) => void;
 }
 
 /** @internal */

--- a/packages/react-wallet-kit/src/tests/oauth-test.ts
+++ b/packages/react-wallet-kit/src/tests/oauth-test.ts
@@ -53,6 +53,7 @@ describe("parseOAuthRedirect", () => {
         sessionKey: "sess_1",
         oauthIntent: null,
         nonce: null,
+        captchaToken: null,
       });
     });
 
@@ -103,6 +104,7 @@ describe("parseOAuthRedirect", () => {
         sessionKey: "sess_g1",
         oauthIntent: null,
         nonce: null,
+        captchaToken: null,
       });
     });
 
@@ -294,6 +296,7 @@ describe("OAuth utils", () => {
         openModal: null,
         oauthIntent: null,
         nonce: null,
+        captchaToken: null,
       });
     });
 
@@ -315,6 +318,7 @@ describe("OAuth utils", () => {
         openModal: null,
         oauthIntent: null,
         nonce: null,
+        captchaToken: null,
       });
     });
   });

--- a/packages/react-wallet-kit/src/types/base.ts
+++ b/packages/react-wallet-kit/src/types/base.ts
@@ -112,6 +112,9 @@ export interface TurnkeyProviderConfig extends TurnkeySDKClientConfig {
   /** whether to automatically fetch the wallet kit config on initialization. */
   autoFetchWalletKitConfig?: boolean;
 
+  /** site key for Turnstile bot detection. Fetched automatically from the auth proxy. */
+  turnstileSiteKey?: string;
+
   /** default stamper type to use for requests that require stamping. */
   defaultStamperType?: StamperType;
 

--- a/packages/react-wallet-kit/src/types/method-types.ts
+++ b/packages/react-wallet-kit/src/types/method-types.ts
@@ -44,6 +44,7 @@ export type HandleDiscordOauthParams = {
   secondaryClientIds?: string[];
   additionalState?: Record<string, string>;
   openInPage?: boolean;
+  captchaToken?: string;
   onOauthSuccess?: (params: {
     publicKey: string;
     oidcToken: string;
@@ -56,6 +57,7 @@ export type HandleXOauthParams = {
   secondaryClientIds?: string[];
   additionalState?: Record<string, string>;
   openInPage?: boolean;
+  captchaToken?: string;
   onOauthSuccess?: (params: {
     publicKey: string;
     oidcToken: string;
@@ -68,6 +70,7 @@ export type HandleGoogleOauthParams = {
   secondaryClientIds?: string[];
   additionalState?: Record<string, string>;
   openInPage?: boolean;
+  captchaToken?: string;
   onOauthSuccess?: (params: {
     publicKey: string;
     oidcToken: string;
@@ -80,6 +83,7 @@ export type HandleAppleOauthParams = {
   secondaryClientIds?: string[];
   additionalState?: Record<string, string>;
   openInPage?: boolean;
+  captchaToken?: string;
   onOauthSuccess?: (params: {
     publicKey: string;
     oidcToken: string;
@@ -92,6 +96,7 @@ export type HandleFacebookOauthParams = {
   secondaryClientIds?: string[];
   additionalState?: Record<string, string>;
   openInPage?: boolean;
+  captchaToken?: string;
   onOauthSuccess?: (params: {
     publicKey: string;
     oidcToken: string;

--- a/packages/react-wallet-kit/src/utils/captcha.ts
+++ b/packages/react-wallet-kit/src/utils/captcha.ts
@@ -1,0 +1,48 @@
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
+
+/**
+ * Polls for a captcha token to become available, resolving immediately if one already exists.
+ * Returns null if the timeout is reached without a token.
+ */
+export const waitForCaptchaToken = (
+  getTurnstileToken: () => string | null,
+  timeoutMs = 5000,
+): Promise<string | null> => {
+  return new Promise((resolve) => {
+    const token = getTurnstileToken();
+    if (token) return resolve(token);
+
+    const interval = 200;
+    let elapsed = 0;
+    const poll = setInterval(() => {
+      elapsed += interval;
+      const t = getTurnstileToken();
+      if (t) {
+        clearInterval(poll);
+        return resolve(t);
+      }
+      if (elapsed >= timeoutMs) {
+        clearInterval(poll);
+        return resolve(null);
+      }
+    }, interval);
+  });
+};
+
+/**
+ * Waits for a captcha token, then consumes it (clears state and resets the widget for a fresh token).
+ * Returns `{ captchaToken }` if a token was available, or `{}` if timed out.
+ */
+export const consumeCaptchaToken = async (
+  getTurnstileToken: () => string | null,
+  setTurnstileToken: (token: string | null) => void,
+  turnstileRef?: React.RefObject<TurnstileInstance | null>,
+): Promise<{ captchaToken: string } | Record<string, never>> => {
+  const token = await waitForCaptchaToken(getTurnstileToken);
+  if (token) {
+    setTurnstileToken(null);
+    turnstileRef?.current?.reset();
+    return { captchaToken: token };
+  }
+  return {};
+};

--- a/packages/react-wallet-kit/src/utils/captcha.ts
+++ b/packages/react-wallet-kit/src/utils/captcha.ts
@@ -1,3 +1,4 @@
+import type { RefObject } from "react";
 import type { TurnstileInstance } from "@marsidev/react-turnstile";
 
 /**
@@ -23,6 +24,9 @@ export const waitForCaptchaToken = (
       }
       if (elapsed >= timeoutMs) {
         clearInterval(poll);
+        console.warn(
+          "[turnkey] CAPTCHA token not available within timeout — proceeding without token",
+        );
         return resolve(null);
       }
     }, interval);
@@ -36,7 +40,7 @@ export const waitForCaptchaToken = (
 export const consumeCaptchaToken = async (
   getTurnstileToken: () => string | null,
   setTurnstileToken: (token: string | null) => void,
-  turnstileRef?: React.RefObject<TurnstileInstance | null>,
+  turnstileRef?: RefObject<TurnstileInstance | null>,
 ): Promise<{ captchaToken: string } | Record<string, never>> => {
   const token = await waitForCaptchaToken(getTurnstileToken);
   if (token) {

--- a/packages/react-wallet-kit/src/utils/oauth/completion.ts
+++ b/packages/react-wallet-kit/src/utils/oauth/completion.ts
@@ -24,6 +24,8 @@ export interface CompleteOAuthFlowParams {
   oidcToken: string;
   /** Optional session key from the state parameter */
   sessionKey?: string | undefined;
+  /** Optional captcha token for bot detection */
+  captchaToken?: string | undefined;
   /** Optional callbacks for custom handling */
   callbacks?: TurnkeyCallbacks | undefined;
   /** Function to complete the OAuth authentication flow */
@@ -32,6 +34,7 @@ export interface CompleteOAuthFlowParams {
     publicKey: string;
     providerName: string;
     sessionKey?: string;
+    captchaToken?: string;
   }) => Promise<BaseAuthResult & { action: AuthAction }>;
   /** Optional callback when OAuth succeeds (alternative to completeOauth) */
   onOauthSuccess?:
@@ -61,6 +64,7 @@ export async function completeOAuthFlow(
     publicKey,
     oidcToken,
     sessionKey,
+    captchaToken,
     callbacks,
     completeOauth,
     onOauthSuccess,
@@ -88,6 +92,7 @@ export async function completeOAuthFlow(
       publicKey,
       providerName: provider,
       ...(sessionKey && { sessionKey }),
+      ...(captchaToken && { captchaToken }),
     });
   }
 }
@@ -100,12 +105,15 @@ export interface CompleteOAuthPopupParams {
   provider: OAuthProviders;
   publicKey: string;
   result: OAuthResponseResult;
+  /** Optional captcha token for bot detection */
+  captchaToken?: string | undefined;
   callbacks?: TurnkeyCallbacks | undefined;
   completeOauth: (params: {
     oidcToken: string;
     publicKey: string;
     providerName: string;
     sessionKey?: string;
+    captchaToken?: string;
   }) => Promise<BaseAuthResult & { action: AuthAction }>;
   onOauthSuccess?:
     | ((params: {
@@ -129,6 +137,7 @@ export async function completeOAuthPopup(
     provider,
     publicKey,
     result,
+    captchaToken,
     callbacks,
     completeOauth,
     onOauthSuccess,
@@ -150,6 +159,7 @@ export async function completeOAuthPopup(
       publicKey,
       providerName: provider as PKCEProvider,
       sessionKey: result.sessionKey,
+      captchaToken,
       callbacks,
       completeOauth,
       onOauthSuccess,
@@ -162,6 +172,7 @@ export async function completeOAuthPopup(
       publicKey,
       oidcToken: result.idToken!,
       sessionKey: result.sessionKey,
+      captchaToken,
       callbacks,
       completeOauth,
       onOauthSuccess,
@@ -180,6 +191,8 @@ export interface CompletePKCEFlowParams {
   providerName: PKCEProvider;
   /** Optional session key from the state parameter */
   sessionKey?: string | undefined;
+  /** Optional captcha token for bot detection */
+  captchaToken?: string | undefined;
   /** Optional callbacks for custom handling */
   callbacks?: TurnkeyCallbacks | undefined;
   /** Function to complete the OAuth flow */
@@ -188,6 +201,7 @@ export interface CompletePKCEFlowParams {
     publicKey: string;
     providerName: string;
     sessionKey?: string;
+    captchaToken?: string;
   }) => Promise<BaseAuthResult & { action: AuthAction }>;
   /** Optional callback when OAuth succeeds (used in popup flow) */
   onOauthSuccess?:
@@ -227,6 +241,7 @@ export async function completePKCEFlow({
   publicKey,
   providerName,
   sessionKey,
+  captchaToken,
   callbacks,
   completeOauth,
   onOauthSuccess,
@@ -245,6 +260,7 @@ export async function completePKCEFlow({
     publicKey,
     oidcToken,
     sessionKey,
+    captchaToken,
     callbacks,
     completeOauth,
     onOauthSuccess,

--- a/packages/react-wallet-kit/src/utils/oauth/url.ts
+++ b/packages/react-wallet-kit/src/utils/oauth/url.ts
@@ -132,6 +132,8 @@ export interface OAuthResponseResult {
   oauthIntent?: string | null;
   /** Nonce from state */
   nonce?: string | null;
+  /** Captcha token from state (encoded before redirect) */
+  captchaToken?: string | null;
 }
 
 /**
@@ -203,6 +205,7 @@ export function parseOAuthResponse(
     sessionKey,
     oauthIntent,
     nonce,
+    captchaToken,
   } = parseStateParam(stateString);
 
   // If we have an expected provider (popup flow), validate it matches
@@ -232,6 +235,7 @@ export function parseOAuthResponse(
     sessionKey: sessionKey ?? undefined,
     oauthIntent: oauthIntent ?? null,
     nonce: nonce ?? null,
+    captchaToken: captchaToken ?? null,
   };
 }
 

--- a/packages/react-wallet-kit/tsconfig.json
+++ b/packages/react-wallet-kit/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
+  "skipLibCheck": true,
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/react-wallet-kit/tsconfig.json
+++ b/packages/react-wallet-kit/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "skipLibCheck": true,
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/sdk-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-browser/src/__generated__/sdk-client-base.ts
@@ -4311,7 +4311,7 @@ export class TurnkeySDKClientBase {
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
       },
-      "ethSendTransactionResult",
+      "ethSendTransactionResultV2",
     );
   };
 

--- a/packages/sdk-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-browser/src/__generated__/sdk_api_types.ts
@@ -976,7 +976,7 @@ export type TEmailAuthBody =
     commandOverrideParams;
 
 export type TEthSendTransactionResponse =
-  operations["PublicApiService_EthSendTransaction"]["responses"]["200"]["schema"]["activity"]["result"]["ethSendTransactionResult"] &
+  operations["PublicApiService_EthSendTransaction"]["responses"]["200"]["schema"]["activity"]["result"]["ethSendTransactionResultV2"] &
     definitions["v1ActivityResponse"];
 
 export type TEthSendTransactionInput = { body: TEthSendTransactionBody };

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -875,7 +875,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1195,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -5127,7 +5127,8 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
       ]
     },
     "v1AddressFormat": {
@@ -5586,11 +5587,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5607,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -7188,6 +7193,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -9037,6 +9046,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9092,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9130,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9175,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9251,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9260,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9816,7 +9917,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10462,6 +10565,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +11921,9 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         }
       }
     },
@@ -11998,6 +12110,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -13458,6 +13576,9 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
         }
       }
     },
@@ -14925,6 +15046,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +15062,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15381,6 +15507,10 @@
             "type": "string"
           },
           "description": "Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider."
+        },
+        "captchaEnabled": {
+          "type": "boolean",
+          "description": "Whether captcha verification is required on sign up \u0026 otp init."
         }
       }
     },
@@ -16749,6 +16879,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +16916,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -113,7 +113,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +153,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -923,7 +923,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1139,9 +1140,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1151,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1776,6 +1779,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2525,6 +2530,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,7 +2555,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -2573,7 +2588,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2610,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2911,7 +2965,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -3203,6 +3259,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,6 +3822,7 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -3858,6 +3921,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4457,6 +4526,7 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -5060,6 +5130,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5257,6 +5329,8 @@ export type definitions = {
     verificationTokenRequiredForGetAccountPii?: boolean;
     /** @description Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider. */
     socialLinkingClientIds?: string[];
+    /** @description Whether captcha verification is required on sign up & otp init. */
+    captchaEnabled?: boolean;
   };
   v1UpdateAuthProxyConfigResult: {
     /** @description Unique identifier for a given User. (representing the turnkey signer user id) */
@@ -5794,6 +5868,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +5880,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6359,7 +6437,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6617,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -80,7 +80,7 @@
     }
   },
   "devDependencies": {
-    "@types/react": "18.2.14",
+    "@types/react": "18.3.24",
     "@types/react-dom": "18.2.6",
     "postcss-import": "^16.1.0",
     "react": "^18.2.0"

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -3406,7 +3406,7 @@ export class TurnkeySDKClientBase {
         timestampMs: timestampMs ?? String(Date.now()),
         type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
       },
-      "ethSendTransactionResult",
+      "ethSendTransactionResultV2",
     );
   };
 

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -875,7 +875,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1195,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -5127,7 +5127,8 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
       ]
     },
     "v1AddressFormat": {
@@ -5586,11 +5587,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5607,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -7188,6 +7193,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -9037,6 +9046,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9092,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9130,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9175,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9251,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9260,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9816,7 +9917,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10462,6 +10565,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +11921,9 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         }
       }
     },
@@ -11998,6 +12110,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -13458,6 +13576,9 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
         }
       }
     },
@@ -14925,6 +15046,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +15062,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15381,6 +15507,10 @@
             "type": "string"
           },
           "description": "Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider."
+        },
+        "captchaEnabled": {
+          "type": "boolean",
+          "description": "Whether captcha verification is required on sign up \u0026 otp init."
         }
       }
     },
@@ -16749,6 +16879,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +16916,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -113,7 +113,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +153,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -923,7 +923,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1139,9 +1140,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1151,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1776,6 +1779,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2525,6 +2530,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,7 +2555,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -2573,7 +2588,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2610,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2911,7 +2965,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -3203,6 +3259,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,6 +3822,7 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -3858,6 +3921,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4457,6 +4526,7 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -5060,6 +5130,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5257,6 +5329,8 @@ export type definitions = {
     verificationTokenRequiredForGetAccountPii?: boolean;
     /** @description Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider. */
     socialLinkingClientIds?: string[];
+    /** @description Whether captcha verification is required on sign up & otp init. */
+    captchaEnabled?: boolean;
   };
   v1UpdateAuthProxyConfigResult: {
     /** @description Unique identifier for a given User. (representing the turnkey signer user id) */
@@ -5794,6 +5868,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +5880,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6359,7 +6437,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6617,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {

--- a/packages/sdk-types/src/__generated__/types.ts
+++ b/packages/sdk-types/src/__generated__/types.ts
@@ -139,6 +139,12 @@ export type v1GetAccountResponse = {
   organizationId?: string;
 };
 
+export type v1GetWalletKitClientParamsRequest = {};
+export type v1GetWalletKitClientParamsResponse = {
+  /** Site key for Turnstile, used to protect WalletKit flows with bot detection. */
+  turnstileSiteKey?: string;
+};
+
 export type v1GetWalletKitConfigRequest = {};
 export type v1GetWalletKitConfigResponse = {
   /** List of enabled authentication providers (e.g., 'facebook', 'google', 'apple', 'email', 'sms', 'passkey', 'wallet') */
@@ -384,6 +390,8 @@ export type v1WalletAccountParams = {
   path: string;
   /** Address format used to generate a wallet Acccount. */
   addressFormat: v1AddressFormat;
+  /** Optional human-readable name for the account. */
+  name?: string;
 };
 
 export type v1WalletParams = {
@@ -748,7 +756,8 @@ export type v1ActivityType =
   | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
   | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
   | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-  | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+  | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+  | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
 
 export type v1ApiKey = {
   /** A User credential that can be used to authenticate to Turnkey. */
@@ -875,9 +884,9 @@ export type v1BootProof = {
   ephemeralPublicKeyHex: string;
   /** The DER encoded COSE Sign1 struct Attestation doc. */
   awsAttestationDocB64: string;
-  /** The borsch serialized base64 encoded Manifest. */
+  /** The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
   qosManifestB64: string;
-  /** The borsch serialized base64 encoded Manifest Envelope. */
+  /** The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
   qosManifestEnvelopeB64: string;
   /** The label under which the enclave app was deployed. */
   deploymentLabel: string;
@@ -886,6 +895,8 @@ export type v1BootProof = {
   /** Owner of the app i.e. 'tkhq' */
   owner: string;
   createdAt: externaldatav1Timestamp;
+  /** QOS manifest schema version. */
+  qosManifestVersion?: string;
 };
 
 export type v1BootProofResponse = {
@@ -1524,6 +1535,8 @@ export type v1CreateTvcAppIntent = {
   shareSetParams?: v1TvcOperatorSetParams;
   /** Enables network egress for this TVC app. Default if not provided: false. */
   enableEgress?: boolean;
+  /** When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+  enableDebugModeDeployments?: boolean;
 };
 
 export type v1CreateTvcAppRequest = {
@@ -2322,6 +2335,15 @@ export type v1EnableAuthProxyResult = {
   userId: string;
 };
 
+export type v1EthCallParams = {
+  /** Recipient address as a hex string with 0x prefix. */
+  to: string;
+  /** Amount of native asset to send in wei. */
+  value?: string;
+  /** Hex-encoded call data for contract interactions. */
+  data?: string;
+};
+
 export type v1EthFailureDetails = {
   /** Ethereum revert chain, ordered from outermost to innermost. */
   revertChain?: v1RevertChainEntry[];
@@ -2337,7 +2359,9 @@ export type v1EthSendRawTransactionIntent = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
 };
 
 export type v1EthSendRawTransactionResult = {
@@ -2357,7 +2381,9 @@ export type v1EthSendTransactionIntent = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Recipient address as a hex string with 0x prefix. */
   to: string;
   /** Amount of native asset to send in wei. */
@@ -2378,17 +2404,53 @@ export type v1EthSendTransactionIntent = {
   gasStationNonce?: string;
 };
 
+export type v1EthSendTransactionIntentV2 = {
+  /** A wallet or private key address to sign with. This does not support private key IDs. */
+  from: string;
+  /** CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet). */
+  caip2:
+    | "eip155:1"
+    | "eip155:11155111"
+    | "eip155:8453"
+    | "eip155:84532"
+    | "eip155:137"
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
+  /** Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+  sponsor?: boolean;
+  /** Outer transaction nonce. Omit to auto-fetch. */
+  nonce?: string;
+  /** Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+  gasLimit?: string;
+  /** Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+  maxFeePerGas?: string;
+  /** Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+  maxPriorityFeePerGas?: string;
+  /** Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+  deadline?: string;
+  /** The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+  gasStationNonce?: string;
+  /** Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+  calls: v1EthCallParams[];
+};
+
 export type v1EthSendTransactionRequest = {
-  type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+  type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
   /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
   timestampMs: string;
   /** Unique identifier for a given Organization. */
   organizationId: string;
-  parameters: v1EthSendTransactionIntent;
+  parameters: v1EthSendTransactionIntentV2;
   generateAppProofs?: boolean;
 };
 
 export type v1EthSendTransactionResult = {
+  /** The send_transaction_status ID associated with the transaction submission */
+  sendTransactionStatusId: string;
+};
+
+export type v1EthSendTransactionResultV2 = {
   /** The send_transaction_status ID associated with the transaction submission */
   sendTransactionStatusId: string;
 };
@@ -2721,7 +2783,9 @@ export type v1GetNoncesRequest = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Whether to fetch the standard on-chain nonce. */
   nonce?: boolean;
   /** Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -3024,6 +3088,12 @@ export type v1GetWalletAddressBalancesRequest = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -3587,6 +3657,7 @@ export type v1Intent = {
   sparkClaimTransferIntent?: v1SparkClaimTransferIntent;
   sparkPrepareLightningReceiveIntent?: v1SparkPrepareLightningReceiveIntent;
   postTvcQuorumKeyShareIntent?: v1PostTvcQuorumKeyShareIntent;
+  ethSendTransactionIntentV2?: v1EthSendTransactionIntentV2;
 };
 
 export type v1InvitationParams = {
@@ -3670,6 +3741,12 @@ export type v1ListSupportedAssetsRequest = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -4243,6 +4320,7 @@ export type v1Result = {
   sparkClaimTransferResult?: v1SparkClaimTransferResult;
   sparkPrepareLightningReceiveResult?: v1SparkPrepareLightningReceiveResult;
   postTvcQuorumKeyShareResult?: v1PostTvcQuorumKeyShareResult;
+  ethSendTransactionResultV2?: v1EthSendTransactionResultV2;
 };
 
 export type v1RevertChainEntry = {
@@ -4862,6 +4940,8 @@ export type v1TvcApp = {
   liveDeploymentId?: string;
   /** The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
   publicDomain: string;
+  /** Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+  enableDebugModeDeployments: boolean;
 };
 
 export type v1TvcContainerSpec = {
@@ -5042,6 +5122,8 @@ export type v1UpdateAuthProxyConfigIntent = {
   verificationTokenRequiredForGetAccountPii?: boolean;
   /** Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider. */
   socialLinkingClientIds?: string[];
+  /** Whether captcha verification is required on sign up & otp init. */
+  captchaEnabled?: boolean;
 };
 
 export type v1UpdateAuthProxyConfigResult = {
@@ -5609,6 +5691,8 @@ export type v1WalletAccount = {
   publicKey?: string;
   /** Wallet details for this account. This is only present when include_wallet_details=true. */
   walletDetails?: v1Wallet;
+  /** Human-readable name for this Wallet Account, unique within the organization. */
+  name?: string;
 };
 
 export type v1WalletKitSettingsParams = {
@@ -5803,7 +5887,9 @@ export type TGetNoncesBody = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Whether to fetch the standard on-chain nonce. */
   nonce?: boolean;
   /** Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -6029,6 +6115,12 @@ export type TGetWalletAddressBalancesBody = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -6166,6 +6258,12 @@ export type TListSupportedAssetsBody = {
     | "eip155:84532"
     | "eip155:137"
     | "eip155:80002"
+    | "eip155:42161"
+    | "eip155:4217"
+    | "eip155:42431"
+    | "eip155:421614"
+    | "eip155:56"
+    | "eip155:97"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -6664,6 +6762,8 @@ export type TCreateTvcAppBody = {
   shareSetParams?: v1TvcOperatorSetParams;
   /** Enables network egress for this TVC app. Default if not provided: false. */
   enableEgress?: boolean;
+  /** When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+  enableDebugModeDeployments?: boolean;
 };
 
 export type TCreateTvcAppInput = { body: TCreateTvcAppBody };
@@ -7208,7 +7308,9 @@ export type TEthSendTransactionBody = {
     | "eip155:8453"
     | "eip155:84532"
     | "eip155:137"
-    | "eip155:80002";
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97";
   /** Recipient address as a hex string with 0x prefix. */
   to: string;
   /** Amount of native asset to send in wei. */
@@ -8511,6 +8613,17 @@ export type ProxyTSignupV2Body = {
 };
 
 export type ProxyTSignupV2Input = { body: ProxyTSignupV2Body };
+
+export type ProxyTGetWalletKitClientParamsResponse = {
+  /** Site key for Turnstile, used to protect WalletKit flows with bot detection. */
+  turnstileSiteKey?: string;
+};
+
+export type ProxyTGetWalletKitClientParamsBody = {};
+
+export type ProxyTGetWalletKitClientParamsInput = {
+  body: ProxyTGetWalletKitClientParamsBody;
+};
 
 export type ProxyTGetWalletKitConfigResponse = {
   /** List of enabled authentication providers (e.g., 'facebook', 'google', 'apple', 'email', 'sms', 'passkey', 'wallet') */

--- a/packages/sdk-types/src/__inputs__/auth_proxy.swagger.json
+++ b/packages/sdk-types/src/__inputs__/auth_proxy.swagger.json
@@ -364,6 +364,38 @@
         "tags": ["Auth"]
       }
     },
+    "/v1/wallet_kit_client_params": {
+      "post": {
+        "summary": "Get WalletKit Client Params",
+        "description": "Get client parameters needed to initialize WalletKit flows, such as a client token for the calling organization.",
+        "operationId": "AuthProxyService_GetWalletKitClientParams",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletKitClientParamsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetWalletKitClientParamsRequest"
+            }
+          }
+        ],
+        "tags": ["Wallet Kit"]
+      }
+    },
     "/v1/wallet_kit_config": {
       "post": {
         "summary": "Get WalletKit Config",
@@ -640,6 +672,19 @@
       "properties": {
         "organizationId": {
           "type": "string"
+        }
+      }
+    },
+    "v1GetWalletKitClientParamsRequest": {
+      "type": "object"
+    },
+    "v1GetWalletKitClientParamsResponse": {
+      "type": "object",
+      "properties": {
+        "turnstileSiteKey": {
+          "type": "string",
+          "description": "Site key for Turnstile, used to protect WalletKit flows with bot detection.",
+          "title": "Turnstile Site Key"
         }
       }
     },
@@ -1207,6 +1252,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-types/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-types/src/__inputs__/public_api.swagger.json
@@ -875,7 +875,7 @@
     "/public/v1/query/get_wallet_address_balances": {
       "post": {
         "summary": "Get balances",
-        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.",
+        "description": "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.",
         "operationId": "PublicApiService_GetWalletAddressBalances",
         "responses": {
           "200": {
@@ -1195,7 +1195,7 @@
     "/public/v1/query/list_supported_assets": {
       "post": {
         "summary": "List supported assets",
-        "description": "List supported assets for the specified network. This feature is in beta - please contact support for access.",
+        "description": "List supported assets for the specified network.",
         "operationId": "PublicApiService_ListSupportedAssets",
         "responses": {
           "200": {
@@ -5127,7 +5127,8 @@
         "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
         "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
         "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE",
-        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+        "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+        "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"
       ]
     },
     "v1AddressFormat": {
@@ -5586,11 +5587,11 @@
         },
         "qosManifestB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest."
+          "description": "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."
         },
         "qosManifestEnvelopeB64": {
           "type": "string",
-          "description": "The borsch serialized base64 encoded Manifest Envelope."
+          "description": "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."
         },
         "deploymentLabel": {
           "type": "string",
@@ -5606,6 +5607,10 @@
         },
         "createdAt": {
           "$ref": "#/definitions/externaldatav1Timestamp"
+        },
+        "qosManifestVersion": {
+          "type": "string",
+          "description": "QOS manifest schema version."
         }
       },
       "required": [
@@ -7188,6 +7193,10 @@
         "enableEgress": {
           "type": "boolean",
           "description": "Enables network egress for this TVC app. Default if not provided: false."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."
         }
       },
       "required": ["name", "quorumPublicKey"]
@@ -9037,6 +9046,24 @@
       },
       "required": ["userId"]
     },
+    "v1EthCallParams": {
+      "type": "object",
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Recipient address as a hex string with 0x prefix."
+        },
+        "value": {
+          "type": "string",
+          "description": "Amount of native asset to send in wei."
+        },
+        "data": {
+          "type": "string",
+          "description": "Hex-encoded call data for contract interactions."
+        }
+      },
+      "required": ["to"]
+    },
     "v1EthFailureDetails": {
       "type": "object",
       "properties": {
@@ -9065,7 +9092,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -9101,7 +9130,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -9144,12 +9175,72 @@
       },
       "required": ["from", "caip2", "to"]
     },
+    "v1EthSendTransactionIntentV2": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to sign with. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the outer transaction. Omit to auto-estimate."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        },
+        "deadline": {
+          "type": "string",
+          "description": "Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EthCallParams"
+          },
+          "description": "Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station."
+        }
+      },
+      "required": ["from", "caip2", "calls"]
+    },
     "v1EthSendTransactionRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION"]
+          "enum": ["ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -9160,7 +9251,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1EthSendTransactionIntent"
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -9169,6 +9260,16 @@
       "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1EthSendTransactionResult": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
+    "v1EthSendTransactionResultV2": {
       "type": "object",
       "properties": {
         "sendTransactionStatusId": {
@@ -9816,7 +9917,9 @@
             "eip155:8453",
             "eip155:84532",
             "eip155:137",
-            "eip155:80002"
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -10462,6 +10565,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -11812,6 +11921,9 @@
         },
         "postTvcQuorumKeyShareIntent": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareIntent"
+        },
+        "ethSendTransactionIntentV2": {
+          "$ref": "#/definitions/v1EthSendTransactionIntentV2"
         }
       }
     },
@@ -11998,6 +12110,12 @@
             "eip155:84532",
             "eip155:137",
             "eip155:80002",
+            "eip155:42161",
+            "eip155:4217",
+            "eip155:42431",
+            "eip155:421614",
+            "eip155:56",
+            "eip155:97",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -13458,6 +13576,9 @@
         },
         "postTvcQuorumKeyShareResult": {
           "$ref": "#/definitions/v1PostTvcQuorumKeyShareResult"
+        },
+        "ethSendTransactionResultV2": {
+          "$ref": "#/definitions/v1EthSendTransactionResultV2"
         }
       }
     },
@@ -14925,6 +15046,10 @@
         "publicDomain": {
           "type": "string",
           "description": "The public domain for ingress to this TVC App (in the format \"app-\u003cID\u003e.turnkey.cloud\")."
+        },
+        "enableDebugModeDeployments": {
+          "type": "boolean",
+          "description": "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."
         }
       },
       "required": [
@@ -14937,7 +15062,8 @@
         "enableEgress",
         "createdAt",
         "updatedAt",
-        "publicDomain"
+        "publicDomain",
+        "enableDebugModeDeployments"
       ]
     },
     "v1TvcContainerSpec": {
@@ -15381,6 +15507,10 @@
             "type": "string"
           },
           "description": "Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider."
+        },
+        "captchaEnabled": {
+          "type": "boolean",
+          "description": "Whether captcha verification is required on sign up \u0026 otp init."
         }
       }
     },
@@ -16749,6 +16879,10 @@
         "walletDetails": {
           "$ref": "#/definitions/v1Wallet",
           "description": "Wallet details for this account. This is only present when include_wallet_details=true."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account, unique within the organization."
         }
       },
       "required": [
@@ -16782,6 +16916,10 @@
         "addressFormat": {
           "$ref": "#/definitions/v1AddressFormat",
           "description": "Address format used to generate a wallet Acccount."
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional human-readable name for the account."
         }
       },
       "required": ["curve", "pathFormat", "path", "addressFormat"]

--- a/packages/sdk-types/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-types/src/__inputs__/public_api.types.ts
@@ -113,7 +113,7 @@ export type paths = {
     post: operations["PublicApiService_GetWalletAccount"];
   };
   "/public/v1/query/get_wallet_address_balances": {
-    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+    /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
     post: operations["PublicApiService_GetWalletAddressBalances"];
   };
   "/public/v1/query/list_activities": {
@@ -153,7 +153,7 @@ export type paths = {
     post: operations["PublicApiService_GetSubOrgIds"];
   };
   "/public/v1/query/list_supported_assets": {
-    /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+    /** List supported assets for the specified network. */
     post: operations["PublicApiService_ListSupportedAssets"];
   };
   "/public/v1/query/list_tvc_app_deployments": {
@@ -923,7 +923,8 @@ export type definitions = {
     | "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"
     | "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
-    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE";
+    | "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE"
+    | "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1139,9 +1140,9 @@ export type definitions = {
     ephemeralPublicKeyHex: string;
     /** @description The DER encoded COSE Sign1 struct Attestation doc. */
     awsAttestationDocB64: string;
-    /** @description The borsch serialized base64 encoded Manifest. */
+    /** @description The base64 encoded QOS manifest. Encoding depends on qos_manifest_version. */
     qosManifestB64: string;
-    /** @description The borsch serialized base64 encoded Manifest Envelope. */
+    /** @description The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version. */
     qosManifestEnvelopeB64: string;
     /** @description The label under which the enclave app was deployed. */
     deploymentLabel: string;
@@ -1150,6 +1151,8 @@ export type definitions = {
     /** @description Owner of the app i.e. 'tkhq' */
     owner: string;
     createdAt: definitions["externaldatav1Timestamp"];
+    /** @description QOS manifest schema version. */
+    qosManifestVersion?: string;
   };
   v1BootProofResponse: {
     bootProof: definitions["v1BootProof"];
@@ -1776,6 +1779,8 @@ export type definitions = {
     shareSetParams?: definitions["v1TvcOperatorSetParams"];
     /** @description Enables network egress for this TVC app. Default if not provided: false. */
     enableEgress?: boolean;
+    /** @description When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false. */
+    enableDebugModeDeployments?: boolean;
   };
   v1CreateTvcAppRequest: {
     /** @enum {string} */
@@ -2525,6 +2530,14 @@ export type definitions = {
     /** @description A User ID with permission to initiate authentication. */
     userId: string;
   };
+  v1EthCallParams: {
+    /** @description Recipient address as a hex string with 0x prefix. */
+    to: string;
+    /** @description Amount of native asset to send in wei. */
+    value?: string;
+    /** @description Hex-encoded call data for contract interactions. */
+    data?: string;
+  };
   v1EthFailureDetails: {
     /** @description Ethereum revert chain, ordered from outermost to innermost. */
     revertChain?: definitions["v1RevertChainEntry"][];
@@ -2542,7 +2555,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -2573,7 +2588,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -2593,17 +2610,54 @@ export type definitions = {
     /** @description The gas station delegate contract nonce. Only used when sponsor=true. Include this if you want maximal security posture. */
     gasStationNonce?: string;
   };
+  v1EthSendTransactionIntentV2: {
+    /** @description A wallet or private key address to sign with. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
+    /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
+    sponsor?: boolean;
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the outer transaction. Omit to auto-estimate. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+    /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
+    deadline?: string;
+    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
+    calls: definitions["v1EthCallParams"][];
+  };
   v1EthSendTransactionRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION";
+    type: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1EthSendTransactionIntent"];
+    parameters: definitions["v1EthSendTransactionIntentV2"];
     generateAppProofs?: boolean;
   };
   v1EthSendTransactionResult: {
+    /** @description The send_transaction_status ID associated with the transaction submission */
+    sendTransactionStatusId: string;
+  };
+  v1EthSendTransactionResultV2: {
     /** @description The send_transaction_status ID associated with the transaction submission */
     sendTransactionStatusId: string;
   };
@@ -2911,7 +2965,9 @@ export type definitions = {
       | "eip155:8453"
       | "eip155:84532"
       | "eip155:137"
-      | "eip155:80002";
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -3203,6 +3259,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -3760,6 +3822,7 @@ export type definitions = {
     sparkClaimTransferIntent?: definitions["v1SparkClaimTransferIntent"];
     sparkPrepareLightningReceiveIntent?: definitions["v1SparkPrepareLightningReceiveIntent"];
     postTvcQuorumKeyShareIntent?: definitions["v1PostTvcQuorumKeyShareIntent"];
+    ethSendTransactionIntentV2?: definitions["v1EthSendTransactionIntentV2"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -3858,6 +3921,12 @@ export type definitions = {
       | "eip155:84532"
       | "eip155:137"
       | "eip155:80002"
+      | "eip155:42161"
+      | "eip155:4217"
+      | "eip155:42431"
+      | "eip155:421614"
+      | "eip155:56"
+      | "eip155:97"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4457,6 +4526,7 @@ export type definitions = {
     sparkClaimTransferResult?: definitions["v1SparkClaimTransferResult"];
     sparkPrepareLightningReceiveResult?: definitions["v1SparkPrepareLightningReceiveResult"];
     postTvcQuorumKeyShareResult?: definitions["v1PostTvcQuorumKeyShareResult"];
+    ethSendTransactionResultV2?: definitions["v1EthSendTransactionResultV2"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -5060,6 +5130,8 @@ export type definitions = {
     liveDeploymentId?: string;
     /** @description The public domain for ingress to this TVC App (in the format "app-<ID>.turnkey.cloud"). */
     publicDomain: string;
+    /** @description Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture. */
+    enableDebugModeDeployments: boolean;
   };
   v1TvcContainerSpec: {
     /** @description The URL for this container image. */
@@ -5257,6 +5329,8 @@ export type definitions = {
     verificationTokenRequiredForGetAccountPii?: boolean;
     /** @description Whitelisted OAuth client IDs for social account linking. When a user authenticates via a social provider with an email matching an existing account, the accounts will be linked if the client ID is in this list and the issuer is considered a trusted provider. */
     socialLinkingClientIds?: string[];
+    /** @description Whether captcha verification is required on sign up & otp init. */
+    captchaEnabled?: boolean;
   };
   v1UpdateAuthProxyConfigResult: {
     /** @description Unique identifier for a given User. (representing the turnkey signer user id) */
@@ -5794,6 +5868,8 @@ export type definitions = {
     publicKey?: string;
     /** @description Wallet details for this account. This is only present when include_wallet_details=true. */
     walletDetails?: definitions["v1Wallet"];
+    /** @description Human-readable name for this Wallet Account, unique within the organization. */
+    name?: string;
   };
   v1WalletAccountParams: {
     /** @description Cryptographic curve used to generate a wallet Account. */
@@ -5804,6 +5880,8 @@ export type definitions = {
     path: string;
     /** @description Address format used to generate a wallet Acccount. */
     addressFormat: definitions["v1AddressFormat"];
+    /** @description Optional human-readable name for the account. */
+    name?: string;
   };
   v1WalletKitSettingsParams: {
     /**
@@ -6359,7 +6437,7 @@ export type operations = {
       };
     };
   };
-  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access. */
+  /** Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. */
   PublicApiService_GetWalletAddressBalances: {
     parameters: {
       body: {
@@ -6539,7 +6617,7 @@ export type operations = {
       };
     };
   };
-  /** List supported assets for the specified network. This feature is in beta - please contact support for access. */
+  /** List supported assets for the specified network. */
   PublicApiService_ListSupportedAssets: {
     parameters: {
       body: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4504,6 +4504,9 @@ importers:
       '@lottiefiles/react-lottie-player':
         specifier: ^3.6.0
         version: 3.6.0(react@18.3.1)
+      '@marsidev/react-turnstile':
+        specifier: ^1.4.2
+        version: 1.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@noble/hashes':
         specifier: ^1.8.0
         version: 1.8.0
@@ -4625,19 +4628,19 @@ importers:
     dependencies:
       '@emotion/react':
         specifier: ^11.13.3
-        version: 11.14.0(@types/react@18.2.14)(react@18.3.1)
+        version: 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@emotion/styled':
         specifier: ^11.13.0
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
       '@icons-pack/react-simple-icons':
         specifier: ^10.1.0
         version: 10.2.0(react@18.3.1)
       '@mui/icons-material':
         specifier: ^6.1.5
-        version: 6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)
+        version: 6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
       '@mui/material':
         specifier: ^6.1.5
-        version: 6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+        version: 6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       '@noble/hashes':
         specifier: 1.4.0
         version: 1.4.0
@@ -4682,8 +4685,8 @@ importers:
         version: 3.1.1(react@18.3.1)
     devDependencies:
       '@types/react':
-        specifier: 18.2.14
-        version: 18.2.14
+        specifier: 18.3.24
+        version: 18.3.24
       '@types/react-dom':
         specifier: 18.2.6
         version: 18.2.6
@@ -7398,6 +7401,12 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@marsidev/react-turnstile@1.5.3':
+    resolution: {integrity: sha512-8Dij2jiNGNczq1U4EKpO4do2XepcTPxSMc2ZzvHndO+gcp68tvMULm27z2P99rGkdB89hc3452NZeu2Rti4g6A==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.0.0 || ^19.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
@@ -21274,7 +21283,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1)':
+  '@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/babel-plugin': 11.13.5
@@ -21286,7 +21295,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.2.14
+      '@types/react': 18.3.24
     transitivePeerDependencies:
       - supports-color
 
@@ -21315,18 +21324,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@18.2.14)(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
       '@emotion/utils': 1.4.2
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.2.14
+      '@types/react': 18.3.24
     transitivePeerDependencies:
       - supports-color
 
@@ -23490,6 +23499,11 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@marsidev/react-turnstile@1.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@mediapipe/tasks-vision@0.10.17': {}
 
   '@mempool/mempool.js@3.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
@@ -23883,13 +23897,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.14
 
-  '@mui/icons-material@6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)':
+  '@mui/icons-material@6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.2.14
+      '@types/react': 18.3.24
 
   '@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -23912,15 +23926,15 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react@18.2.0)
       '@types/react': 18.2.14
 
-  '@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
+  '@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/core-downloads-tracker': 6.5.0
-      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.2.14)
-      '@mui/utils': 6.4.9(@types/react@18.2.14)(react@18.3.1)
+      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
+      '@mui/types': 7.2.24(@types/react@18.3.24)
+      '@mui/utils': 6.4.9(@types/react@18.3.24)(react@18.3.1)
       '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@18.2.14)
+      '@types/react-transition-group': 4.4.12(@types/react@18.3.24)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -23929,9 +23943,9 @@ snapshots:
       react-is: 19.1.1
       react-transition-group: 4.4.5(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.2.14)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)
-      '@types/react': 18.2.14
+      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
+      '@types/react': 18.3.24
 
   '@mui/private-theming@6.4.9(@types/react@18.2.14)(react@18.2.0)':
     dependencies:
@@ -23942,14 +23956,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.14
 
-  '@mui/private-theming@6.4.9(@types/react@18.2.14)(react@18.3.1)':
+  '@mui/private-theming@6.4.9(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@mui/utils': 6.4.9(@types/react@18.2.14)(react@18.3.1)
+      '@mui/utils': 6.4.9(@types/react@18.3.24)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 18.2.14
+      '@types/react': 18.3.24
 
   '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -23964,7 +23978,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@18.2.14)(react@18.2.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react@18.2.0)
 
-  '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(react@18.3.1)':
+  '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/cache': 11.14.0
@@ -23974,8 +23988,8 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.2.14)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
 
   '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react@18.2.0)':
     dependencies:
@@ -23993,25 +24007,29 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.2.0))(@types/react@18.2.14)(react@18.2.0)
       '@types/react': 18.2.14
 
-  '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)':
+  '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@mui/private-theming': 6.4.9(@types/react@18.2.14)(react@18.3.1)
-      '@mui/styled-engine': 6.5.0(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.2.14)
-      '@mui/utils': 6.4.9(@types/react@18.2.14)(react@18.3.1)
+      '@mui/private-theming': 6.4.9(@types/react@18.3.24)(react@18.3.1)
+      '@mui/styled-engine': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(react@18.3.1)
+      '@mui/types': 7.2.24(@types/react@18.3.24)
+      '@mui/utils': 6.4.9(@types/react@18.3.24)(react@18.3.1)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.2.14)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.2.14)(react@18.3.1))(@types/react@18.2.14)(react@18.3.1)
-      '@types/react': 18.2.14
+      '@emotion/react': 11.14.0(@types/react@18.3.24)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1)
+      '@types/react': 18.3.24
 
   '@mui/types@7.2.24(@types/react@18.2.14)':
     optionalDependencies:
       '@types/react': 18.2.14
+
+  '@mui/types@7.2.24(@types/react@18.3.24)':
+    optionalDependencies:
+      '@types/react': 18.3.24
 
   '@mui/utils@6.4.9(@types/react@18.2.14)(react@18.2.0)':
     dependencies:
@@ -24025,17 +24043,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.14
 
-  '@mui/utils@6.4.9(@types/react@18.2.14)(react@18.3.1)':
+  '@mui/utils@6.4.9(@types/react@18.3.24)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@mui/types': 7.2.24(@types/react@18.2.14)
+      '@mui/types': 7.2.24(@types/react@18.3.24)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.3.1
       react-is: 19.1.1
     optionalDependencies:
-      '@types/react': 18.2.14
+      '@types/react': 18.3.24
 
   '@multiformats/dns@1.0.15':
     dependencies:
@@ -30088,6 +30106,10 @@ snapshots:
     dependencies:
       '@types/react': 18.2.14
 
+  '@types/react-transition-group@4.4.12(@types/react@18.3.24)':
+    dependencies:
+      '@types/react': 18.3.24
+
   '@types/react@18.2.14':
     dependencies:
       '@types/prop-types': 15.7.15
@@ -36011,8 +36033,8 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@8.56.0)(typescript@5.4.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.5(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.56.0)
@@ -36051,21 +36073,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.56.0
-      get-tsconfig: 4.10.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.56.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -36077,7 +36084,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36122,14 +36129,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@8.56.0)(typescript@5.4.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36184,7 +36191,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -36195,7 +36202,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@8.56.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Addresses all review comments from Justin's review on PR #1237.

## Changes

### P0 — `packages/react-wallet-kit/src/utils/captcha.ts`: Missing React import
- Added `import type { RefObject } from 'react'`
- Changed `React.RefObject<TurnstileInstance | null>` → `RefObject<TurnstileInstance | null>` (fixes build failure)

### P2 — `packages/react-wallet-kit/src/utils/captcha.ts`: Silent token timeout
- Added `console.warn` when `waitForCaptchaToken` times out

### P1 — `packages/react-wallet-kit/src/components/auth/OTP.tsx`: Resend no disabled/loading state while awaiting CAPTCHA
- Added `captchaReady` state (false when Turnstile configured, true on widget success)
- Set `captchaReady = false` when `handleResend` consumes the token (widget resets)
- Wired to Resend button `disabled` prop

### P1 — `packages/react-wallet-kit/src/components/auth/index.tsx` + `OAuth.tsx`: OAuth buttons not disabled while CAPTCHA pending
- Added `disabled?: boolean` prop to `OAuthButton`, forwarded to `ActionButton`
- Passed `disabled={!authEnabled}` to all five OAuth entries in `oauthButtonMap`

### P1 — `packages/react-wallet-kit/src/components/auth/index.tsx`: `authEnabled` not reset on Turnstile error
- Added `setAuthEnabled(false)` to the `onError` handler

### P1 — `packages/core/src/__clients__/core.ts` + related: `captchaToken` not forwarded to `loginWithOtp`
- Added `captchaToken?: string` to `LoginWithOtpParams` in `shared.ts`
- Destructured and forwarded `captchaToken` through `loginWithOtp` → `proxyOtpLoginV2`
- Added `captchaToken?` param to `proxyOtpLoginV2` in `sdk-client-base.ts`
- Passed `captchaToken` in `completeOtp`'s login branch call to `loginWithOtp`