### PR TITLE
chore: bump pnpm to 11.1.3

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -25,5 +25,5 @@
     "packages/react-native-wallet-kit"
   ],
   "sandboxes": ["/examples/demos/react-components"],
-  "node": "20"
+  "node": "24"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "build-all",
+  "buildCommand": "codesandbox-install",
   "packages": [
     "packages/cosmjs",
     "packages/eip-1193-provider",
@@ -25,5 +25,5 @@
     "packages/react-native-wallet-kit"
   ],
   "sandboxes": ["/examples/demos/react-components"],
-  "node": "24"
+  "node": "20"
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": ">=18.0.0",
     "npm": "^8.0.0",
-    "pnpm": "10.16.0"
+    "pnpm": "11.1.3"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
@@ -56,12 +56,5 @@
     "typedoc-plugin-markdown": "^4.12.0",
     "typescript": "5.4.3"
   },
-  "packageManager": "pnpm@10.16.0+sha512.8066e7b034217b700a9a4dbb3a005061d641ba130a89915213a10b3ca4919c19c037bec8066afdc559b89635fdb806b16ea673f2468fbb28aabfa13c53e3f769",
-  "pnpm": {
-    "auditConfig": {
-      "ignoreCves": [
-        "CVE-2025-3194"
-      ]
-    }
-  }
+  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "typecheck-all": "pnpm run -r typecheck",
     "typecheck": "turbo typecheck",
     "codegen-all": "pnpm run -r codegen",
-    "prepare-release": "pnpm changeset version && pnpm run version"
+    "prepare-release": "pnpm changeset version && pnpm run version",
+    "codesandbox-install": "npx --yes @pnpm/exe@11.1.3 install --frozen-lockfile"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ auditConfig:
     - CVE-2025-3194
 
 minimumReleaseAge: 10080
+verifyDepsBeforeRun: false
 
 overrides:
   "@openzeppelin/contracts@<4.9.0": "4.9.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,29 @@ packages:
   - "!examples/advanced/foundry/lib/**"
   - "!examples/authentication/oauth-cross-platform/mobile/**"
 
+allowBuilds:
+  '@tailwindcss/oxide': true
+  bigint-buffer: true
+  blake-hash: true
+  bufferutil: true
+  chacha-native: true
+  es5-ext: true
+  esbuild: true
+  keccak: true
+  react-native-inappbrowser-reborn: true
+  secp256k1: true
+  tiny-secp256k1: true
+  unrs-resolver: true
+  usb: true
+  utf-8-validate: true
+  web3: true
+  web3-bzz: true
+  web3-shh: true
+
+auditConfig:
+  ignoreCves:
+    - CVE-2025-3194
+
 minimumReleaseAge: 10080
 
 overrides:


### PR DESCRIPTION
## Summary & Motivation

minimumReleaseAge was not honored when running `pnpm install --frozen-lockfile` prior to v11.1.3
Also moved the configs to where pnpm expects them in v11

## How I Tested These Changes

CI

## Did you add a changeset?

N/A