### PR TITLE
fix(react-wallet-kit): only show OTP-screen captcha when resending

### DIFF
--- a/.changeset/nice-days-cut.md
+++ b/.changeset/nice-days-cut.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/react-wallet-kit": patch
+---
+
+Only render the OTP screen's Turnstile widget when the user requests a new code; submitting the code never used it.

--- a/packages/react-wallet-kit/src/components/auth/OTP.tsx
+++ b/packages/react-wallet-kit/src/components/auth/OTP.tsx
@@ -42,8 +42,15 @@ export function OtpVerification(props: OtpVerificationProps) {
   const [error, setError] = useState<string | null>(null);
   const [shaking, setShaking] = useState(false);
 
-  const { turnstile, consumeToken, authEnabled, turnstileConfigured } =
-    useTurnstile({ visible: !submitting });
+  // Deferred: entering the code doesn't need a captcha, only resending does. The
+  // widget stays unmounted until the user actually asks for a new code.
+  const { turnstile, requestToken, turnstileConfigured } = useTurnstile({
+    visible: !submitting,
+    deferred: true,
+  });
+
+  // The widget is only ever on screen while a resend is waiting on a challenge.
+  const awaitingCaptcha = turnstile !== null;
 
   const shakeInput = () => {
     setShaking(true);
@@ -83,7 +90,7 @@ export function OtpVerification(props: OtpVerificationProps) {
     setResending(true);
     setError(null);
     try {
-      const captchaParams = await consumeToken();
+      const captchaParams = await requestToken();
       if (turnstileConfigured && !("captchaToken" in captchaParams)) {
         setError("Please complete the CAPTCHA verification before continuing.");
         return;
@@ -146,18 +153,16 @@ export function OtpVerification(props: OtpVerificationProps) {
         )}
         <BaseButton
           onClick={handleResend}
-          disabled={resending || resent || !authEnabled}
-          className={`text-xs text-inherit font-semibold bg-transparent border-none ${(resent || !authEnabled) && "opacity-30"}`}
+          disabled={resending || resent}
+          className={`text-xs text-inherit font-semibold bg-transparent border-none ${resent && "opacity-30"}`}
         >
           {resending ? (
             <span className="flex items-center gap-2.5">
               <Spinner className="size-3" />
-              Resending...
+              {awaitingCaptcha ? "Waiting for verification..." : "Resending..."}
             </span>
           ) : resent ? (
             "Code sent!"
-          ) : !authEnabled ? (
-            "Waiting for verification..."
           ) : (
             "Resend Code"
           )}

--- a/packages/react-wallet-kit/src/components/auth/TurnstileWidget.tsx
+++ b/packages/react-wallet-kit/src/components/auth/TurnstileWidget.tsx
@@ -3,10 +3,19 @@ import { Turnstile, type TurnstileInstance } from "./Turnstile";
 import { useTurnkey } from "../../providers/client/Hook";
 import { consumeCaptchaToken } from "../../utils/captcha";
 
+// How long `requestToken` waits for the user to clear an interactive challenge
+// before giving up. Generous, because the challenge only starts once the user
+// has asked for the gated action.
+const INTERACTIVE_CHALLENGE_TIMEOUT_MS = 120_000;
+
 interface UseTurnstileOptions {
   // Allows the caller to hide the widget while it's busy (e.g. while a request
   // is in flight). The widget is still subject to its own visibility rules.
   visible?: boolean;
+  // When true, nothing is rendered until `requestToken()` is called. Use this on
+  // screens where the captcha only guards an optional secondary action, so users
+  // who never take that action are never shown a challenge.
+  deferred?: boolean;
 }
 
 /**
@@ -20,10 +29,12 @@ interface UseTurnstileOptions {
  *   existed on mount). Cleared when a token is consumed or wait times out,
  *   then set back to `true` on widget `onSuccess`.
  * - `consumeToken`: waits for and consumes the current token before a request.
+ * - `requestToken`: mounts the widget on demand (in `deferred` mode) and waits
+ *   for the user to clear the challenge before consuming the token.
  * - `turnstileConfigured`: whether a Turnstile site key is present.
  */
 export function useTurnstile(options?: UseTurnstileOptions) {
-  const { visible = true } = options ?? {};
+  const { visible = true, deferred = false } = options ?? {};
   const { config, getTurnstileToken, setTurnstileToken } = useTurnkey();
 
   const turnstileConfigured = !!config?.turnstileSiteKey;
@@ -40,6 +51,15 @@ export function useTurnstile(options?: UseTurnstileOptions) {
   const [turnstileErrorMessage, setTurnstileErrorMessage] = useState<
     string | null
   >(null);
+  // In deferred mode the widget stays unmounted until `requestToken` arms it.
+  const [armed, setArmed] = useState(!deferred);
+  // Resolver for an in-flight `requestToken`, settled by onSuccess/onError.
+  const pendingToken = useRef<((token: string | null) => void) | null>(null);
+
+  const settlePendingToken = (token: string | null) => {
+    pendingToken.current?.(token);
+    pendingToken.current = null;
+  };
 
   const consumeToken = async () => {
     const result = await consumeCaptchaToken(
@@ -60,13 +80,42 @@ export function useTurnstile(options?: UseTurnstileOptions) {
     return result;
   };
 
+  /**
+   * Obtains a token for a user-initiated action. Resolves right away when one is
+   * already pre-warmed, so no challenge is ever shown; otherwise mounts the
+   * widget now and waits for the user to clear it. Returns `{}` if the challenge
+   * failed or was never completed.
+   */
+  const requestToken = async () => {
+    if (!turnstileConfigured) return {};
+    if (getTurnstileToken()) return consumeToken();
+
+    setArmed(true);
+    const token = await new Promise<string | null>((resolve) => {
+      pendingToken.current = resolve;
+      setTimeout(() => {
+        if (pendingToken.current === resolve) settlePendingToken(null);
+      }, INTERACTIVE_CHALLENGE_TIMEOUT_MS);
+    });
+    // Re-hide so an unused challenge never lingers on screen.
+    if (deferred) setArmed(false);
+
+    // onSuccess already stored the token, so consumeToken resolves immediately.
+    return token ? consumeToken() : {};
+  };
+
   const shouldRender =
-    turnstileConfigured && visible && (!hadTokenOnMount || showTurnstileError);
+    turnstileConfigured &&
+    visible &&
+    // Deferred callers render only once `requestToken` arms them; whether a token
+    // existed at mount is moot by then, since it's already been consumed.
+    (deferred ? armed : !hadTokenOnMount || showTurnstileError);
 
   const onSuccess = (token: string) => {
     setTurnstileToken(token);
     setAuthEnabled(true);
     setTurnstileErrorMessage(null);
+    settlePendingToken(token);
   };
 
   const onError = () => {
@@ -74,6 +123,7 @@ export function useTurnstile(options?: UseTurnstileOptions) {
     setAuthEnabled(false);
     setShowTurnstileError(true);
     setTurnstileErrorMessage("Verification failed. Please try again.");
+    settlePendingToken(null);
   };
 
   const onExpire = () => {
@@ -122,5 +172,11 @@ export function useTurnstile(options?: UseTurnstileOptions) {
       </>
     ) : null;
 
-  return { turnstile, consumeToken, authEnabled, turnstileConfigured };
+  return {
+    turnstile,
+    consumeToken,
+    requestToken,
+    authEnabled,
+    turnstileConfigured,
+  };
 }


### PR DESCRIPTION
## Summary & Motivation

During the initial screen of the auth modal, the captcha correctly runs. But after logging in, the OTP view gets shown, and it was incorrectly loading a captcha. It was not requiring the captcha to be verified before entering the OTP code, which is correct.

The fix is to *not* display the captcha in the OTP view unless resending the code.

Added a `deferred` option to `useTurnstile` that keeps the widget unmounted until `requestToken()` asks for it, and turned it on for the OTP screen. A challenge now appears only if you click Resend and there's no usable token already.

## How I Tested These Changes
Locally. Forced widget to render.

## Did you add a changeset?

Yes
