### PR TITLE
Secrets API examples: api-key-storage and programmable-credential-access

### DIFF
--- a/examples/key-management/api-key-storage/.env.local.example
+++ b/examples/key-management/api-key-storage/.env.local.example
@@ -1,0 +1,4 @@
+API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
+API_PRIVATE_KEY="<Turnkey API Private Key>"
+BASE_URL="https://api.turnkey.com"
+ORGANIZATION_ID="<Turnkey organization ID>"

--- a/examples/key-management/api-key-storage/README.md
+++ b/examples/key-management/api-key-storage/README.md
@@ -1,0 +1,54 @@
+# Example: `api-key-storage`
+
+This example demonstrates programmatic API key storage with Turnkey secrets, following the [API key storage](https://docs.turnkey.com/solutions/key-management/api-key-storage) solution:
+
+- Creating a trading service user with its own API key
+- Importing an API key as a secret, with policy-visible static properties bound at import time
+- Creating a policy that scopes retrieval of trade-only exchange keys to that service user
+- Listing the organization's secrets (metadata only)
+- Retrieving the plaintext at runtime with `exportSecret`, as the service user
+
+For a multi-party retrieval flow where two agents approve the same export in parallel, see the [`programmable-credential-access`](../programmable-credential-access/) example.
+
+## Getting started
+
+### 1/ Cloning the example
+
+Make sure you have `Node.js` installed locally; we recommend using Node v18+.
+
+```bash
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/key-management/api-key-storage/
+```
+
+### 2/ Setting up Turnkey
+
+The first step is to set up your Turnkey organization. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
+
+- A public/private API key pair for Turnkey
+- An organization ID
+
+Once you've gathered these values, add them to a new `.env.local` file. Notice that your private key should be securely managed and **_never_** be committed to git.
+
+```bash
+$ cp .env.local.example .env.local
+```
+
+Now open `.env.local` and add the missing environment variables:
+
+- `API_PUBLIC_KEY`
+- `API_PRIVATE_KEY`
+- `BASE_URL`
+- `ORGANIZATION_ID`
+
+### 3/ Running the script
+
+```bash
+$ pnpm start
+```
+
+The script creates the trading service user, imports a demo credential, creates the retrieval policy, lists the org's secrets, exports the credential as the service user, and verifies the round trip.

--- a/examples/key-management/api-key-storage/package.json
+++ b/examples/key-management/api-key-storage/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@turnkey/example-api-key-storage",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "pnpm tsx src/index.ts",
+    "clean": "rimraf ./dist ./.cache",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@turnkey/crypto": "workspace:*",
+    "@turnkey/sdk-server": "workspace:*",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/examples/key-management/api-key-storage/src/index.ts
+++ b/examples/key-management/api-key-storage/src/index.ts
@@ -1,0 +1,110 @@
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { Turnkey } from "@turnkey/sdk-server";
+import { generateP256KeyPair } from "@turnkey/crypto";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+// Store an exchange API key as a Turnkey secret, gate its retrieval with a
+// policy, list the org's secrets, and retrieve the plaintext at runtime.
+// See https://docs.turnkey.com/solutions/key-management/api-key-storage
+async function main() {
+  const organizationId = process.env.ORGANIZATION_ID!;
+  const apiBaseUrl = process.env.BASE_URL!;
+  const suffix = Date.now();
+
+  const apiClient = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    defaultOrganizationId: organizationId,
+  }).apiClient();
+
+  // 0/ Model the trading service as its own Turnkey user with its own API key,
+  // so the example is self-contained and the retrieval below runs as a
+  // non-root user that only the policy in step 2 authorizes. In production
+  // these would be scoped, expiring session keys.
+  const tradingServiceKeyPair = generateP256KeyPair();
+  const { userIds } = await apiClient.createUsers({
+    users: [
+      {
+        userName: `trading-service-${suffix}`,
+        apiKeys: [
+          {
+            apiKeyName: "trading-service-key",
+            publicKey: tradingServiceKeyPair.publicKey,
+            curveType: "API_KEY_CURVE_P256",
+          },
+        ],
+        authenticators: [],
+        oauthProviders: [],
+        userTags: [],
+      },
+    ],
+  });
+  const [userId] = userIds;
+  console.log(`Created trading service user with id: ${userId}`);
+
+  const tradingService = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: tradingServiceKeyPair.publicKey,
+    apiPrivateKey: tradingServiceKeyPair.privateKey,
+    defaultOrganizationId: organizationId,
+  }).apiClient();
+
+  // 1/ Import the credential. The plaintext is encrypted to a single-use
+  // enclave target key on this machine; Turnkey's API and database only ever
+  // see ciphertext. The static properties are bound immutably at import time
+  // so policies can target classes of keys instead of individual IDs.
+  const emsJwt = `demo-ems-jwt-${suffix}`;
+  const secretId = await apiClient.importSecret({
+    plaintext: emsJwt,
+    name: `ems-trading-key-${suffix}`,
+    staticProperties: {
+      kind: "exchangeApiKey",
+      permissions: "trade",
+      environment: "production",
+    },
+  });
+  console.log(`Imported secret with id: ${secretId}`);
+
+  // 2/ Gate retrieval with a policy: only this service user may export
+  // trade-only exchange keys.
+  const { policyId } = await apiClient.createPolicy({
+    policyName: `Trading service can retrieve trade-only exchange keys (${suffix})`,
+    effect: "EFFECT_ALLOW",
+    consensus: `approvers.any(u, u.id == '${userId}')`,
+    condition:
+      `secret.static_properties['kind'] == 'exchangeApiKey' && ` +
+      `secret.static_properties['permissions'] == 'trade' && ` +
+      `activity.type == 'ACTIVITY_TYPE_EXPORT_SECRETS'`,
+    notes:
+      "Scopes retrieval of trade-only exchange keys to the trading service",
+  });
+  console.log(`Created retrieval policy with id: ${policyId}`);
+
+  // 3/ List the organization's secrets. Only metadata comes back; the
+  // plaintext never leaves the enclave on this path.
+  const secrets = await apiClient.getSecrets();
+  console.log(`Organization has ${secrets.length} secret(s):`);
+  for (const secret of secrets) {
+    console.log(
+      `- ${secret.secretId} (${secret.name ?? "<unnamed>"}) ${JSON.stringify(secret.staticProperties)}`,
+    );
+  }
+
+  // 4/ Retrieve the credential at runtime, as the trading service user the
+  // policy authorizes. exportSecret generates an ephemeral P-256 keypair,
+  // submits the export activity, and decrypts the payload into this process's
+  // memory only.
+  const exported = await tradingService.exportSecret({ secretId });
+  if (exported !== emsJwt) {
+    throw new Error("Exported plaintext does not match the imported value");
+  }
+  console.log(`Exported secret plaintext matches the imported credential ✅`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/key-management/api-key-storage/tsconfig.json
+++ b/examples/key-management/api-key-storage/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"]
+}

--- a/examples/key-management/programmable-credential-access/.env.local.example
+++ b/examples/key-management/programmable-credential-access/.env.local.example
@@ -1,0 +1,4 @@
+API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
+API_PRIVATE_KEY="<Turnkey API Private Key>"
+BASE_URL="https://api.turnkey.com"
+ORGANIZATION_ID="<Turnkey organization ID>"

--- a/examples/key-management/programmable-credential-access/README.md
+++ b/examples/key-management/programmable-credential-access/README.md
@@ -1,0 +1,56 @@
+# Example: `programmable-credential-access`
+
+This example demonstrates multi-agent consensus for credential access with Turnkey secrets, following the [Programmable credential access](https://docs.turnkey.com/solutions/key-management/programmable-credential-access) solution:
+
+- Modeling two agent roles (a payment agent and a browser agent) as Turnkey users
+- Importing a credit card as a secret with policy-visible static properties
+- Creating a consensus policy that requires both agents to approve any export
+- Both agents signing and submitting the byte-identical export proposal in parallel
+- The payment agent — and only the payment agent — decrypting the released payload
+
+For the single-service retrieval flow, see the [`api-key-storage`](../api-key-storage/) example.
+
+## Getting started
+
+### 1/ Cloning the example
+
+Make sure you have `Node.js` installed locally; we recommend using Node v18+.
+
+```bash
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/key-management/programmable-credential-access/
+```
+
+### 2/ Setting up Turnkey
+
+The first step is to set up your Turnkey organization. By following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart) guide, you should have:
+
+- A public/private API key pair for Turnkey (a root user: the script creates the agent users and the policy)
+- An organization ID
+
+Once you've gathered these values, add them to a new `.env.local` file. Notice that your private key should be securely managed and **_never_** be committed to git.
+
+```bash
+$ cp .env.local.example .env.local
+```
+
+Now open `.env.local` and add the missing environment variables:
+
+- `API_PUBLIC_KEY`
+- `API_PRIVATE_KEY`
+- `BASE_URL`
+- `ORGANIZATION_ID`
+
+### 3/ Running the script
+
+```bash
+$ pnpm start
+```
+
+The script creates the two agent users with locally generated API keys, imports a demo card, creates the consensus policy, has both agents co-sign the export in parallel, and verifies that the payment agent can decrypt the released payload.
+
+Note: each run creates two new users and a policy in your organization (names are timestamped so reruns don't collide); clean them up from the dashboard as needed.

--- a/examples/key-management/programmable-credential-access/package.json
+++ b/examples/key-management/programmable-credential-access/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@turnkey/example-programmable-credential-access",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "pnpm tsx src/index.ts",
+    "clean": "rimraf ./dist ./.cache",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@turnkey/crypto": "workspace:*",
+    "@turnkey/sdk-server": "workspace:*",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/examples/key-management/programmable-credential-access/src/index.ts
+++ b/examples/key-management/programmable-credential-access/src/index.ts
@@ -1,0 +1,164 @@
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { Turnkey, TurnkeyApiClient } from "@turnkey/sdk-server";
+import { generateP256KeyPair } from "@turnkey/crypto";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+// Multi-agent consensus for credential access: a browser agent and a payment
+// agent must both sign the same export before the enclave releases a stored
+// credit card, and only the payment agent holds the decryption key.
+// See https://docs.turnkey.com/solutions/key-management/programmable-credential-access
+async function main() {
+  const organizationId = process.env.ORGANIZATION_ID!;
+  const apiBaseUrl = process.env.BASE_URL!;
+
+  const rootClient = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    defaultOrganizationId: organizationId,
+  }).apiClient();
+
+  // 1/ Model each agent role as a durable Turnkey user with its own API key.
+  // In production these would be scoped, expiring session keys; a long-lived
+  // API key keeps the example self-contained.
+  const paymentAgentKeyPair = generateP256KeyPair();
+  const browserAgentKeyPair = generateP256KeyPair();
+  const suffix = Date.now();
+  const { userIds } = await rootClient.createUsers({
+    users: [
+      {
+        userName: `payment-agent-${suffix}`,
+        apiKeys: [
+          {
+            apiKeyName: "payment-agent-key",
+            publicKey: paymentAgentKeyPair.publicKey,
+            curveType: "API_KEY_CURVE_P256",
+          },
+        ],
+        authenticators: [],
+        oauthProviders: [],
+        userTags: [],
+      },
+      {
+        userName: `browser-agent-${suffix}`,
+        apiKeys: [
+          {
+            apiKeyName: "browser-agent-key",
+            publicKey: browserAgentKeyPair.publicKey,
+            curveType: "API_KEY_CURVE_P256",
+          },
+        ],
+        authenticators: [],
+        oauthProviders: [],
+        userTags: [],
+      },
+    ],
+  });
+  const [paymentAgentUserId, browserAgentUserId] = userIds;
+  console.log(
+    `Created agent users: payment-agent (${paymentAgentUserId}), browser-agent (${browserAgentUserId})`,
+  );
+
+  const paymentAgent = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: paymentAgentKeyPair.publicKey,
+    apiPrivateKey: paymentAgentKeyPair.privateKey,
+    defaultOrganizationId: organizationId,
+  }).apiClient();
+  const browserAgent = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: browserAgentKeyPair.publicKey,
+    apiPrivateKey: browserAgentKeyPair.privateKey,
+    defaultOrganizationId: organizationId,
+  }).apiClient();
+
+  // 2/ Import the credential with static properties the consensus policy
+  // targets. The plaintext is encrypted to the enclave on this machine.
+  const card = JSON.stringify({
+    number: "4242424242424242",
+    exp: "11/29",
+    cvv: "123",
+  });
+  const secretId = await rootClient.importSecret({
+    plaintext: card,
+    name: `corporate-visa-${suffix}`,
+    staticProperties: {
+      kind: "creditCard",
+      requiresConsensus: "true",
+    },
+  });
+  console.log(`Imported secret with id: ${secretId}`);
+
+  // 3/ Require both agent roles to approve before the card is released.
+  const { policyId } = await rootClient.createPolicy({
+    policyName: `Require both agents for credit card access (${suffix})`,
+    effect: "EFFECT_ALLOW",
+    consensus:
+      `approvers.any(u, u.id == '${paymentAgentUserId}') && ` +
+      `approvers.any(u, u.id == '${browserAgentUserId}')`,
+    condition:
+      `secret.static_properties['requiresConsensus'] == 'true' && ` +
+      `secret.static_properties['kind'] == 'creditCard' && ` +
+      `activity.type == 'ACTIVITY_TYPE_EXPORT_SECRETS'`,
+    notes: "Neither agent can retrieve the card alone",
+  });
+  console.log(`Created consensus policy with id: ${policyId}`);
+
+  // 4/ The payment agent — the intended recipient — generates an ephemeral
+  // keypair and builds the proposal locally (no network call). The proposal
+  // contains no key material and can be shared with co-signers over any
+  // channel.
+  // The export activity requires a 65-byte uncompressed target key.
+  const {
+    privateKey: embeddedPrivateKey,
+    publicKeyUncompressed: targetPublicKey,
+  } = generateP256KeyPair();
+  const proposal = paymentAgent.createExportSecretsProposal({
+    secrets: [{ secretId }],
+    targetPublicKey,
+    organizationId,
+  });
+  console.log(
+    `Built export proposal with fingerprint: ${proposal.fingerprint}`,
+  );
+
+  // 5/ Both agents stamp and submit the byte-identical proposal in parallel.
+  // Order doesn't matter: the first submission creates the activity and the
+  // other registers as an approval vote. If the two submissions race to
+  // create the activity, the loser gets a conflict error and its retry lands
+  // as the approval.
+  const submitAsAgent = async (agent: TurnkeyApiClient, label: string) => {
+    try {
+      const result = await agent.submitExportSecrets(proposal);
+      console.log(`${label} submitted: ${result.status}`);
+    } catch (_) {
+      const result = await agent.submitExportSecrets(proposal);
+      console.log(
+        `${label} submitted (after conflict retry): ${result.status}`,
+      );
+    }
+  };
+  await Promise.all([
+    submitAsAgent(paymentAgent, "payment-agent"),
+    submitAsAgent(browserAgent, "browser-agent"),
+  ]);
+
+  // 6/ Consensus is satisfied, so the enclave re-encrypts the card to the
+  // payment agent's ephemeral key. The browser agent approved the export but
+  // cannot read the payload.
+  const [exportedCard] = await paymentAgent.awaitExportedSecrets({
+    proposal,
+    embeddedPrivateKey,
+  });
+  if (exportedCard !== card) {
+    throw new Error("Exported plaintext does not match the imported value");
+  }
+  console.log(`Payment agent decrypted the card after both approvals ✅`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/key-management/programmable-credential-access/src/index.ts
+++ b/examples/key-management/programmable-credential-access/src/index.ts
@@ -115,10 +115,13 @@ async function main() {
     privateKey: embeddedPrivateKey,
     publicKeyUncompressed: targetPublicKey,
   } = generateP256KeyPair();
+  // The timestamp is part of the signed bytes, so every co-signer shares this
+  // one value: the proposal is built once and passed around.
   const proposal = paymentAgent.createExportSecretsProposal({
     secrets: [{ secretId }],
     targetPublicKey,
     organizationId,
+    timestampMs: String(Date.now()),
   });
   console.log(
     `Built export proposal with fingerprint: ${proposal.fingerprint}`,
@@ -133,14 +136,16 @@ async function main() {
     try {
       const result = await agent.submitExportSecrets(proposal);
       console.log(`${label} submitted: ${result.status}`);
+      return result;
     } catch (_) {
       const result = await agent.submitExportSecrets(proposal);
       console.log(
         `${label} submitted (after conflict retry): ${result.status}`,
       );
+      return result;
     }
   };
-  await Promise.all([
+  const [paymentSubmission] = await Promise.all([
     submitAsAgent(paymentAgent, "payment-agent"),
     submitAsAgent(browserAgent, "browser-agent"),
   ]);
@@ -151,6 +156,7 @@ async function main() {
   const [exportedCard] = await paymentAgent.awaitExportedSecrets({
     proposal,
     embeddedPrivateKey,
+    activityId: paymentSubmission.activityId,
   });
   if (exportedCard !== card) {
     throw new Error("Exported plaintext does not match the imported value");

--- a/examples/key-management/programmable-credential-access/tsconfig.json
+++ b/examples/key-management/programmable-credential-access/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"]
+}

--- a/packages/sdk-server/src/secrets.ts
+++ b/packages/sdk-server/src/secrets.ts
@@ -59,7 +59,7 @@ export type ExportSecretParams = {
 
 export type CreateExportSecretsProposalParams = {
   secrets: { secretId: string }[];
-  /** Recipient's ephemeral P-256 public key (compressed hex). Only the holder of the private half can decrypt the export. */
+  /** Recipient's ephemeral P-256 public key (65-byte uncompressed hex, e.g. `generateP256KeyPair().publicKeyUncompressed`). Only the holder of the private half can decrypt the export. */
   targetPublicKey: string;
   organizationId?: string;
   /** Part of the signed bytes: all co-signers share this value. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3576,6 +3576,18 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/sdk-server
 
+  examples/key-management/api-key-storage:
+    dependencies:
+      '@turnkey/crypto':
+        specifier: workspace:*
+        version: link:../../../packages/crypto
+      '@turnkey/sdk-server':
+        specifier: workspace:*
+        version: link:../../../packages/sdk-server
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.6.1
+
   examples/key-management/disaster-recovery:
     dependencies:
       '@peculiar/webcrypto':
@@ -3809,6 +3821,18 @@ importers:
       '@types/prompts':
         specifier: ^2.4.2
         version: 2.4.2
+
+  examples/key-management/programmable-credential-access:
+    dependencies:
+      '@turnkey/crypto':
+        specifier: workspace:*
+        version: link:../../../packages/crypto
+      '@turnkey/sdk-server':
+        specifier: workspace:*
+        version: link:../../../packages/sdk-server
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.6.1
 
   examples/key-management/wallet-export-sign:
     dependencies:


### PR DESCRIPTION
Stacked on #1479.

Adds two runnable examples under `examples/key-management/`, mirroring the docs solution pages:

- **`api-key-storage`** ([docs](https://docs.turnkey.com/solutions/key-management/api-key-storage)): imports an exchange API key as a secret with policy-visible static properties, creates a policy scoping retrieval of trade-only keys to a service user, lists the org's secrets, and retrieves the plaintext with `exportSecret`.
- **`programmable-credential-access`** ([docs](https://docs.turnkey.com/solutions/key-management/programmable-credential-access)): multi-agent consensus. Bootstraps `payment-agent` and `browser-agent` users with locally generated P-256 API keys, imports a credit card secret, creates a policy requiring both agents to approve any export, has both agents submit the byte-identical export proposal in parallel (with a conflict retry for the create-activity race), and decrypts on the payment-agent side only.

Both examples typecheck; the lockfile diff is hand-minimized to the two new importers and validates under `--frozen-lockfile`. Not run against a live org (requires a secrets-beta-enabled org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)