### PR TITLE
added missing captchaToken param to signUpWithWallet request

### DIFF
--- a/.changeset/tidy-numbers-learn.md
+++ b/.changeset/tidy-numbers-learn.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/core": patch
+---
+
+Added missing optional captchaToken param to `SignUpWithWalletParams`

--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -1224,6 +1224,7 @@ export class TurnkeyClient {
    * @param params.sessionKey - session key to use for storing the session (defaults to the default session key).
    * @param params.expirationSeconds - session expiration time in seconds (defaults to the configured default).
    * @param params.organizationId - organization ID to target (defaults to the session's organization ID or the parent organization ID).
+   * @param params.captchaToken - optional captcha token for bot prevention during sign up (must be enabled in the auth proxy config to take effect).
    * @returns A promise that resolves to a {@link WalletAuthResult}, which includes:
    *          - `sessionToken`: the signed JWT session token.
    *          - `address`: the authenticated wallet address.
@@ -1236,6 +1237,7 @@ export class TurnkeyClient {
       walletProvider,
       createSubOrgParams,
       sessionKey = SessionKey.DefaultSessionkey,
+      captchaToken,
     } = params;
 
     return withTurnkeyErrorHandling(
@@ -1256,7 +1258,10 @@ export class TurnkeyClient {
           },
         });
 
-        const res = await this.httpClient.proxySignupV2(signUpBody);
+        const res = await this.httpClient.proxySignupV2(
+          signUpBody,
+          captchaToken,
+        );
 
         if (!res) {
           throw new TurnkeyError(


### PR DESCRIPTION
## Summary & Motivation

- The captcha token param was missed in the `SignUpWithWalletRequest` body during the major Captcha change. This PR adds it in.

## How I Tested These Changes

- Locally

## Did you add a changeset?

- Yes

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
