### PR TITLE
fix(react-wallet-kit): open OAuth popup before async work

### DIFF
--- a/.changeset/quiet-otters-safari-popup.md
+++ b/.changeset/quiet-otters-safari-popup.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Fix OAuth popup login (Discord, X, Google, Apple, Facebook) being blocked by Safari's popup blocker. The popup is now opened synchronously, before any async key/nonce generation, preserving the click's user-activation window that Safari requires for `window.open`.

--- a/packages/react-wallet-kit/src/providers/client/Provider.tsx
+++ b/packages/react-wallet-kit/src/providers/client/Provider.tsx
@@ -17,7 +17,7 @@ import {
   completePKCEFlow,
   hasPKCEVerifier,
   OAUTH_INTENT_ADD_PROVIDER,
-  openOAuthPopup,
+  openOAuthPopupAndNavigate,
   parseOAuthResponse,
   type PKCEProvider,
   redirectToOAuthProvider,
@@ -3543,49 +3543,53 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       const flow = openInPage ? "redirect" : "popup";
       const redirectUri = masterConfig.auth?.oauthConfig.oauthRedirectUri;
 
-      // Create key pair and generate nonce
-      const publicKey = await createApiKeyPair();
-      if (!publicKey) {
-        throw new Error("Failed to create public key for OAuth.");
-      }
-      const nonce = bytesToHex(sha256(publicKey));
+      let publicKey!: string;
+      let nonce!: string;
 
-      // Generate PKCE challenge pair and store verifier
-      const { verifier, codeChallenge } = await generateChallengePair();
-      storePKCEVerifier(provider, verifier);
+      const buildAuthUrl = async (): Promise<string> => {
+        // Create key pair and generate nonce
+        publicKey = await createApiKeyPair();
+        if (!publicKey) {
+          throw new Error("Failed to create public key for OAuth.");
+        }
+        nonce = bytesToHex(sha256(publicKey));
 
-      // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
-      if (openInPage && captchaToken) {
-        storeOAuthCaptchaToken(captchaToken);
-      }
+        // Generate PKCE challenge pair and store verifier
+        const { verifier, codeChallenge } = await generateChallengePair();
+        storePKCEVerifier(provider, verifier);
 
-      // Build OAuth URL
-      const authUrl = buildOAuthUrl({
-        provider,
-        clientId,
-        redirectUri,
-        publicKey,
-        nonce,
-        flow,
-        codeChallenge,
-        additionalState: {
-          ...additionalParameters,
-        },
-      });
+        // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
+        if (openInPage && captchaToken) {
+          storeOAuthCaptchaToken(captchaToken);
+        }
+
+        // Build OAuth URL
+        return buildOAuthUrl({
+          provider,
+          clientId,
+          redirectUri,
+          publicKey,
+          nonce,
+          flow,
+          codeChallenge,
+          additionalState: {
+            ...additionalParameters,
+          },
+        });
+      };
 
       if (openInPage) {
         // Remainder of logic will occur in completeRedirectOauth
-        return redirectToOAuthProvider(authUrl);
+        return redirectToOAuthProvider(await buildAuthUrl());
       }
 
-      // Popup flow
-      const authWindow = openOAuthPopup();
-      if (!authWindow) {
-        throw new Error(
-          `Failed to open ${capitalizeProviderName(provider)} login window.`,
-        );
-      }
-      authWindow.location.href = authUrl;
+      // Popup flow: open the popup synchronously (before any async work), so
+      // the click's user-activation window is preserved - Safari blocks
+      // window.open once it runs after an await.
+      const authWindow = await openOAuthPopupAndNavigate(
+        provider,
+        buildAuthUrl,
+      );
 
       return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {
@@ -3698,49 +3702,53 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       const flow = openInPage ? "redirect" : "popup";
       const redirectUri = masterConfig.auth?.oauthConfig.oauthRedirectUri;
 
-      // Create key pair and generate nonce
-      const publicKey = await createApiKeyPair();
-      if (!publicKey) {
-        throw new Error("Failed to create public key for OAuth.");
-      }
-      const nonce = bytesToHex(sha256(publicKey));
+      let publicKey!: string;
+      let nonce!: string;
 
-      // Generate PKCE challenge pair and store verifier
-      const { verifier, codeChallenge } = await generateChallengePair();
-      storePKCEVerifier(provider, verifier);
+      const buildAuthUrl = async (): Promise<string> => {
+        // Create key pair and generate nonce
+        publicKey = await createApiKeyPair();
+        if (!publicKey) {
+          throw new Error("Failed to create public key for OAuth.");
+        }
+        nonce = bytesToHex(sha256(publicKey));
 
-      // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
-      if (openInPage && captchaToken) {
-        storeOAuthCaptchaToken(captchaToken);
-      }
+        // Generate PKCE challenge pair and store verifier
+        const { verifier, codeChallenge } = await generateChallengePair();
+        storePKCEVerifier(provider, verifier);
 
-      // Build OAuth URL
-      const authUrl = buildOAuthUrl({
-        provider,
-        clientId,
-        redirectUri,
-        publicKey,
-        nonce,
-        flow,
-        codeChallenge,
-        additionalState: {
-          ...additionalParameters,
-        },
-      });
+        // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
+        if (openInPage && captchaToken) {
+          storeOAuthCaptchaToken(captchaToken);
+        }
+
+        // Build OAuth URL
+        return buildOAuthUrl({
+          provider,
+          clientId,
+          redirectUri,
+          publicKey,
+          nonce,
+          flow,
+          codeChallenge,
+          additionalState: {
+            ...additionalParameters,
+          },
+        });
+      };
 
       if (openInPage) {
         // Remainder of logic will occur in completeRedirectOauth
-        return redirectToOAuthProvider(authUrl);
+        return redirectToOAuthProvider(await buildAuthUrl());
       }
 
-      // Popup flow
-      const authWindow = openOAuthPopup();
-      if (!authWindow) {
-        throw new Error(
-          `Failed to open ${capitalizeProviderName(provider)} login window.`,
-        );
-      }
-      authWindow.location.href = authUrl;
+      // Popup flow: open the popup synchronously (before any async work), so
+      // the click's user-activation window is preserved - Safari blocks
+      // window.open once it runs after an await.
+      const authWindow = await openOAuthPopupAndNavigate(
+        provider,
+        buildAuthUrl,
+      );
 
       return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {
@@ -3856,44 +3864,48 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       const redirectUri =
         masterConfig.auth?.oauthConfig.oauthRedirectUri.replace(/\/$/, "");
 
-      // Create key pair and generate nonce
-      const publicKey = await createApiKeyPair();
-      if (!publicKey) {
-        throw new Error("Failed to create public key for OAuth.");
-      }
-      const nonce = bytesToHex(sha256(publicKey));
+      let publicKey!: string;
+      let nonce!: string;
 
-      // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
-      if (openInPage && captchaToken) {
-        storeOAuthCaptchaToken(captchaToken);
-      }
+      const buildAuthUrl = async (): Promise<string> => {
+        // Create key pair and generate nonce
+        publicKey = await createApiKeyPair();
+        if (!publicKey) {
+          throw new Error("Failed to create public key for OAuth.");
+        }
+        nonce = bytesToHex(sha256(publicKey));
 
-      // Build OAuth URL
-      const authUrl = buildOAuthUrl({
-        provider,
-        clientId,
-        redirectUri,
-        publicKey,
-        nonce,
-        flow,
-        additionalState: {
-          ...additionalParameters,
-        },
-      });
+        // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
+        if (openInPage && captchaToken) {
+          storeOAuthCaptchaToken(captchaToken);
+        }
+
+        // Build OAuth URL
+        return buildOAuthUrl({
+          provider,
+          clientId,
+          redirectUri,
+          publicKey,
+          nonce,
+          flow,
+          additionalState: {
+            ...additionalParameters,
+          },
+        });
+      };
 
       if (openInPage) {
         // Remainder of logic will occur in completeRedirectOauth
-        return redirectToOAuthProvider(authUrl);
+        return redirectToOAuthProvider(await buildAuthUrl());
       }
 
-      // Popup flow
-      const authWindow = openOAuthPopup();
-      if (!authWindow) {
-        throw new Error(
-          `Failed to open ${capitalizeProviderName(provider)} login window.`,
-        );
-      }
-      authWindow.location.href = authUrl;
+      // Popup flow: open the popup synchronously (before any async work), so
+      // the click's user-activation window is preserved - Safari blocks
+      // window.open once it runs after an await.
+      const authWindow = await openOAuthPopupAndNavigate(
+        provider,
+        buildAuthUrl,
+      );
 
       return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {
@@ -3996,44 +4008,48 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       // TODO (Amir): Apple needs the '/' at the end. Maybe we should add it if not there?
       const redirectUri = masterConfig.auth?.oauthConfig.oauthRedirectUri;
 
-      // Create key pair and generate nonce
-      const publicKey = await createApiKeyPair();
-      if (!publicKey) {
-        throw new Error("Failed to create public key for OAuth.");
-      }
-      const nonce = bytesToHex(sha256(publicKey));
+      let publicKey!: string;
+      let nonce!: string;
 
-      // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
-      if (openInPage && captchaToken) {
-        storeOAuthCaptchaToken(captchaToken);
-      }
+      const buildAuthUrl = async (): Promise<string> => {
+        // Create key pair and generate nonce
+        publicKey = await createApiKeyPair();
+        if (!publicKey) {
+          throw new Error("Failed to create public key for OAuth.");
+        }
+        nonce = bytesToHex(sha256(publicKey));
 
-      // Build OAuth URL
-      const authUrl = buildOAuthUrl({
-        provider,
-        clientId,
-        redirectUri,
-        publicKey,
-        nonce,
-        flow,
-        additionalState: {
-          ...additionalParameters,
-        },
-      });
+        // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
+        if (openInPage && captchaToken) {
+          storeOAuthCaptchaToken(captchaToken);
+        }
+
+        // Build OAuth URL
+        return buildOAuthUrl({
+          provider,
+          clientId,
+          redirectUri,
+          publicKey,
+          nonce,
+          flow,
+          additionalState: {
+            ...additionalParameters,
+          },
+        });
+      };
 
       if (openInPage) {
         // Remainder of logic will occur in completeRedirectOauth
-        return redirectToOAuthProvider(authUrl);
+        return redirectToOAuthProvider(await buildAuthUrl());
       }
 
-      // Popup flow
-      const authWindow = openOAuthPopup();
-      if (!authWindow) {
-        throw new Error(
-          `Failed to open ${capitalizeProviderName(provider)} login window.`,
-        );
-      }
-      authWindow.location.href = authUrl;
+      // Popup flow: open the popup synchronously (before any async work), so
+      // the click's user-activation window is preserved - Safari blocks
+      // window.open once it runs after an await.
+      const authWindow = await openOAuthPopupAndNavigate(
+        provider,
+        buildAuthUrl,
+      );
 
       return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {
@@ -4135,49 +4151,53 @@ export const ClientProvider: React.FC<ClientProviderProps> = ({
       const flow = openInPage ? "redirect" : "popup";
       const redirectUri = masterConfig.auth?.oauthConfig.oauthRedirectUri;
 
-      // Create key pair and generate nonce
-      const publicKey = await createApiKeyPair();
-      if (!publicKey) {
-        throw new Error("Failed to create public key for OAuth.");
-      }
-      const nonce = bytesToHex(sha256(publicKey));
+      let publicKey!: string;
+      let nonce!: string;
 
-      // Generate PKCE challenge pair and store verifier
-      const { verifier, codeChallenge } = await generateChallengePair();
-      storePKCEVerifier(provider, verifier);
+      const buildAuthUrl = async (): Promise<string> => {
+        // Create key pair and generate nonce
+        publicKey = await createApiKeyPair();
+        if (!publicKey) {
+          throw new Error("Failed to create public key for OAuth.");
+        }
+        nonce = bytesToHex(sha256(publicKey));
 
-      // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
-      if (openInPage && captchaToken) {
-        storeOAuthCaptchaToken(captchaToken);
-      }
+        // Generate PKCE challenge pair and store verifier
+        const { verifier, codeChallenge } = await generateChallengePair();
+        storePKCEVerifier(provider, verifier);
 
-      // Build OAuth URL
-      const authUrl = buildOAuthUrl({
-        provider,
-        clientId,
-        redirectUri,
-        publicKey,
-        nonce,
-        flow,
-        codeChallenge,
-        additionalState: {
-          ...additionalParameters,
-        },
-      });
+        // Persist captcha out of the redirect URL (same pattern as PKCE verifier)
+        if (openInPage && captchaToken) {
+          storeOAuthCaptchaToken(captchaToken);
+        }
+
+        // Build OAuth URL
+        return buildOAuthUrl({
+          provider,
+          clientId,
+          redirectUri,
+          publicKey,
+          nonce,
+          flow,
+          codeChallenge,
+          additionalState: {
+            ...additionalParameters,
+          },
+        });
+      };
 
       if (openInPage) {
         // Remainder of logic will occur in completeRedirectOauth
-        return redirectToOAuthProvider(authUrl);
+        return redirectToOAuthProvider(await buildAuthUrl());
       }
 
-      // Popup flow
-      const authWindow = openOAuthPopup();
-      if (!authWindow) {
-        throw new Error(
-          `Failed to open ${capitalizeProviderName(provider)} login window.`,
-        );
-      }
-      authWindow.location.href = authUrl;
+      // Popup flow: open the popup synchronously (before any async work), so
+      // the click's user-activation window is preserved - Safari blocks
+      // window.open once it runs after an await.
+      const authWindow = await openOAuthPopupAndNavigate(
+        provider,
+        buildAuthUrl,
+      );
 
       return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {

--- a/packages/react-wallet-kit/src/tests/oauth-popup-test.ts
+++ b/packages/react-wallet-kit/src/tests/oauth-popup-test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { OAuthProviders } from "@turnkey/sdk-types";
+import { openOAuthPopupAndNavigate } from "../utils/oauth/url";
+
+function createMockWindow() {
+  return {
+    location: { href: "" },
+    closed: false,
+    close: jest.fn(),
+  } as unknown as Window;
+}
+
+describe("openOAuthPopupAndNavigate", () => {
+  it("opens the popup before running buildAuthUrl, even when buildAuthUrl resolves on a later tick", async () => {
+    const callOrder: string[] = [];
+    const mockWindow = createMockWindow();
+    const openPopup = jest.fn(() => {
+      callOrder.push("open");
+      return mockWindow;
+    });
+    const buildAuthUrl = jest.fn(async () => {
+      // Resolve past a real setTimeout tick, not just a microtask, to prove
+      // the popup was already open before any async work started - not only
+      // in the fast-resolving case a manual repro happens to hit.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      callOrder.push("build");
+      return "https://example.com/oauth";
+    });
+
+    const result = await openOAuthPopupAndNavigate(
+      OAuthProviders.GOOGLE,
+      buildAuthUrl,
+      openPopup,
+    );
+
+    expect(callOrder).toEqual(["open", "build"]);
+    expect(result).toBe(mockWindow);
+    expect(mockWindow.location.href).toBe("https://example.com/oauth");
+  });
+
+  it("throws the standard error and never calls buildAuthUrl when the popup is blocked", async () => {
+    const openPopup = jest.fn(() => null);
+    const buildAuthUrl = jest.fn(async () => "https://example.com/oauth");
+
+    await expect(
+      openOAuthPopupAndNavigate(OAuthProviders.GOOGLE, buildAuthUrl, openPopup),
+    ).rejects.toThrow("Failed to open Google login window.");
+    expect(buildAuthUrl).not.toHaveBeenCalled();
+  });
+
+  it("closes the popup instead of leaving a stray blank window when buildAuthUrl rejects", async () => {
+    const mockWindow = createMockWindow();
+    const openPopup = jest.fn(() => mockWindow);
+    const buildAuthUrl = jest.fn(async () => {
+      throw new Error("failed to create api key pair");
+    });
+
+    await expect(
+      openOAuthPopupAndNavigate(OAuthProviders.GOOGLE, buildAuthUrl, openPopup),
+    ).rejects.toThrow("failed to create api key pair");
+    expect(mockWindow.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-wallet-kit/src/utils/oauth/url.ts
+++ b/packages/react-wallet-kit/src/utils/oauth/url.ts
@@ -9,6 +9,7 @@ import {
   consumeOAuthState,
   consumeOAuthCaptchaToken,
 } from "./storage";
+import { capitalizeProviderName } from "./helpers";
 
 /**
  * Builds the OAuth state parameter string
@@ -53,6 +54,32 @@ export function openOAuthPopup(): Window | null {
     "_blank",
     `width=${width},height=${height},top=${top},left=${left},scrollbars=yes,resizable=yes`,
   );
+}
+
+/**
+ * Opens an OAuth popup synchronously (to preserve the click's user-activation
+ * window, which Safari requires for window.open), then runs `buildAuthUrl` and
+ * navigates the popup to the result. If `buildAuthUrl` throws, the popup is
+ * closed instead of being left open on a blank page.
+ */
+export async function openOAuthPopupAndNavigate(
+  provider: OAuthProviders,
+  buildAuthUrl: () => Promise<string>,
+  openPopup: () => Window | null = openOAuthPopup,
+): Promise<Window> {
+  const authWindow = openPopup();
+  if (!authWindow) {
+    throw new Error(
+      `Failed to open ${capitalizeProviderName(provider)} login window.`,
+    );
+  }
+  try {
+    authWindow.location.href = await buildAuthUrl();
+    return authWindow;
+  } catch (err) {
+    authWindow.close();
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary & Motivation

Fixes #1451.

OAuth popup login (Discord, X, Google, Apple, Facebook) is silently blocked by Safari's
popup blocker. In all five handlers in
[`Provider.tsx`](packages/react-wallet-kit/src/providers/client/Provider.tsx),
`window.open()` was called only after `await createApiKeyPair()` (and, for Discord/X/Facebook,
`await generateChallengePair()`). Safari revokes a click's user-activation flag as soon as any
`await` runs after the click handler starts, so by the time `window.open()` ran, it was no
longer inside a "trusted" user gesture and Safari blocked it — the popup call returned `null`
and the flow threw `Failed to open <Provider> login window.` even though the user did click
the login button.

Chrome/Firefox are more lenient about this timing, which is presumably why this shipped
unnoticed.

### Fix

Added `openOAuthPopupAndNavigate` in
[`utils/oauth/url.ts`](packages/react-wallet-kit/src/utils/oauth/url.ts): it opens the popup
**synchronously**, then runs the async work needed to build the auth URL (key-pair creation,
nonce, PKCE), and only then navigates the already-open popup to that URL. If the async work
throws, the popup is closed instead of being left open on a blank page (a related rough edge
mentioned in the issue).

Each of the five handlers in `Provider.tsx` now wraps its key/nonce/PKCE/URL-building logic in
a `buildAuthUrl` closure and passes it to `openOAuthPopupAndNavigate`, so the popup opens before
any `await` in the popup-flow branch. The `openInPage` (redirect) branch is behaviorally
unchanged — it still awaits `buildAuthUrl()` and then redirects.

### Out of scope

- Two pre-existing, unrelated issues found while verifying the baseline (left untouched, per
  scope discipline): `src/tests/timers-test.ts` fails to run because `jest-environment-jsdom`
  isn't declared as a devDependency of this package, and `src/components/auth/wallet/QRCodeDisplay.tsx`
  has a stale `@ts-expect-error` that now fails `tsc --noEmit`. Both are present on `main`
  before this change (confirmed via `git stash`).
- The issue's optional suggestion of auto-retrying via redirect flow when the popup is blocked
  is left for a follow-up/maintainer decision — it's a UX change beyond fixing the ordering bug.

## How I Tested These Changes

Added `src/tests/oauth-popup-test.ts` covering `openOAuthPopupAndNavigate` directly (popup
opener and auth-URL builder are injected, so no `jsdom`/real `window` is needed):

- popup opens before `buildAuthUrl` runs, even when `buildAuthUrl` resolves after a real
  `setTimeout` tick (not just a microtask) — proves the ordering fix isn't an artifact of how
  fast the async work happens to resolve.
- the standard `Failed to open <Provider> login window.` error is thrown, and `buildAuthUrl` is
  never called, when the popup is blocked.
- the popup is closed (not left open on a blank page) when `buildAuthUrl` rejects.

All three fail with the pre-fix code (`openOAuthPopupAndNavigate` didn't exist) and pass after.

```
pnpm --filter @turnkey/react-wallet-kit test
...
PASS src/tests/captcha-test.ts
PASS src/tests/oauth-popup-test.ts
PASS src/tests/oauth-test.ts
PASS src/tests/utils-test.ts
FAIL src/tests/timers-test.ts   (pre-existing, unrelated — see "Out of scope")

Test Suites: 1 failed, 4 passed, 5 total
Tests:       40 passed, 40 total
```

Also ran (both clean aside from the pre-existing, unrelated issue noted above):
```
pnpm --filter @turnkey/react-wallet-kit typecheck
pnpm --filter @turnkey/react-wallet-kit build
pnpm prettier --check <changed files>
```

## Did you add a changeset?

Yes — `.changeset/quiet-otters-safari-popup.md`, `@turnkey/react-wallet-kit` patch.
