### PR TITLE
chore: remove audit gate from actions

### DIFF
--- a/.github/actions/js-setup/action.yml
+++ b/.github/actions/js-setup/action.yml
@@ -24,11 +24,6 @@ runs:
         npm -v
         pnpm -v
 
-    - name: Audit dependencies (before installing anything)
-      # Ignore "low" and "moderate" advisories for now.
-      run: pnpm audit --audit-level high
-      shell: bash
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash


### PR DESCRIPTION
## Summary & Motivation

We are instituting a 7 day minimum release age policy to protect against supply chain attacks.
This hard-failing audit cannot exist at the same time as the minimum release age requirement. We would effectively block all development for at least 7 days after any high or critical CVE is published.

We will continue to maintain good hygiene and address vulnerable dependencies, just without this PR/build gate.

## How I Tested These Changes

CI

## Did you add a changeset?

N/A