### PR TITLE
Add Permit2 EIP-712 signing examples

### DIFF
--- a/examples/chain-integrations/with-ethers/package.json
+++ b/examples/chain-integrations/with-ethers/package.json
@@ -9,6 +9,7 @@
     "start-hyperliquid": "tsx src/eip712/hyperliquid.ts",
     "start-erc2612-permit": "tsx src/eip712/erc2612_permit.ts",
     "start-erc3009-transfer": "tsx src/eip712/erc3009_transfer.ts",
+    "start-permit2": "tsx src/eip712/permit2.ts",
     "clean": "rimraf ./dist ./.cache",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/chain-integrations/with-ethers/src/eip712/permit2.ts
+++ b/examples/chain-integrations/with-ethers/src/eip712/permit2.ts
@@ -1,0 +1,92 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { TurnkeySigner } from "@turnkey/ethers";
+import { ethers } from "ethers";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import { createNewWallet } from "../createNewWallet";
+import { print, assertEqual } from "../util";
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  const turnkeySigner = new TurnkeySigner({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  const address = await turnkeySigner.getAddress();
+  print("Address:", address);
+
+  // Sign a Permit2 signature-transfer authorization. This example signs and
+  // recovers the payload; it does not execute the transfer onchain.
+  const permit2Payload = {
+    types: {
+      TokenPermissions: [
+        { name: "token", type: "address" },
+        { name: "amount", type: "uint256" },
+      ],
+      PermitTransferFrom: [
+        { name: "permitted", type: "TokenPermissions" },
+        { name: "spender", type: "address" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    domain: {
+      name: "Permit2",
+      chainId: 1,
+      verifyingContract: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    },
+    message: {
+      permitted: {
+        // Mainnet USDC, with six decimal places.
+        token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        amount: 1_000_000n,
+      },
+      spender: "0x2222222222222222222222222222222222222222",
+      nonce: 0n,
+      deadline: 1_992_689_033n,
+    },
+  };
+
+  const signature = await turnkeySigner.signTypedData(
+    permit2Payload.domain,
+    permit2Payload.types,
+    permit2Payload.message,
+  );
+
+  const recoveredAddress = ethers.verifyTypedData(
+    permit2Payload.domain,
+    permit2Payload.types,
+    permit2Payload.message,
+    signature,
+  );
+
+  assertEqual(recoveredAddress, address);
+  print("Turnkey-powered Permit2 signature:", signature);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/chain-integrations/with-viem/package.json
+++ b/examples/chain-integrations/with-viem/package.json
@@ -8,6 +8,7 @@
     "start-hyperliquid": "tsx src/eip712/hyperliquid.ts",
     "start-erc2612-permit": "tsx src/eip712/erc2612_permit.ts",
     "start-erc3009-transfer": "tsx src/eip712/erc3009_transfer.ts",
+    "start-permit2": "tsx src/eip712/permit2.ts",
     "start-contracts": "tsx src/contracts.ts",
     "start-legacy": "tsx src/legacy/index.ts",
     "start-1559-sign-raw": "tsx src/eip1559/signRawTransaction.ts",

--- a/examples/chain-integrations/with-viem/src/eip712/permit2.ts
+++ b/examples/chain-integrations/with-viem/src/eip712/permit2.ts
@@ -1,0 +1,104 @@
+import * as path from "path";
+import * as dotenv from "dotenv";
+
+import { createAccount } from "@turnkey/viem";
+import { TurnkeyClient } from "@turnkey/http";
+import { ApiKeyStamper } from "@turnkey/api-key-stamper";
+import {
+  createWalletClient,
+  http,
+  recoverTypedDataAddress,
+  type Account,
+} from "viem";
+import { mainnet } from "viem/chains";
+import { print, assertEqual } from "../util";
+import { createNewWallet } from "../createNewWallet";
+
+// Load environment variables from `.env.local`
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  if (!process.env.SIGN_WITH) {
+    // If you don't specify a `SIGN_WITH`, we'll create a new wallet for you via calling the Turnkey API.
+    await createNewWallet();
+    return;
+  }
+
+  const turnkeyClient = new TurnkeyClient(
+    {
+      baseUrl: process.env.BASE_URL!,
+    },
+    new ApiKeyStamper({
+      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    }),
+  );
+
+  const turnkeyAccount = await createAccount({
+    client: turnkeyClient,
+    organizationId: process.env.ORGANIZATION_ID!,
+    signWith: process.env.SIGN_WITH!,
+  });
+
+  const client = createWalletClient({
+    account: turnkeyAccount as Account,
+    chain: mainnet,
+    transport: http(
+      `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY!}`,
+    ),
+  });
+
+  const typedData = {
+    account: turnkeyAccount as Account,
+    domain: {
+      name: "Permit2",
+      chainId: 1n,
+      verifyingContract: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    },
+    types: {
+      // Including EIP712Domain explicitly ensures direct serializers preserve
+      // every domain field as well.
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      TokenPermissions: [
+        { name: "token", type: "address" },
+        { name: "amount", type: "uint256" },
+      ],
+      PermitTransferFrom: [
+        { name: "permitted", type: "TokenPermissions" },
+        { name: "spender", type: "address" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    primaryType: "PermitTransferFrom",
+    message: {
+      permitted: {
+        // Mainnet USDC, with six decimal places.
+        token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        amount: 1_000_000n,
+      },
+      spender: "0x2222222222222222222222222222222222222222",
+      nonce: 0n,
+      deadline: 1_992_689_033n,
+    },
+  } as const;
+
+  // This signs and recovers the payload; it does not execute the transfer onchain.
+  const signature = await client.signTypedData(typedData);
+  const recoveredAddress = await recoverTypedDataAddress({
+    ...typedData,
+    signature,
+  });
+
+  assertEqual(client.account.address, recoveredAddress);
+  print("Turnkey-powered Permit2 signature:", signature);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add a Permit2 `PermitTransferFrom` EIP-712 sign-and-recover example for `@turnkey/ethers`
- add the equivalent `@turnkey/viem` example with an explicit `EIP712Domain` definition
- expose both examples through a `start-permit2` package script

## Why

The SDK already demonstrated EIP-3009 and EIP-2612, but it did not include a known-good Permit2 typed-data example. These examples show the complete Permit2 domain and message submitted through Turnkey's server-side EIP-712 hashing path.

The scripts only sign and recover the typed data. They do not execute a token transfer.

## Validation

- Ethers example typecheck
- Viem example typecheck
- Prettier check for both examples and package manifests
- Ethers and Viem produce the same typed-data hash for the sample payload
- `git diff --check`
