### PR TITLE
chore: enforce minimum release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts=true
+min-release-age=7

--- a/.npmrc.ci
+++ b/.npmrc.ci
@@ -1,1 +1,2 @@
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": ">=18.0.0",
     "npm": "^8.0.0",
-    "pnpm": "10.6.3"
+    "pnpm": "10.16.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
@@ -56,7 +56,7 @@
     "typedoc-plugin-markdown": "^4.12.0",
     "typescript": "5.4.3"
   },
-  "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6",
+  "packageManager": "pnpm@10.16.0+sha512.8066e7b034217b700a9a4dbb3a005061d641ba130a89915213a10b3ca4919c19c037bec8066afdc559b89635fdb806b16ea673f2468fbb28aabfa13c53e3f769",
   "pnpm": {
     "auditConfig": {
       "ignoreCves": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
   - "!examples/advanced/foundry/lib/**"
   - "!examples/authentication/oauth-cross-platform/mobile/**"
 
+minimumReleaseAge: 10080
+
 overrides:
   "@openzeppelin/contracts@<4.9.0": "4.9.6"
   "@openzeppelin/contracts@3.4.1-solc-0.7-2": "4.9.6"


### PR DESCRIPTION
## Summary & Motivation

npm has a config for `min-release-age` in days
pnpm has `minimumReleaseAge` in minutes
Both are set to 7 days
pnpm introduced `minimumReleaseAge` in version 10.16.0, so we needed to update the pinned version of pnpm for this config to work.

## How I Tested These Changes

local testing/quality gates, and CI

## Did you add a changeset?

No, not needed