### PR TITLE
Update sdk as per mono v2026.8.0

### DIFF
--- a/.changeset/honest-snails-wink.md
+++ b/.changeset/honest-snails-wink.md
@@ -1,0 +1,30 @@
+---
+"@turnkey/sdk-browser": minor
+"@turnkey/sdk-server": minor
+"@turnkey/sdk-types": minor
+"@turnkey/core": minor
+"@turnkey/http": minor
+---
+
+Sync generated API clients and types with the latest public API swagger.
+
+### New query endpoints
+
+- `getClaimEarnFeesStatus` (`POST /public/v1/query/get_claim_earn_fees_status`) — poll Earn fee-claim status by the `claimRequestId` returned from `ClaimEarnFees`. Response status is `PENDING` | `COMPLETED` | `FAILED`, with optional `claimTxHash` / `error`.
+- `getSwapStatus` (`POST /public/v1/query/get_swap_status`) — poll swap status by the `swapRequestId` returned from `ExecuteSwap`. Covers same-chain and cross-chain swaps, and returns provider, input/output tokens and amounts, origin/destination tx hashes, optional refund info on failure, and normalized error details.
+
+### New submit endpoints / activities
+
+- `claimSwapFees` (`POST /public/v1/submit/claim_swap_fees`, `ACTIVITY_TYPE_CLAIM_SWAP_FEES`) — claim swap fees through the activity pipeline; result includes a Relay `requestId`.
+- `ethUndelegate7702` (`POST /public/v1/submit/eth_undelegate_7702`, `ACTIVITY_TYPE_ETH_UNDELEGATE_7702`) — submit an EIP-7702 undelegation for a wallet/private-key address on a supported CAIP-2 chain. Optional nonce / gas / fee fields; result returns a `sendTransactionStatusId` for polling.
+- `upsertSwapConfig` (`POST /public/v1/submit/upsert_swap_config`, `ACTIVITY_TYPE_UPSERT_SWAP_CONFIG`) — enable or update org swap config (`feeReceiverWalletAddress`, `feeBps`, and Enterprise-only `stableFeeBps` for stablecoin pairs).
+- `createSwapQuote` (`ACTIVITY_TYPE_CREATE_SWAP_QUOTE`) — request provider quotes for a swap (`signWith`, CAIP-19 `inputToken` / `outputToken`, `inputAmount`, optional `slippageBps`). Returns one or more `v1SwapQuote` values; pass `quoteId` into execute-swap v2.
+
+### Related activity / type updates
+
+- `ACTIVITY_TYPE_EXECUTE_SWAP_V2` / `v1ExecuteSwapIntentV2` — quote-bound swap execution. Takes `quoteId` plus the exact quoted amounts (`inputAmount`, `quotedOutputAmount`, `minOutputAmount`, `sponsor`), with optional `evmNonce` / `recentBlockhash` / `gasStationNonce`. Signer is derived from the quote and must not be resupplied. Result still exposes `swapRequestId` for `getSwapStatus`.
+- `ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME` / `v1UpdateWalletAccountNameIntent` — rename a wallet account by `walletAccountId`.
+- Supporting swap types: `v1SwapQuote`, `v1SwapError`, `v1SwapRefund`.
+- CAIP-2 enums used by transaction intents (including undelegation) now include `eip155:143`.
+
+These surfaces are generated into `@turnkey/http`, `@turnkey/sdk-types`, `@turnkey/sdk-browser`, `@turnkey/sdk-server`, and `@turnkey/core`.

--- a/packages/core/src/__generated__/sdk-client-base.ts
+++ b/packages/core/src/__generated__/sdk-client-base.ts
@@ -671,6 +671,53 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getClaimEarnFeesStatus = async (
+    input: SdkTypes.TGetClaimEarnFeesStatusBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetClaimEarnFeesStatusResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_claim_earn_fees_status",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetClaimEarnFeesStatus = async (
+    input: SdkTypes.TGetClaimEarnFeesStatusBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_claim_earn_fees_status";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getEarnDeployStatus = async (
     input: SdkTypes.TGetEarnDeployStatusBody,
     stampWith?: StamperType,
@@ -1635,6 +1682,52 @@ export class TurnkeySDKClientBase {
     const session = await this.storageManager?.getActiveSession();
     const fullUrl =
       this.config.apiBaseUrl + "/public/v1/query/get_smart_contract_interface";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getSwapStatus = async (
+    input: SdkTypes.TGetSwapStatusBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetSwapStatusResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_swap_status",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetSwapStatus = async (
+    input: SdkTypes.TGetSwapStatusBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_swap_status";
     const body = {
       ...input,
       organizationId:
@@ -3293,6 +3386,64 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  claimSwapFees = async (
+    input: SdkTypes.TClaimSwapFeesBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TClaimSwapFeesResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/claim_swap_fees",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
+      },
+      "claimSwapFeesResult",
+      stampWith,
+    );
+  };
+
+  stampClaimSwapFees = async (
+    input: SdkTypes.TClaimSwapFeesBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/claim_swap_fees";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -6142,6 +6293,64 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  ethUndelegate7702 = async (
+    input: SdkTypes.TEthUndelegate7702Body,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TEthUndelegate7702Response> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/eth_undelegate_7702",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_ETH_UNDELEGATE_7702",
+      },
+      "ethUndelegate7702Result",
+      stampWith,
+    );
+  };
+
+  stampEthUndelegate7702 = async (
+    input: SdkTypes.TEthUndelegate7702Body,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/eth_undelegate_7702";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_ETH_UNDELEGATE_7702",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   exportPrivateKey = async (
     input: SdkTypes.TExportPrivateKeyBody,
     stampWith?: StamperType,
@@ -8784,6 +8993,64 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  upsertSwapConfig = async (
+    input: SdkTypes.TUpsertSwapConfigBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TUpsertSwapConfigResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/upsert_swap_config",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_UPSERT_SWAP_CONFIG",
+      },
+      "upsertSwapConfigResult",
+      stampWith,
+    );
+  };
+
+  stampUpsertSwapConfig = async (
+    input: SdkTypes.TUpsertSwapConfigBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/upsert_swap_config";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_UPSERT_SWAP_CONFIG",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/core/src/__inputs__/public_api.swagger.json
+++ b/packages/core/src/__inputs__/public_api.swagger.json
@@ -296,6 +296,38 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_claim_earn_fees_status": {
+      "post": {
+        "summary": "Get Earn claim fees status",
+        "description": "Poll the status of a fee claim by its claim_request_id.",
+        "operationId": "PublicApiService_GetClaimEarnFeesStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Earn"]
+      }
+    },
     "/public/v1/query/get_earn_deploy_status": {
       "post": {
         "summary": "Get Earn deploy status",
@@ -966,6 +998,38 @@
           }
         ],
         "tags": ["Policies"]
+      }
+    },
+    "/public/v1/query/get_swap_status": {
+      "post": {
+        "summary": "Get swap status",
+        "description": "Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.",
+        "operationId": "PublicApiService_GetSwapStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/query/get_tvc_app": {
@@ -2086,6 +2150,38 @@
           }
         ],
         "tags": ["Earn"]
+      }
+    },
+    "/public/v1/submit/claim_swap_fees": {
+      "post": {
+        "summary": "Claim swap fees",
+        "description": "Claim swap fees through the activity pipeline.",
+        "operationId": "PublicApiService_ClaimSwapFees",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ClaimSwapFeesRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/submit/create_api_keys": {
@@ -3688,6 +3784,38 @@
         "tags": ["Broadcasting"]
       }
     },
+    "/public/v1/submit/eth_undelegate_7702": {
+      "post": {
+        "summary": "Undelegate an EVM account",
+        "description": "Submit an EIP-7702 undelegation transaction.",
+        "operationId": "PublicApiService_EthUndelegate7702",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1EthUndelegate7702Request"
+            }
+          }
+        ],
+        "tags": ["Broadcasting"]
+      }
+    },
     "/public/v1/submit/export_private_key": {
       "post": {
         "summary": "Export private key",
@@ -5192,6 +5320,38 @@
         "tags": ["Organizations"]
       }
     },
+    "/public/v1/submit/upsert_swap_config": {
+      "post": {
+        "summary": "Upsert swap config",
+        "description": "Enable or disable swap configuration for an organization.",
+        "operationId": "PublicApiService_UpsertSwapConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpsertSwapConfigRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
+      }
+    },
     "/public/v1/submit/verify_otp": {
       "post": {
         "summary": "Verify generic OTP",
@@ -5918,7 +6078,11 @@
         "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2",
         "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
         "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE",
-        "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+        "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+        "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME",
+        "ACTIVITY_TYPE_ETH_UNDELEGATE_7702",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
       ]
     },
     "v1AddressFormat": {
@@ -6202,6 +6366,10 @@
         "name": {
           "type": "string",
           "description": "The asset name"
+        },
+        "stable": {
+          "type": "boolean",
+          "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
         }
       }
     },
@@ -6508,6 +6676,30 @@
     },
     "v1ClaimSwapFeesIntent": {
       "type": "object"
+    },
+    "v1ClaimSwapFeesRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CLAIM_SWAP_FEES"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1ClaimSwapFeesIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1ClaimSwapFeesResult": {
       "type": "object",
@@ -7239,6 +7431,10 @@
         "notes": {
           "type": "string",
           "description": "Notes for a Policy."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect"
         }
       },
       "required": ["policyName", "effect", "notes"]
@@ -8174,6 +8370,46 @@
       },
       "required": ["subOrganizationId"]
     },
+    "v1CreateSwapQuoteIntent": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
+    "v1CreateSwapQuoteResult": {
+      "type": "object",
+      "properties": {
+        "quotes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SwapQuote"
+          },
+          "description": "One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution."
+        }
+      },
+      "required": ["quotes"]
+    },
     "v1CreateTvcAppIntent": {
       "type": "object",
       "properties": {
@@ -8255,13 +8491,32 @@
           "type": "integer",
           "format": "int64",
           "description": "The required number of approvals for the manifest set"
+        },
+        "shareSetId": {
+          "type": "string",
+          "description": "The unique identifier for the TVC share set"
+        },
+        "shareSetOperatorIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The unique identifiers of the share set operators"
+        },
+        "shareSetThreshold": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The required number of approvals for the share set"
         }
       },
       "required": [
         "appId",
         "manifestSetId",
         "manifestSetOperatorIds",
-        "manifestSetThreshold"
+        "manifestSetThreshold",
+        "shareSetId",
+        "shareSetOperatorIds",
+        "shareSetThreshold"
       ]
     },
     "v1CreateTvcDeploymentIntent": {
@@ -9963,7 +10218,7 @@
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+          "description": "Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%)."
         },
         "clientFeeWallet": {
           "type": "string",
@@ -10108,7 +10363,7 @@
         },
         "apyPct": {
           "type": "string",
-          "description": "Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees)."
+          "description": "Gross annual percentage yield, expressed as a decimal fraction (before fees)."
         },
         "totalDeposited": {
           "type": "string",
@@ -10120,11 +10375,11 @@
         },
         "netApyPct": {
           "type": "string",
-          "description": "Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction."
+          "description": "Annual percentage yield net of fees, expressed as a decimal fraction."
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting."
+          "description": "Client fee taken on yield, in basis points."
         },
         "depositsDisabled": {
           "type": "boolean",
@@ -10140,11 +10395,15 @@
         },
         "claimableClientFee": {
           "type": "string",
-          "description": "The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
+          "description": "The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
         },
         "claimableClientFeeDisplay": {
           "$ref": "#/definitions/v1EarnValueDisplay",
           "description": "Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
         }
       }
     },
@@ -10719,6 +10978,10 @@
         "deliveryDelayType": {
           "type": "string",
           "description": "Delay type for DeliveryDelay events"
+        },
+        "complaintFeedbackType": {
+          "type": "string",
+          "description": "Feedback type for Complaint events"
         }
       }
     },
@@ -10935,7 +11198,7 @@
         },
         "gasStationNonce": {
           "type": "string",
-          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+          "description": "The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection."
         },
         "calls": {
           "type": "array",
@@ -11056,6 +11319,86 @@
         "transfers"
       ]
     },
+    "v1EthUndelegate7702Intent": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to undelegate. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97",
+            "eip155:10",
+            "eip155:11155420",
+            "eip155:143",
+            "eip155:10143",
+            "eip155:42161",
+            "eip155:421614"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        }
+      },
+      "required": ["from", "caip2"]
+    },
+    "v1EthUndelegate7702Request": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_ETH_UNDELEGATE_7702"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1EthUndelegate7702Result": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the undelegation transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
     "v1ExecuteSwapIntent": {
       "type": "object",
       "properties": {
@@ -11085,7 +11428,7 @@
         },
         "provider": {
           "type": "string",
-          "description": "Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider."
+          "description": "Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider."
         },
         "minOutputAmount": {
           "type": "string",
@@ -11100,12 +11443,66 @@
         "minOutputAmount"
       ]
     },
+    "v1ExecuteSwapIntentV2": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
     "v1ExecuteSwapResult": {
       "type": "object",
       "properties": {
-        "sendTransactionStatusId": {
+        "swapRequestId": {
           "type": "string",
-          "description": "The send_transaction_status ID associated with the swap transaction submission"
+          "description": "Identifier to poll swap status via GetSwapStatus."
         },
         "provider": {
           "type": "string",
@@ -11116,7 +11513,7 @@
           "description": "Quote identifier used for execution, if any."
         }
       },
-      "required": ["sendTransactionStatusId"]
+      "required": ["swapRequestId"]
     },
     "v1ExportPrivateKeyIntent": {
       "type": "object",
@@ -11664,6 +12061,39 @@
       },
       "required": ["organizationId", "ephemeralKey"]
     },
+    "v1GetClaimEarnFeesStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "claimRequestId": {
+          "type": "string",
+          "description": "The claim_request_id returned by ClaimEarnFees."
+        }
+      },
+      "required": ["organizationId", "claimRequestId"]
+    },
+    "v1GetClaimEarnFeesStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["PENDING", "COMPLETED", "FAILED"],
+          "description": "Status of the fee claim."
+        },
+        "claimTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee claim, once available."
+        },
+        "error": {
+          "type": "string",
+          "description": "Reason the fee claim transaction failed, when status is FAILED."
+        }
+      },
+      "required": ["status"]
+    },
     "v1GetEarnDeployStatusRequest": {
       "type": "object",
       "properties": {
@@ -11824,7 +12254,7 @@
         },
         "appName": {
           "type": "string",
-          "description": "Name of enclave app."
+          "description": "Unique identifier (UUID) of the enclave app."
         }
       },
       "required": ["organizationId", "appName"]
@@ -12369,6 +12799,85 @@
       },
       "required": ["organizationIds"]
     },
+    "v1GetSwapStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "swapRequestId": {
+          "type": "string",
+          "description": "The swap_request_id returned by ExecuteSwap."
+        }
+      },
+      "required": ["organizationId", "swapRequestId"]
+    },
+    "v1GetSwapStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Normalized swap status. One of PENDING, COMPLETED, FAILED."
+        },
+        "swapKind": {
+          "type": "string",
+          "description": "SAME_CHAIN or CROSS_CHAIN."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that executed the swap."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "originTxHash": {
+          "type": "string",
+          "description": "Final included origin-chain transaction hash, when known."
+        },
+        "destinationTxHashes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Actual base-unit output amount on COMPLETED, when known. Unset on FAILED."
+        },
+        "refund": {
+          "$ref": "#/definitions/v1SwapRefund",
+          "description": "Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED."
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "Timestamp of the last swap status change, as millisecond epoch string."
+        },
+        "error": {
+          "$ref": "#/definitions/v1SwapError",
+          "description": "Normalized failure details, present whenever status is FAILED."
+        }
+      },
+      "required": [
+        "status",
+        "swapKind",
+        "provider",
+        "inputToken",
+        "outputToken",
+        "inputAmount",
+        "updatedAt"
+      ]
+    },
     "v1GetTvcAppDeploymentsRequest": {
       "type": "object",
       "properties": {
@@ -12687,6 +13196,7 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
+            "eip155:421614",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14119,6 +14629,18 @@
         },
         "claimEarnFeesIntent": {
           "$ref": "#/definitions/v1ClaimEarnFeesIntent"
+        },
+        "updateWalletAccountNameIntent": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameIntent"
+        },
+        "ethUndelegate7702Intent": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "executeSwapIntentV2": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV2"
+        },
+        "createSwapQuoteIntent": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntent"
         }
       }
     },
@@ -14308,7 +14830,11 @@
             "type": "object",
             "$ref": "#/definitions/v1EarnVault"
           },
-          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor."
+          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor."
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo",
+          "description": "Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them."
         }
       }
     },
@@ -14543,7 +15069,8 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:421614",
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet or 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' for Solana mainnet). Human-readable Solana aliases ('solana:mainnet', 'solana:devnet') are also accepted and normalized to canonical CAIP-2 values."
@@ -15291,8 +15818,26 @@
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
         "OUTCOME_ERROR",
-        "OUTCOME_REQUIRES_AUTHENTICATORS"
+        "OUTCOME_REQUIRES_AUTHENTICATORS",
+        "OUTCOME_TIME_INACTIVE"
       ]
+    },
+    "v1PageInfo": {
+      "type": "object",
+      "properties": {
+        "hasNextPage": {
+          "type": "boolean"
+        },
+        "hasPreviousPage": {
+          "type": "boolean"
+        },
+        "startCursor": {
+          "type": "string"
+        },
+        "endCursor": {
+          "type": "string"
+        }
+      }
     },
     "v1Pagination": {
       "type": "object",
@@ -15356,6 +15901,10 @@
         "condition": {
           "type": "string",
           "description": "A condition expression that evalutes to true or false."
+        },
+        "time": {
+          "type": "string",
+          "description": "A time expression that evalutes to true or false."
         }
       },
       "required": [
@@ -16248,6 +16797,15 @@
         },
         "claimEarnFeesResult": {
           "$ref": "#/definitions/v1ClaimEarnFeesResult"
+        },
+        "updateWalletAccountNameResult": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameResult"
+        },
+        "ethUndelegate7702Result": {
+          "$ref": "#/definitions/v1EthUndelegate7702Result"
+        },
+        "createSwapQuoteResult": {
+          "$ref": "#/definitions/v1CreateSwapQuoteResult"
         }
       }
     },
@@ -17797,6 +18355,87 @@
       },
       "required": ["session"]
     },
+    "v1SwapError": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description of the swap failure."
+        },
+        "originTxError": {
+          "$ref": "#/definitions/v1TxError",
+          "description": "Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available."
+        }
+      },
+      "required": ["reason", "message"]
+    },
+    "v1SwapQuote": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that produced this quote."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Estimated base-unit amount of the output asset."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Minimum acceptable base-unit amount of the output asset after slippage."
+        },
+        "expiresAt": {
+          "type": "string",
+          "description": "Quote expiration as a millisecond epoch string."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set."
+        },
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount."
+        },
+        "estimatedTimeSeconds": {
+          "type": "string",
+          "description": "Provider-estimated completion time in seconds, when available."
+        }
+      },
+      "required": [
+        "quoteId",
+        "provider",
+        "outputAmount",
+        "minOutputAmount",
+        "expiresAt",
+        "clientFeeBps"
+      ]
+    },
+    "v1SwapRefund": {
+      "type": "object",
+      "properties": {
+        "asset": {
+          "type": "string",
+          "description": "CAIP-19 asset returned to the user after a failed swap."
+        },
+        "amount": {
+          "type": "string",
+          "description": "Base-unit amount of the refunded asset."
+        },
+        "txHash": {
+          "type": "string",
+          "description": "Transaction that delivered the refunded funds, when applicable."
+        }
+      },
+      "required": ["asset", "amount"]
+    },
     "v1TagType": {
       "type": "string",
       "enum": ["TAG_TYPE_USER", "TAG_TYPE_PRIVATE_KEY"]
@@ -18826,6 +19465,10 @@
         "policyNotes": {
           "type": "string",
           "description": "Accompanying notes for a Policy (optional)."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect (optional)."
         }
       },
       "required": ["policyId"]
@@ -19295,6 +19938,30 @@
       },
       "required": ["userTagId"]
     },
+    "v1UpdateWalletAccountNameIntent": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account."
+        }
+      },
+      "required": ["walletAccountId", "name"]
+    },
+    "v1UpdateWalletAccountNameResult": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        }
+      },
+      "required": ["walletAccountId"]
+    },
     "v1UpdateWalletIntent": {
       "type": "object",
       "properties": {
@@ -19453,14 +20120,35 @@
           "type": "string",
           "description": "Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set."
         },
-        "provider": {
-          "type": "string"
-        },
         "stableFeeBps": {
           "type": "string",
-          "description": "Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset."
+          "description": "Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps."
         }
       }
+    },
+    "v1UpsertSwapConfigRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPSERT_SWAP_CONFIG"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpsertSwapConfigIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1UpsertSwapConfigResult": {
       "type": "object",

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -121,10 +121,6 @@ import type {
   TGetSmartContractInterfaceResponse,
 } from "./public_api.fetcher";
 import type {
-  TGetSwapQuoteBody,
-  TGetSwapQuoteResponse,
-} from "./public_api.fetcher";
-import type {
   TGetSwapStatusBody,
   TGetSwapStatusResponse,
 } from "./public_api.fetcher";
@@ -330,6 +326,10 @@ import type {
   TCreateSubOrganizationResponse,
 } from "./public_api.fetcher";
 import type {
+  TCreateSwapQuoteBody,
+  TCreateSwapQuoteResponse,
+} from "./public_api.fetcher";
+import type {
   TCreateTvcAppBody,
   TCreateTvcAppResponse,
 } from "./public_api.fetcher";
@@ -473,6 +473,10 @@ import type {
 import type {
   TEthSendTransactionBody,
   TEthSendTransactionResponse,
+} from "./public_api.fetcher";
+import type {
+  TEthUndelegate7702Body,
+  TEthUndelegate7702Response,
 } from "./public_api.fetcher";
 import type {
   TExecuteSwapBody,
@@ -1659,38 +1663,7 @@ export class TurnkeyClient {
   };
 
   /**
-   * Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported.
-   *
-   * Sign the provided `TGetSwapQuoteBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_swap_quote).
-   *
-   * See also {@link stampGetSwapQuote}.
-   */
-  getSwapQuote = async (
-    input: TGetSwapQuoteBody,
-  ): Promise<TGetSwapQuoteResponse> => {
-    return this.request("/public/v1/query/get_swap_quote", input);
-  };
-
-  /**
-   * Produce a `SignedRequest` from `TGetSwapQuoteBody` by using the client's `stamp` function.
-   *
-   * See also {@link GetSwapQuote}.
-   */
-  stampGetSwapQuote = async (
-    input: TGetSwapQuoteBody,
-  ): Promise<TSignedRequest> => {
-    const fullUrl = this.config.baseUrl + "/public/v1/query/get_swap_quote";
-    const body = JSON.stringify(input);
-    const stamp = await this.stamper.stamp(body);
-    return {
-      body: body,
-      stamp: stamp,
-      url: fullUrl,
-    };
-  };
-
-  /**
-   * Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps.
+   * Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.
    *
    * Sign the provided `TGetSwapStatusBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_swap_status).
    *
@@ -3415,6 +3388,37 @@ export class TurnkeyClient {
   };
 
   /**
+   * Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported.
+   *
+   * Sign the provided `TCreateSwapQuoteBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_swap_quote).
+   *
+   * See also {@link stampCreateSwapQuote}.
+   */
+  createSwapQuote = async (
+    input: TCreateSwapQuoteBody,
+  ): Promise<TCreateSwapQuoteResponse> => {
+    return this.request("/public/v1/submit/create_swap_quote", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TCreateSwapQuoteBody` by using the client's `stamp` function.
+   *
+   * See also {@link CreateSwapQuote}.
+   */
+  stampCreateSwapQuote = async (
+    input: TCreateSwapQuoteBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl = this.config.baseUrl + "/public/v1/submit/create_swap_quote";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * Create a new TVC application
    *
    * Sign the provided `TCreateTvcAppBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_tvc_app).
@@ -4592,7 +4596,39 @@ export class TurnkeyClient {
   };
 
   /**
-   * Execute a quoted swap through the activity pipeline and Turnkey broadcasting.
+   * Submit an EIP-7702 undelegation transaction.
+   *
+   * Sign the provided `TEthUndelegate7702Body` with the client's `stamp` function, and submit the request (POST /public/v1/submit/eth_undelegate_7702).
+   *
+   * See also {@link stampEthUndelegate7702}.
+   */
+  ethUndelegate7702 = async (
+    input: TEthUndelegate7702Body,
+  ): Promise<TEthUndelegate7702Response> => {
+    return this.request("/public/v1/submit/eth_undelegate_7702", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TEthUndelegate7702Body` by using the client's `stamp` function.
+   *
+   * See also {@link EthUndelegate7702}.
+   */
+  stampEthUndelegate7702 = async (
+    input: TEthUndelegate7702Body,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/submit/eth_undelegate_7702";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2.
    *
    * Sign the provided `TExecuteSwapBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/execute_swap).
    *

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -1500,52 +1500,6 @@ export const signGetSmartContractInterface = (
   });
 
 /**
- * `POST /public/v1/query/get_swap_quote`
- */
-export type TGetSwapQuoteResponse =
-  operations["PublicApiService_GetSwapQuote"]["responses"]["200"]["schema"];
-
-/**
- * `POST /public/v1/query/get_swap_quote`
- */
-export type TGetSwapQuoteInput = { body: TGetSwapQuoteBody };
-
-/**
- * `POST /public/v1/query/get_swap_quote`
- */
-export type TGetSwapQuoteBody =
-  operations["PublicApiService_GetSwapQuote"]["parameters"]["body"]["body"];
-
-/**
- * Get swap quote
- *
- * Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported.
- *
- * `POST /public/v1/query/get_swap_quote`
- */
-export const getSwapQuote = (input: TGetSwapQuoteInput) =>
-  request<TGetSwapQuoteResponse, TGetSwapQuoteBody, never, never, never>({
-    uri: "/public/v1/query/get_swap_quote",
-    method: "POST",
-    body: input.body,
-  });
-
-/**
- * Request a WebAuthn assertion and return a signed `GetSwapQuote` request, ready to be POSTed to Turnkey.
- *
- * See {@link GetSwapQuote}
- */
-export const signGetSwapQuote = (
-  input: TGetSwapQuoteInput,
-  options?: TurnkeyCredentialRequestOptions,
-) =>
-  signedRequest<TGetSwapQuoteBody, never, never>({
-    uri: "/public/v1/query/get_swap_quote",
-    body: input.body,
-    options,
-  });
-
-/**
  * `POST /public/v1/query/get_swap_status`
  */
 export type TGetSwapStatusResponse =
@@ -1565,7 +1519,7 @@ export type TGetSwapStatusBody =
 /**
  * Get swap status
  *
- * Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps.
+ * Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.
  *
  * `POST /public/v1/query/get_swap_status`
  */
@@ -4308,6 +4262,52 @@ export const signCreateSubOrganization = (
   });
 
 /**
+ * `POST /public/v1/submit/create_swap_quote`
+ */
+export type TCreateSwapQuoteResponse =
+  operations["PublicApiService_CreateSwapQuote"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/create_swap_quote`
+ */
+export type TCreateSwapQuoteInput = { body: TCreateSwapQuoteBody };
+
+/**
+ * `POST /public/v1/submit/create_swap_quote`
+ */
+export type TCreateSwapQuoteBody =
+  operations["PublicApiService_CreateSwapQuote"]["parameters"]["body"]["body"];
+
+/**
+ * Get swap quote
+ *
+ * Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported.
+ *
+ * `POST /public/v1/submit/create_swap_quote`
+ */
+export const createSwapQuote = (input: TCreateSwapQuoteInput) =>
+  request<TCreateSwapQuoteResponse, TCreateSwapQuoteBody, never, never, never>({
+    uri: "/public/v1/submit/create_swap_quote",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `CreateSwapQuote` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link CreateSwapQuote}
+ */
+export const signCreateSwapQuote = (
+  input: TCreateSwapQuoteInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TCreateSwapQuoteBody, never, never>({
+    uri: "/public/v1/submit/create_swap_quote",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/submit/create_tvc_app`
  */
 export type TCreateTvcAppResponse =
@@ -6166,6 +6166,58 @@ export const signEthSendTransaction = (
   });
 
 /**
+ * `POST /public/v1/submit/eth_undelegate_7702`
+ */
+export type TEthUndelegate7702Response =
+  operations["PublicApiService_EthUndelegate7702"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/eth_undelegate_7702`
+ */
+export type TEthUndelegate7702Input = { body: TEthUndelegate7702Body };
+
+/**
+ * `POST /public/v1/submit/eth_undelegate_7702`
+ */
+export type TEthUndelegate7702Body =
+  operations["PublicApiService_EthUndelegate7702"]["parameters"]["body"]["body"];
+
+/**
+ * Undelegate an EVM account
+ *
+ * Submit an EIP-7702 undelegation transaction.
+ *
+ * `POST /public/v1/submit/eth_undelegate_7702`
+ */
+export const ethUndelegate7702 = (input: TEthUndelegate7702Input) =>
+  request<
+    TEthUndelegate7702Response,
+    TEthUndelegate7702Body,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/submit/eth_undelegate_7702",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `EthUndelegate7702` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link EthUndelegate7702}
+ */
+export const signEthUndelegate7702 = (
+  input: TEthUndelegate7702Input,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TEthUndelegate7702Body, never, never>({
+    uri: "/public/v1/submit/eth_undelegate_7702",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/submit/execute_swap`
  */
 export type TExecuteSwapResponse =
@@ -6185,7 +6237,7 @@ export type TExecuteSwapBody =
 /**
  * Execute swap
  *
- * Execute a quoted swap through the activity pipeline and Turnkey broadcasting.
+ * Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2.
  *
  * `POST /public/v1/submit/execute_swap`
  */

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -1032,42 +1032,10 @@
         "tags": ["Policies"]
       }
     },
-    "/public/v1/query/get_swap_quote": {
-      "post": {
-        "summary": "Get swap quote",
-        "description": "Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported.",
-        "operationId": "PublicApiService_GetSwapQuote",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1GetSwapQuoteResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1GetSwapQuoteRequest"
-            }
-          }
-        ],
-        "tags": ["Swaps"]
-      }
-    },
     "/public/v1/query/get_swap_status": {
       "post": {
         "summary": "Get swap status",
-        "description": "Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps.",
+        "description": "Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.",
         "operationId": "PublicApiService_GetSwapStatus",
         "responses": {
           "200": {
@@ -2824,6 +2792,38 @@
         "tags": ["Organizations"]
       }
     },
+    "/public/v1/submit/create_swap_quote": {
+      "post": {
+        "summary": "Get swap quote",
+        "description": "Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported.",
+        "operationId": "PublicApiService_CreateSwapQuote",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateSwapQuoteRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
+      }
+    },
     "/public/v1/submit/create_tvc_app": {
       "post": {
         "summary": "Create a TVC App",
@@ -4008,10 +4008,42 @@
         "tags": ["Broadcasting"]
       }
     },
+    "/public/v1/submit/eth_undelegate_7702": {
+      "post": {
+        "summary": "Undelegate an EVM account",
+        "description": "Submit an EIP-7702 undelegation transaction.",
+        "operationId": "PublicApiService_EthUndelegate7702",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1EthUndelegate7702Request"
+            }
+          }
+        ],
+        "tags": ["Broadcasting"]
+      }
+    },
     "/public/v1/submit/execute_swap": {
       "post": {
         "summary": "Execute swap",
-        "description": "Execute a quoted swap through the activity pipeline and Turnkey broadcasting.",
+        "description": "Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2.",
         "operationId": "PublicApiService_ExecuteSwap",
         "responses": {
           "200": {
@@ -6462,7 +6494,11 @@
         "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2",
         "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
         "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE",
-        "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+        "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+        "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME",
+        "ACTIVITY_TYPE_ETH_UNDELEGATE_7702",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
       ]
     },
     "v1AddressFormat": {
@@ -6746,6 +6782,10 @@
         "name": {
           "type": "string",
           "description": "The asset name"
+        },
+        "stable": {
+          "type": "boolean",
+          "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
         }
       }
     },
@@ -7831,6 +7871,10 @@
         "notes": {
           "type": "string",
           "description": "Notes for a Policy."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect"
         }
       },
       "required": ["policyName", "effect", "notes"]
@@ -8766,6 +8810,70 @@
       },
       "required": ["subOrganizationId"]
     },
+    "v1CreateSwapQuoteIntent": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
+    "v1CreateSwapQuoteRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_SWAP_QUOTE"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateSwapQuoteResult": {
+      "type": "object",
+      "properties": {
+        "quotes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SwapQuote"
+          },
+          "description": "One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution."
+        }
+      },
+      "required": ["quotes"]
+    },
     "v1CreateTvcAppIntent": {
       "type": "object",
       "properties": {
@@ -8847,13 +8955,32 @@
           "type": "integer",
           "format": "int64",
           "description": "The required number of approvals for the manifest set"
+        },
+        "shareSetId": {
+          "type": "string",
+          "description": "The unique identifier for the TVC share set"
+        },
+        "shareSetOperatorIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The unique identifiers of the share set operators"
+        },
+        "shareSetThreshold": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The required number of approvals for the share set"
         }
       },
       "required": [
         "appId",
         "manifestSetId",
         "manifestSetOperatorIds",
-        "manifestSetThreshold"
+        "manifestSetThreshold",
+        "shareSetId",
+        "shareSetOperatorIds",
+        "shareSetThreshold"
       ]
     },
     "v1CreateTvcDeploymentIntent": {
@@ -10603,7 +10730,7 @@
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+          "description": "Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%)."
         },
         "clientFeeWallet": {
           "type": "string",
@@ -10748,7 +10875,7 @@
         },
         "apyPct": {
           "type": "string",
-          "description": "Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees)."
+          "description": "Gross annual percentage yield, expressed as a decimal fraction (before fees)."
         },
         "totalDeposited": {
           "type": "string",
@@ -10760,11 +10887,11 @@
         },
         "netApyPct": {
           "type": "string",
-          "description": "Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction."
+          "description": "Annual percentage yield net of fees, expressed as a decimal fraction."
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting."
+          "description": "Client fee taken on yield, in basis points."
         },
         "depositsDisabled": {
           "type": "boolean",
@@ -10780,11 +10907,15 @@
         },
         "claimableClientFee": {
           "type": "string",
-          "description": "The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
+          "description": "The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
         },
         "claimableClientFeeDisplay": {
           "$ref": "#/definitions/v1EarnValueDisplay",
           "description": "Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
         }
       }
     },
@@ -11359,6 +11490,10 @@
         "deliveryDelayType": {
           "type": "string",
           "description": "Delay type for DeliveryDelay events"
+        },
+        "complaintFeedbackType": {
+          "type": "string",
+          "description": "Feedback type for Complaint events"
         }
       }
     },
@@ -11599,7 +11734,7 @@
         },
         "gasStationNonce": {
           "type": "string",
-          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+          "description": "The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection."
         },
         "calls": {
           "type": "array",
@@ -11720,6 +11855,86 @@
         "transfers"
       ]
     },
+    "v1EthUndelegate7702Intent": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to undelegate. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97",
+            "eip155:10",
+            "eip155:11155420",
+            "eip155:143",
+            "eip155:10143",
+            "eip155:42161",
+            "eip155:421614"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        }
+      },
+      "required": ["from", "caip2"]
+    },
+    "v1EthUndelegate7702Request": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_ETH_UNDELEGATE_7702"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1EthUndelegate7702Result": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the undelegation transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
     "v1ExecuteSwapIntent": {
       "type": "object",
       "properties": {
@@ -11749,7 +11964,7 @@
         },
         "provider": {
           "type": "string",
-          "description": "Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider."
+          "description": "Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider."
         },
         "minOutputAmount": {
           "type": "string",
@@ -11764,12 +11979,66 @@
         "minOutputAmount"
       ]
     },
+    "v1ExecuteSwapIntentV2": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
     "v1ExecuteSwapRequest": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ACTIVITY_TYPE_EXECUTE_SWAP"]
+          "enum": ["ACTIVITY_TYPE_EXECUTE_SWAP_V2"]
         },
         "timestampMs": {
           "type": "string",
@@ -11780,7 +12049,7 @@
           "description": "Unique identifier for a given Organization."
         },
         "parameters": {
-          "$ref": "#/definitions/v1ExecuteSwapIntent"
+          "$ref": "#/definitions/v1ExecuteSwapIntentV2"
         },
         "generateAppProofs": {
           "type": "boolean"
@@ -11791,9 +12060,9 @@
     "v1ExecuteSwapResult": {
       "type": "object",
       "properties": {
-        "sendTransactionStatusId": {
+        "swapRequestId": {
           "type": "string",
-          "description": "The send_transaction_status ID associated with the swap transaction submission"
+          "description": "Identifier to poll swap status via GetSwapStatus."
         },
         "provider": {
           "type": "string",
@@ -11804,7 +12073,7 @@
           "description": "Quote identifier used for execution, if any."
         }
       },
-      "required": ["sendTransactionStatusId"]
+      "required": ["swapRequestId"]
     },
     "v1ExportPrivateKeyIntent": {
       "type": "object",
@@ -12545,7 +12814,7 @@
         },
         "appName": {
           "type": "string",
-          "description": "Name of enclave app."
+          "description": "Unique identifier (UUID) of the enclave app."
         }
       },
       "required": ["organizationId", "appName"]
@@ -13110,68 +13379,6 @@
       },
       "required": ["organizationIds"]
     },
-    "v1GetSwapQuoteRequest": {
-      "type": "object",
-      "properties": {
-        "organizationId": {
-          "type": "string",
-          "description": "Unique identifier for a given Organization."
-        },
-        "inputToken": {
-          "type": "string",
-          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
-        },
-        "outputToken": {
-          "type": "string",
-          "description": "CAIP-19 asset ID for the output asset."
-        },
-        "inputAmount": {
-          "type": "string",
-          "description": "Base-unit amount of the input asset."
-        },
-        "walletAccount": {
-          "type": "string",
-          "description": "Wallet account address used to price the executable provider quote."
-        },
-        "slippage": {
-          "type": "string",
-          "description": "Maximum allowed slippage in basis points."
-        }
-      },
-      "required": [
-        "organizationId",
-        "inputToken",
-        "outputToken",
-        "inputAmount",
-        "walletAccount"
-      ]
-    },
-    "v1GetSwapQuoteResponse": {
-      "type": "object",
-      "properties": {
-        "inputToken": {
-          "type": "string",
-          "description": "CAIP-19 asset ID for the input asset."
-        },
-        "outputToken": {
-          "type": "string",
-          "description": "CAIP-19 asset ID for the output asset."
-        },
-        "inputAmount": {
-          "type": "string",
-          "description": "Base-unit amount of the input asset."
-        },
-        "quotes": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1SwapQuoteOption"
-          },
-          "description": "One quote per available swap provider."
-        }
-      },
-      "required": ["inputToken", "outputToken", "inputAmount", "quotes"]
-    },
     "v1GetSwapStatusRequest": {
       "type": "object",
       "properties": {
@@ -13179,12 +13386,12 @@
           "type": "string",
           "description": "Unique identifier for a given Organization."
         },
-        "sendTransactionStatusId": {
+        "swapRequestId": {
           "type": "string",
-          "description": "Identifier returned in the execute_swap activity result."
+          "description": "The swap_request_id returned by ExecuteSwap."
         }
       },
-      "required": ["organizationId", "sendTransactionStatusId"]
+      "required": ["organizationId", "swapRequestId"]
     },
     "v1GetSwapStatusResponse": {
       "type": "object",
@@ -13217,38 +13424,34 @@
           "type": "string",
           "description": "Final included origin-chain transaction hash, when known."
         },
-        "destinationTxHash": {
-          "type": "string",
-          "description": "Destination-chain fill transaction hash; cross-chain COMPLETED only."
+        "destinationTxHashes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only."
         },
         "outputAmount": {
           "type": "string",
-          "description": "Actual base-unit output amount on COMPLETED, when known."
+          "description": "Actual base-unit output amount on COMPLETED, when known. Unset on FAILED."
         },
-        "settledAsset": {
-          "type": "string",
-          "description": "CAIP-19 of the asset the user holds after a FAILED swap, when recoverable."
-        },
-        "settledAmount": {
-          "type": "string",
-          "description": "Base-unit amount of settled_asset."
-        },
-        "settlementTxHash": {
-          "type": "string",
-          "description": "Transaction that delivered the settled funds, when applicable."
-        },
-        "providerStatus": {
-          "type": "string",
-          "description": "Non-normative raw provider status passthrough; cross-chain only."
+        "refund": {
+          "$ref": "#/definitions/v1SwapRefund",
+          "description": "Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED."
         },
         "updatedAt": {
           "type": "string",
           "description": "Timestamp of the last swap status change, as millisecond epoch string."
+        },
+        "error": {
+          "$ref": "#/definitions/v1SwapError",
+          "description": "Normalized failure details, present whenever status is FAILED."
         }
       },
       "required": [
         "status",
         "swapKind",
+        "provider",
         "inputToken",
         "outputToken",
         "inputAmount",
@@ -13603,6 +13806,7 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
+            "eip155:421614",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -15056,6 +15260,18 @@
         },
         "claimEarnFeesIntent": {
           "$ref": "#/definitions/v1ClaimEarnFeesIntent"
+        },
+        "updateWalletAccountNameIntent": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameIntent"
+        },
+        "ethUndelegate7702Intent": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "executeSwapIntentV2": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV2"
+        },
+        "createSwapQuoteIntent": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntent"
         }
       }
     },
@@ -15306,7 +15522,11 @@
             "type": "object",
             "$ref": "#/definitions/v1EarnVault"
           },
-          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor."
+          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor."
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo",
+          "description": "Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them."
         }
       }
     },
@@ -15541,7 +15761,8 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:421614",
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet or 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' for Solana mainnet). Human-readable Solana aliases ('solana:mainnet', 'solana:devnet') are also accepted and normalized to canonical CAIP-2 values."
@@ -16359,8 +16580,26 @@
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
         "OUTCOME_ERROR",
-        "OUTCOME_REQUIRES_AUTHENTICATORS"
+        "OUTCOME_REQUIRES_AUTHENTICATORS",
+        "OUTCOME_TIME_INACTIVE"
       ]
+    },
+    "v1PageInfo": {
+      "type": "object",
+      "properties": {
+        "hasNextPage": {
+          "type": "boolean"
+        },
+        "hasPreviousPage": {
+          "type": "boolean"
+        },
+        "startCursor": {
+          "type": "string"
+        },
+        "endCursor": {
+          "type": "string"
+        }
+      }
     },
     "v1Pagination": {
       "type": "object",
@@ -16424,6 +16663,10 @@
         "condition": {
           "type": "string",
           "description": "A condition expression that evalutes to true or false."
+        },
+        "time": {
+          "type": "string",
+          "description": "A time expression that evalutes to true or false."
         }
       },
       "required": [
@@ -17367,6 +17610,15 @@
         },
         "claimEarnFeesResult": {
           "$ref": "#/definitions/v1ClaimEarnFeesResult"
+        },
+        "updateWalletAccountNameResult": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameResult"
+        },
+        "ethUndelegate7702Result": {
+          "$ref": "#/definitions/v1EthUndelegate7702Result"
+        },
+        "createSwapQuoteResult": {
+          "$ref": "#/definitions/v1CreateSwapQuoteResult"
         }
       }
     },
@@ -18930,16 +19182,34 @@
       },
       "required": ["session"]
     },
-    "v1SwapQuoteOption": {
+    "v1SwapError": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description of the swap failure."
+        },
+        "originTxError": {
+          "$ref": "#/definitions/v1TxError",
+          "description": "Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available."
+        }
+      },
+      "required": ["reason", "message"]
+    },
+    "v1SwapQuote": {
       "type": "object",
       "properties": {
         "quoteId": {
           "type": "string",
-          "description": "Identifier for this provider quote."
+          "description": "Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute."
         },
         "provider": {
           "type": "string",
-          "description": "Swap provider that produced this quote. Pass this value to execute_swap to force a specific provider."
+          "description": "Swap provider that produced this quote."
         },
         "outputAmount": {
           "type": "string",
@@ -18948,9 +19218,50 @@
         "minOutputAmount": {
           "type": "string",
           "description": "Minimum acceptable base-unit amount of the output asset after slippage."
+        },
+        "expiresAt": {
+          "type": "string",
+          "description": "Quote expiration as a millisecond epoch string."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set."
+        },
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount."
+        },
+        "estimatedTimeSeconds": {
+          "type": "string",
+          "description": "Provider-estimated completion time in seconds, when available."
         }
       },
-      "required": ["quoteId", "provider", "outputAmount"]
+      "required": [
+        "quoteId",
+        "provider",
+        "outputAmount",
+        "minOutputAmount",
+        "expiresAt",
+        "clientFeeBps"
+      ]
+    },
+    "v1SwapRefund": {
+      "type": "object",
+      "properties": {
+        "asset": {
+          "type": "string",
+          "description": "CAIP-19 asset returned to the user after a failed swap."
+        },
+        "amount": {
+          "type": "string",
+          "description": "Base-unit amount of the refunded asset."
+        },
+        "txHash": {
+          "type": "string",
+          "description": "Transaction that delivered the refunded funds, when applicable."
+        }
+      },
+      "required": ["asset", "amount"]
     },
     "v1TagType": {
       "type": "string",
@@ -20003,6 +20314,10 @@
         "policyNotes": {
           "type": "string",
           "description": "Accompanying notes for a Policy (optional)."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect (optional)."
         }
       },
       "required": ["policyId"]
@@ -20472,6 +20787,30 @@
       },
       "required": ["userTagId"]
     },
+    "v1UpdateWalletAccountNameIntent": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account."
+        }
+      },
+      "required": ["walletAccountId", "name"]
+    },
+    "v1UpdateWalletAccountNameResult": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        }
+      },
+      "required": ["walletAccountId"]
+    },
     "v1UpdateWalletIntent": {
       "type": "object",
       "properties": {
@@ -20630,12 +20969,9 @@
           "type": "string",
           "description": "Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set."
         },
-        "provider": {
-          "type": "string"
-        },
         "stableFeeBps": {
           "type": "string",
-          "description": "Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset."
+          "description": "Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps."
         }
       }
     },

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -124,12 +124,8 @@ export type paths = {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
   };
-  "/public/v1/query/get_swap_quote": {
-    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-    post: operations["PublicApiService_GetSwapQuote"];
-  };
   "/public/v1/query/get_swap_status": {
-    /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+    /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
     post: operations["PublicApiService_GetSwapStatus"];
   };
   "/public/v1/query/get_tvc_app": {
@@ -348,6 +344,10 @@ export type paths = {
     /** Create a new sub-organization. Each root user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the sub-organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateSubOrganization"];
   };
+  "/public/v1/submit/create_swap_quote": {
+    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+    post: operations["PublicApiService_CreateSwapQuote"];
+  };
   "/public/v1/submit/create_tvc_app": {
     /** Create a new TVC application */
     post: operations["PublicApiService_CreateTvcApp"];
@@ -496,8 +496,12 @@ export type paths = {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
     post: operations["PublicApiService_EthSendTransaction"];
   };
+  "/public/v1/submit/eth_undelegate_7702": {
+    /** Submit an EIP-7702 undelegation transaction. */
+    post: operations["PublicApiService_EthUndelegate7702"];
+  };
   "/public/v1/submit/execute_swap": {
-    /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+    /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
     post: operations["PublicApiService_ExecuteSwap"];
   };
   "/public/v1/submit/export_private_key": {
@@ -1080,7 +1084,11 @@ export type definitions = {
     | "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2"
     | "ACTIVITY_TYPE_CLAIM_SWAP_FEES"
     | "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE"
-    | "ACTIVITY_TYPE_CLAIM_EARN_FEES";
+    | "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+    | "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME"
+    | "ACTIVITY_TYPE_ETH_UNDELEGATE_7702"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1230,6 +1238,8 @@ export type definitions = {
     logoUrl?: string;
     /** @description The asset name */
     name?: string;
+    /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
+    stable?: boolean;
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -1651,6 +1661,8 @@ export type definitions = {
     consensus?: string;
     /** @description Notes for a Policy. */
     notes: string;
+    /** @description The time expression that triggers the Effect */
+    time?: string;
   };
   v1CreatePolicyRequest: {
     /** @enum {string} */
@@ -2026,6 +2038,32 @@ export type definitions = {
     wallet?: definitions["v1WalletResult"];
     rootUserIds?: string[];
   };
+  v1CreateSwapQuoteIntent: {
+    /** @description Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+  };
+  v1CreateSwapQuoteRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSwapQuoteIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateSwapQuoteResult: {
+    /** @description One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution. */
+    quotes: definitions["v1SwapQuote"][];
+  };
   v1CreateTvcAppIntent: {
     /** @description The name of the new TVC application */
     name: string;
@@ -2065,6 +2103,15 @@ export type definitions = {
      * @description The required number of approvals for the manifest set
      */
     manifestSetThreshold: number;
+    /** @description The unique identifier for the TVC share set */
+    shareSetId: string;
+    /** @description The unique identifiers of the share set operators */
+    shareSetOperatorIds: string[];
+    /**
+     * Format: int64
+     * @description The required number of approvals for the share set
+     */
+    shareSetThreshold: number;
   };
   v1CreateTvcDeploymentIntent: {
     /** @description The unique identifier of the to-be-deployed TVC application */
@@ -2770,7 +2817,7 @@ export type definitions = {
       | "eip155:137"
       | "eip155:56"
       | "eip155:4217";
-    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    /** @description Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%). */
     clientFeeBps: string;
     /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
     clientFeeWallet: string;
@@ -2837,15 +2884,15 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description CAIP-19 asset ID of the vault's underlying asset (e.g. 'eip155:8453/erc20:0x833589...'); the chain is encoded in the identifier. */
     caip19?: string;
-    /** @description Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees). */
+    /** @description Gross annual percentage yield, expressed as a decimal fraction (before fees). */
     apyPct?: string;
     /** @description Total deposited through this wrapper (wrapper TVL), in raw on-chain units of the underlying asset. */
     totalDeposited?: string;
     /** @description Normalized total-deposited values for display only (usd + crypto). Do not do arithmetic with these; use total_deposited instead. */
     display?: definitions["v1EarnValueDisplay"];
-    /** @description Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction. */
+    /** @description Annual percentage yield net of fees, expressed as a decimal fraction. */
     netApyPct?: string;
-    /** @description Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting. */
+    /** @description Client fee taken on yield, in basis points. */
     clientFeeBps?: string;
     /** @description When true, deposits to this wrapper are rejected; withdrawals are unaffected. Toggled via EarnSetWrapperState. */
     depositsDisabled?: boolean;
@@ -2853,10 +2900,12 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
-    /** @description The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
+    /** @description The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
     claimableClientFee?: string;
     /** @description Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries. */
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
+    clientFeeWallet?: string;
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3127,6 +3176,8 @@ export type definitions = {
     deliveryProcessingTimeMillis?: string;
     /** @description Delay type for DeliveryDelay events */
     deliveryDelayType?: string;
+    /** @description Feedback type for Complaint events */
+    complaintFeedbackType?: string;
   };
   v1EnableAuthProxyIntent: { [key: string]: unknown };
   v1EnableAuthProxyResult: {
@@ -3265,7 +3316,7 @@ export type definitions = {
     maxPriorityFeePerGas?: string;
     /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
     deadline?: string;
-    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    /** @description The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection. */
     gasStationNonce?: string;
     /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
     calls: definitions["v1EthCallParams"][];
@@ -3315,6 +3366,51 @@ export type definitions = {
     /** @description Turnkey-specific metadata for transactions originated by Turnkey. */
     turnkey?: definitions["v1TransactionHistoryTurnkey"];
   };
+  v1EthUndelegate7702Intent: {
+    /** @description A wallet or private key address to undelegate. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97"
+      | "eip155:10"
+      | "eip155:11155420"
+      | "eip155:143"
+      | "eip155:10143"
+      | "eip155:42161"
+      | "eip155:421614";
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+  };
+  v1EthUndelegate7702Request: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_ETH_UNDELEGATE_7702";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1EthUndelegate7702Intent"];
+    generateAppProofs?: boolean;
+  };
+  v1EthUndelegate7702Result: {
+    /** @description The send_transaction_status ID associated with the undelegation transaction submission */
+    sendTransactionStatusId: string;
+  };
   v1ExecuteSwapIntent: {
     /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
     inputToken: string;
@@ -3328,24 +3424,46 @@ export type definitions = {
     sponsor?: boolean;
     /** @description Maximum allowed slippage in basis points. */
     slippage?: string;
-    /** @description Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider. */
+    /** @description Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider. */
     provider?: string;
     /** @description Minimum acceptable base-unit amount of the output asset. Execution fails if the swap provider's quoted minimum output falls below this floor at execution time. */
     minOutputAmount: string;
   };
+  v1ExecuteSwapIntentV2: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+  };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_EXECUTE_SWAP";
+    type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1ExecuteSwapIntent"];
+    parameters: definitions["v1ExecuteSwapIntentV2"];
     generateAppProofs?: boolean;
   };
   v1ExecuteSwapResult: {
-    /** @description The send_transaction_status ID associated with the swap transaction submission */
-    sendTransactionStatusId: string;
+    /** @description Identifier to poll swap status via GetSwapStatus. */
+    swapRequestId: string;
     /** @description Swap provider used to build the transaction. */
     provider?: string;
     /** @description Quote identifier used for execution, if any. */
@@ -3703,7 +3821,7 @@ export type definitions = {
   v1GetLatestBootProofRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Name of enclave app. */
+    /** @description Unique identifier (UUID) of the enclave app. */
     appName: string;
   };
   v1GetMfaPoliciesRequest: {
@@ -3943,35 +4061,11 @@ export type definitions = {
     /** @description List of unique identifiers for the matching sub-organizations. */
     organizationIds: string[];
   };
-  v1GetSwapQuoteRequest: {
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description Wallet account address used to price the executable provider quote. */
-    walletAccount: string;
-    /** @description Maximum allowed slippage in basis points. */
-    slippage?: string;
-  };
-  v1GetSwapQuoteResponse: {
-    /** @description CAIP-19 asset ID for the input asset. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description One quote per available swap provider. */
-    quotes: definitions["v1SwapQuoteOption"][];
-  };
   v1GetSwapStatusRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Identifier returned in the execute_swap activity result. */
-    sendTransactionStatusId: string;
+    /** @description The swap_request_id returned by ExecuteSwap. */
+    swapRequestId: string;
   };
   v1GetSwapStatusResponse: {
     /** @description Normalized swap status. One of PENDING, COMPLETED, FAILED. */
@@ -3979,7 +4073,7 @@ export type definitions = {
     /** @description SAME_CHAIN or CROSS_CHAIN. */
     swapKind: string;
     /** @description Swap provider that executed the swap. */
-    provider?: string;
+    provider: string;
     /** @description CAIP-19 asset ID for the input asset. */
     inputToken: string;
     /** @description CAIP-19 asset ID for the output asset. */
@@ -3988,20 +4082,16 @@ export type definitions = {
     inputAmount: string;
     /** @description Final included origin-chain transaction hash, when known. */
     originTxHash?: string;
-    /** @description Destination-chain fill transaction hash; cross-chain COMPLETED only. */
-    destinationTxHash?: string;
-    /** @description Actual base-unit output amount on COMPLETED, when known. */
+    /** @description Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only. */
+    destinationTxHashes?: string[];
+    /** @description Actual base-unit output amount on COMPLETED, when known. Unset on FAILED. */
     outputAmount?: string;
-    /** @description CAIP-19 of the asset the user holds after a FAILED swap, when recoverable. */
-    settledAsset?: string;
-    /** @description Base-unit amount of settled_asset. */
-    settledAmount?: string;
-    /** @description Transaction that delivered the settled funds, when applicable. */
-    settlementTxHash?: string;
-    /** @description Non-normative raw provider status passthrough; cross-chain only. */
-    providerStatus?: string;
+    /** @description Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED. */
+    refund?: definitions["v1SwapRefund"];
     /** @description Timestamp of the last swap status change, as millisecond epoch string. */
     updatedAt: string;
+    /** @description Normalized failure details, present whenever status is FAILED. */
+    error?: definitions["v1SwapError"];
   };
   v1GetTvcAppDeploymentsRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4164,6 +4254,7 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
+      | "eip155:421614"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4761,6 +4852,10 @@ export type definitions = {
     claimSwapFeesIntent?: definitions["v1ClaimSwapFeesIntent"];
     earnSetWrapperStateIntent?: definitions["v1EarnSetWrapperStateIntent"];
     claimEarnFeesIntent?: definitions["v1ClaimEarnFeesIntent"];
+    updateWalletAccountNameIntent?: definitions["v1UpdateWalletAccountNameIntent"];
+    ethUndelegate7702Intent?: definitions["v1EthUndelegate7702Intent"];
+    executeSwapIntentV2?: definitions["v1ExecuteSwapIntentV2"];
+    createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -4856,8 +4951,10 @@ export type definitions = {
     paginationOptions?: definitions["v1Pagination"];
   };
   v1ListEarnVaultsResponse: {
-    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor. */
+    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor. */
     vaults?: definitions["v1EarnVault"][];
+    /** @description Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them. */
+    pageInfo?: definitions["v1PageInfo"];
   };
   v1ListEmailEventsRequest: {
     /** @description Unique identifier for a given organization */
@@ -4972,7 +5069,8 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+      | "eip155:421614"
+      | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
   v1ListSupportedAssetsResponse: {
@@ -5305,7 +5403,14 @@ export type definitions = {
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
     | "OUTCOME_ERROR"
-    | "OUTCOME_REQUIRES_AUTHENTICATORS";
+    | "OUTCOME_REQUIRES_AUTHENTICATORS"
+    | "OUTCOME_TIME_INACTIVE";
+  v1PageInfo: {
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+    startCursor?: string;
+    endCursor?: string;
+  };
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -5337,6 +5442,8 @@ export type definitions = {
     consensus: string;
     /** @description A condition expression that evalutes to true or false. */
     condition: string;
+    /** @description A time expression that evalutes to true or false. */
+    time?: string;
   };
   v1PostTvcQuorumKeyShareIntent: {
     /** @description Unique identifier of the TVC deployment receiving quorum key share */
@@ -5669,6 +5776,9 @@ export type definitions = {
     claimSwapFeesResult?: definitions["v1ClaimSwapFeesResult"];
     earnSetWrapperStateResult?: definitions["v1EarnSetWrapperStateResult"];
     claimEarnFeesResult?: definitions["v1ClaimEarnFeesResult"];
+    updateWalletAccountNameResult?: definitions["v1UpdateWalletAccountNameResult"];
+    ethUndelegate7702Result?: definitions["v1EthUndelegate7702Result"];
+    createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -6291,15 +6401,39 @@ export type definitions = {
     /** @description Signed JWT containing an expiry, public key, session type, user id, and organization id */
     session: string;
   };
-  v1SwapQuoteOption: {
-    /** @description Identifier for this provider quote. */
+  v1SwapError: {
+    /** @description Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED. */
+    reason: string;
+    /** @description Human-readable description of the swap failure. */
+    message: string;
+    /** @description Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available. */
+    originTxError?: definitions["v1TxError"];
+  };
+  v1SwapQuote: {
+    /** @description Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute. */
     quoteId: string;
-    /** @description Swap provider that produced this quote. Pass this value to execute_swap to force a specific provider. */
+    /** @description Swap provider that produced this quote. */
     provider: string;
     /** @description Estimated base-unit amount of the output asset. */
     outputAmount: string;
     /** @description Minimum acceptable base-unit amount of the output asset after slippage. */
-    minOutputAmount?: string;
+    minOutputAmount: string;
+    /** @description Quote expiration as a millisecond epoch string. */
+    expiresAt: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set. */
+    slippageBps?: string;
+    /** @description Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount. */
+    clientFeeBps: string;
+    /** @description Provider-estimated completion time in seconds, when available. */
+    estimatedTimeSeconds?: string;
+  };
+  v1SwapRefund: {
+    /** @description CAIP-19 asset returned to the user after a failed swap. */
+    asset: string;
+    /** @description Base-unit amount of the refunded asset. */
+    amount: string;
+    /** @description Transaction that delivered the refunded funds, when applicable. */
+    txHash?: string;
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
@@ -6772,6 +6906,8 @@ export type definitions = {
     policyConsensus?: string;
     /** @description Accompanying notes for a Policy (optional). */
     policyNotes?: string;
+    /** @description The time expression that triggers the Effect (optional). */
+    time?: string;
   };
   v1UpdatePolicyRequest: {
     /** @enum {string} */
@@ -6964,6 +7100,16 @@ export type definitions = {
     /** @description Unique identifier for a given User Tag. */
     userTagId: string;
   };
+  v1UpdateWalletAccountNameIntent: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+    /** @description Human-readable name for this Wallet Account. */
+    name: string;
+  };
+  v1UpdateWalletAccountNameResult: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+  };
   v1UpdateWalletIntent: {
     /** @description Unique identifier for a given Wallet. */
     walletId: string;
@@ -7030,8 +7176,7 @@ export type definitions = {
     feeReceiverWalletAddress?: string;
     /** @description Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set. */
     feeBps?: string;
-    provider?: string;
-    /** @description Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset. */
+    /** @description Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps. */
     stableFeeBps?: string;
   };
   v1UpsertSwapConfigRequest: {
@@ -7853,25 +7998,7 @@ export type operations = {
       };
     };
   };
-  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-  PublicApiService_GetSwapQuote: {
-    parameters: {
-      body: {
-        body: definitions["v1GetSwapQuoteRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetSwapQuoteResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+  /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
   PublicApiService_GetSwapStatus: {
     parameters: {
       body: {
@@ -8861,6 +8988,24 @@ export type operations = {
       };
     };
   };
+  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+  PublicApiService_CreateSwapQuote: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSwapQuoteRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a new TVC application */
   PublicApiService_CreateTvcApp: {
     parameters: {
@@ -9527,7 +9672,25 @@ export type operations = {
       };
     };
   };
-  /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+  /** Submit an EIP-7702 undelegation transaction. */
+  PublicApiService_EthUndelegate7702: {
+    parameters: {
+      body: {
+        body: definitions["v1EthUndelegate7702Request"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
   PublicApiService_ExecuteSwap: {
     parameters: {
       body: {

--- a/packages/sdk-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-browser/src/__generated__/sdk-client-base.ts
@@ -442,6 +442,48 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getClaimEarnFeesStatus = async (
+    input: SdkApiTypes.TGetClaimEarnFeesStatusBody,
+  ): Promise<SdkApiTypes.TGetClaimEarnFeesStatusResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_claim_earn_fees_status", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetClaimEarnFeesStatus = async (
+    input: SdkApiTypes.TGetClaimEarnFeesStatusBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_claim_earn_fees_status";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getEarnDeployStatus = async (
     input: SdkApiTypes.TGetEarnDeployStatusBody,
   ): Promise<SdkApiTypes.TGetEarnDeployStatusResponse> => {
@@ -1301,6 +1343,47 @@ export class TurnkeySDKClientBase {
     const session = sessionData ? parseSession(sessionData) : null;
     const fullUrl =
       this.config.apiBaseUrl + "/public/v1/query/get_smart_contract_interface";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getSwapStatus = async (
+    input: SdkApiTypes.TGetSwapStatusBody,
+  ): Promise<SdkApiTypes.TGetSwapStatusResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_swap_status", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetSwapStatus = async (
+    input: SdkApiTypes.TGetSwapStatusBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_swap_status";
     const body = {
       ...input,
       organizationId:
@@ -2780,6 +2863,58 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  claimSwapFees = async (
+    input: SdkApiTypes.TClaimSwapFeesBody,
+  ): Promise<SdkApiTypes.TClaimSwapFeesResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/claim_swap_fees",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
+      },
+      "claimSwapFeesResult",
+    );
+  };
+
+  stampClaimSwapFees = async (
+    input: SdkApiTypes.TClaimSwapFeesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/claim_swap_fees";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -5387,6 +5522,58 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  ethUndelegate7702 = async (
+    input: SdkApiTypes.TEthUndelegate7702Body,
+  ): Promise<SdkApiTypes.TEthUndelegate7702Response> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/eth_undelegate_7702",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_ETH_UNDELEGATE7702",
+      },
+      "ethUndelegate7702Result",
+    );
+  };
+
+  stampEthUndelegate7702 = async (
+    input: SdkApiTypes.TEthUndelegate7702Body,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/eth_undelegate_7702";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_ETH_UNDELEGATE7702",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   exportPrivateKey = async (
     input: SdkApiTypes.TExportPrivateKeyBody,
   ): Promise<SdkApiTypes.TExportPrivateKeyResponse> => {
@@ -7803,6 +7990,58 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  upsertSwapConfig = async (
+    input: SdkApiTypes.TUpsertSwapConfigBody,
+  ): Promise<SdkApiTypes.TUpsertSwapConfigResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/upsert_swap_config",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPSERT_SWAP_CONFIG",
+      },
+      "upsertSwapConfigResult",
+    );
+  };
+
+  stampUpsertSwapConfig = async (
+    input: SdkApiTypes.TUpsertSwapConfigBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/upsert_swap_config";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_UPSERT_SWAP_CONFIG",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/sdk-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-browser/src/__generated__/sdk_api_types.ts
@@ -84,6 +84,19 @@ export type TGetBootProofBody = Omit<
 > &
   queryOverrideParams;
 
+export type TGetClaimEarnFeesStatusResponse =
+  operations["PublicApiService_GetClaimEarnFeesStatus"]["responses"]["200"]["schema"];
+
+export type TGetClaimEarnFeesStatusInput = {
+  body: TGetClaimEarnFeesStatusBody;
+};
+
+export type TGetClaimEarnFeesStatusBody = Omit<
+  operations["PublicApiService_GetClaimEarnFeesStatus"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetEarnDeployStatusResponse =
   operations["PublicApiService_GetEarnDeployStatus"]["responses"]["200"]["schema"];
 
@@ -319,6 +332,17 @@ export type TGetSmartContractInterfaceInput = {
 
 export type TGetSmartContractInterfaceBody = Omit<
   operations["PublicApiService_GetSmartContractInterface"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
+export type TGetSwapStatusResponse =
+  operations["PublicApiService_GetSwapStatus"]["responses"]["200"]["schema"];
+
+export type TGetSwapStatusInput = { body: TGetSwapStatusBody };
+
+export type TGetSwapStatusBody = Omit<
+  operations["PublicApiService_GetSwapStatus"]["parameters"]["body"]["body"],
   "organizationId"
 > &
   queryOverrideParams;
@@ -716,6 +740,16 @@ export type TClaimEarnFeesInput = { body: TClaimEarnFeesBody };
 
 export type TClaimEarnFeesBody =
   operations["PublicApiService_ClaimEarnFees"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TClaimSwapFeesResponse =
+  operations["PublicApiService_ClaimSwapFees"]["responses"]["200"]["schema"]["activity"]["result"]["claimSwapFeesResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TClaimSwapFeesInput = { body: TClaimSwapFeesBody };
+
+export type TClaimSwapFeesBody =
+  operations["PublicApiService_ClaimSwapFees"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TCreateApiKeysResponse =
@@ -1236,6 +1270,16 @@ export type TEthSendTransactionBody =
   operations["PublicApiService_EthSendTransaction"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
+export type TEthUndelegate7702Response =
+  operations["PublicApiService_EthUndelegate7702"]["responses"]["200"]["schema"]["activity"]["result"]["ethUndelegate7702Result"] &
+    definitions["v1ActivityResponse"];
+
+export type TEthUndelegate7702Input = { body: TEthUndelegate7702Body };
+
+export type TEthUndelegate7702Body =
+  operations["PublicApiService_EthUndelegate7702"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
 export type TExportPrivateKeyResponse =
   operations["PublicApiService_ExportPrivateKey"]["responses"]["200"]["schema"]["activity"]["result"]["exportPrivateKeyResult"] &
     definitions["v1ActivityResponse"];
@@ -1718,6 +1762,16 @@ export type TUpdateWebhookEndpointInput = { body: TUpdateWebhookEndpointBody };
 
 export type TUpdateWebhookEndpointBody =
   operations["PublicApiService_UpdateWebhookEndpoint"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TUpsertSwapConfigResponse =
+  operations["PublicApiService_UpsertSwapConfig"]["responses"]["200"]["schema"]["activity"]["result"]["upsertSwapConfigResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TUpsertSwapConfigInput = { body: TUpsertSwapConfigBody };
+
+export type TUpsertSwapConfigBody =
+  operations["PublicApiService_UpsertSwapConfig"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TVerifyOtpResponse =

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -296,6 +296,38 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_claim_earn_fees_status": {
+      "post": {
+        "summary": "Get Earn claim fees status",
+        "description": "Poll the status of a fee claim by its claim_request_id.",
+        "operationId": "PublicApiService_GetClaimEarnFeesStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Earn"]
+      }
+    },
     "/public/v1/query/get_earn_deploy_status": {
       "post": {
         "summary": "Get Earn deploy status",
@@ -966,6 +998,38 @@
           }
         ],
         "tags": ["Policies"]
+      }
+    },
+    "/public/v1/query/get_swap_status": {
+      "post": {
+        "summary": "Get swap status",
+        "description": "Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.",
+        "operationId": "PublicApiService_GetSwapStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/query/get_tvc_app": {
@@ -2086,6 +2150,38 @@
           }
         ],
         "tags": ["Earn"]
+      }
+    },
+    "/public/v1/submit/claim_swap_fees": {
+      "post": {
+        "summary": "Claim swap fees",
+        "description": "Claim swap fees through the activity pipeline.",
+        "operationId": "PublicApiService_ClaimSwapFees",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ClaimSwapFeesRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/submit/create_api_keys": {
@@ -3688,6 +3784,38 @@
         "tags": ["Broadcasting"]
       }
     },
+    "/public/v1/submit/eth_undelegate_7702": {
+      "post": {
+        "summary": "Undelegate an EVM account",
+        "description": "Submit an EIP-7702 undelegation transaction.",
+        "operationId": "PublicApiService_EthUndelegate7702",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1EthUndelegate7702Request"
+            }
+          }
+        ],
+        "tags": ["Broadcasting"]
+      }
+    },
     "/public/v1/submit/export_private_key": {
       "post": {
         "summary": "Export private key",
@@ -5192,6 +5320,38 @@
         "tags": ["Organizations"]
       }
     },
+    "/public/v1/submit/upsert_swap_config": {
+      "post": {
+        "summary": "Upsert swap config",
+        "description": "Enable or disable swap configuration for an organization.",
+        "operationId": "PublicApiService_UpsertSwapConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpsertSwapConfigRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
+      }
+    },
     "/public/v1/submit/verify_otp": {
       "post": {
         "summary": "Verify generic OTP",
@@ -5918,7 +6078,11 @@
         "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2",
         "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
         "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE",
-        "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+        "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+        "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME",
+        "ACTIVITY_TYPE_ETH_UNDELEGATE_7702",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
       ]
     },
     "v1AddressFormat": {
@@ -6202,6 +6366,10 @@
         "name": {
           "type": "string",
           "description": "The asset name"
+        },
+        "stable": {
+          "type": "boolean",
+          "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
         }
       }
     },
@@ -6508,6 +6676,30 @@
     },
     "v1ClaimSwapFeesIntent": {
       "type": "object"
+    },
+    "v1ClaimSwapFeesRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CLAIM_SWAP_FEES"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1ClaimSwapFeesIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1ClaimSwapFeesResult": {
       "type": "object",
@@ -7239,6 +7431,10 @@
         "notes": {
           "type": "string",
           "description": "Notes for a Policy."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect"
         }
       },
       "required": ["policyName", "effect", "notes"]
@@ -8174,6 +8370,46 @@
       },
       "required": ["subOrganizationId"]
     },
+    "v1CreateSwapQuoteIntent": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
+    "v1CreateSwapQuoteResult": {
+      "type": "object",
+      "properties": {
+        "quotes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SwapQuote"
+          },
+          "description": "One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution."
+        }
+      },
+      "required": ["quotes"]
+    },
     "v1CreateTvcAppIntent": {
       "type": "object",
       "properties": {
@@ -8255,13 +8491,32 @@
           "type": "integer",
           "format": "int64",
           "description": "The required number of approvals for the manifest set"
+        },
+        "shareSetId": {
+          "type": "string",
+          "description": "The unique identifier for the TVC share set"
+        },
+        "shareSetOperatorIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The unique identifiers of the share set operators"
+        },
+        "shareSetThreshold": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The required number of approvals for the share set"
         }
       },
       "required": [
         "appId",
         "manifestSetId",
         "manifestSetOperatorIds",
-        "manifestSetThreshold"
+        "manifestSetThreshold",
+        "shareSetId",
+        "shareSetOperatorIds",
+        "shareSetThreshold"
       ]
     },
     "v1CreateTvcDeploymentIntent": {
@@ -9963,7 +10218,7 @@
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+          "description": "Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%)."
         },
         "clientFeeWallet": {
           "type": "string",
@@ -10108,7 +10363,7 @@
         },
         "apyPct": {
           "type": "string",
-          "description": "Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees)."
+          "description": "Gross annual percentage yield, expressed as a decimal fraction (before fees)."
         },
         "totalDeposited": {
           "type": "string",
@@ -10120,11 +10375,11 @@
         },
         "netApyPct": {
           "type": "string",
-          "description": "Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction."
+          "description": "Annual percentage yield net of fees, expressed as a decimal fraction."
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting."
+          "description": "Client fee taken on yield, in basis points."
         },
         "depositsDisabled": {
           "type": "boolean",
@@ -10140,11 +10395,15 @@
         },
         "claimableClientFee": {
           "type": "string",
-          "description": "The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
+          "description": "The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
         },
         "claimableClientFeeDisplay": {
           "$ref": "#/definitions/v1EarnValueDisplay",
           "description": "Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
         }
       }
     },
@@ -10719,6 +10978,10 @@
         "deliveryDelayType": {
           "type": "string",
           "description": "Delay type for DeliveryDelay events"
+        },
+        "complaintFeedbackType": {
+          "type": "string",
+          "description": "Feedback type for Complaint events"
         }
       }
     },
@@ -10935,7 +11198,7 @@
         },
         "gasStationNonce": {
           "type": "string",
-          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+          "description": "The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection."
         },
         "calls": {
           "type": "array",
@@ -11056,6 +11319,86 @@
         "transfers"
       ]
     },
+    "v1EthUndelegate7702Intent": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to undelegate. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97",
+            "eip155:10",
+            "eip155:11155420",
+            "eip155:143",
+            "eip155:10143",
+            "eip155:42161",
+            "eip155:421614"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        }
+      },
+      "required": ["from", "caip2"]
+    },
+    "v1EthUndelegate7702Request": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_ETH_UNDELEGATE_7702"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1EthUndelegate7702Result": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the undelegation transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
     "v1ExecuteSwapIntent": {
       "type": "object",
       "properties": {
@@ -11085,7 +11428,7 @@
         },
         "provider": {
           "type": "string",
-          "description": "Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider."
+          "description": "Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider."
         },
         "minOutputAmount": {
           "type": "string",
@@ -11100,12 +11443,66 @@
         "minOutputAmount"
       ]
     },
+    "v1ExecuteSwapIntentV2": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
     "v1ExecuteSwapResult": {
       "type": "object",
       "properties": {
-        "sendTransactionStatusId": {
+        "swapRequestId": {
           "type": "string",
-          "description": "The send_transaction_status ID associated with the swap transaction submission"
+          "description": "Identifier to poll swap status via GetSwapStatus."
         },
         "provider": {
           "type": "string",
@@ -11116,7 +11513,7 @@
           "description": "Quote identifier used for execution, if any."
         }
       },
-      "required": ["sendTransactionStatusId"]
+      "required": ["swapRequestId"]
     },
     "v1ExportPrivateKeyIntent": {
       "type": "object",
@@ -11664,6 +12061,39 @@
       },
       "required": ["organizationId", "ephemeralKey"]
     },
+    "v1GetClaimEarnFeesStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "claimRequestId": {
+          "type": "string",
+          "description": "The claim_request_id returned by ClaimEarnFees."
+        }
+      },
+      "required": ["organizationId", "claimRequestId"]
+    },
+    "v1GetClaimEarnFeesStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["PENDING", "COMPLETED", "FAILED"],
+          "description": "Status of the fee claim."
+        },
+        "claimTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee claim, once available."
+        },
+        "error": {
+          "type": "string",
+          "description": "Reason the fee claim transaction failed, when status is FAILED."
+        }
+      },
+      "required": ["status"]
+    },
     "v1GetEarnDeployStatusRequest": {
       "type": "object",
       "properties": {
@@ -11824,7 +12254,7 @@
         },
         "appName": {
           "type": "string",
-          "description": "Name of enclave app."
+          "description": "Unique identifier (UUID) of the enclave app."
         }
       },
       "required": ["organizationId", "appName"]
@@ -12369,6 +12799,85 @@
       },
       "required": ["organizationIds"]
     },
+    "v1GetSwapStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "swapRequestId": {
+          "type": "string",
+          "description": "The swap_request_id returned by ExecuteSwap."
+        }
+      },
+      "required": ["organizationId", "swapRequestId"]
+    },
+    "v1GetSwapStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Normalized swap status. One of PENDING, COMPLETED, FAILED."
+        },
+        "swapKind": {
+          "type": "string",
+          "description": "SAME_CHAIN or CROSS_CHAIN."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that executed the swap."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "originTxHash": {
+          "type": "string",
+          "description": "Final included origin-chain transaction hash, when known."
+        },
+        "destinationTxHashes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Actual base-unit output amount on COMPLETED, when known. Unset on FAILED."
+        },
+        "refund": {
+          "$ref": "#/definitions/v1SwapRefund",
+          "description": "Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED."
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "Timestamp of the last swap status change, as millisecond epoch string."
+        },
+        "error": {
+          "$ref": "#/definitions/v1SwapError",
+          "description": "Normalized failure details, present whenever status is FAILED."
+        }
+      },
+      "required": [
+        "status",
+        "swapKind",
+        "provider",
+        "inputToken",
+        "outputToken",
+        "inputAmount",
+        "updatedAt"
+      ]
+    },
     "v1GetTvcAppDeploymentsRequest": {
       "type": "object",
       "properties": {
@@ -12687,6 +13196,7 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
+            "eip155:421614",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14119,6 +14629,18 @@
         },
         "claimEarnFeesIntent": {
           "$ref": "#/definitions/v1ClaimEarnFeesIntent"
+        },
+        "updateWalletAccountNameIntent": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameIntent"
+        },
+        "ethUndelegate7702Intent": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "executeSwapIntentV2": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV2"
+        },
+        "createSwapQuoteIntent": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntent"
         }
       }
     },
@@ -14308,7 +14830,11 @@
             "type": "object",
             "$ref": "#/definitions/v1EarnVault"
           },
-          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor."
+          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor."
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo",
+          "description": "Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them."
         }
       }
     },
@@ -14543,7 +15069,8 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:421614",
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet or 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' for Solana mainnet). Human-readable Solana aliases ('solana:mainnet', 'solana:devnet') are also accepted and normalized to canonical CAIP-2 values."
@@ -15291,8 +15818,26 @@
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
         "OUTCOME_ERROR",
-        "OUTCOME_REQUIRES_AUTHENTICATORS"
+        "OUTCOME_REQUIRES_AUTHENTICATORS",
+        "OUTCOME_TIME_INACTIVE"
       ]
+    },
+    "v1PageInfo": {
+      "type": "object",
+      "properties": {
+        "hasNextPage": {
+          "type": "boolean"
+        },
+        "hasPreviousPage": {
+          "type": "boolean"
+        },
+        "startCursor": {
+          "type": "string"
+        },
+        "endCursor": {
+          "type": "string"
+        }
+      }
     },
     "v1Pagination": {
       "type": "object",
@@ -15356,6 +15901,10 @@
         "condition": {
           "type": "string",
           "description": "A condition expression that evalutes to true or false."
+        },
+        "time": {
+          "type": "string",
+          "description": "A time expression that evalutes to true or false."
         }
       },
       "required": [
@@ -16248,6 +16797,15 @@
         },
         "claimEarnFeesResult": {
           "$ref": "#/definitions/v1ClaimEarnFeesResult"
+        },
+        "updateWalletAccountNameResult": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameResult"
+        },
+        "ethUndelegate7702Result": {
+          "$ref": "#/definitions/v1EthUndelegate7702Result"
+        },
+        "createSwapQuoteResult": {
+          "$ref": "#/definitions/v1CreateSwapQuoteResult"
         }
       }
     },
@@ -17797,6 +18355,87 @@
       },
       "required": ["session"]
     },
+    "v1SwapError": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description of the swap failure."
+        },
+        "originTxError": {
+          "$ref": "#/definitions/v1TxError",
+          "description": "Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available."
+        }
+      },
+      "required": ["reason", "message"]
+    },
+    "v1SwapQuote": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that produced this quote."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Estimated base-unit amount of the output asset."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Minimum acceptable base-unit amount of the output asset after slippage."
+        },
+        "expiresAt": {
+          "type": "string",
+          "description": "Quote expiration as a millisecond epoch string."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set."
+        },
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount."
+        },
+        "estimatedTimeSeconds": {
+          "type": "string",
+          "description": "Provider-estimated completion time in seconds, when available."
+        }
+      },
+      "required": [
+        "quoteId",
+        "provider",
+        "outputAmount",
+        "minOutputAmount",
+        "expiresAt",
+        "clientFeeBps"
+      ]
+    },
+    "v1SwapRefund": {
+      "type": "object",
+      "properties": {
+        "asset": {
+          "type": "string",
+          "description": "CAIP-19 asset returned to the user after a failed swap."
+        },
+        "amount": {
+          "type": "string",
+          "description": "Base-unit amount of the refunded asset."
+        },
+        "txHash": {
+          "type": "string",
+          "description": "Transaction that delivered the refunded funds, when applicable."
+        }
+      },
+      "required": ["asset", "amount"]
+    },
     "v1TagType": {
       "type": "string",
       "enum": ["TAG_TYPE_USER", "TAG_TYPE_PRIVATE_KEY"]
@@ -18826,6 +19465,10 @@
         "policyNotes": {
           "type": "string",
           "description": "Accompanying notes for a Policy (optional)."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect (optional)."
         }
       },
       "required": ["policyId"]
@@ -19295,6 +19938,30 @@
       },
       "required": ["userTagId"]
     },
+    "v1UpdateWalletAccountNameIntent": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account."
+        }
+      },
+      "required": ["walletAccountId", "name"]
+    },
+    "v1UpdateWalletAccountNameResult": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        }
+      },
+      "required": ["walletAccountId"]
+    },
     "v1UpdateWalletIntent": {
       "type": "object",
       "properties": {
@@ -19453,14 +20120,35 @@
           "type": "string",
           "description": "Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set."
         },
-        "provider": {
-          "type": "string"
-        },
         "stableFeeBps": {
           "type": "string",
-          "description": "Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset."
+          "description": "Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps."
         }
       }
+    },
+    "v1UpsertSwapConfigRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPSERT_SWAP_CONFIG"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpsertSwapConfigIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1UpsertSwapConfigResult": {
       "type": "object",

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -124,12 +124,8 @@ export type paths = {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
   };
-  "/public/v1/query/get_swap_quote": {
-    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-    post: operations["PublicApiService_GetSwapQuote"];
-  };
   "/public/v1/query/get_swap_status": {
-    /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+    /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
     post: operations["PublicApiService_GetSwapStatus"];
   };
   "/public/v1/query/get_tvc_app": {
@@ -348,6 +344,10 @@ export type paths = {
     /** Create a new sub-organization. Each root user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the sub-organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateSubOrganization"];
   };
+  "/public/v1/submit/create_swap_quote": {
+    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+    post: operations["PublicApiService_CreateSwapQuote"];
+  };
   "/public/v1/submit/create_tvc_app": {
     /** Create a new TVC application */
     post: operations["PublicApiService_CreateTvcApp"];
@@ -496,8 +496,12 @@ export type paths = {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
     post: operations["PublicApiService_EthSendTransaction"];
   };
+  "/public/v1/submit/eth_undelegate_7702": {
+    /** Submit an EIP-7702 undelegation transaction. */
+    post: operations["PublicApiService_EthUndelegate7702"];
+  };
   "/public/v1/submit/execute_swap": {
-    /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+    /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
     post: operations["PublicApiService_ExecuteSwap"];
   };
   "/public/v1/submit/export_private_key": {
@@ -1080,7 +1084,11 @@ export type definitions = {
     | "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2"
     | "ACTIVITY_TYPE_CLAIM_SWAP_FEES"
     | "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE"
-    | "ACTIVITY_TYPE_CLAIM_EARN_FEES";
+    | "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+    | "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME"
+    | "ACTIVITY_TYPE_ETH_UNDELEGATE_7702"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1230,6 +1238,8 @@ export type definitions = {
     logoUrl?: string;
     /** @description The asset name */
     name?: string;
+    /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
+    stable?: boolean;
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -1651,6 +1661,8 @@ export type definitions = {
     consensus?: string;
     /** @description Notes for a Policy. */
     notes: string;
+    /** @description The time expression that triggers the Effect */
+    time?: string;
   };
   v1CreatePolicyRequest: {
     /** @enum {string} */
@@ -2026,6 +2038,32 @@ export type definitions = {
     wallet?: definitions["v1WalletResult"];
     rootUserIds?: string[];
   };
+  v1CreateSwapQuoteIntent: {
+    /** @description Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+  };
+  v1CreateSwapQuoteRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSwapQuoteIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateSwapQuoteResult: {
+    /** @description One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution. */
+    quotes: definitions["v1SwapQuote"][];
+  };
   v1CreateTvcAppIntent: {
     /** @description The name of the new TVC application */
     name: string;
@@ -2065,6 +2103,15 @@ export type definitions = {
      * @description The required number of approvals for the manifest set
      */
     manifestSetThreshold: number;
+    /** @description The unique identifier for the TVC share set */
+    shareSetId: string;
+    /** @description The unique identifiers of the share set operators */
+    shareSetOperatorIds: string[];
+    /**
+     * Format: int64
+     * @description The required number of approvals for the share set
+     */
+    shareSetThreshold: number;
   };
   v1CreateTvcDeploymentIntent: {
     /** @description The unique identifier of the to-be-deployed TVC application */
@@ -2770,7 +2817,7 @@ export type definitions = {
       | "eip155:137"
       | "eip155:56"
       | "eip155:4217";
-    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    /** @description Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%). */
     clientFeeBps: string;
     /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
     clientFeeWallet: string;
@@ -2837,15 +2884,15 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description CAIP-19 asset ID of the vault's underlying asset (e.g. 'eip155:8453/erc20:0x833589...'); the chain is encoded in the identifier. */
     caip19?: string;
-    /** @description Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees). */
+    /** @description Gross annual percentage yield, expressed as a decimal fraction (before fees). */
     apyPct?: string;
     /** @description Total deposited through this wrapper (wrapper TVL), in raw on-chain units of the underlying asset. */
     totalDeposited?: string;
     /** @description Normalized total-deposited values for display only (usd + crypto). Do not do arithmetic with these; use total_deposited instead. */
     display?: definitions["v1EarnValueDisplay"];
-    /** @description Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction. */
+    /** @description Annual percentage yield net of fees, expressed as a decimal fraction. */
     netApyPct?: string;
-    /** @description Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting. */
+    /** @description Client fee taken on yield, in basis points. */
     clientFeeBps?: string;
     /** @description When true, deposits to this wrapper are rejected; withdrawals are unaffected. Toggled via EarnSetWrapperState. */
     depositsDisabled?: boolean;
@@ -2853,10 +2900,12 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
-    /** @description The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
+    /** @description The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
     claimableClientFee?: string;
     /** @description Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries. */
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
+    clientFeeWallet?: string;
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3127,6 +3176,8 @@ export type definitions = {
     deliveryProcessingTimeMillis?: string;
     /** @description Delay type for DeliveryDelay events */
     deliveryDelayType?: string;
+    /** @description Feedback type for Complaint events */
+    complaintFeedbackType?: string;
   };
   v1EnableAuthProxyIntent: { [key: string]: unknown };
   v1EnableAuthProxyResult: {
@@ -3265,7 +3316,7 @@ export type definitions = {
     maxPriorityFeePerGas?: string;
     /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
     deadline?: string;
-    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    /** @description The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection. */
     gasStationNonce?: string;
     /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
     calls: definitions["v1EthCallParams"][];
@@ -3315,6 +3366,51 @@ export type definitions = {
     /** @description Turnkey-specific metadata for transactions originated by Turnkey. */
     turnkey?: definitions["v1TransactionHistoryTurnkey"];
   };
+  v1EthUndelegate7702Intent: {
+    /** @description A wallet or private key address to undelegate. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97"
+      | "eip155:10"
+      | "eip155:11155420"
+      | "eip155:143"
+      | "eip155:10143"
+      | "eip155:42161"
+      | "eip155:421614";
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+  };
+  v1EthUndelegate7702Request: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_ETH_UNDELEGATE_7702";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1EthUndelegate7702Intent"];
+    generateAppProofs?: boolean;
+  };
+  v1EthUndelegate7702Result: {
+    /** @description The send_transaction_status ID associated with the undelegation transaction submission */
+    sendTransactionStatusId: string;
+  };
   v1ExecuteSwapIntent: {
     /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
     inputToken: string;
@@ -3328,24 +3424,46 @@ export type definitions = {
     sponsor?: boolean;
     /** @description Maximum allowed slippage in basis points. */
     slippage?: string;
-    /** @description Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider. */
+    /** @description Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider. */
     provider?: string;
     /** @description Minimum acceptable base-unit amount of the output asset. Execution fails if the swap provider's quoted minimum output falls below this floor at execution time. */
     minOutputAmount: string;
   };
+  v1ExecuteSwapIntentV2: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+  };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_EXECUTE_SWAP";
+    type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1ExecuteSwapIntent"];
+    parameters: definitions["v1ExecuteSwapIntentV2"];
     generateAppProofs?: boolean;
   };
   v1ExecuteSwapResult: {
-    /** @description The send_transaction_status ID associated with the swap transaction submission */
-    sendTransactionStatusId: string;
+    /** @description Identifier to poll swap status via GetSwapStatus. */
+    swapRequestId: string;
     /** @description Swap provider used to build the transaction. */
     provider?: string;
     /** @description Quote identifier used for execution, if any. */
@@ -3703,7 +3821,7 @@ export type definitions = {
   v1GetLatestBootProofRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Name of enclave app. */
+    /** @description Unique identifier (UUID) of the enclave app. */
     appName: string;
   };
   v1GetMfaPoliciesRequest: {
@@ -3943,35 +4061,11 @@ export type definitions = {
     /** @description List of unique identifiers for the matching sub-organizations. */
     organizationIds: string[];
   };
-  v1GetSwapQuoteRequest: {
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description Wallet account address used to price the executable provider quote. */
-    walletAccount: string;
-    /** @description Maximum allowed slippage in basis points. */
-    slippage?: string;
-  };
-  v1GetSwapQuoteResponse: {
-    /** @description CAIP-19 asset ID for the input asset. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description One quote per available swap provider. */
-    quotes: definitions["v1SwapQuoteOption"][];
-  };
   v1GetSwapStatusRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Identifier returned in the execute_swap activity result. */
-    sendTransactionStatusId: string;
+    /** @description The swap_request_id returned by ExecuteSwap. */
+    swapRequestId: string;
   };
   v1GetSwapStatusResponse: {
     /** @description Normalized swap status. One of PENDING, COMPLETED, FAILED. */
@@ -3979,7 +4073,7 @@ export type definitions = {
     /** @description SAME_CHAIN or CROSS_CHAIN. */
     swapKind: string;
     /** @description Swap provider that executed the swap. */
-    provider?: string;
+    provider: string;
     /** @description CAIP-19 asset ID for the input asset. */
     inputToken: string;
     /** @description CAIP-19 asset ID for the output asset. */
@@ -3988,20 +4082,16 @@ export type definitions = {
     inputAmount: string;
     /** @description Final included origin-chain transaction hash, when known. */
     originTxHash?: string;
-    /** @description Destination-chain fill transaction hash; cross-chain COMPLETED only. */
-    destinationTxHash?: string;
-    /** @description Actual base-unit output amount on COMPLETED, when known. */
+    /** @description Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only. */
+    destinationTxHashes?: string[];
+    /** @description Actual base-unit output amount on COMPLETED, when known. Unset on FAILED. */
     outputAmount?: string;
-    /** @description CAIP-19 of the asset the user holds after a FAILED swap, when recoverable. */
-    settledAsset?: string;
-    /** @description Base-unit amount of settled_asset. */
-    settledAmount?: string;
-    /** @description Transaction that delivered the settled funds, when applicable. */
-    settlementTxHash?: string;
-    /** @description Non-normative raw provider status passthrough; cross-chain only. */
-    providerStatus?: string;
+    /** @description Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED. */
+    refund?: definitions["v1SwapRefund"];
     /** @description Timestamp of the last swap status change, as millisecond epoch string. */
     updatedAt: string;
+    /** @description Normalized failure details, present whenever status is FAILED. */
+    error?: definitions["v1SwapError"];
   };
   v1GetTvcAppDeploymentsRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4164,6 +4254,7 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
+      | "eip155:421614"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4761,6 +4852,10 @@ export type definitions = {
     claimSwapFeesIntent?: definitions["v1ClaimSwapFeesIntent"];
     earnSetWrapperStateIntent?: definitions["v1EarnSetWrapperStateIntent"];
     claimEarnFeesIntent?: definitions["v1ClaimEarnFeesIntent"];
+    updateWalletAccountNameIntent?: definitions["v1UpdateWalletAccountNameIntent"];
+    ethUndelegate7702Intent?: definitions["v1EthUndelegate7702Intent"];
+    executeSwapIntentV2?: definitions["v1ExecuteSwapIntentV2"];
+    createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -4856,8 +4951,10 @@ export type definitions = {
     paginationOptions?: definitions["v1Pagination"];
   };
   v1ListEarnVaultsResponse: {
-    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor. */
+    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor. */
     vaults?: definitions["v1EarnVault"][];
+    /** @description Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them. */
+    pageInfo?: definitions["v1PageInfo"];
   };
   v1ListEmailEventsRequest: {
     /** @description Unique identifier for a given organization */
@@ -4972,7 +5069,8 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+      | "eip155:421614"
+      | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
   v1ListSupportedAssetsResponse: {
@@ -5305,7 +5403,14 @@ export type definitions = {
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
     | "OUTCOME_ERROR"
-    | "OUTCOME_REQUIRES_AUTHENTICATORS";
+    | "OUTCOME_REQUIRES_AUTHENTICATORS"
+    | "OUTCOME_TIME_INACTIVE";
+  v1PageInfo: {
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+    startCursor?: string;
+    endCursor?: string;
+  };
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -5337,6 +5442,8 @@ export type definitions = {
     consensus: string;
     /** @description A condition expression that evalutes to true or false. */
     condition: string;
+    /** @description A time expression that evalutes to true or false. */
+    time?: string;
   };
   v1PostTvcQuorumKeyShareIntent: {
     /** @description Unique identifier of the TVC deployment receiving quorum key share */
@@ -5669,6 +5776,9 @@ export type definitions = {
     claimSwapFeesResult?: definitions["v1ClaimSwapFeesResult"];
     earnSetWrapperStateResult?: definitions["v1EarnSetWrapperStateResult"];
     claimEarnFeesResult?: definitions["v1ClaimEarnFeesResult"];
+    updateWalletAccountNameResult?: definitions["v1UpdateWalletAccountNameResult"];
+    ethUndelegate7702Result?: definitions["v1EthUndelegate7702Result"];
+    createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -6291,15 +6401,39 @@ export type definitions = {
     /** @description Signed JWT containing an expiry, public key, session type, user id, and organization id */
     session: string;
   };
-  v1SwapQuoteOption: {
-    /** @description Identifier for this provider quote. */
+  v1SwapError: {
+    /** @description Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED. */
+    reason: string;
+    /** @description Human-readable description of the swap failure. */
+    message: string;
+    /** @description Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available. */
+    originTxError?: definitions["v1TxError"];
+  };
+  v1SwapQuote: {
+    /** @description Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute. */
     quoteId: string;
-    /** @description Swap provider that produced this quote. Pass this value to execute_swap to force a specific provider. */
+    /** @description Swap provider that produced this quote. */
     provider: string;
     /** @description Estimated base-unit amount of the output asset. */
     outputAmount: string;
     /** @description Minimum acceptable base-unit amount of the output asset after slippage. */
-    minOutputAmount?: string;
+    minOutputAmount: string;
+    /** @description Quote expiration as a millisecond epoch string. */
+    expiresAt: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set. */
+    slippageBps?: string;
+    /** @description Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount. */
+    clientFeeBps: string;
+    /** @description Provider-estimated completion time in seconds, when available. */
+    estimatedTimeSeconds?: string;
+  };
+  v1SwapRefund: {
+    /** @description CAIP-19 asset returned to the user after a failed swap. */
+    asset: string;
+    /** @description Base-unit amount of the refunded asset. */
+    amount: string;
+    /** @description Transaction that delivered the refunded funds, when applicable. */
+    txHash?: string;
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
@@ -6772,6 +6906,8 @@ export type definitions = {
     policyConsensus?: string;
     /** @description Accompanying notes for a Policy (optional). */
     policyNotes?: string;
+    /** @description The time expression that triggers the Effect (optional). */
+    time?: string;
   };
   v1UpdatePolicyRequest: {
     /** @enum {string} */
@@ -6964,6 +7100,16 @@ export type definitions = {
     /** @description Unique identifier for a given User Tag. */
     userTagId: string;
   };
+  v1UpdateWalletAccountNameIntent: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+    /** @description Human-readable name for this Wallet Account. */
+    name: string;
+  };
+  v1UpdateWalletAccountNameResult: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+  };
   v1UpdateWalletIntent: {
     /** @description Unique identifier for a given Wallet. */
     walletId: string;
@@ -7030,8 +7176,7 @@ export type definitions = {
     feeReceiverWalletAddress?: string;
     /** @description Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set. */
     feeBps?: string;
-    provider?: string;
-    /** @description Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset. */
+    /** @description Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps. */
     stableFeeBps?: string;
   };
   v1UpsertSwapConfigRequest: {
@@ -7853,25 +7998,7 @@ export type operations = {
       };
     };
   };
-  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-  PublicApiService_GetSwapQuote: {
-    parameters: {
-      body: {
-        body: definitions["v1GetSwapQuoteRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetSwapQuoteResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+  /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
   PublicApiService_GetSwapStatus: {
     parameters: {
       body: {
@@ -8861,6 +8988,24 @@ export type operations = {
       };
     };
   };
+  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+  PublicApiService_CreateSwapQuote: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSwapQuoteRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a new TVC application */
   PublicApiService_CreateTvcApp: {
     parameters: {
@@ -9527,7 +9672,25 @@ export type operations = {
       };
     };
   };
-  /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+  /** Submit an EIP-7702 undelegation transaction. */
+  PublicApiService_EthUndelegate7702: {
+    parameters: {
+      body: {
+        body: definitions["v1EthUndelegate7702Request"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
   PublicApiService_ExecuteSwap: {
     parameters: {
       body: {

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -361,6 +361,38 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getClaimEarnFeesStatus = async (
+    input: SdkApiTypes.TGetClaimEarnFeesStatusBody,
+  ): Promise<SdkApiTypes.TGetClaimEarnFeesStatusResponse> => {
+    return this.request("/public/v1/query/get_claim_earn_fees_status", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetClaimEarnFeesStatus = async (
+    input: SdkApiTypes.TGetClaimEarnFeesStatusBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_claim_earn_fees_status";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getEarnDeployStatus = async (
     input: SdkApiTypes.TGetEarnDeployStatusBody,
   ): Promise<SdkApiTypes.TGetEarnDeployStatusResponse> => {
@@ -1013,6 +1045,37 @@ export class TurnkeySDKClientBase {
 
     const fullUrl =
       this.config.apiBaseUrl + "/public/v1/query/get_smart_contract_interface";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  getSwapStatus = async (
+    input: SdkApiTypes.TGetSwapStatusBody,
+  ): Promise<SdkApiTypes.TGetSwapStatusResponse> => {
+    return this.request("/public/v1/query/get_swap_status", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetSwapStatus = async (
+    input: SdkApiTypes.TGetSwapStatusBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl = this.config.apiBaseUrl + "/public/v1/query/get_swap_status";
     const body = {
       ...input,
       organizationId: input.organizationId ?? this.config.organizationId,
@@ -2141,6 +2204,48 @@ export class TurnkeySDKClientBase {
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  claimSwapFees = async (
+    input: SdkApiTypes.TClaimSwapFeesBody,
+  ): Promise<SdkApiTypes.TClaimSwapFeesResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/claim_swap_fees",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
+      },
+      "claimSwapFeesResult",
+    );
+  };
+
+  stampClaimSwapFees = async (
+    input: SdkApiTypes.TClaimSwapFeesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/claim_swap_fees";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4248,6 +4353,48 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  ethUndelegate7702 = async (
+    input: SdkApiTypes.TEthUndelegate7702Body,
+  ): Promise<SdkApiTypes.TEthUndelegate7702Response> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/eth_undelegate_7702",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_ETH_UNDELEGATE7702",
+      },
+      "ethUndelegate7702Result",
+    );
+  };
+
+  stampEthUndelegate7702 = async (
+    input: SdkApiTypes.TEthUndelegate7702Body,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/eth_undelegate_7702";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_ETH_UNDELEGATE7702",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   exportPrivateKey = async (
     input: SdkApiTypes.TExportPrivateKeyBody,
   ): Promise<SdkApiTypes.TExportPrivateKeyResponse> => {
@@ -6196,6 +6343,48 @@ export class TurnkeySDKClientBase {
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  upsertSwapConfig = async (
+    input: SdkApiTypes.TUpsertSwapConfigBody,
+  ): Promise<SdkApiTypes.TUpsertSwapConfigResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/upsert_swap_config",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_UPSERT_SWAP_CONFIG",
+      },
+      "upsertSwapConfigResult",
+    );
+  };
+
+  stampUpsertSwapConfig = async (
+    input: SdkApiTypes.TUpsertSwapConfigBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/upsert_swap_config";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_UPSERT_SWAP_CONFIG",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -296,6 +296,38 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_claim_earn_fees_status": {
+      "post": {
+        "summary": "Get Earn claim fees status",
+        "description": "Poll the status of a fee claim by its claim_request_id.",
+        "operationId": "PublicApiService_GetClaimEarnFeesStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Earn"]
+      }
+    },
     "/public/v1/query/get_earn_deploy_status": {
       "post": {
         "summary": "Get Earn deploy status",
@@ -966,6 +998,38 @@
           }
         ],
         "tags": ["Policies"]
+      }
+    },
+    "/public/v1/query/get_swap_status": {
+      "post": {
+        "summary": "Get swap status",
+        "description": "Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.",
+        "operationId": "PublicApiService_GetSwapStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/query/get_tvc_app": {
@@ -2086,6 +2150,38 @@
           }
         ],
         "tags": ["Earn"]
+      }
+    },
+    "/public/v1/submit/claim_swap_fees": {
+      "post": {
+        "summary": "Claim swap fees",
+        "description": "Claim swap fees through the activity pipeline.",
+        "operationId": "PublicApiService_ClaimSwapFees",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ClaimSwapFeesRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/submit/create_api_keys": {
@@ -3688,6 +3784,38 @@
         "tags": ["Broadcasting"]
       }
     },
+    "/public/v1/submit/eth_undelegate_7702": {
+      "post": {
+        "summary": "Undelegate an EVM account",
+        "description": "Submit an EIP-7702 undelegation transaction.",
+        "operationId": "PublicApiService_EthUndelegate7702",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1EthUndelegate7702Request"
+            }
+          }
+        ],
+        "tags": ["Broadcasting"]
+      }
+    },
     "/public/v1/submit/export_private_key": {
       "post": {
         "summary": "Export private key",
@@ -5192,6 +5320,38 @@
         "tags": ["Organizations"]
       }
     },
+    "/public/v1/submit/upsert_swap_config": {
+      "post": {
+        "summary": "Upsert swap config",
+        "description": "Enable or disable swap configuration for an organization.",
+        "operationId": "PublicApiService_UpsertSwapConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpsertSwapConfigRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
+      }
+    },
     "/public/v1/submit/verify_otp": {
       "post": {
         "summary": "Verify generic OTP",
@@ -5918,7 +6078,11 @@
         "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2",
         "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
         "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE",
-        "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+        "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+        "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME",
+        "ACTIVITY_TYPE_ETH_UNDELEGATE_7702",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
       ]
     },
     "v1AddressFormat": {
@@ -6202,6 +6366,10 @@
         "name": {
           "type": "string",
           "description": "The asset name"
+        },
+        "stable": {
+          "type": "boolean",
+          "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
         }
       }
     },
@@ -6508,6 +6676,30 @@
     },
     "v1ClaimSwapFeesIntent": {
       "type": "object"
+    },
+    "v1ClaimSwapFeesRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CLAIM_SWAP_FEES"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1ClaimSwapFeesIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1ClaimSwapFeesResult": {
       "type": "object",
@@ -7239,6 +7431,10 @@
         "notes": {
           "type": "string",
           "description": "Notes for a Policy."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect"
         }
       },
       "required": ["policyName", "effect", "notes"]
@@ -8174,6 +8370,46 @@
       },
       "required": ["subOrganizationId"]
     },
+    "v1CreateSwapQuoteIntent": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
+    "v1CreateSwapQuoteResult": {
+      "type": "object",
+      "properties": {
+        "quotes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SwapQuote"
+          },
+          "description": "One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution."
+        }
+      },
+      "required": ["quotes"]
+    },
     "v1CreateTvcAppIntent": {
       "type": "object",
       "properties": {
@@ -8255,13 +8491,32 @@
           "type": "integer",
           "format": "int64",
           "description": "The required number of approvals for the manifest set"
+        },
+        "shareSetId": {
+          "type": "string",
+          "description": "The unique identifier for the TVC share set"
+        },
+        "shareSetOperatorIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The unique identifiers of the share set operators"
+        },
+        "shareSetThreshold": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The required number of approvals for the share set"
         }
       },
       "required": [
         "appId",
         "manifestSetId",
         "manifestSetOperatorIds",
-        "manifestSetThreshold"
+        "manifestSetThreshold",
+        "shareSetId",
+        "shareSetOperatorIds",
+        "shareSetThreshold"
       ]
     },
     "v1CreateTvcDeploymentIntent": {
@@ -9963,7 +10218,7 @@
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+          "description": "Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%)."
         },
         "clientFeeWallet": {
           "type": "string",
@@ -10108,7 +10363,7 @@
         },
         "apyPct": {
           "type": "string",
-          "description": "Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees)."
+          "description": "Gross annual percentage yield, expressed as a decimal fraction (before fees)."
         },
         "totalDeposited": {
           "type": "string",
@@ -10120,11 +10375,11 @@
         },
         "netApyPct": {
           "type": "string",
-          "description": "Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction."
+          "description": "Annual percentage yield net of fees, expressed as a decimal fraction."
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting."
+          "description": "Client fee taken on yield, in basis points."
         },
         "depositsDisabled": {
           "type": "boolean",
@@ -10140,11 +10395,15 @@
         },
         "claimableClientFee": {
           "type": "string",
-          "description": "The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
+          "description": "The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
         },
         "claimableClientFeeDisplay": {
           "$ref": "#/definitions/v1EarnValueDisplay",
           "description": "Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
         }
       }
     },
@@ -10719,6 +10978,10 @@
         "deliveryDelayType": {
           "type": "string",
           "description": "Delay type for DeliveryDelay events"
+        },
+        "complaintFeedbackType": {
+          "type": "string",
+          "description": "Feedback type for Complaint events"
         }
       }
     },
@@ -10935,7 +11198,7 @@
         },
         "gasStationNonce": {
           "type": "string",
-          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+          "description": "The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection."
         },
         "calls": {
           "type": "array",
@@ -11056,6 +11319,86 @@
         "transfers"
       ]
     },
+    "v1EthUndelegate7702Intent": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to undelegate. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97",
+            "eip155:10",
+            "eip155:11155420",
+            "eip155:143",
+            "eip155:10143",
+            "eip155:42161",
+            "eip155:421614"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        }
+      },
+      "required": ["from", "caip2"]
+    },
+    "v1EthUndelegate7702Request": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_ETH_UNDELEGATE_7702"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1EthUndelegate7702Result": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the undelegation transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
     "v1ExecuteSwapIntent": {
       "type": "object",
       "properties": {
@@ -11085,7 +11428,7 @@
         },
         "provider": {
           "type": "string",
-          "description": "Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider."
+          "description": "Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider."
         },
         "minOutputAmount": {
           "type": "string",
@@ -11100,12 +11443,66 @@
         "minOutputAmount"
       ]
     },
+    "v1ExecuteSwapIntentV2": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
     "v1ExecuteSwapResult": {
       "type": "object",
       "properties": {
-        "sendTransactionStatusId": {
+        "swapRequestId": {
           "type": "string",
-          "description": "The send_transaction_status ID associated with the swap transaction submission"
+          "description": "Identifier to poll swap status via GetSwapStatus."
         },
         "provider": {
           "type": "string",
@@ -11116,7 +11513,7 @@
           "description": "Quote identifier used for execution, if any."
         }
       },
-      "required": ["sendTransactionStatusId"]
+      "required": ["swapRequestId"]
     },
     "v1ExportPrivateKeyIntent": {
       "type": "object",
@@ -11664,6 +12061,39 @@
       },
       "required": ["organizationId", "ephemeralKey"]
     },
+    "v1GetClaimEarnFeesStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "claimRequestId": {
+          "type": "string",
+          "description": "The claim_request_id returned by ClaimEarnFees."
+        }
+      },
+      "required": ["organizationId", "claimRequestId"]
+    },
+    "v1GetClaimEarnFeesStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["PENDING", "COMPLETED", "FAILED"],
+          "description": "Status of the fee claim."
+        },
+        "claimTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee claim, once available."
+        },
+        "error": {
+          "type": "string",
+          "description": "Reason the fee claim transaction failed, when status is FAILED."
+        }
+      },
+      "required": ["status"]
+    },
     "v1GetEarnDeployStatusRequest": {
       "type": "object",
       "properties": {
@@ -11824,7 +12254,7 @@
         },
         "appName": {
           "type": "string",
-          "description": "Name of enclave app."
+          "description": "Unique identifier (UUID) of the enclave app."
         }
       },
       "required": ["organizationId", "appName"]
@@ -12369,6 +12799,85 @@
       },
       "required": ["organizationIds"]
     },
+    "v1GetSwapStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "swapRequestId": {
+          "type": "string",
+          "description": "The swap_request_id returned by ExecuteSwap."
+        }
+      },
+      "required": ["organizationId", "swapRequestId"]
+    },
+    "v1GetSwapStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Normalized swap status. One of PENDING, COMPLETED, FAILED."
+        },
+        "swapKind": {
+          "type": "string",
+          "description": "SAME_CHAIN or CROSS_CHAIN."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that executed the swap."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "originTxHash": {
+          "type": "string",
+          "description": "Final included origin-chain transaction hash, when known."
+        },
+        "destinationTxHashes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Actual base-unit output amount on COMPLETED, when known. Unset on FAILED."
+        },
+        "refund": {
+          "$ref": "#/definitions/v1SwapRefund",
+          "description": "Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED."
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "Timestamp of the last swap status change, as millisecond epoch string."
+        },
+        "error": {
+          "$ref": "#/definitions/v1SwapError",
+          "description": "Normalized failure details, present whenever status is FAILED."
+        }
+      },
+      "required": [
+        "status",
+        "swapKind",
+        "provider",
+        "inputToken",
+        "outputToken",
+        "inputAmount",
+        "updatedAt"
+      ]
+    },
     "v1GetTvcAppDeploymentsRequest": {
       "type": "object",
       "properties": {
@@ -12687,6 +13196,7 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
+            "eip155:421614",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14119,6 +14629,18 @@
         },
         "claimEarnFeesIntent": {
           "$ref": "#/definitions/v1ClaimEarnFeesIntent"
+        },
+        "updateWalletAccountNameIntent": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameIntent"
+        },
+        "ethUndelegate7702Intent": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "executeSwapIntentV2": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV2"
+        },
+        "createSwapQuoteIntent": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntent"
         }
       }
     },
@@ -14308,7 +14830,11 @@
             "type": "object",
             "$ref": "#/definitions/v1EarnVault"
           },
-          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor."
+          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor."
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo",
+          "description": "Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them."
         }
       }
     },
@@ -14543,7 +15069,8 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:421614",
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet or 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' for Solana mainnet). Human-readable Solana aliases ('solana:mainnet', 'solana:devnet') are also accepted and normalized to canonical CAIP-2 values."
@@ -15291,8 +15818,26 @@
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
         "OUTCOME_ERROR",
-        "OUTCOME_REQUIRES_AUTHENTICATORS"
+        "OUTCOME_REQUIRES_AUTHENTICATORS",
+        "OUTCOME_TIME_INACTIVE"
       ]
+    },
+    "v1PageInfo": {
+      "type": "object",
+      "properties": {
+        "hasNextPage": {
+          "type": "boolean"
+        },
+        "hasPreviousPage": {
+          "type": "boolean"
+        },
+        "startCursor": {
+          "type": "string"
+        },
+        "endCursor": {
+          "type": "string"
+        }
+      }
     },
     "v1Pagination": {
       "type": "object",
@@ -15356,6 +15901,10 @@
         "condition": {
           "type": "string",
           "description": "A condition expression that evalutes to true or false."
+        },
+        "time": {
+          "type": "string",
+          "description": "A time expression that evalutes to true or false."
         }
       },
       "required": [
@@ -16248,6 +16797,15 @@
         },
         "claimEarnFeesResult": {
           "$ref": "#/definitions/v1ClaimEarnFeesResult"
+        },
+        "updateWalletAccountNameResult": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameResult"
+        },
+        "ethUndelegate7702Result": {
+          "$ref": "#/definitions/v1EthUndelegate7702Result"
+        },
+        "createSwapQuoteResult": {
+          "$ref": "#/definitions/v1CreateSwapQuoteResult"
         }
       }
     },
@@ -17797,6 +18355,87 @@
       },
       "required": ["session"]
     },
+    "v1SwapError": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description of the swap failure."
+        },
+        "originTxError": {
+          "$ref": "#/definitions/v1TxError",
+          "description": "Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available."
+        }
+      },
+      "required": ["reason", "message"]
+    },
+    "v1SwapQuote": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that produced this quote."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Estimated base-unit amount of the output asset."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Minimum acceptable base-unit amount of the output asset after slippage."
+        },
+        "expiresAt": {
+          "type": "string",
+          "description": "Quote expiration as a millisecond epoch string."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set."
+        },
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount."
+        },
+        "estimatedTimeSeconds": {
+          "type": "string",
+          "description": "Provider-estimated completion time in seconds, when available."
+        }
+      },
+      "required": [
+        "quoteId",
+        "provider",
+        "outputAmount",
+        "minOutputAmount",
+        "expiresAt",
+        "clientFeeBps"
+      ]
+    },
+    "v1SwapRefund": {
+      "type": "object",
+      "properties": {
+        "asset": {
+          "type": "string",
+          "description": "CAIP-19 asset returned to the user after a failed swap."
+        },
+        "amount": {
+          "type": "string",
+          "description": "Base-unit amount of the refunded asset."
+        },
+        "txHash": {
+          "type": "string",
+          "description": "Transaction that delivered the refunded funds, when applicable."
+        }
+      },
+      "required": ["asset", "amount"]
+    },
     "v1TagType": {
       "type": "string",
       "enum": ["TAG_TYPE_USER", "TAG_TYPE_PRIVATE_KEY"]
@@ -18826,6 +19465,10 @@
         "policyNotes": {
           "type": "string",
           "description": "Accompanying notes for a Policy (optional)."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect (optional)."
         }
       },
       "required": ["policyId"]
@@ -19295,6 +19938,30 @@
       },
       "required": ["userTagId"]
     },
+    "v1UpdateWalletAccountNameIntent": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account."
+        }
+      },
+      "required": ["walletAccountId", "name"]
+    },
+    "v1UpdateWalletAccountNameResult": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        }
+      },
+      "required": ["walletAccountId"]
+    },
     "v1UpdateWalletIntent": {
       "type": "object",
       "properties": {
@@ -19453,14 +20120,35 @@
           "type": "string",
           "description": "Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set."
         },
-        "provider": {
-          "type": "string"
-        },
         "stableFeeBps": {
           "type": "string",
-          "description": "Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset."
+          "description": "Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps."
         }
       }
+    },
+    "v1UpsertSwapConfigRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPSERT_SWAP_CONFIG"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpsertSwapConfigIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1UpsertSwapConfigResult": {
       "type": "object",

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -124,12 +124,8 @@ export type paths = {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
   };
-  "/public/v1/query/get_swap_quote": {
-    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-    post: operations["PublicApiService_GetSwapQuote"];
-  };
   "/public/v1/query/get_swap_status": {
-    /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+    /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
     post: operations["PublicApiService_GetSwapStatus"];
   };
   "/public/v1/query/get_tvc_app": {
@@ -348,6 +344,10 @@ export type paths = {
     /** Create a new sub-organization. Each root user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the sub-organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateSubOrganization"];
   };
+  "/public/v1/submit/create_swap_quote": {
+    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+    post: operations["PublicApiService_CreateSwapQuote"];
+  };
   "/public/v1/submit/create_tvc_app": {
     /** Create a new TVC application */
     post: operations["PublicApiService_CreateTvcApp"];
@@ -496,8 +496,12 @@ export type paths = {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
     post: operations["PublicApiService_EthSendTransaction"];
   };
+  "/public/v1/submit/eth_undelegate_7702": {
+    /** Submit an EIP-7702 undelegation transaction. */
+    post: operations["PublicApiService_EthUndelegate7702"];
+  };
   "/public/v1/submit/execute_swap": {
-    /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+    /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
     post: operations["PublicApiService_ExecuteSwap"];
   };
   "/public/v1/submit/export_private_key": {
@@ -1080,7 +1084,11 @@ export type definitions = {
     | "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2"
     | "ACTIVITY_TYPE_CLAIM_SWAP_FEES"
     | "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE"
-    | "ACTIVITY_TYPE_CLAIM_EARN_FEES";
+    | "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+    | "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME"
+    | "ACTIVITY_TYPE_ETH_UNDELEGATE_7702"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1230,6 +1238,8 @@ export type definitions = {
     logoUrl?: string;
     /** @description The asset name */
     name?: string;
+    /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
+    stable?: boolean;
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -1651,6 +1661,8 @@ export type definitions = {
     consensus?: string;
     /** @description Notes for a Policy. */
     notes: string;
+    /** @description The time expression that triggers the Effect */
+    time?: string;
   };
   v1CreatePolicyRequest: {
     /** @enum {string} */
@@ -2026,6 +2038,32 @@ export type definitions = {
     wallet?: definitions["v1WalletResult"];
     rootUserIds?: string[];
   };
+  v1CreateSwapQuoteIntent: {
+    /** @description Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+  };
+  v1CreateSwapQuoteRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSwapQuoteIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateSwapQuoteResult: {
+    /** @description One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution. */
+    quotes: definitions["v1SwapQuote"][];
+  };
   v1CreateTvcAppIntent: {
     /** @description The name of the new TVC application */
     name: string;
@@ -2065,6 +2103,15 @@ export type definitions = {
      * @description The required number of approvals for the manifest set
      */
     manifestSetThreshold: number;
+    /** @description The unique identifier for the TVC share set */
+    shareSetId: string;
+    /** @description The unique identifiers of the share set operators */
+    shareSetOperatorIds: string[];
+    /**
+     * Format: int64
+     * @description The required number of approvals for the share set
+     */
+    shareSetThreshold: number;
   };
   v1CreateTvcDeploymentIntent: {
     /** @description The unique identifier of the to-be-deployed TVC application */
@@ -2770,7 +2817,7 @@ export type definitions = {
       | "eip155:137"
       | "eip155:56"
       | "eip155:4217";
-    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    /** @description Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%). */
     clientFeeBps: string;
     /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
     clientFeeWallet: string;
@@ -2837,15 +2884,15 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description CAIP-19 asset ID of the vault's underlying asset (e.g. 'eip155:8453/erc20:0x833589...'); the chain is encoded in the identifier. */
     caip19?: string;
-    /** @description Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees). */
+    /** @description Gross annual percentage yield, expressed as a decimal fraction (before fees). */
     apyPct?: string;
     /** @description Total deposited through this wrapper (wrapper TVL), in raw on-chain units of the underlying asset. */
     totalDeposited?: string;
     /** @description Normalized total-deposited values for display only (usd + crypto). Do not do arithmetic with these; use total_deposited instead. */
     display?: definitions["v1EarnValueDisplay"];
-    /** @description Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction. */
+    /** @description Annual percentage yield net of fees, expressed as a decimal fraction. */
     netApyPct?: string;
-    /** @description Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting. */
+    /** @description Client fee taken on yield, in basis points. */
     clientFeeBps?: string;
     /** @description When true, deposits to this wrapper are rejected; withdrawals are unaffected. Toggled via EarnSetWrapperState. */
     depositsDisabled?: boolean;
@@ -2853,10 +2900,12 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
-    /** @description The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
+    /** @description The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
     claimableClientFee?: string;
     /** @description Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries. */
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
+    clientFeeWallet?: string;
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3127,6 +3176,8 @@ export type definitions = {
     deliveryProcessingTimeMillis?: string;
     /** @description Delay type for DeliveryDelay events */
     deliveryDelayType?: string;
+    /** @description Feedback type for Complaint events */
+    complaintFeedbackType?: string;
   };
   v1EnableAuthProxyIntent: { [key: string]: unknown };
   v1EnableAuthProxyResult: {
@@ -3265,7 +3316,7 @@ export type definitions = {
     maxPriorityFeePerGas?: string;
     /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
     deadline?: string;
-    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    /** @description The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection. */
     gasStationNonce?: string;
     /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
     calls: definitions["v1EthCallParams"][];
@@ -3315,6 +3366,51 @@ export type definitions = {
     /** @description Turnkey-specific metadata for transactions originated by Turnkey. */
     turnkey?: definitions["v1TransactionHistoryTurnkey"];
   };
+  v1EthUndelegate7702Intent: {
+    /** @description A wallet or private key address to undelegate. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97"
+      | "eip155:10"
+      | "eip155:11155420"
+      | "eip155:143"
+      | "eip155:10143"
+      | "eip155:42161"
+      | "eip155:421614";
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+  };
+  v1EthUndelegate7702Request: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_ETH_UNDELEGATE_7702";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1EthUndelegate7702Intent"];
+    generateAppProofs?: boolean;
+  };
+  v1EthUndelegate7702Result: {
+    /** @description The send_transaction_status ID associated with the undelegation transaction submission */
+    sendTransactionStatusId: string;
+  };
   v1ExecuteSwapIntent: {
     /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
     inputToken: string;
@@ -3328,24 +3424,46 @@ export type definitions = {
     sponsor?: boolean;
     /** @description Maximum allowed slippage in basis points. */
     slippage?: string;
-    /** @description Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider. */
+    /** @description Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider. */
     provider?: string;
     /** @description Minimum acceptable base-unit amount of the output asset. Execution fails if the swap provider's quoted minimum output falls below this floor at execution time. */
     minOutputAmount: string;
   };
+  v1ExecuteSwapIntentV2: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+  };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_EXECUTE_SWAP";
+    type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1ExecuteSwapIntent"];
+    parameters: definitions["v1ExecuteSwapIntentV2"];
     generateAppProofs?: boolean;
   };
   v1ExecuteSwapResult: {
-    /** @description The send_transaction_status ID associated with the swap transaction submission */
-    sendTransactionStatusId: string;
+    /** @description Identifier to poll swap status via GetSwapStatus. */
+    swapRequestId: string;
     /** @description Swap provider used to build the transaction. */
     provider?: string;
     /** @description Quote identifier used for execution, if any. */
@@ -3703,7 +3821,7 @@ export type definitions = {
   v1GetLatestBootProofRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Name of enclave app. */
+    /** @description Unique identifier (UUID) of the enclave app. */
     appName: string;
   };
   v1GetMfaPoliciesRequest: {
@@ -3943,35 +4061,11 @@ export type definitions = {
     /** @description List of unique identifiers for the matching sub-organizations. */
     organizationIds: string[];
   };
-  v1GetSwapQuoteRequest: {
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description Wallet account address used to price the executable provider quote. */
-    walletAccount: string;
-    /** @description Maximum allowed slippage in basis points. */
-    slippage?: string;
-  };
-  v1GetSwapQuoteResponse: {
-    /** @description CAIP-19 asset ID for the input asset. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description One quote per available swap provider. */
-    quotes: definitions["v1SwapQuoteOption"][];
-  };
   v1GetSwapStatusRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Identifier returned in the execute_swap activity result. */
-    sendTransactionStatusId: string;
+    /** @description The swap_request_id returned by ExecuteSwap. */
+    swapRequestId: string;
   };
   v1GetSwapStatusResponse: {
     /** @description Normalized swap status. One of PENDING, COMPLETED, FAILED. */
@@ -3979,7 +4073,7 @@ export type definitions = {
     /** @description SAME_CHAIN or CROSS_CHAIN. */
     swapKind: string;
     /** @description Swap provider that executed the swap. */
-    provider?: string;
+    provider: string;
     /** @description CAIP-19 asset ID for the input asset. */
     inputToken: string;
     /** @description CAIP-19 asset ID for the output asset. */
@@ -3988,20 +4082,16 @@ export type definitions = {
     inputAmount: string;
     /** @description Final included origin-chain transaction hash, when known. */
     originTxHash?: string;
-    /** @description Destination-chain fill transaction hash; cross-chain COMPLETED only. */
-    destinationTxHash?: string;
-    /** @description Actual base-unit output amount on COMPLETED, when known. */
+    /** @description Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only. */
+    destinationTxHashes?: string[];
+    /** @description Actual base-unit output amount on COMPLETED, when known. Unset on FAILED. */
     outputAmount?: string;
-    /** @description CAIP-19 of the asset the user holds after a FAILED swap, when recoverable. */
-    settledAsset?: string;
-    /** @description Base-unit amount of settled_asset. */
-    settledAmount?: string;
-    /** @description Transaction that delivered the settled funds, when applicable. */
-    settlementTxHash?: string;
-    /** @description Non-normative raw provider status passthrough; cross-chain only. */
-    providerStatus?: string;
+    /** @description Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED. */
+    refund?: definitions["v1SwapRefund"];
     /** @description Timestamp of the last swap status change, as millisecond epoch string. */
     updatedAt: string;
+    /** @description Normalized failure details, present whenever status is FAILED. */
+    error?: definitions["v1SwapError"];
   };
   v1GetTvcAppDeploymentsRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4164,6 +4254,7 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
+      | "eip155:421614"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4761,6 +4852,10 @@ export type definitions = {
     claimSwapFeesIntent?: definitions["v1ClaimSwapFeesIntent"];
     earnSetWrapperStateIntent?: definitions["v1EarnSetWrapperStateIntent"];
     claimEarnFeesIntent?: definitions["v1ClaimEarnFeesIntent"];
+    updateWalletAccountNameIntent?: definitions["v1UpdateWalletAccountNameIntent"];
+    ethUndelegate7702Intent?: definitions["v1EthUndelegate7702Intent"];
+    executeSwapIntentV2?: definitions["v1ExecuteSwapIntentV2"];
+    createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -4856,8 +4951,10 @@ export type definitions = {
     paginationOptions?: definitions["v1Pagination"];
   };
   v1ListEarnVaultsResponse: {
-    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor. */
+    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor. */
     vaults?: definitions["v1EarnVault"][];
+    /** @description Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them. */
+    pageInfo?: definitions["v1PageInfo"];
   };
   v1ListEmailEventsRequest: {
     /** @description Unique identifier for a given organization */
@@ -4972,7 +5069,8 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+      | "eip155:421614"
+      | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
   v1ListSupportedAssetsResponse: {
@@ -5305,7 +5403,14 @@ export type definitions = {
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
     | "OUTCOME_ERROR"
-    | "OUTCOME_REQUIRES_AUTHENTICATORS";
+    | "OUTCOME_REQUIRES_AUTHENTICATORS"
+    | "OUTCOME_TIME_INACTIVE";
+  v1PageInfo: {
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+    startCursor?: string;
+    endCursor?: string;
+  };
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -5337,6 +5442,8 @@ export type definitions = {
     consensus: string;
     /** @description A condition expression that evalutes to true or false. */
     condition: string;
+    /** @description A time expression that evalutes to true or false. */
+    time?: string;
   };
   v1PostTvcQuorumKeyShareIntent: {
     /** @description Unique identifier of the TVC deployment receiving quorum key share */
@@ -5669,6 +5776,9 @@ export type definitions = {
     claimSwapFeesResult?: definitions["v1ClaimSwapFeesResult"];
     earnSetWrapperStateResult?: definitions["v1EarnSetWrapperStateResult"];
     claimEarnFeesResult?: definitions["v1ClaimEarnFeesResult"];
+    updateWalletAccountNameResult?: definitions["v1UpdateWalletAccountNameResult"];
+    ethUndelegate7702Result?: definitions["v1EthUndelegate7702Result"];
+    createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -6291,15 +6401,39 @@ export type definitions = {
     /** @description Signed JWT containing an expiry, public key, session type, user id, and organization id */
     session: string;
   };
-  v1SwapQuoteOption: {
-    /** @description Identifier for this provider quote. */
+  v1SwapError: {
+    /** @description Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED. */
+    reason: string;
+    /** @description Human-readable description of the swap failure. */
+    message: string;
+    /** @description Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available. */
+    originTxError?: definitions["v1TxError"];
+  };
+  v1SwapQuote: {
+    /** @description Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute. */
     quoteId: string;
-    /** @description Swap provider that produced this quote. Pass this value to execute_swap to force a specific provider. */
+    /** @description Swap provider that produced this quote. */
     provider: string;
     /** @description Estimated base-unit amount of the output asset. */
     outputAmount: string;
     /** @description Minimum acceptable base-unit amount of the output asset after slippage. */
-    minOutputAmount?: string;
+    minOutputAmount: string;
+    /** @description Quote expiration as a millisecond epoch string. */
+    expiresAt: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set. */
+    slippageBps?: string;
+    /** @description Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount. */
+    clientFeeBps: string;
+    /** @description Provider-estimated completion time in seconds, when available. */
+    estimatedTimeSeconds?: string;
+  };
+  v1SwapRefund: {
+    /** @description CAIP-19 asset returned to the user after a failed swap. */
+    asset: string;
+    /** @description Base-unit amount of the refunded asset. */
+    amount: string;
+    /** @description Transaction that delivered the refunded funds, when applicable. */
+    txHash?: string;
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
@@ -6772,6 +6906,8 @@ export type definitions = {
     policyConsensus?: string;
     /** @description Accompanying notes for a Policy (optional). */
     policyNotes?: string;
+    /** @description The time expression that triggers the Effect (optional). */
+    time?: string;
   };
   v1UpdatePolicyRequest: {
     /** @enum {string} */
@@ -6964,6 +7100,16 @@ export type definitions = {
     /** @description Unique identifier for a given User Tag. */
     userTagId: string;
   };
+  v1UpdateWalletAccountNameIntent: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+    /** @description Human-readable name for this Wallet Account. */
+    name: string;
+  };
+  v1UpdateWalletAccountNameResult: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+  };
   v1UpdateWalletIntent: {
     /** @description Unique identifier for a given Wallet. */
     walletId: string;
@@ -7030,8 +7176,7 @@ export type definitions = {
     feeReceiverWalletAddress?: string;
     /** @description Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set. */
     feeBps?: string;
-    provider?: string;
-    /** @description Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset. */
+    /** @description Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps. */
     stableFeeBps?: string;
   };
   v1UpsertSwapConfigRequest: {
@@ -7853,25 +7998,7 @@ export type operations = {
       };
     };
   };
-  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-  PublicApiService_GetSwapQuote: {
-    parameters: {
-      body: {
-        body: definitions["v1GetSwapQuoteRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetSwapQuoteResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+  /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
   PublicApiService_GetSwapStatus: {
     parameters: {
       body: {
@@ -8861,6 +8988,24 @@ export type operations = {
       };
     };
   };
+  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+  PublicApiService_CreateSwapQuote: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSwapQuoteRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a new TVC application */
   PublicApiService_CreateTvcApp: {
     parameters: {
@@ -9527,7 +9672,25 @@ export type operations = {
       };
     };
   };
-  /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+  /** Submit an EIP-7702 undelegation transaction. */
+  PublicApiService_EthUndelegate7702: {
+    parameters: {
+      body: {
+        body: definitions["v1EthUndelegate7702Request"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
   PublicApiService_ExecuteSwap: {
     parameters: {
       body: {

--- a/packages/sdk-types/src/__generated__/types.ts
+++ b/packages/sdk-types/src/__generated__/types.ts
@@ -777,7 +777,11 @@ export type v1ActivityType =
   | "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2"
   | "ACTIVITY_TYPE_CLAIM_SWAP_FEES"
   | "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE"
-  | "ACTIVITY_TYPE_CLAIM_EARN_FEES";
+  | "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+  | "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME"
+  | "ACTIVITY_TYPE_ETH_UNDELEGATE_7702"
+  | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
+  | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
 
 export type v1ApiKey = {
   /** A User credential that can be used to authenticate to Turnkey. */
@@ -860,6 +864,8 @@ export type v1AssetMetadata = {
   logoUrl?: string;
   /** The asset name */
   name?: string;
+  /** Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
+  stable?: boolean;
 };
 
 export type v1AuthenticationMethod = {
@@ -966,6 +972,16 @@ export type v1ClaimEarnFeesResult = {
 };
 
 export type v1ClaimSwapFeesIntent = {};
+export type v1ClaimSwapFeesRequest = {
+  type: "ACTIVITY_TYPE_CLAIM_SWAP_FEES";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1ClaimSwapFeesIntent;
+  generateAppProofs?: boolean;
+};
+
 export type v1ClaimSwapFeesResult = {
   /** Relay claim request ID submitted through the permit endpoint. */
   requestId: string;
@@ -1259,6 +1275,8 @@ export type v1CreatePolicyIntentV3 = {
   consensus?: string;
   /** Notes for a Policy. */
   notes: string;
+  /** The time expression that triggers the Effect */
+  time?: string;
 };
 
 export type v1CreatePolicyRequest = {
@@ -1642,6 +1660,24 @@ export type v1CreateSubOrganizationResultV8 = {
   rootUserIds?: string[];
 };
 
+export type v1CreateSwapQuoteIntent = {
+  /** Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported. */
+  signWith: string;
+  /** CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+  inputToken: string;
+  /** CAIP-19 asset ID for the output asset. */
+  outputToken: string;
+  /** Base-unit amount of the input asset. */
+  inputAmount: string;
+  /** Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+  slippageBps?: string;
+};
+
+export type v1CreateSwapQuoteResult = {
+  /** One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution. */
+  quotes: v1SwapQuote[];
+};
+
 export type v1CreateTvcAppIntent = {
   /** The name of the new TVC application */
   name: string;
@@ -1679,6 +1715,12 @@ export type v1CreateTvcAppResult = {
   manifestSetOperatorIds: string[];
   /** The required number of approvals for the manifest set */
   manifestSetThreshold: number;
+  /** The unique identifier for the TVC share set */
+  shareSetId: string;
+  /** The unique identifiers of the share set operators */
+  shareSetOperatorIds: string[];
+  /** The required number of approvals for the share set */
+  shareSetThreshold: number;
 };
 
 export type v1CreateTvcDeploymentIntent = {
@@ -2404,7 +2446,7 @@ export type v1EarnDeployWrapperIntent = {
     | "eip155:137"
     | "eip155:56"
     | "eip155:4217";
-  /** Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+  /** Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%). */
   clientFeeBps: string;
   /** The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
   clientFeeWallet: string;
@@ -2472,15 +2514,15 @@ export type v1EarnEnabledVault = {
   provider?: v1EarnProvider;
   /** CAIP-19 asset ID of the vault's underlying asset (e.g. 'eip155:8453/erc20:0x833589...'); the chain is encoded in the identifier. */
   caip19?: string;
-  /** Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees). */
+  /** Gross annual percentage yield, expressed as a decimal fraction (before fees). */
   apyPct?: string;
   /** Total deposited through this wrapper (wrapper TVL), in raw on-chain units of the underlying asset. */
   totalDeposited?: string;
   /** Normalized total-deposited values for display only (usd + crypto). Do not do arithmetic with these; use total_deposited instead. */
   display?: v1EarnValueDisplay;
-  /** Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction. */
+  /** Annual percentage yield net of fees, expressed as a decimal fraction. */
   netApyPct?: string;
-  /** Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting. */
+  /** Client fee taken on yield, in basis points. */
   clientFeeBps?: string;
   /** When true, deposits to this wrapper are rejected; withdrawals are unaffected. Toggled via EarnSetWrapperState. */
   depositsDisabled?: boolean;
@@ -2488,10 +2530,12 @@ export type v1EarnEnabledVault = {
   name?: string;
   /** Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
   curator?: string;
-  /** The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
+  /** The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
   claimableClientFee?: string;
   /** Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries. */
   claimableClientFeeDisplay?: v1EarnValueDisplay;
+  /** The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
+  clientFeeWallet?: string;
 };
 
 export type v1EarnPosition = {
@@ -2773,6 +2817,8 @@ export type v1EmailEventDetails = {
   deliveryProcessingTimeMillis?: string;
   /** Delay type for DeliveryDelay events */
   deliveryDelayType?: string;
+  /** Feedback type for Complaint events */
+  complaintFeedbackType?: string;
 };
 
 export type v1EnableAuthProxyIntent = {};
@@ -2899,7 +2945,7 @@ export type v1EthSendTransactionIntentV2 = {
   maxPriorityFeePerGas?: string;
   /** Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
   deadline?: string;
-  /** The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+  /** The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection. */
   gasStationNonce?: string;
   /** Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
   calls: v1EthCallParams[];
@@ -2951,6 +2997,50 @@ export type v1EthTransactionHistoryItem = {
   turnkey?: v1TransactionHistoryTurnkey;
 };
 
+export type v1EthUndelegate7702Intent = {
+  /** A wallet or private key address to undelegate. This does not support private key IDs. */
+  from: string;
+  /** CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet). */
+  caip2:
+    | "eip155:1"
+    | "eip155:11155111"
+    | "eip155:8453"
+    | "eip155:84532"
+    | "eip155:137"
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97"
+    | "eip155:10"
+    | "eip155:11155420"
+    | "eip155:143"
+    | "eip155:10143"
+    | "eip155:42161"
+    | "eip155:421614";
+  /** Outer transaction nonce. Omit to auto-fetch. */
+  nonce?: string;
+  /** Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
+  gasLimit?: string;
+  /** Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+  maxFeePerGas?: string;
+  /** Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+  maxPriorityFeePerGas?: string;
+};
+
+export type v1EthUndelegate7702Request = {
+  type: "ACTIVITY_TYPE_ETH_UNDELEGATE_7702";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1EthUndelegate7702Intent;
+  generateAppProofs?: boolean;
+};
+
+export type v1EthUndelegate7702Result = {
+  /** The send_transaction_status ID associated with the undelegation transaction submission */
+  sendTransactionStatusId: string;
+};
+
 export type v1ExecuteSwapIntent = {
   /** CAIP-19 asset ID for the input asset. The chain is derived from this value. */
   inputToken: string;
@@ -2964,15 +3054,38 @@ export type v1ExecuteSwapIntent = {
   sponsor?: boolean;
   /** Maximum allowed slippage in basis points. */
   slippage?: string;
-  /** Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider. */
+  /** Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider. */
   provider?: string;
   /** Minimum acceptable base-unit amount of the output asset. Execution fails if the swap provider's quoted minimum output falls below this floor at execution time. */
   minOutputAmount: string;
 };
 
+export type v1ExecuteSwapIntentV2 = {
+  /** Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+  quoteId: string;
+  /** CAIP-19 asset ID for the input asset. */
+  inputToken: string;
+  /** Exact base-unit amount of the input asset committed by the quote. */
+  inputAmount: string;
+  /** CAIP-19 asset ID for the output asset. */
+  outputToken: string;
+  /** Exact quoted base-unit output amount committed by the quote. */
+  quotedOutputAmount: string;
+  /** Exact minimum base-unit output committed by the quote. */
+  minOutputAmount: string;
+  /** Whether the quoted transaction is sponsored. */
+  sponsor: boolean;
+  /** Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+  evmNonce?: string;
+  /** Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+  recentBlockhash?: string;
+  /** Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+  gasStationNonce?: string;
+};
+
 export type v1ExecuteSwapResult = {
-  /** The send_transaction_status ID associated with the swap transaction submission */
-  sendTransactionStatusId: string;
+  /** Identifier to poll swap status via GetSwapStatus. */
+  swapRequestId: string;
   /** Swap provider used to build the transaction. */
   provider?: string;
   /** Quote identifier used for execution, if any. */
@@ -3260,6 +3373,22 @@ export type v1GetBootProofRequest = {
   ephemeralKey: string;
 };
 
+export type v1GetClaimEarnFeesStatusRequest = {
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  /** The claim_request_id returned by ClaimEarnFees. */
+  claimRequestId: string;
+};
+
+export type v1GetClaimEarnFeesStatusResponse = {
+  /** Status of the fee claim. */
+  status: "PENDING" | "COMPLETED" | "FAILED";
+  /** Transaction hash of the fee claim, once available. */
+  claimTxHash?: string;
+  /** Reason the fee claim transaction failed, when status is FAILED. */
+  error?: string;
+};
+
 export type v1GetEarnDeployStatusRequest = {
   /** Unique identifier for a given Organization. */
   organizationId: string;
@@ -3336,7 +3465,7 @@ export type v1GetIpAllowlistResponse = {
 export type v1GetLatestBootProofRequest = {
   /** Unique identifier for a given Organization. */
   organizationId: string;
-  /** Name of enclave app. */
+  /** Unique identifier (UUID) of the enclave app. */
   appName: string;
 };
 
@@ -3598,6 +3727,40 @@ export type v1GetSubOrgIdsResponse = {
   organizationIds: string[];
 };
 
+export type v1GetSwapStatusRequest = {
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  /** The swap_request_id returned by ExecuteSwap. */
+  swapRequestId: string;
+};
+
+export type v1GetSwapStatusResponse = {
+  /** Normalized swap status. One of PENDING, COMPLETED, FAILED. */
+  status: string;
+  /** SAME_CHAIN or CROSS_CHAIN. */
+  swapKind: string;
+  /** Swap provider that executed the swap. */
+  provider: string;
+  /** CAIP-19 asset ID for the input asset. */
+  inputToken: string;
+  /** CAIP-19 asset ID for the output asset. */
+  outputToken: string;
+  /** Base-unit amount of the input asset. */
+  inputAmount: string;
+  /** Final included origin-chain transaction hash, when known. */
+  originTxHash?: string;
+  /** Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only. */
+  destinationTxHashes?: string[];
+  /** Actual base-unit output amount on COMPLETED, when known. Unset on FAILED. */
+  outputAmount?: string;
+  /** Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED. */
+  refund?: v1SwapRefund;
+  /** Timestamp of the last swap status change, as millisecond epoch string. */
+  updatedAt: string;
+  /** Normalized failure details, present whenever status is FAILED. */
+  error?: v1SwapError;
+};
+
 export type v1GetTvcAppDeploymentsRequest = {
   /** Unique identifier for a given organization. */
   organizationId: string;
@@ -3752,6 +3915,7 @@ export type v1GetWalletAddressBalancesRequest = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
+    | "eip155:421614"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -4345,6 +4509,10 @@ export type v1Intent = {
   claimSwapFeesIntent?: v1ClaimSwapFeesIntent;
   earnSetWrapperStateIntent?: v1EarnSetWrapperStateIntent;
   claimEarnFeesIntent?: v1ClaimEarnFeesIntent;
+  updateWalletAccountNameIntent?: v1UpdateWalletAccountNameIntent;
+  ethUndelegate7702Intent?: v1EthUndelegate7702Intent;
+  executeSwapIntentV2?: v1ExecuteSwapIntentV2;
+  createSwapQuoteIntent?: v1CreateSwapQuoteIntent;
 };
 
 export type v1InvitationParams = {
@@ -4427,8 +4595,10 @@ export type v1ListEarnVaultsRequest = {
 };
 
 export type v1ListEarnVaultsResponse = {
-  /** The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor. */
+  /** The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor. */
   vaults?: v1EarnVault[];
+  /** Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them. */
+  pageInfo?: v1PageInfo;
 };
 
 export type v1ListEmailEventsRequest = {
@@ -4547,7 +4717,8 @@ export type v1ListSupportedAssetsRequest = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+    | "eip155:421614"
+    | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
 
@@ -4851,7 +5022,15 @@ export type v1Outcome =
   | "OUTCOME_REQUIRES_CONSENSUS"
   | "OUTCOME_REJECTED"
   | "OUTCOME_ERROR"
-  | "OUTCOME_REQUIRES_AUTHENTICATORS";
+  | "OUTCOME_REQUIRES_AUTHENTICATORS"
+  | "OUTCOME_TIME_INACTIVE";
+
+export type v1PageInfo = {
+  hasNextPage?: boolean;
+  hasPreviousPage?: boolean;
+  startCursor?: string;
+  endCursor?: string;
+};
 
 export type v1Pagination = {
   /** A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
@@ -4883,6 +5062,8 @@ export type v1Policy = {
   consensus: string;
   /** A condition expression that evalutes to true or false. */
   condition: string;
+  /** A time expression that evalutes to true or false. */
+  time?: string;
 };
 
 export type v1PostTvcQuorumKeyShareIntent = {
@@ -5212,6 +5393,9 @@ export type v1Result = {
   claimSwapFeesResult?: v1ClaimSwapFeesResult;
   earnSetWrapperStateResult?: v1EarnSetWrapperStateResult;
   claimEarnFeesResult?: v1ClaimEarnFeesResult;
+  updateWalletAccountNameResult?: v1UpdateWalletAccountNameResult;
+  ethUndelegate7702Result?: v1EthUndelegate7702Result;
+  createSwapQuoteResult?: v1CreateSwapQuoteResult;
 };
 
 export type v1RevertChainEntry = {
@@ -5860,6 +6044,43 @@ export type v1StampLoginResult = {
   session: string;
 };
 
+export type v1SwapError = {
+  /** Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED. */
+  reason: string;
+  /** Human-readable description of the swap failure. */
+  message: string;
+  /** Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available. */
+  originTxError?: v1TxError;
+};
+
+export type v1SwapQuote = {
+  /** Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute. */
+  quoteId: string;
+  /** Swap provider that produced this quote. */
+  provider: string;
+  /** Estimated base-unit amount of the output asset. */
+  outputAmount: string;
+  /** Minimum acceptable base-unit amount of the output asset after slippage. */
+  minOutputAmount: string;
+  /** Quote expiration as a millisecond epoch string. */
+  expiresAt: string;
+  /** Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set. */
+  slippageBps?: string;
+  /** Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount. */
+  clientFeeBps: string;
+  /** Provider-estimated completion time in seconds, when available. */
+  estimatedTimeSeconds?: string;
+};
+
+export type v1SwapRefund = {
+  /** CAIP-19 asset returned to the user after a failed swap. */
+  asset: string;
+  /** Base-unit amount of the refunded asset. */
+  amount: string;
+  /** Transaction that delivered the refunded funds, when applicable. */
+  txHash?: string;
+};
+
 export type v1TagType = "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
 
 export type v1TokenUsage = {
@@ -6312,6 +6533,8 @@ export type v1UpdatePolicyIntentV2 = {
   policyConsensus?: string;
   /** Accompanying notes for a Policy (optional). */
   policyNotes?: string;
+  /** The time expression that triggers the Effect (optional). */
+  time?: string;
 };
 
 export type v1UpdatePolicyRequest = {
@@ -6518,6 +6741,18 @@ export type v1UpdateUserTagResult = {
   userTagId: string;
 };
 
+export type v1UpdateWalletAccountNameIntent = {
+  /** Unique identifier for a given Wallet Account. */
+  walletAccountId: string;
+  /** Human-readable name for this Wallet Account. */
+  name: string;
+};
+
+export type v1UpdateWalletAccountNameResult = {
+  /** Unique identifier for a given Wallet Account. */
+  walletAccountId: string;
+};
+
 export type v1UpdateWalletIntent = {
   /** Unique identifier for a given Wallet. */
   walletId: string;
@@ -6590,9 +6825,18 @@ export type v1UpsertSwapConfigIntent = {
   feeReceiverWalletAddress?: string;
   /** Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set. */
   feeBps?: string;
-  provider?: string;
-  /** Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset. */
+  /** Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps. */
   stableFeeBps?: string;
+};
+
+export type v1UpsertSwapConfigRequest = {
+  type: "ACTIVITY_TYPE_UPSERT_SWAP_CONFIG";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1UpsertSwapConfigIntent;
+  generateAppProofs?: boolean;
 };
 
 export type v1UpsertSwapConfigResult = {
@@ -6922,6 +7166,25 @@ export type TGetBootProofBody = {
 
 export type TGetBootProofInput = { body: TGetBootProofBody };
 
+export type TGetClaimEarnFeesStatusResponse = {
+  /** Status of the fee claim. */
+  status: "PENDING" | "COMPLETED" | "FAILED";
+  /** Transaction hash of the fee claim, once available. */
+  claimTxHash?: string;
+  /** Reason the fee claim transaction failed, when status is FAILED. */
+  error?: string;
+};
+
+export type TGetClaimEarnFeesStatusBody = {
+  organizationId?: string;
+  /** The claim_request_id returned by ClaimEarnFees. */
+  claimRequestId: string;
+};
+
+export type TGetClaimEarnFeesStatusInput = {
+  body: TGetClaimEarnFeesStatusBody;
+};
+
 export type TGetEarnDeployStatusResponse = {
   /** Status of the wrapper deployment. */
   status: "PENDING" | "COMPLETED" | "FAILED";
@@ -7006,7 +7269,7 @@ export type TGetLatestBootProofResponse = {
 
 export type TGetLatestBootProofBody = {
   organizationId?: string;
-  /** Name of enclave app. */
+  /** Unique identifier (UUID) of the enclave app. */
   appName: string;
 };
 
@@ -7247,6 +7510,41 @@ export type TGetSmartContractInterfaceInput = {
   body: TGetSmartContractInterfaceBody;
 };
 
+export type TGetSwapStatusResponse = {
+  /** Normalized swap status. One of PENDING, COMPLETED, FAILED. */
+  status: string;
+  /** SAME_CHAIN or CROSS_CHAIN. */
+  swapKind: string;
+  /** Swap provider that executed the swap. */
+  provider: string;
+  /** CAIP-19 asset ID for the input asset. */
+  inputToken: string;
+  /** CAIP-19 asset ID for the output asset. */
+  outputToken: string;
+  /** Base-unit amount of the input asset. */
+  inputAmount: string;
+  /** Final included origin-chain transaction hash, when known. */
+  originTxHash?: string;
+  /** Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only. */
+  destinationTxHashes?: string[];
+  /** Actual base-unit output amount on COMPLETED, when known. Unset on FAILED. */
+  outputAmount?: string;
+  /** Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED. */
+  refund?: v1SwapRefund;
+  /** Timestamp of the last swap status change, as millisecond epoch string. */
+  updatedAt: string;
+  /** Normalized failure details, present whenever status is FAILED. */
+  error?: v1SwapError;
+};
+
+export type TGetSwapStatusBody = {
+  organizationId?: string;
+  /** The swap_request_id returned by ExecuteSwap. */
+  swapRequestId: string;
+};
+
+export type TGetSwapStatusInput = { body: TGetSwapStatusBody };
+
 export type TGetTvcAppResponse = {
   /** Details about a single TVC App */
   tvcApp: v1TvcApp;
@@ -7361,6 +7659,7 @@ export type TGetWalletAddressBalancesBody = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
+    | "eip155:421614"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -7427,8 +7726,10 @@ export type TListEarnPositionsBody = {
 export type TListEarnPositionsInput = { body: TListEarnPositionsBody };
 
 export type TListEarnVaultsResponse = {
-  /** The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor. */
+  /** The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor. */
   vaults?: v1EarnVault[];
+  /** Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them. */
+  pageInfo?: v1PageInfo;
 };
 
 export type TListEarnVaultsBody = {
@@ -7627,7 +7928,8 @@ export type TListSupportedAssetsBody = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+    | "eip155:421614"
+    | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
 
@@ -7795,6 +8097,20 @@ export type TClaimEarnFeesBody = {
 };
 
 export type TClaimEarnFeesInput = { body: TClaimEarnFeesBody };
+
+export type TClaimSwapFeesResponse = {
+  activity: v1Activity;
+  /** Relay claim request ID submitted through the permit endpoint. */
+  requestId: string;
+};
+
+export type TClaimSwapFeesBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  generateAppProofs?: boolean;
+};
+
+export type TClaimSwapFeesInput = { body: TClaimSwapFeesBody };
 
 export type TCreateApiKeysResponse = {
   activity: v1Activity;
@@ -7976,6 +8292,8 @@ export type TCreatePolicyBody = {
   consensus?: string;
   /** Notes for a Policy. */
   notes: string;
+  /** The time expression that triggers the Effect */
+  time?: string;
   generateAppProofs?: boolean;
 };
 
@@ -8168,6 +8486,12 @@ export type TCreateTvcAppResponse = {
   manifestSetOperatorIds: string[];
   /** The required number of approvals for the manifest set */
   manifestSetThreshold: number;
+  /** The unique identifier for the TVC share set */
+  shareSetId: string;
+  /** The unique identifiers of the share set operators */
+  shareSetOperatorIds: string[];
+  /** The required number of approvals for the share set */
+  shareSetThreshold: number;
 };
 
 export type TCreateTvcAppBody = {
@@ -8721,7 +9045,7 @@ export type TEarnDeployWrapperBody = {
     | "eip155:137"
     | "eip155:56"
     | "eip155:4217";
-  /** Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+  /** Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%). */
   clientFeeBps: string;
   /** The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
   clientFeeWallet: string;
@@ -8843,6 +9167,46 @@ export type TEmailAuthBody = {
 };
 
 export type TEmailAuthInput = { body: TEmailAuthBody };
+
+export type TEthUndelegate7702Response = {
+  activity: v1Activity;
+  /** The send_transaction_status ID associated with the undelegation transaction submission */
+  sendTransactionStatusId: string;
+};
+
+export type TEthUndelegate7702Body = {
+  timestampMs?: string;
+  organizationId?: string;
+  /** A wallet or private key address to undelegate. This does not support private key IDs. */
+  from: string;
+  /** CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet). */
+  caip2:
+    | "eip155:1"
+    | "eip155:11155111"
+    | "eip155:8453"
+    | "eip155:84532"
+    | "eip155:137"
+    | "eip155:80002"
+    | "eip155:56"
+    | "eip155:97"
+    | "eip155:10"
+    | "eip155:11155420"
+    | "eip155:143"
+    | "eip155:10143"
+    | "eip155:42161"
+    | "eip155:421614";
+  /** Outer transaction nonce. Omit to auto-fetch. */
+  nonce?: string;
+  /** Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
+  gasLimit?: string;
+  /** Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+  maxFeePerGas?: string;
+  /** Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+  maxPriorityFeePerGas?: string;
+  generateAppProofs?: boolean;
+};
+
+export type TEthUndelegate7702Input = { body: TEthUndelegate7702Body };
 
 export type TExportPrivateKeyResponse = {
   activity: v1Activity;
@@ -9689,6 +10053,8 @@ export type TUpdatePolicyBody = {
   policyConsensus?: string;
   /** Accompanying notes for a Policy (optional). */
   policyNotes?: string;
+  /** The time expression that triggers the Effect (optional). */
+  time?: string;
   generateAppProofs?: boolean;
 };
 
@@ -9878,6 +10244,26 @@ export type TUpdateWebhookEndpointBody = {
 
 export type TUpdateWebhookEndpointInput = { body: TUpdateWebhookEndpointBody };
 
+export type TUpsertSwapConfigResponse = {
+  activity: v1Activity;
+  feeReceiverWalletAddress?: string;
+  feeBps?: string;
+  stableFeeBps?: string;
+};
+
+export type TUpsertSwapConfigBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  feeReceiverWalletAddress?: string;
+  /** Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set. */
+  feeBps?: string;
+  /** Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps. */
+  stableFeeBps?: string;
+  generateAppProofs?: boolean;
+};
+
+export type TUpsertSwapConfigInput = { body: TUpsertSwapConfigBody };
+
 export type TVerifyOtpResponse = {
   activity: v1Activity;
   /** Signed JWT containing a unique id, expiry, verification type, contact. Verification status of a user is updated when the token is consumed (in OTP_LOGIN requests) */
@@ -9997,7 +10383,7 @@ export type TEthSendTransactionV2Body = {
   maxPriorityFeePerGas?: string;
   /** Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
   deadline?: string;
-  /** The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+  /** The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection. */
   gasStationNonce?: string;
   /** Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
   calls: v1EthCallParams[];

--- a/packages/sdk-types/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-types/src/__inputs__/public_api.swagger.json
@@ -296,6 +296,38 @@
         "tags": ["Boot Proof"]
       }
     },
+    "/public/v1/query/get_claim_earn_fees_status": {
+      "post": {
+        "summary": "Get Earn claim fees status",
+        "description": "Poll the status of a fee claim by its claim_request_id.",
+        "operationId": "PublicApiService_GetClaimEarnFeesStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetClaimEarnFeesStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Earn"]
+      }
+    },
     "/public/v1/query/get_earn_deploy_status": {
       "post": {
         "summary": "Get Earn deploy status",
@@ -966,6 +998,38 @@
           }
         ],
         "tags": ["Policies"]
+      }
+    },
+    "/public/v1/query/get_swap_status": {
+      "post": {
+        "summary": "Get swap status",
+        "description": "Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.",
+        "operationId": "PublicApiService_GetSwapStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetSwapStatusRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/query/get_tvc_app": {
@@ -2086,6 +2150,38 @@
           }
         ],
         "tags": ["Earn"]
+      }
+    },
+    "/public/v1/submit/claim_swap_fees": {
+      "post": {
+        "summary": "Claim swap fees",
+        "description": "Claim swap fees through the activity pipeline.",
+        "operationId": "PublicApiService_ClaimSwapFees",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ClaimSwapFeesRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
       }
     },
     "/public/v1/submit/create_api_keys": {
@@ -3688,6 +3784,38 @@
         "tags": ["Broadcasting"]
       }
     },
+    "/public/v1/submit/eth_undelegate_7702": {
+      "post": {
+        "summary": "Undelegate an EVM account",
+        "description": "Submit an EIP-7702 undelegation transaction.",
+        "operationId": "PublicApiService_EthUndelegate7702",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1EthUndelegate7702Request"
+            }
+          }
+        ],
+        "tags": ["Broadcasting"]
+      }
+    },
     "/public/v1/submit/export_private_key": {
       "post": {
         "summary": "Export private key",
@@ -5192,6 +5320,38 @@
         "tags": ["Organizations"]
       }
     },
+    "/public/v1/submit/upsert_swap_config": {
+      "post": {
+        "summary": "Upsert swap config",
+        "description": "Enable or disable swap configuration for an organization.",
+        "operationId": "PublicApiService_UpsertSwapConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpsertSwapConfigRequest"
+            }
+          }
+        ],
+        "tags": ["Swaps"]
+      }
+    },
     "/public/v1/submit/verify_otp": {
       "post": {
         "summary": "Verify generic OTP",
@@ -5918,7 +6078,11 @@
         "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2",
         "ACTIVITY_TYPE_CLAIM_SWAP_FEES",
         "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE",
-        "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+        "ACTIVITY_TYPE_CLAIM_EARN_FEES",
+        "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME",
+        "ACTIVITY_TYPE_ETH_UNDELEGATE_7702",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
       ]
     },
     "v1AddressFormat": {
@@ -6202,6 +6366,10 @@
         "name": {
           "type": "string",
           "description": "The asset name"
+        },
+        "stable": {
+          "type": "boolean",
+          "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
         }
       }
     },
@@ -6508,6 +6676,30 @@
     },
     "v1ClaimSwapFeesIntent": {
       "type": "object"
+    },
+    "v1ClaimSwapFeesRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CLAIM_SWAP_FEES"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1ClaimSwapFeesIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1ClaimSwapFeesResult": {
       "type": "object",
@@ -7239,6 +7431,10 @@
         "notes": {
           "type": "string",
           "description": "Notes for a Policy."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect"
         }
       },
       "required": ["policyName", "effect", "notes"]
@@ -8174,6 +8370,46 @@
       },
       "required": ["subOrganizationId"]
     },
+    "v1CreateSwapQuoteIntent": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
+    "v1CreateSwapQuoteResult": {
+      "type": "object",
+      "properties": {
+        "quotes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SwapQuote"
+          },
+          "description": "One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution."
+        }
+      },
+      "required": ["quotes"]
+    },
     "v1CreateTvcAppIntent": {
       "type": "object",
       "properties": {
@@ -8255,13 +8491,32 @@
           "type": "integer",
           "format": "int64",
           "description": "The required number of approvals for the manifest set"
+        },
+        "shareSetId": {
+          "type": "string",
+          "description": "The unique identifier for the TVC share set"
+        },
+        "shareSetOperatorIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The unique identifiers of the share set operators"
+        },
+        "shareSetThreshold": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The required number of approvals for the share set"
         }
       },
       "required": [
         "appId",
         "manifestSetId",
         "manifestSetOperatorIds",
-        "manifestSetThreshold"
+        "manifestSetThreshold",
+        "shareSetId",
+        "shareSetOperatorIds",
+        "shareSetThreshold"
       ]
     },
     "v1CreateTvcDeploymentIntent": {
@@ -9963,7 +10218,7 @@
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield."
+          "description": "Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%)."
         },
         "clientFeeWallet": {
           "type": "string",
@@ -10108,7 +10363,7 @@
         },
         "apyPct": {
           "type": "string",
-          "description": "Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees)."
+          "description": "Gross annual percentage yield, expressed as a decimal fraction (before fees)."
         },
         "totalDeposited": {
           "type": "string",
@@ -10120,11 +10375,11 @@
         },
         "netApyPct": {
           "type": "string",
-          "description": "Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction."
+          "description": "Annual percentage yield net of fees, expressed as a decimal fraction."
         },
         "clientFeeBps": {
           "type": "string",
-          "description": "Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting."
+          "description": "Client fee taken on yield, in basis points."
         },
         "depositsDisabled": {
           "type": "boolean",
@@ -10140,11 +10395,15 @@
         },
         "claimableClientFee": {
           "type": "string",
-          "description": "The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
+          "description": "The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."
         },
         "claimableClientFeeDisplay": {
           "$ref": "#/definitions/v1EarnValueDisplay",
           "description": "Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries."
+        },
+        "clientFeeWallet": {
+          "type": "string",
+          "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
         }
       }
     },
@@ -10719,6 +10978,10 @@
         "deliveryDelayType": {
           "type": "string",
           "description": "Delay type for DeliveryDelay events"
+        },
+        "complaintFeedbackType": {
+          "type": "string",
+          "description": "Feedback type for Complaint events"
         }
       }
     },
@@ -10935,7 +11198,7 @@
         },
         "gasStationNonce": {
           "type": "string",
-          "description": "The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch."
+          "description": "The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection."
         },
         "calls": {
           "type": "array",
@@ -11056,6 +11319,86 @@
         "transfers"
       ]
     },
+    "v1EthUndelegate7702Intent": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "A wallet or private key address to undelegate. This does not support private key IDs."
+        },
+        "caip2": {
+          "type": "string",
+          "enum": [
+            "eip155:1",
+            "eip155:11155111",
+            "eip155:8453",
+            "eip155:84532",
+            "eip155:137",
+            "eip155:80002",
+            "eip155:56",
+            "eip155:97",
+            "eip155:10",
+            "eip155:11155420",
+            "eip155:143",
+            "eip155:10143",
+            "eip155:42161",
+            "eip155:421614"
+          ],
+          "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "Outer transaction nonce. Omit to auto-fetch."
+        },
+        "gasLimit": {
+          "type": "string",
+          "description": "Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit."
+        },
+        "maxFeePerGas": {
+          "type": "string",
+          "description": "Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate."
+        },
+        "maxPriorityFeePerGas": {
+          "type": "string",
+          "description": "Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate."
+        }
+      },
+      "required": ["from", "caip2"]
+    },
+    "v1EthUndelegate7702Request": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_ETH_UNDELEGATE_7702"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1EthUndelegate7702Result": {
+      "type": "object",
+      "properties": {
+        "sendTransactionStatusId": {
+          "type": "string",
+          "description": "The send_transaction_status ID associated with the undelegation transaction submission"
+        }
+      },
+      "required": ["sendTransactionStatusId"]
+    },
     "v1ExecuteSwapIntent": {
       "type": "object",
       "properties": {
@@ -11085,7 +11428,7 @@
         },
         "provider": {
           "type": "string",
-          "description": "Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider."
+          "description": "Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider."
         },
         "minOutputAmount": {
           "type": "string",
@@ -11100,12 +11443,66 @@
         "minOutputAmount"
       ]
     },
+    "v1ExecuteSwapIntentV2": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
     "v1ExecuteSwapResult": {
       "type": "object",
       "properties": {
-        "sendTransactionStatusId": {
+        "swapRequestId": {
           "type": "string",
-          "description": "The send_transaction_status ID associated with the swap transaction submission"
+          "description": "Identifier to poll swap status via GetSwapStatus."
         },
         "provider": {
           "type": "string",
@@ -11116,7 +11513,7 @@
           "description": "Quote identifier used for execution, if any."
         }
       },
-      "required": ["sendTransactionStatusId"]
+      "required": ["swapRequestId"]
     },
     "v1ExportPrivateKeyIntent": {
       "type": "object",
@@ -11664,6 +12061,39 @@
       },
       "required": ["organizationId", "ephemeralKey"]
     },
+    "v1GetClaimEarnFeesStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "claimRequestId": {
+          "type": "string",
+          "description": "The claim_request_id returned by ClaimEarnFees."
+        }
+      },
+      "required": ["organizationId", "claimRequestId"]
+    },
+    "v1GetClaimEarnFeesStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["PENDING", "COMPLETED", "FAILED"],
+          "description": "Status of the fee claim."
+        },
+        "claimTxHash": {
+          "type": "string",
+          "description": "Transaction hash of the fee claim, once available."
+        },
+        "error": {
+          "type": "string",
+          "description": "Reason the fee claim transaction failed, when status is FAILED."
+        }
+      },
+      "required": ["status"]
+    },
     "v1GetEarnDeployStatusRequest": {
       "type": "object",
       "properties": {
@@ -11824,7 +12254,7 @@
         },
         "appName": {
           "type": "string",
-          "description": "Name of enclave app."
+          "description": "Unique identifier (UUID) of the enclave app."
         }
       },
       "required": ["organizationId", "appName"]
@@ -12369,6 +12799,85 @@
       },
       "required": ["organizationIds"]
     },
+    "v1GetSwapStatusRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "swapRequestId": {
+          "type": "string",
+          "description": "The swap_request_id returned by ExecuteSwap."
+        }
+      },
+      "required": ["organizationId", "swapRequestId"]
+    },
+    "v1GetSwapStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Normalized swap status. One of PENDING, COMPLETED, FAILED."
+        },
+        "swapKind": {
+          "type": "string",
+          "description": "SAME_CHAIN or CROSS_CHAIN."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that executed the swap."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "originTxHash": {
+          "type": "string",
+          "description": "Final included origin-chain transaction hash, when known."
+        },
+        "destinationTxHashes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Actual base-unit output amount on COMPLETED, when known. Unset on FAILED."
+        },
+        "refund": {
+          "$ref": "#/definitions/v1SwapRefund",
+          "description": "Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED."
+        },
+        "updatedAt": {
+          "type": "string",
+          "description": "Timestamp of the last swap status change, as millisecond epoch string."
+        },
+        "error": {
+          "$ref": "#/definitions/v1SwapError",
+          "description": "Normalized failure details, present whenever status is FAILED."
+        }
+      },
+      "required": [
+        "status",
+        "swapKind",
+        "provider",
+        "inputToken",
+        "outputToken",
+        "inputAmount",
+        "updatedAt"
+      ]
+    },
     "v1GetTvcAppDeploymentsRequest": {
       "type": "object",
       "properties": {
@@ -12687,6 +13196,7 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
+            "eip155:421614",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14119,6 +14629,18 @@
         },
         "claimEarnFeesIntent": {
           "$ref": "#/definitions/v1ClaimEarnFeesIntent"
+        },
+        "updateWalletAccountNameIntent": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameIntent"
+        },
+        "ethUndelegate7702Intent": {
+          "$ref": "#/definitions/v1EthUndelegate7702Intent"
+        },
+        "executeSwapIntentV2": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV2"
+        },
+        "createSwapQuoteIntent": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntent"
         }
       }
     },
@@ -14308,7 +14830,11 @@
             "type": "object",
             "$ref": "#/definitions/v1EarnVault"
           },
-          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor."
+          "description": "The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor."
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo",
+          "description": "Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them."
         }
       }
     },
@@ -14543,7 +15069,8 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:421614",
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet or 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' for Solana mainnet). Human-readable Solana aliases ('solana:mainnet', 'solana:devnet') are also accepted and normalized to canonical CAIP-2 values."
@@ -15291,8 +15818,26 @@
         "OUTCOME_REQUIRES_CONSENSUS",
         "OUTCOME_REJECTED",
         "OUTCOME_ERROR",
-        "OUTCOME_REQUIRES_AUTHENTICATORS"
+        "OUTCOME_REQUIRES_AUTHENTICATORS",
+        "OUTCOME_TIME_INACTIVE"
       ]
+    },
+    "v1PageInfo": {
+      "type": "object",
+      "properties": {
+        "hasNextPage": {
+          "type": "boolean"
+        },
+        "hasPreviousPage": {
+          "type": "boolean"
+        },
+        "startCursor": {
+          "type": "string"
+        },
+        "endCursor": {
+          "type": "string"
+        }
+      }
     },
     "v1Pagination": {
       "type": "object",
@@ -15356,6 +15901,10 @@
         "condition": {
           "type": "string",
           "description": "A condition expression that evalutes to true or false."
+        },
+        "time": {
+          "type": "string",
+          "description": "A time expression that evalutes to true or false."
         }
       },
       "required": [
@@ -16248,6 +16797,15 @@
         },
         "claimEarnFeesResult": {
           "$ref": "#/definitions/v1ClaimEarnFeesResult"
+        },
+        "updateWalletAccountNameResult": {
+          "$ref": "#/definitions/v1UpdateWalletAccountNameResult"
+        },
+        "ethUndelegate7702Result": {
+          "$ref": "#/definitions/v1EthUndelegate7702Result"
+        },
+        "createSwapQuoteResult": {
+          "$ref": "#/definitions/v1CreateSwapQuoteResult"
         }
       }
     },
@@ -17797,6 +18355,87 @@
       },
       "required": ["session"]
     },
+    "v1SwapError": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description of the swap failure."
+        },
+        "originTxError": {
+          "$ref": "#/definitions/v1TxError",
+          "description": "Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available."
+        }
+      },
+      "required": ["reason", "message"]
+    },
+    "v1SwapQuote": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Swap provider that produced this quote."
+        },
+        "outputAmount": {
+          "type": "string",
+          "description": "Estimated base-unit amount of the output asset."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Minimum acceptable base-unit amount of the output asset after slippage."
+        },
+        "expiresAt": {
+          "type": "string",
+          "description": "Quote expiration as a millisecond epoch string."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set."
+        },
+        "clientFeeBps": {
+          "type": "string",
+          "description": "Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount."
+        },
+        "estimatedTimeSeconds": {
+          "type": "string",
+          "description": "Provider-estimated completion time in seconds, when available."
+        }
+      },
+      "required": [
+        "quoteId",
+        "provider",
+        "outputAmount",
+        "minOutputAmount",
+        "expiresAt",
+        "clientFeeBps"
+      ]
+    },
+    "v1SwapRefund": {
+      "type": "object",
+      "properties": {
+        "asset": {
+          "type": "string",
+          "description": "CAIP-19 asset returned to the user after a failed swap."
+        },
+        "amount": {
+          "type": "string",
+          "description": "Base-unit amount of the refunded asset."
+        },
+        "txHash": {
+          "type": "string",
+          "description": "Transaction that delivered the refunded funds, when applicable."
+        }
+      },
+      "required": ["asset", "amount"]
+    },
     "v1TagType": {
       "type": "string",
       "enum": ["TAG_TYPE_USER", "TAG_TYPE_PRIVATE_KEY"]
@@ -18826,6 +19465,10 @@
         "policyNotes": {
           "type": "string",
           "description": "Accompanying notes for a Policy (optional)."
+        },
+        "time": {
+          "type": "string",
+          "description": "The time expression that triggers the Effect (optional)."
         }
       },
       "required": ["policyId"]
@@ -19295,6 +19938,30 @@
       },
       "required": ["userTagId"]
     },
+    "v1UpdateWalletAccountNameIntent": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this Wallet Account."
+        }
+      },
+      "required": ["walletAccountId", "name"]
+    },
+    "v1UpdateWalletAccountNameResult": {
+      "type": "object",
+      "properties": {
+        "walletAccountId": {
+          "type": "string",
+          "description": "Unique identifier for a given Wallet Account."
+        }
+      },
+      "required": ["walletAccountId"]
+    },
     "v1UpdateWalletIntent": {
       "type": "object",
       "properties": {
@@ -19453,14 +20120,35 @@
           "type": "string",
           "description": "Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set."
         },
-        "provider": {
-          "type": "string"
-        },
         "stableFeeBps": {
           "type": "string",
-          "description": "Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset."
+          "description": "Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps."
         }
       }
+    },
+    "v1UpsertSwapConfigRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_UPSERT_SWAP_CONFIG"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1UpsertSwapConfigIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
     },
     "v1UpsertSwapConfigResult": {
       "type": "object",

--- a/packages/sdk-types/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-types/src/__inputs__/public_api.types.ts
@@ -124,12 +124,8 @@ export type paths = {
     /** Get details about a smart contract interface. */
     post: operations["PublicApiService_GetSmartContractInterface"];
   };
-  "/public/v1/query/get_swap_quote": {
-    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-    post: operations["PublicApiService_GetSwapQuote"];
-  };
   "/public/v1/query/get_swap_status": {
-    /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+    /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
     post: operations["PublicApiService_GetSwapStatus"];
   };
   "/public/v1/query/get_tvc_app": {
@@ -348,6 +344,10 @@ export type paths = {
     /** Create a new sub-organization. Each root user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the sub-organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateSubOrganization"];
   };
+  "/public/v1/submit/create_swap_quote": {
+    /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+    post: operations["PublicApiService_CreateSwapQuote"];
+  };
   "/public/v1/submit/create_tvc_app": {
     /** Create a new TVC application */
     post: operations["PublicApiService_CreateTvcApp"];
@@ -496,8 +496,12 @@ export type paths = {
     /** Submit a transaction intent describing an EVM transaction you would like to broadcast. */
     post: operations["PublicApiService_EthSendTransaction"];
   };
+  "/public/v1/submit/eth_undelegate_7702": {
+    /** Submit an EIP-7702 undelegation transaction. */
+    post: operations["PublicApiService_EthUndelegate7702"];
+  };
   "/public/v1/submit/execute_swap": {
-    /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+    /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
     post: operations["PublicApiService_ExecuteSwap"];
   };
   "/public/v1/submit/export_private_key": {
@@ -1080,7 +1084,11 @@ export type definitions = {
     | "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2"
     | "ACTIVITY_TYPE_CLAIM_SWAP_FEES"
     | "ACTIVITY_TYPE_EARN_SET_WRAPPER_STATE"
-    | "ACTIVITY_TYPE_CLAIM_EARN_FEES";
+    | "ACTIVITY_TYPE_CLAIM_EARN_FEES"
+    | "ACTIVITY_TYPE_UPDATE_WALLET_ACCOUNT_NAME"
+    | "ACTIVITY_TYPE_ETH_UNDELEGATE_7702"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1230,6 +1238,8 @@ export type definitions = {
     logoUrl?: string;
     /** @description The asset name */
     name?: string;
+    /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
+    stable?: boolean;
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -1651,6 +1661,8 @@ export type definitions = {
     consensus?: string;
     /** @description Notes for a Policy. */
     notes: string;
+    /** @description The time expression that triggers the Effect */
+    time?: string;
   };
   v1CreatePolicyRequest: {
     /** @enum {string} */
@@ -2026,6 +2038,32 @@ export type definitions = {
     wallet?: definitions["v1WalletResult"];
     rootUserIds?: string[];
   };
+  v1CreateSwapQuoteIntent: {
+    /** @description Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+  };
+  v1CreateSwapQuoteRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateSwapQuoteIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateSwapQuoteResult: {
+    /** @description One or more provider quotes for this request. Today this contains a single Relay quote; pass quotes[i].quoteId to execute_swap_v2 to bind execution. */
+    quotes: definitions["v1SwapQuote"][];
+  };
   v1CreateTvcAppIntent: {
     /** @description The name of the new TVC application */
     name: string;
@@ -2065,6 +2103,15 @@ export type definitions = {
      * @description The required number of approvals for the manifest set
      */
     manifestSetThreshold: number;
+    /** @description The unique identifier for the TVC share set */
+    shareSetId: string;
+    /** @description The unique identifiers of the share set operators */
+    shareSetOperatorIds: string[];
+    /**
+     * Format: int64
+     * @description The required number of approvals for the share set
+     */
+    shareSetThreshold: number;
   };
   v1CreateTvcDeploymentIntent: {
     /** @description The unique identifier of the to-be-deployed TVC application */
@@ -2770,7 +2817,7 @@ export type definitions = {
       | "eip155:137"
       | "eip155:56"
       | "eip155:4217";
-    /** @description Your performance fee on gross yield, in basis points (e.g., '2000' for 20%). Your fee plus Turnkey's fee cannot exceed 50% of yield. */
+    /** @description Your fee on gross yield, in basis points (e.g., '2000' for 20%). Maximum is 4000 (40%). */
     clientFeeBps: string;
     /** @description The wallet address that receives the client's fee payouts on-chain. Must be a Turnkey-managed wallet address. */
     clientFeeWallet: string;
@@ -2837,15 +2884,15 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description CAIP-19 asset ID of the vault's underlying asset (e.g. 'eip155:8453/erc20:0x833589...'); the chain is encoded in the identifier. */
     caip19?: string;
-    /** @description Gross annual percentage yield, expressed as a decimal fraction (before Turnkey and client fees). */
+    /** @description Gross annual percentage yield, expressed as a decimal fraction (before fees). */
     apyPct?: string;
     /** @description Total deposited through this wrapper (wrapper TVL), in raw on-chain units of the underlying asset. */
     totalDeposited?: string;
     /** @description Normalized total-deposited values for display only (usd + crypto). Do not do arithmetic with these; use total_deposited instead. */
     display?: definitions["v1EarnValueDisplay"];
-    /** @description Annual percentage yield net of the Turnkey and client performance fees, expressed as a decimal fraction. */
+    /** @description Annual percentage yield net of fees, expressed as a decimal fraction. */
     netApyPct?: string;
-    /** @description Client performance fee taken on yield, in basis points. Currently org-wide; moving to a per-vault setting. */
+    /** @description Client fee taken on yield, in basis points. */
     clientFeeBps?: string;
     /** @description When true, deposits to this wrapper are rejected; withdrawals are unaffected. Toggled via EarnSetWrapperState. */
     depositsDisabled?: boolean;
@@ -2853,10 +2900,12 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
-    /** @description The client's claimable performance fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
+    /** @description The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries. */
     claimableClientFee?: string;
     /** @description Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries. */
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
+    clientFeeWallet?: string;
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3127,6 +3176,8 @@ export type definitions = {
     deliveryProcessingTimeMillis?: string;
     /** @description Delay type for DeliveryDelay events */
     deliveryDelayType?: string;
+    /** @description Feedback type for Complaint events */
+    complaintFeedbackType?: string;
   };
   v1EnableAuthProxyIntent: { [key: string]: unknown };
   v1EnableAuthProxyResult: {
@@ -3265,7 +3316,7 @@ export type definitions = {
     maxPriorityFeePerGas?: string;
     /** @description Unix timestamp in seconds for EIP-712 execution deadline. Only used when sponsor=true. */
     deadline?: string;
-    /** @description The gas station delegate contract nonce. Only used when sponsor=true. Omit to auto-fetch. */
+    /** @description The gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored transactions and non-sponsored multi-call batches. Omit to auto-fetch. Use the nonces endpoint for replay protection. */
     gasStationNonce?: string;
     /** @description Ordered list of calls to execute. Must contain between 1 and 50 entries. A single entry with sponsor=false uses EIP-1559; multiple entries use EIP-7702 batch execution via Gas Station. */
     calls: definitions["v1EthCallParams"][];
@@ -3315,6 +3366,51 @@ export type definitions = {
     /** @description Turnkey-specific metadata for transactions originated by Turnkey. */
     turnkey?: definitions["v1TransactionHistoryTurnkey"];
   };
+  v1EthUndelegate7702Intent: {
+    /** @description A wallet or private key address to undelegate. This does not support private key IDs. */
+    from: string;
+    /**
+     * @description CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet).
+     * @enum {string}
+     */
+    caip2:
+      | "eip155:1"
+      | "eip155:11155111"
+      | "eip155:8453"
+      | "eip155:84532"
+      | "eip155:137"
+      | "eip155:80002"
+      | "eip155:56"
+      | "eip155:97"
+      | "eip155:10"
+      | "eip155:11155420"
+      | "eip155:143"
+      | "eip155:10143"
+      | "eip155:42161"
+      | "eip155:421614";
+    /** @description Outer transaction nonce. Omit to auto-fetch. */
+    nonce?: string;
+    /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
+    gasLimit?: string;
+    /** @description Maximum total fee per gas unit (base fee + priority fee) in wei. Omit to auto-estimate. */
+    maxFeePerGas?: string;
+    /** @description Maximum priority fee (tip) per gas unit in wei. Omit to auto-estimate. */
+    maxPriorityFeePerGas?: string;
+  };
+  v1EthUndelegate7702Request: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_ETH_UNDELEGATE_7702";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1EthUndelegate7702Intent"];
+    generateAppProofs?: boolean;
+  };
+  v1EthUndelegate7702Result: {
+    /** @description The send_transaction_status ID associated with the undelegation transaction submission */
+    sendTransactionStatusId: string;
+  };
   v1ExecuteSwapIntent: {
     /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
     inputToken: string;
@@ -3328,24 +3424,46 @@ export type definitions = {
     sponsor?: boolean;
     /** @description Maximum allowed slippage in basis points. */
     slippage?: string;
-    /** @description Swap provider to execute with, as returned by get_swap_quote. When omitted, execution uses the default provider. */
+    /** @description Swap provider to execute with, as returned by create_swap_quote. When omitted, execution uses the default provider. */
     provider?: string;
     /** @description Minimum acceptable base-unit amount of the output asset. Execution fails if the swap provider's quoted minimum output falls below this floor at execution time. */
     minOutputAmount: string;
   };
+  v1ExecuteSwapIntentV2: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+  };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
-    type: "ACTIVITY_TYPE_EXECUTE_SWAP";
+    type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2";
     /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
     timestampMs: string;
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    parameters: definitions["v1ExecuteSwapIntent"];
+    parameters: definitions["v1ExecuteSwapIntentV2"];
     generateAppProofs?: boolean;
   };
   v1ExecuteSwapResult: {
-    /** @description The send_transaction_status ID associated with the swap transaction submission */
-    sendTransactionStatusId: string;
+    /** @description Identifier to poll swap status via GetSwapStatus. */
+    swapRequestId: string;
     /** @description Swap provider used to build the transaction. */
     provider?: string;
     /** @description Quote identifier used for execution, if any. */
@@ -3703,7 +3821,7 @@ export type definitions = {
   v1GetLatestBootProofRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Name of enclave app. */
+    /** @description Unique identifier (UUID) of the enclave app. */
     appName: string;
   };
   v1GetMfaPoliciesRequest: {
@@ -3943,35 +4061,11 @@ export type definitions = {
     /** @description List of unique identifiers for the matching sub-organizations. */
     organizationIds: string[];
   };
-  v1GetSwapQuoteRequest: {
-    /** @description Unique identifier for a given Organization. */
-    organizationId: string;
-    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description Wallet account address used to price the executable provider quote. */
-    walletAccount: string;
-    /** @description Maximum allowed slippage in basis points. */
-    slippage?: string;
-  };
-  v1GetSwapQuoteResponse: {
-    /** @description CAIP-19 asset ID for the input asset. */
-    inputToken: string;
-    /** @description CAIP-19 asset ID for the output asset. */
-    outputToken: string;
-    /** @description Base-unit amount of the input asset. */
-    inputAmount: string;
-    /** @description One quote per available swap provider. */
-    quotes: definitions["v1SwapQuoteOption"][];
-  };
   v1GetSwapStatusRequest: {
     /** @description Unique identifier for a given Organization. */
     organizationId: string;
-    /** @description Identifier returned in the execute_swap activity result. */
-    sendTransactionStatusId: string;
+    /** @description The swap_request_id returned by ExecuteSwap. */
+    swapRequestId: string;
   };
   v1GetSwapStatusResponse: {
     /** @description Normalized swap status. One of PENDING, COMPLETED, FAILED. */
@@ -3979,7 +4073,7 @@ export type definitions = {
     /** @description SAME_CHAIN or CROSS_CHAIN. */
     swapKind: string;
     /** @description Swap provider that executed the swap. */
-    provider?: string;
+    provider: string;
     /** @description CAIP-19 asset ID for the input asset. */
     inputToken: string;
     /** @description CAIP-19 asset ID for the output asset. */
@@ -3988,20 +4082,16 @@ export type definitions = {
     inputAmount: string;
     /** @description Final included origin-chain transaction hash, when known. */
     originTxHash?: string;
-    /** @description Destination-chain fill transaction hash; cross-chain COMPLETED only. */
-    destinationTxHash?: string;
-    /** @description Actual base-unit output amount on COMPLETED, when known. */
+    /** @description Provider-reported destination-chain transaction hashes; cross-chain COMPLETED only. */
+    destinationTxHashes?: string[];
+    /** @description Actual base-unit output amount on COMPLETED, when known. Unset on FAILED. */
     outputAmount?: string;
-    /** @description CAIP-19 of the asset the user holds after a FAILED swap, when recoverable. */
-    settledAsset?: string;
-    /** @description Base-unit amount of settled_asset. */
-    settledAmount?: string;
-    /** @description Transaction that delivered the settled funds, when applicable. */
-    settlementTxHash?: string;
-    /** @description Non-normative raw provider status passthrough; cross-chain only. */
-    providerStatus?: string;
+    /** @description Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED. */
+    refund?: definitions["v1SwapRefund"];
     /** @description Timestamp of the last swap status change, as millisecond epoch string. */
     updatedAt: string;
+    /** @description Normalized failure details, present whenever status is FAILED. */
+    error?: definitions["v1SwapError"];
   };
   v1GetTvcAppDeploymentsRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4164,6 +4254,7 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
+      | "eip155:421614"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4761,6 +4852,10 @@ export type definitions = {
     claimSwapFeesIntent?: definitions["v1ClaimSwapFeesIntent"];
     earnSetWrapperStateIntent?: definitions["v1EarnSetWrapperStateIntent"];
     claimEarnFeesIntent?: definitions["v1ClaimEarnFeesIntent"];
+    updateWalletAccountNameIntent?: definitions["v1UpdateWalletAccountNameIntent"];
+    ethUndelegate7702Intent?: definitions["v1EthUndelegate7702Intent"];
+    executeSwapIntentV2?: definitions["v1ExecuteSwapIntentV2"];
+    createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -4856,8 +4951,10 @@ export type definitions = {
     paginationOptions?: definitions["v1Pagination"];
   };
   v1ListEarnVaultsResponse: {
-    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass the last vault_address as the pagination after cursor. */
+    /** @description The catalog of wrappable vaults, sorted by TVL (USD) descending. To page, pass page_info.end_cursor as the pagination after cursor. */
     vaults?: definitions["v1EarnVault"][];
+    /** @description Pagination metadata for the returned page. Pass end_cursor as the next request's after cursor (or start_cursor as the before cursor) to page through the catalog. Cursors are opaque; do not parse them. */
+    pageInfo?: definitions["v1PageInfo"];
   };
   v1ListEmailEventsRequest: {
     /** @description Unique identifier for a given organization */
@@ -4972,7 +5069,8 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+      | "eip155:421614"
+      | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
   v1ListSupportedAssetsResponse: {
@@ -5305,7 +5403,14 @@ export type definitions = {
     | "OUTCOME_REQUIRES_CONSENSUS"
     | "OUTCOME_REJECTED"
     | "OUTCOME_ERROR"
-    | "OUTCOME_REQUIRES_AUTHENTICATORS";
+    | "OUTCOME_REQUIRES_AUTHENTICATORS"
+    | "OUTCOME_TIME_INACTIVE";
+  v1PageInfo: {
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+    startCursor?: string;
+    endCursor?: string;
+  };
   v1Pagination: {
     /** @description A limit of the number of object to be returned, between 1 and 100. Defaults to 10. */
     limit?: string;
@@ -5337,6 +5442,8 @@ export type definitions = {
     consensus: string;
     /** @description A condition expression that evalutes to true or false. */
     condition: string;
+    /** @description A time expression that evalutes to true or false. */
+    time?: string;
   };
   v1PostTvcQuorumKeyShareIntent: {
     /** @description Unique identifier of the TVC deployment receiving quorum key share */
@@ -5669,6 +5776,9 @@ export type definitions = {
     claimSwapFeesResult?: definitions["v1ClaimSwapFeesResult"];
     earnSetWrapperStateResult?: definitions["v1EarnSetWrapperStateResult"];
     claimEarnFeesResult?: definitions["v1ClaimEarnFeesResult"];
+    updateWalletAccountNameResult?: definitions["v1UpdateWalletAccountNameResult"];
+    ethUndelegate7702Result?: definitions["v1EthUndelegate7702Result"];
+    createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -6291,15 +6401,39 @@ export type definitions = {
     /** @description Signed JWT containing an expiry, public key, session type, user id, and organization id */
     session: string;
   };
-  v1SwapQuoteOption: {
-    /** @description Identifier for this provider quote. */
+  v1SwapError: {
+    /** @description Stable machine-readable failure reason. One of ORIGIN_TRANSACTION_FAILED or PROVIDER_FILL_FAILED. */
+    reason: string;
+    /** @description Human-readable description of the swap failure. */
+    message: string;
+    /** @description Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available. */
+    originTxError?: definitions["v1TxError"];
+  };
+  v1SwapQuote: {
+    /** @description Identifier for this provider quote. Pass this value to execute_swap_v2 to bind execution to this exact quote. The signer is derived from the quote; clients do not resupply sign_with on execute. */
     quoteId: string;
-    /** @description Swap provider that produced this quote. Pass this value to execute_swap to force a specific provider. */
+    /** @description Swap provider that produced this quote. */
     provider: string;
     /** @description Estimated base-unit amount of the output asset. */
     outputAmount: string;
     /** @description Minimum acceptable base-unit amount of the output asset after slippage. */
-    minOutputAmount?: string;
+    minOutputAmount: string;
+    /** @description Quote expiration as a millisecond epoch string. */
+    expiresAt: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set. */
+    slippageBps?: string;
+    /** @description Client fee in basis points applied for this pair. Informational only; already reflected in output_amount and min_output_amount. */
+    clientFeeBps: string;
+    /** @description Provider-estimated completion time in seconds, when available. */
+    estimatedTimeSeconds?: string;
+  };
+  v1SwapRefund: {
+    /** @description CAIP-19 asset returned to the user after a failed swap. */
+    asset: string;
+    /** @description Base-unit amount of the refunded asset. */
+    amount: string;
+    /** @description Transaction that delivered the refunded funds, when applicable. */
+    txHash?: string;
   };
   /** @enum {string} */
   v1TagType: "TAG_TYPE_USER" | "TAG_TYPE_PRIVATE_KEY";
@@ -6772,6 +6906,8 @@ export type definitions = {
     policyConsensus?: string;
     /** @description Accompanying notes for a Policy (optional). */
     policyNotes?: string;
+    /** @description The time expression that triggers the Effect (optional). */
+    time?: string;
   };
   v1UpdatePolicyRequest: {
     /** @enum {string} */
@@ -6964,6 +7100,16 @@ export type definitions = {
     /** @description Unique identifier for a given User Tag. */
     userTagId: string;
   };
+  v1UpdateWalletAccountNameIntent: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+    /** @description Human-readable name for this Wallet Account. */
+    name: string;
+  };
+  v1UpdateWalletAccountNameResult: {
+    /** @description Unique identifier for a given Wallet Account. */
+    walletAccountId: string;
+  };
   v1UpdateWalletIntent: {
     /** @description Unique identifier for a given Wallet. */
     walletId: string;
@@ -7030,8 +7176,7 @@ export type definitions = {
     feeReceiverWalletAddress?: string;
     /** @description Client fee in basis points applied to swaps; used for all pairs unless stable_fee_bps is set. */
     feeBps?: string;
-    provider?: string;
-    /** @description Optional override applied when both swap assets are stablecoins; falls back to fee_bps when unset. */
+    /** @description Optional Enterprise-only override applied when both swap assets are stablecoins; falls back to fee_bps when unset. Non-Enterprise orgs may only set fee_bps. */
     stableFeeBps?: string;
   };
   v1UpsertSwapConfigRequest: {
@@ -7853,25 +7998,7 @@ export type operations = {
       };
     };
   };
-  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
-  PublicApiService_GetSwapQuote: {
-    parameters: {
-      body: {
-        body: definitions["v1GetSwapQuoteRequest"];
-      };
-    };
-    responses: {
-      /** A successful response. */
-      200: {
-        schema: definitions["v1GetSwapQuoteResponse"];
-      };
-      /** An unexpected error response. */
-      default: {
-        schema: definitions["rpcStatus"];
-      };
-    };
-  };
-  /** Get the status of a swap by the send_transaction_status_id returned from execute_swap. Covers same-chain and cross-chain swaps. */
+  /** Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps. */
   PublicApiService_GetSwapStatus: {
     parameters: {
       body: {
@@ -8861,6 +8988,24 @@ export type operations = {
       };
     };
   };
+  /** Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported. */
+  PublicApiService_CreateSwapQuote: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateSwapQuoteRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a new TVC application */
   PublicApiService_CreateTvcApp: {
     parameters: {
@@ -9527,7 +9672,25 @@ export type operations = {
       };
     };
   };
-  /** Execute a quoted swap through the activity pipeline and Turnkey broadcasting. */
+  /** Submit an EIP-7702 undelegation transaction. */
+  PublicApiService_EthUndelegate7702: {
+    parameters: {
+      body: {
+        body: definitions["v1EthUndelegate7702Request"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2. */
   PublicApiService_ExecuteSwap: {
     parameters: {
       body: {


### PR DESCRIPTION
## Summary & Motivation
Update sdk as per mono v2026.8.0
## How I Tested These Changes
Update sdk as per mono v2026.8.0
## Did you add a changeset?
YES
If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
