### PR TITLE
react-wallet-kit: validate OAuth redirect endpoints

### DIFF
--- a/.changeset/strict-oauth-redirects.md
+++ b/.changeset/strict-oauth-redirects.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Validate the configured OAuth redirect endpoint before processing popup responses, aligned with RFC 6749.

--- a/packages/react-wallet-kit/src/providers/client/Provider.tsx
+++ b/packages/react-wallet-kit/src/providers/client/Provider.tsx
@@ -16,6 +16,8 @@ import {
   getProviderIcon,
   completePKCEFlow,
   hasPKCEVerifier,
+  isExpectedOAuthRedirectUrl,
+  OAUTH_PROVIDER_CONFIGS,
   OAUTH_INTENT_ADD_PROVIDER,
   openOAuthPopup,
   parseOAuthResponse,
@@ -3597,7 +3599,13 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
             }
 
             const url = authWindow.location.href || "";
-            if (url.startsWith(window.location.origin)) {
+            if (
+              isExpectedOAuthRedirectUrl(
+                url,
+                redirectUri,
+                OAUTH_PROVIDER_CONFIGS[provider].expectedResponseMode,
+              )
+            ) {
               const result = parseOAuthResponse(url, provider);
               if (result) {
                 authWindow.close();
@@ -3752,7 +3760,13 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
             }
 
             const url = authWindow.location.href || "";
-            if (url.startsWith(window.location.origin)) {
+            if (
+              isExpectedOAuthRedirectUrl(
+                url,
+                redirectUri,
+                OAUTH_PROVIDER_CONFIGS[provider].expectedResponseMode,
+              )
+            ) {
               const result = parseOAuthResponse(url, provider);
               if (result) {
                 authWindow.close();
@@ -3905,7 +3919,13 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
             }
 
             const url = authWindow.location.href || "";
-            if (url.startsWith(window.location.origin)) {
+            if (
+              isExpectedOAuthRedirectUrl(
+                url,
+                redirectUri,
+                OAUTH_PROVIDER_CONFIGS[provider].expectedResponseMode,
+              )
+            ) {
               const result = parseOAuthResponse(url, provider);
               if (result) {
                 authWindow.close();
@@ -4045,7 +4065,13 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
             }
 
             const url = authWindow.location.href || "";
-            if (url.startsWith(window.location.origin)) {
+            if (
+              isExpectedOAuthRedirectUrl(
+                url,
+                redirectUri,
+                OAUTH_PROVIDER_CONFIGS[provider].expectedResponseMode,
+              )
+            ) {
               const result = parseOAuthResponse(url, provider);
               if (result) {
                 authWindow.close();
@@ -4189,7 +4215,13 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
             }
 
             const url = authWindow.location.href || "";
-            if (url.startsWith(window.location.origin)) {
+            if (
+              isExpectedOAuthRedirectUrl(
+                url,
+                redirectUri,
+                OAUTH_PROVIDER_CONFIGS[provider].expectedResponseMode,
+              )
+            ) {
               const result = parseOAuthResponse(url, provider);
               if (result) {
                 authWindow.close();

--- a/packages/react-wallet-kit/src/tests/oauth-test.ts
+++ b/packages/react-wallet-kit/src/tests/oauth-test.ts
@@ -2,12 +2,14 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 import { OAuthProviders, TurnkeyErrorCodes } from "@turnkey/sdk-types";
 import {
   OAUTH_CAPTCHA_TOKEN_KEY,
+  OAuthResponseMode,
   OAUTH_STATE_KEY,
   buildOAuthState,
   buildOAuthUrl,
   clearAllOAuthData,
   consumeOAuthCaptchaToken,
   consumeOAuthState,
+  isExpectedOAuthRedirectUrl,
   parseStateParam,
   parseOAuthResponse,
   storeOAuthCaptchaToken,
@@ -34,6 +36,161 @@ beforeEach(() => {
         store = {};
       },
     },
+  });
+});
+
+describe("isExpectedOAuthRedirectUrl", () => {
+  const redirectUri = "https://example.com/oauth/callback";
+  const matchesFragment = (response: string, expected = redirectUri) =>
+    isExpectedOAuthRedirectUrl(response, expected, OAuthResponseMode.Fragment);
+  const matchesQuery = (response: string, expected = redirectUri) =>
+    isExpectedOAuthRedirectUrl(response, expected, OAuthResponseMode.Query);
+
+  describe("fragment responses", () => {
+    it("accepts the exact configured endpoint", () => {
+      expect(matchesFragment(`${redirectUri}#id_token=token&state=state`)).toBe(
+        true,
+      );
+    });
+
+    it("rejects query parameters added before the fragment", () => {
+      expect(
+        matchesFragment(
+          `${redirectUri}?state=attacker-controlled#id_token=token`,
+        ),
+      ).toBe(false);
+    });
+
+    it("normalizes URLs while preserving case-sensitive components", () => {
+      expect(
+        matchesFragment("HTTPS://EXAMPLE.COM/oauth/callback#id_token=token"),
+      ).toBe(true);
+      expect(
+        matchesFragment(
+          `${redirectUri}#id_token=token`,
+          "HTTPS://EXAMPLE.COM:443/oauth/callback",
+        ),
+      ).toBe(true);
+      expect(
+        matchesFragment("https://example.com/OAuth/callback#id_token=token"),
+      ).toBe(false);
+      expect(
+        matchesFragment(
+          `${redirectUri}?tenant=turnkey#id_token=token`,
+          `${redirectUri}?tenant=Turnkey`,
+        ),
+      ).toBe(false);
+    });
+
+    it.each([
+      "https://example.com/oauth/callback/child#id_token=token",
+      "https://example.com/oauth/callback-evil#id_token=token",
+      "https://example.com/another-path#id_token=token",
+      "https://example.com.evil/oauth/callback#id_token=token",
+      "not a URL",
+    ])("rejects a different endpoint: %s", (response) => {
+      expect(matchesFragment(response)).toBe(false);
+    });
+
+    it("rejects an empty fragment", () => {
+      expect(matchesFragment(`${redirectUri}#`)).toBe(false);
+    });
+  });
+
+  describe("query responses", () => {
+    it("accepts the exact configured endpoint", () => {
+      expect(matchesQuery(`${redirectUri}?code=code&state=state`)).toBe(true);
+    });
+
+    it("requires configured query parameters to match", () => {
+      const expected = `${redirectUri}?tenant=turnkey&tenant=wallet`;
+
+      expect(matchesQuery(`${expected}&code=code&state=state`, expected)).toBe(
+        true,
+      );
+      expect(
+        matchesQuery(
+          `${redirectUri}?tenant=other&code=code&state=state`,
+          expected,
+        ),
+      ).toBe(false);
+      expect(
+        matchesQuery(`${redirectUri}?code=code&state=state`, expected),
+      ).toBe(false);
+    });
+
+    it("ignores unrecognized response parameters", () => {
+      expect(
+        matchesQuery(
+          `${redirectUri}?code=code&state=state&provider_extension=value`,
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects a response containing both a code and an error", () => {
+      expect(
+        matchesQuery(
+          `${redirectUri}?code=code&error=access_denied&state=state`,
+        ),
+      ).toBe(false);
+    });
+
+    it("rejects duplicate configured query parameters", () => {
+      const expected = `${redirectUri}?tenant=trusted`;
+
+      expect(
+        matchesQuery(
+          `${expected}&tenant=attacker&code=code&state=state`,
+          expected,
+        ),
+      ).toBe(false);
+    });
+
+    it("rejects configured response parameter names", () => {
+      const expected = `${redirectUri}?state=route-value`;
+
+      expect(matchesQuery(`${expected}&code=code&state=state`, expected)).toBe(
+        false,
+      );
+    });
+
+    it("handles configured query delimiters", () => {
+      expect(
+        matchesQuery(`${redirectUri}?code=code&state=state`, `${redirectUri}?`),
+      ).toBe(true);
+      expect(
+        matchesQuery(
+          `${redirectUri}?tenant=turnkey&code=code&state=state`,
+          `${redirectUri}?tenant=turnkey&`,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("shared validation", () => {
+    it("requires the configured response mode", () => {
+      expect(matchesFragment(`${redirectUri}?code=code&state=state`)).toBe(
+        false,
+      );
+      expect(matchesQuery(`${redirectUri}#id_token=token&state=state`)).toBe(
+        false,
+      );
+    });
+
+    it("rejects configured fragments, including an empty fragment", () => {
+      expect(
+        matchesFragment(
+          `${redirectUri}#id_token=token`,
+          `${redirectUri}#configured-fragment`,
+        ),
+      ).toBe(false);
+      expect(
+        matchesFragment(
+          "https://example.com/some/url#",
+          "https://example.com/some/url#",
+        ),
+      ).toBe(false);
+    });
   });
 });
 

--- a/packages/react-wallet-kit/src/utils/oauth/config.ts
+++ b/packages/react-wallet-kit/src/utils/oauth/config.ts
@@ -13,6 +13,11 @@ export const FACEBOOK_GRAPH_URL =
 export const popupWidth = 500;
 export const popupHeight = 600;
 
+export enum OAuthResponseMode {
+  Query = "query",
+  Fragment = "fragment",
+}
+
 /**
  * OAuth provider configuration for unified OAuth flow handling
  */
@@ -27,8 +32,10 @@ export interface OAuthProviderConfig {
   usesPKCE: boolean;
   /** Response type for the OAuth request */
   responseType: string;
+  /** Response mode expected from this provider, including protocol defaults */
+  expectedResponseMode: OAuthResponseMode;
   /** Optional response mode (e.g., 'fragment' for Apple) */
-  responseMode?: string;
+  responseMode?: OAuthResponseMode;
   /** Whether to include nonce in the URL params (vs state) */
   nonceInParams?: boolean;
 }
@@ -46,6 +53,7 @@ export const OAUTH_PROVIDER_CONFIGS: Record<
     scopes: "openid email profile",
     usesPKCE: false,
     responseType: "id_token",
+    expectedResponseMode: OAuthResponseMode.Fragment,
     nonceInParams: true,
   },
   [OAuthProviders.APPLE]: {
@@ -54,7 +62,8 @@ export const OAUTH_PROVIDER_CONFIGS: Record<
     scopes: "",
     usesPKCE: false,
     responseType: "code id_token",
-    responseMode: "fragment",
+    expectedResponseMode: OAuthResponseMode.Fragment,
+    responseMode: OAuthResponseMode.Fragment,
     nonceInParams: true,
   },
   [OAuthProviders.FACEBOOK]: {
@@ -63,6 +72,7 @@ export const OAUTH_PROVIDER_CONFIGS: Record<
     scopes: "openid",
     usesPKCE: true,
     responseType: "code",
+    expectedResponseMode: OAuthResponseMode.Query,
     nonceInParams: true,
   },
   [OAuthProviders.DISCORD]: {
@@ -71,6 +81,7 @@ export const OAUTH_PROVIDER_CONFIGS: Record<
     scopes: "identify email",
     usesPKCE: true,
     responseType: "code",
+    expectedResponseMode: OAuthResponseMode.Query,
     nonceInParams: false,
   },
   [OAuthProviders.X]: {
@@ -79,6 +90,7 @@ export const OAUTH_PROVIDER_CONFIGS: Record<
     scopes: "tweet.read users.read",
     usesPKCE: true,
     responseType: "code",
+    expectedResponseMode: OAuthResponseMode.Query,
     nonceInParams: false,
   },
 };

--- a/packages/react-wallet-kit/src/utils/oauth/url.ts
+++ b/packages/react-wallet-kit/src/utils/oauth/url.ts
@@ -3,7 +3,12 @@ import {
   TurnkeyError,
   TurnkeyErrorCodes,
 } from "@turnkey/sdk-types";
-import { OAUTH_PROVIDER_CONFIGS, popupWidth, popupHeight } from "./config";
+import {
+  OAUTH_PROVIDER_CONFIGS,
+  OAuthResponseMode,
+  popupWidth,
+  popupHeight,
+} from "./config";
 import {
   storeOAuthState,
   consumeOAuthState,
@@ -67,6 +72,103 @@ export function redirectToOAuthProvider(url: string): Promise<never> {
     }, timeLimit);
     window.addEventListener("beforeunload", () => clearTimeout(timeout));
   });
+}
+
+const OAUTH_QUERY_RESPONSE_PARAMS = new Set([
+  "code",
+  "error",
+  "error_description",
+  "error_uri",
+  "iss",
+  "scope",
+  "session_state",
+  "state",
+]);
+
+type QueryParam = [string, string];
+
+function hasSameUrlBase(response: URL, expected: URL): boolean {
+  return (
+    response.protocol === expected.protocol &&
+    response.username === expected.username &&
+    response.password === expected.password &&
+    response.host === expected.host &&
+    response.pathname === expected.pathname
+  );
+}
+
+function isExpectedFragmentResponse(response: URL, expected: URL): boolean {
+  return (
+    response.hash !== "" &&
+    hasSameUrlBase(response, expected) &&
+    response.search === expected.search
+  );
+}
+
+function hasValidQueryResponseParams(
+  appendedParams: QueryParam[],
+  expectedNames: Set<string>,
+): boolean {
+  const responseNames = appendedParams.map(([name]) => name);
+  if (responseNames.some((name) => expectedNames.has(name))) return false;
+
+  const recognizedNames = responseNames.filter((name) =>
+    OAUTH_QUERY_RESPONSE_PARAMS.has(name),
+  );
+  const uniqueNames = new Set(recognizedNames);
+  if (recognizedNames.length !== uniqueNames.size) return false;
+
+  const hasCode = uniqueNames.has("code");
+  const hasError = uniqueNames.has("error");
+  // Every authorization request built by this package includes state. Its
+  // exact value is validated by parseOAuthResponse immediately afterward.
+  return uniqueNames.has("state") && hasCode !== hasError;
+}
+
+function isExpectedQueryResponse(response: URL, expected: URL): boolean {
+  if (!hasSameUrlBase(response, expected)) return false;
+
+  const expectedParams = Array.from(expected.searchParams.entries());
+  const expectedNames = new Set(expectedParams.map(([name]) => name));
+  const hasReservedName = expectedParams.some(([name]) =>
+    OAUTH_QUERY_RESPONSE_PARAMS.has(name),
+  );
+  if (hasReservedName) return false;
+
+  const responseParams = Array.from(response.searchParams.entries());
+  const configuredQuery = new URLSearchParams(
+    responseParams.slice(0, expectedParams.length),
+  ).toString();
+  if (configuredQuery !== expected.searchParams.toString()) return false;
+
+  const oauthParams = responseParams.slice(expectedParams.length);
+  return hasValidQueryResponseParams(oauthParams, expectedNames);
+}
+
+/** Checks that an OAuth response used the expected mode and redirect URI. */
+export function isExpectedOAuthRedirectUrl(
+  responseUrl: string,
+  redirectUri: string,
+  responseMode: OAuthResponseMode,
+): boolean {
+  // OAuth redirect URIs cannot contain fragments, including an empty one.
+  if (redirectUri.includes("#")) return false;
+  if (responseMode !== OAuthResponseMode.Fragment && responseUrl.includes("#"))
+    return false;
+
+  let response: URL;
+  let expected: URL;
+
+  try {
+    response = new URL(responseUrl);
+    expected = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+
+  return responseMode === OAuthResponseMode.Fragment
+    ? isExpectedFragmentResponse(response, expected)
+    : isExpectedQueryResponse(response, expected);
 }
 
 /**


### PR DESCRIPTION
## Summary & Motivation

Require OAuth popup responses to return to the configured redirect URI before processing the authorization response. This ensures authentication results are handled only at the intended callback endpoint.

## How I Tested These Changes

I added unit tests, but I have not done a complete e2e test. If someone already has some kind of OAuth integration set up just for testing, it'd be awesome if you could help me test!

## Did you add a changeset?

Yes!
