### PR TITLE
fix(react-wallet-kit): add missing jest-environment-jsdom devDep

### DIFF
--- a/.changeset/tame-otters-jsdom.md
+++ b/.changeset/tame-otters-jsdom.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Fix `pnpm test` failing to run `src/tests/timers-test.ts` due to a missing `jest-environment-jsdom` devDependency. No runtime behavior change; test-only fix.

--- a/packages/react-wallet-kit/package.json
+++ b/packages/react-wallet-kit/package.json
@@ -69,6 +69,7 @@
     "@types/react-dom": "^18.2.7",
     "autoprefixer": "^10.0.1",
     "glob": "^8.0.3",
+    "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.38",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4623,6 +4623,9 @@ importers:
       glob:
         specifier: '>=10.5.0'
         version: 13.0.0
+      jest-environment-jsdom:
+        specifier: ^29.7.0
+        version: 29.7.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       postcss:
         specifier: '>=8.5.18'
         version: 8.5.23


### PR DESCRIPTION
## Summary & Motivation

Fixes #1473.

`@turnkey/react-wallet-kit`'s test suite is broken: `src/tests/timers-test.ts` declares

```ts
/**
 * @jest-environment jsdom
 */
```

which requires `jest-environment-jsdom` to be resolvable, but that package was never a
devDependency of `react-wallet-kit` — only of the unrelated `packages/telegram-cloud-storage-stamper`.
Since the repo's `.npmrc` sets no hoist pattern, pnpm's default strict linking means one
workspace package can't resolve another's devDependency as a phantom dependency, so this
fails on both a full `pnpm install -r` and a scoped `--filter` install.

This has gone unnoticed because `.github/workflows/reusable-test.yml` runs
`pnpm test --filter="$(./.github/scripts/get-turbo-affected.sh ...)"` — only packages
turbo considers affected by the current diff. None of the recent merges to `main` touched
`react-wallet-kit`, so its test job was silently skipped every time.

Fix: add `jest-environment-jsdom` (matching the `^29.7.0` version already used by
`telegram-cloud-storage-stamper`) to `react-wallet-kit`'s devDependencies. No source or
runtime change — this only makes the existing test declaration resolvable.

## How I Tested These Changes

```
pnpm --filter @turnkey/react-wallet-kit test
```

Before:
```
FAIL src/tests/timers-test.ts
  ● Test suite failed to run
    Test environment jest-environment-jsdom cannot be found. ...

Test Suites: 1 failed, 3 passed, 4 total
Tests:       37 passed, 37 total
```

After:
```
PASS src/tests/captcha-test.ts
PASS src/tests/oauth-test.ts
PASS src/tests/timers-test.ts
PASS src/tests/utils-test.ts

Test Suites: 4 passed, 4 total
Tests:       49 passed, 49 total
```

Also ran `pnpm --filter @turnkey/react-wallet-kit build` and `pnpm prettier --check` on the
changed files — both clean.

`pnpm-lock.yaml` change is a hand-verified minimal 3-line addition (checked with
`pnpm install --frozen-lockfile --filter "@turnkey/react-wallet-kit..."`, which reported
"Lockfile is up to date, resolution step is skipped" — no drift).

## Did you add a changeset?

Yes — `.changeset/tame-otters-jsdom.md`, `@turnkey/react-wallet-kit` patch.
