### PR TITLE
fix(core): forward explicit stampWith to eth send and status polling

### DIFF
--- a/.changeset/silly-cars-jump.md
+++ b/.changeset/silly-cars-jump.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/core": patch
+---
+
+Fixed `ethSendTransaction` and the transaction-status polling used by `pollTransactionStatus` ignoring an explicit `stampWith` and falling back to the client's default stamper. Callers who passed `stampWith` (e.g. to require a passkey) were previously signed with the default stamper instead.

--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -2995,14 +2995,20 @@ export class TurnkeyClient {
         // TODO (breaking change): eventually, we wont generate the v1 activity at all, remove this check and update the intent.
         const resp =
           "calls" in transaction
-            ? await this.httpClient.ethSendTransactionV2({
-                ...transaction,
-                organizationId,
-              })
-            : await this.httpClient.ethSendTransaction({
-                ...transaction,
-                organizationId,
-              });
+            ? await this.httpClient.ethSendTransactionV2(
+                {
+                  ...transaction,
+                  organizationId,
+                },
+                stampWith,
+              )
+            : await this.httpClient.ethSendTransaction(
+                {
+                  ...transaction,
+                  organizationId,
+                },
+                stampWith,
+              );
 
         const id = resp.sendTransactionStatusId;
         if (!id) {
@@ -3166,10 +3172,13 @@ export class TurnkeyClient {
           const timeoutMs = 60_000; // 1 minute
 
           const ref = setInterval(async () => {
-            const resp = await this.httpClient.getSendTransactionStatus({
-              organizationId,
-              sendTransactionStatusId,
-            });
+            const resp = await this.httpClient.getSendTransactionStatus(
+              {
+                organizationId,
+                sendTransactionStatusId,
+              },
+              stampWith,
+            );
 
             const txStatus = resp?.txStatus;
 

--- a/packages/core/src/__tests__/eth-send-transaction-test.ts
+++ b/packages/core/src/__tests__/eth-send-transaction-test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+jest.mock(
+  "@polyfills/window",
+  () => ({
+    __esModule: true,
+    default: {
+      localStorage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    },
+  }),
+  { virtual: true },
+);
+jest.mock(
+  "@utils",
+  () => ({
+    __esModule: true,
+    parseSession: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+import { TurnkeyClient } from "../__clients__/core";
+import { StamperType } from "../__types__";
+
+function createClient(): {
+  client: TurnkeyClient;
+  ethSendTransaction: jest.Mock;
+  ethSendTransactionV2: jest.Mock;
+} {
+  const client = new TurnkeyClient({
+    organizationId: "org-id",
+  });
+
+  (client as any).storageManager = {
+    getActiveSession: async () => undefined,
+  };
+
+  const ethSendTransaction = jest.fn(async () => ({
+    sendTransactionStatusId: "status-id",
+  }));
+  const ethSendTransactionV2 = jest.fn(async () => ({
+    sendTransactionStatusId: "status-id-v2",
+  }));
+
+  (client as any).httpClient = {
+    ethSendTransaction,
+    ethSendTransactionV2,
+  };
+
+  return { client, ethSendTransaction, ethSendTransactionV2 };
+}
+
+describe("ethSendTransaction", () => {
+  it("forwards an explicit stampWith to the v1 endpoint", async () => {
+    const { client, ethSendTransaction } = createClient();
+
+    await client.ethSendTransaction({
+      organizationId: "org-id",
+      stampWith: StamperType.Passkey,
+      transaction: {
+        from: "0xfrom",
+        to: "0xto",
+        caip2: "eip155:1",
+      },
+    });
+
+    expect(ethSendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "0xfrom",
+        to: "0xto",
+        caip2: "eip155:1",
+        organizationId: "org-id",
+      }),
+      StamperType.Passkey,
+    );
+  });
+
+  it("forwards an explicit stampWith to the v2 endpoint", async () => {
+    const { client, ethSendTransactionV2 } = createClient();
+
+    await client.ethSendTransaction({
+      organizationId: "org-id",
+      stampWith: StamperType.Passkey,
+      transaction: {
+        from: "0xfrom",
+        caip2: "eip155:1",
+        calls: [{ to: "0xto" }],
+      },
+    });
+
+    expect(ethSendTransactionV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "0xfrom",
+        caip2: "eip155:1",
+        calls: [{ to: "0xto" }],
+        organizationId: "org-id",
+      }),
+      StamperType.Passkey,
+    );
+  });
+});

--- a/packages/core/src/__tests__/poll-transaction-status-test.ts
+++ b/packages/core/src/__tests__/poll-transaction-status-test.ts
@@ -137,4 +137,39 @@ describe("pollTransactionStatus", () => {
       cause: response,
     });
   });
+
+  it("forwards an explicit stampWith when fetching the transaction status", async () => {
+    jest.useFakeTimers();
+
+    const getSendTransactionStatus = jest.fn(async () => ({
+      txStatus: "INCLUDED",
+      eth: { txHash: "0xhash" },
+    }));
+
+    const client = new TurnkeyClient({
+      organizationId: "org-id",
+    });
+    (client as any).storageManager = {
+      getActiveSession: async () => undefined,
+    };
+    (client as any).httpClient = { getSendTransactionStatus };
+
+    const promise = client.pollTransactionStatus({
+      organizationId: "org-id",
+      sendTransactionStatusId: "status-id",
+      stampWith: StamperType.Passkey,
+      pollingIntervalMs: 10,
+    });
+
+    await jest.advanceTimersByTimeAsync(10);
+    await promise;
+
+    expect(getSendTransactionStatus).toHaveBeenCalledWith(
+      {
+        organizationId: "org-id",
+        sendTransactionStatusId: "status-id",
+      },
+      StamperType.Passkey,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

`TurnkeyClient.ethSendTransaction()` accepts a per-call `stampWith`, but both Ethereum dispatch paths omitted it when invoking the generated HTTP client. The generated client treats a missing value as permission to use its configured default stamper, so a caller who explicitly passed `stampWith` (for example to require a passkey) had the request signed with the default API-key/session stamper instead, with no error.

`solSendTransaction` immediately below already forwards `stampWith` on both of its paths; this brings the Ethereum paths in line.

## Changes

- `ethSendTransaction` now forwards `stampWith` to both `ethSendTransactionV2` and `ethSendTransaction` on the generated client.
- `pollTransactionStatus` now forwards `stampWith` to `getSendTransactionStatus`. This had the same omission, found while auditing the rest of the file.
- Regression tests asserting `stampWith` is forwarded on both eth dispatch paths and when fetching transaction status.
- Patch changeset for `@turnkey/core`.

An audit of all 65 `this.httpClient.*` call sites in `__clients__/core.ts` found these two as the only cases where an in-scope `stampWith` was dropped by a method that accepts one. Every other call site either does not take `stampWith` or already forwards it.

## Testing

- `pnpm --filter @turnkey/core typecheck` — clean.
- `pnpm --filter @turnkey/core test` — 80 passed, 2 failed. Both failures are pre-existing `utils-test.ts` base58-mock cases (`addressFromPublicKey`, `getAuthenticatorAddresses`) that fail identically with these changes stashed.
- Both new tests were confirmed to fail against the unpatched client and pass with the fix.

## Note for reviewers

`getStamper()` in `__generated__/sdk-client-base.ts` silently returns `this.apiKeyStamper` from its `default:` case for unrecognized values, which is what turns a dropped parameter into a silent fallback rather than an error. That file is codegen output, so hardening it belongs in the generator and is intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)