### PR TITLE
crypto: add policy-aware QOS proof verification

### DIFF
--- a/.changeset/tough-proofs-verify.md
+++ b/.changeset/tough-proofs-verify.md
@@ -1,0 +1,5 @@
+---
+"@turnkey/crypto": minor
+---
+
+Add policy-aware QOS proof verification with independently pinned manifest and PCR measurements plus the live PCR17 manifest/Ephemeral Key commitment.

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -69,3 +69,29 @@ const event = JSON.parse(body.toString("utf8"));
 ```
 
 Do not verify a parsed and re-stringified JSON object. Even harmless-looking changes to whitespace or key ordering will change the signed payload.
+
+## Policy-aware QOS proof verification
+
+The existing `verify()` helper checks the App Proof signature, AWS Nitro
+attestation signature and certificate chain, manifest hash binding, and
+Ephemeral Key binding. Use `verifyWithQosPolicy()` when the relying party also
+has independently trusted QOS release measurements:
+
+```ts
+import { verifyWithQosPolicy } from "@turnkey/crypto";
+
+await verifyWithQosPolicy(appProof, bootProof, {
+  allowedManifestSha256: [trustedRelease.manifestSha256],
+  expectedPcrs: {
+    0: trustedRelease.pcr0,
+    1: trustedRelease.pcr1,
+    2: trustedRelease.pcr2,
+    3: trustedRelease.pcr3,
+  },
+});
+```
+
+Never populate this policy from the Boot Proof or the service being verified.
+The policy must arrive through an independent trusted release channel. The
+policy-aware verifier additionally requires all attestable PCRs and verifies
+the QOS live manifest/Ephemeral Key commitment in PCR17.

--- a/packages/crypto/src/__tests__/proof-tests.ts
+++ b/packages/crypto/src/__tests__/proof-tests.ts
@@ -161,13 +161,20 @@ describe("Proof verification tests", () => {
         },
       }),
     ).rejects.toThrow(
-      "QOS verification policy must allow at least one manifest SHA-256 digest",
+      "QOS verification policy must allow at least one semantic manifest hash",
     );
   });
 
   test("rejects attestations without the complete QOS PCR bank", async () => {
+    // The policy-aware verifier pins the semantic manifest hash from the
+    // signed attestation. It must not confuse it with SHA-256 of these raw
+    // serialized bytes.
+    const bootProofWithDifferentRawManifest = {
+      ...testBootProof1,
+      qosManifestB64: "AA==",
+    };
     await expect(
-      verifyWithQosPolicy(testAppProof1, testBootProof1, {
+      verifyWithQosPolicy(testAppProof1, bootProofWithDifferentRawManifest, {
         allowedManifestSha256: [
           "24a9e2c0b0ce26bcbc3e65172f8b06b100d5e712591f604832cbea9ff5ce02be",
         ],

--- a/packages/crypto/src/__tests__/proof-tests.ts
+++ b/packages/crypto/src/__tests__/proof-tests.ts
@@ -1,6 +1,11 @@
 /** @jest-environment node */
 
-import { verify, verifyAppProofSignature } from "../proof";
+import {
+  computeQosLiveManifestCommitmentPcr,
+  verify,
+  verifyAppProofSignature,
+  verifyWithQosPolicy,
+} from "../proof";
 import type { v1AppProof, v1BootProof } from "@turnkey/sdk-types";
 import { test, expect, describe } from "@jest/globals";
 
@@ -128,5 +133,51 @@ describe("Proof verification tests", () => {
     await expect(verify(testAppProof2, malformedBootProof2)).rejects.toThrow(
       "attestationDoc's user_data doesn't match the hash of the manifest. ",
     );
+  });
+
+  test("computes the QOS live manifest commitment PCR", () => {
+    const manifestDigest = new Uint8Array(32);
+    const ephemeralPublicKey = new Uint8Array(130).fill(0x11);
+    ephemeralPublicKey[0] = 0x04;
+
+    expect(
+      Buffer.from(
+        computeQosLiveManifestCommitmentPcr(manifestDigest, ephemeralPublicKey),
+      ).toString("hex"),
+    ).toBe(
+      "d19443155765a0795affb170c1e13a2360ea38202a5fa703950261f3d0a0c2321dd0ae2b8d7c9d1798d6898b1e25a94c",
+    );
+  });
+
+  test("requires an independently pinned manifest", async () => {
+    await expect(
+      verifyWithQosPolicy(testAppProof1, testBootProof1, {
+        allowedManifestSha256: [],
+        expectedPcrs: {
+          0: "00".repeat(48),
+          1: "00".repeat(48),
+          2: "00".repeat(48),
+          3: "00".repeat(48),
+        },
+      }),
+    ).rejects.toThrow(
+      "QOS verification policy must allow at least one manifest SHA-256 digest",
+    );
+  });
+
+  test("rejects attestations without the complete QOS PCR bank", async () => {
+    await expect(
+      verifyWithQosPolicy(testAppProof1, testBootProof1, {
+        allowedManifestSha256: [
+          "24a9e2c0b0ce26bcbc3e65172f8b06b100d5e712591f604832cbea9ff5ce02be",
+        ],
+        expectedPcrs: {
+          0: "f67076a8f9796b90d7f0eb148ec6926f66fe04c80861151916961f7dec715b3c8a36e5908e9551c20048719da134b207",
+          1: "f67076a8f9796b90d7f0eb148ec6926f66fe04c80861151916961f7dec715b3c8a36e5908e9551c20048719da134b207",
+          2: "21b9efbc184807662e966d34f390821309eeac6802309798826296bf3e8bec7c10edb30948c90ba67310f7b964fc500a",
+          3: "864e9095a9947ab14698122370c13baf23183f4e9911953cf5b909a49db00f43f446707314674d9309974f3cc4b24728",
+        },
+      }),
+    ).rejects.toThrow("QOS attestation document must contain exactly 32 PCRs");
   });
 });

--- a/packages/crypto/src/proof.ts
+++ b/packages/crypto/src/proof.ts
@@ -4,10 +4,50 @@ import {
 } from "@turnkey/encoding";
 import type { v1AppProof, v1BootProof } from "@turnkey/sdk-types";
 import { p256 } from "@noble/curves/p256";
-import { sha256 } from "@noble/hashes/sha2";
+import { sha256, sha384 } from "@noble/hashes/sha2";
 import * as CBOR from "cbor-js";
 import * as x509 from "@peculiar/x509";
 import { AWS_ROOT_CERT_PEM, AWS_ROOT_CERT_SHA256 } from "./constants";
+
+const QOS_LIVE_MANIFEST_PCR_COMMITMENT_DOMAIN =
+  "qos-live-manifest-pcr-commitment-v1";
+const QOS_LIVE_MANIFEST_COMMITMENT_PCR_INDEX = 17;
+const QOS_ATTESTABLE_PCR_COUNT = 32;
+const SHA256_LENGTH = 32;
+const SHA384_LENGTH = 48;
+const QOS_EPHEMERAL_PUBLIC_KEY_LENGTH = 130;
+
+export type QosIdentityPcrIndex = 0 | 1 | 2 | 3;
+
+/**
+ * Independently trusted values used to identify an expected QOS deployment.
+ *
+ * These values must come from a trusted release channel. Do not derive them
+ * from the boot proof or from the service being verified.
+ */
+export type QosVerificationPolicy = {
+  /** SHA-256 digests of complete, independently approved QOS manifests. */
+  allowedManifestSha256: readonly string[];
+  /** Expected SHA-384 PCR0 through PCR3 measurements. */
+  expectedPcrs: Readonly<Record<QosIdentityPcrIndex, string>>;
+};
+
+type AwsNitroAttestationDocument = {
+  cabundle: Uint8Array[];
+  certificate: Uint8Array;
+  digest: string;
+  module_id: string;
+  nonce?: Uint8Array | null;
+  pcrs: Record<string, Uint8Array>;
+  public_key: Uint8Array;
+  timestamp: number;
+  user_data: Uint8Array;
+};
+
+type VerifiedProofPair = {
+  attestationDoc: AwsNitroAttestationDocument;
+  manifestDigest: Uint8Array;
+};
 
 export const getCryptoInstance = async () => {
   let cryptoInstance: Crypto;
@@ -74,6 +114,108 @@ export async function verify(
   appProof: v1AppProof,
   bootProof: v1BootProof,
 ): Promise<void> {
+  await verifyProofPair(appProof, bootProof);
+}
+
+/**
+ * Verifies an app proof and boot proof pair against an independently trusted
+ * QOS deployment policy.
+ *
+ * In addition to {@link verify}, this pins the complete QOS manifest digest,
+ * checks PCR0 through PCR3, requires the complete attestable PCR bank, and
+ * verifies the QOS live manifest/Ephemeral Key commitment in PCR17.
+ */
+export async function verifyWithQosPolicy(
+  appProof: v1AppProof,
+  bootProof: v1BootProof,
+  policy: QosVerificationPolicy,
+): Promise<void> {
+  const normalizedPolicy = normalizeQosVerificationPolicy(policy);
+  const { attestationDoc, manifestDigest } = await verifyProofPair(
+    appProof,
+    bootProof,
+  );
+
+  if (
+    !normalizedPolicy.allowedManifestDigests.some((allowed) =>
+      bytesEq(allowed, manifestDigest),
+    )
+  ) {
+    throw new Error(
+      `QOS manifest digest is not allowed by policy: ${bytesToHex(manifestDigest)}`,
+    );
+  }
+
+  validateQosAttestationDocument(attestationDoc);
+
+  for (let index = 0; index < QOS_ATTESTABLE_PCR_COUNT; index++) {
+    getAttestationPcr(attestationDoc, index);
+  }
+
+  for (const index of [0, 1, 2, 3] as const) {
+    const actual = getAttestationPcr(attestationDoc, index);
+    const expected = normalizedPolicy.expectedPcrs[index];
+    if (!bytesEq(actual, expected)) {
+      throw new Error(
+        `QOS PCR${index} does not match policy: expected=${bytesToHex(expected)} actual=${bytesToHex(actual)}`,
+      );
+    }
+  }
+
+  const publicKey = asBytes(
+    attestationDoc.public_key,
+    "attestation document public_key",
+  );
+  const expectedLivePcr = computeQosLiveManifestCommitmentPcr(
+    manifestDigest,
+    publicKey,
+  );
+  const actualLivePcr = getAttestationPcr(
+    attestationDoc,
+    QOS_LIVE_MANIFEST_COMMITMENT_PCR_INDEX,
+  );
+  if (!bytesEq(actualLivePcr, expectedLivePcr)) {
+    throw new Error(
+      `QOS PCR${QOS_LIVE_MANIFEST_COMMITMENT_PCR_INDEX} live manifest commitment mismatch: expected=${bytesToHex(expectedLivePcr)} actual=${bytesToHex(actualLivePcr)}`,
+    );
+  }
+}
+
+/**
+ * Computes the QOS live manifest/Ephemeral Key commitment PCR value.
+ *
+ * This mirrors QOS' `expected_manifest_commitment_pcr(Live, ...)`: SHA-384 of
+ * the canonical commitment JSON, followed by a SHA-384 PCR extension from the
+ * all-zero initial PCR value.
+ */
+export function computeQosLiveManifestCommitmentPcr(
+  manifestDigest: Uint8Array,
+  ephemeralPublicKey: Uint8Array,
+): Uint8Array {
+  if (manifestDigest.length !== SHA256_LENGTH) {
+    throw new Error(
+      `QOS manifest digest must be ${SHA256_LENGTH} bytes, got ${manifestDigest.length}`,
+    );
+  }
+  if (ephemeralPublicKey.length !== QOS_EPHEMERAL_PUBLIC_KEY_LENGTH) {
+    throw new Error(
+      `QOS Ephemeral Public Key must be ${QOS_EPHEMERAL_PUBLIC_KEY_LENGTH} bytes, got ${ephemeralPublicKey.length}`,
+    );
+  }
+
+  const preimage = new TextEncoder().encode(
+    `{"domain":"${QOS_LIVE_MANIFEST_PCR_COMMITMENT_DOMAIN}","ephemeralPublicKey":"${bytesToHex(ephemeralPublicKey)}","manifestHash":"${bytesToHex(manifestDigest)}"}`,
+  );
+  const commitment = sha384(preimage);
+  const extensionInput = new Uint8Array(SHA384_LENGTH + commitment.length);
+  extensionInput.set(commitment, SHA384_LENGTH);
+  return sha384(extensionInput);
+}
+
+async function verifyProofPair(
+  appProof: v1AppProof,
+  bootProof: v1BootProof,
+): Promise<VerifiedProofPair> {
   // 1. Verify App Proof
   verifyAppProofSignature(appProof);
 
@@ -86,7 +228,9 @@ export async function verify(
   );
   const coseSign1 = CBOR.decode(coseSign1Der.buffer);
   const [, , payload] = coseSign1;
-  const attestationDoc = CBOR.decode(new Uint8Array(payload).buffer);
+  const attestationDoc = CBOR.decode(
+    new Uint8Array(payload).buffer,
+  ) as AwsNitroAttestationDocument;
 
   // Verify cose sign1 signature
   await verifyCoseSign1Sig(coseSign1, attestationDoc.certificate);
@@ -126,6 +270,8 @@ export async function verify(
       `Ephemeral pub keys from app proof: ${appProof.publicKey}, boot proof structure ${bootProof.ephemeralPublicKeyHex}, and attestation doc ${attestationPubKey} should all match`,
     );
   }
+
+  return { attestationDoc, manifestDigest };
 }
 
 /**
@@ -294,10 +440,113 @@ export async function verifyCoseSign1Sig(
   if (!ok) throw new Error("COSE_Sign1 ES384 verification failed");
 }
 
-function bytesEq(a: ArrayBuffer, b: ArrayBuffer) {
-  const A = new Uint8Array(a),
-    B = new Uint8Array(b);
-  if (A.length !== B.length) return false;
-  for (let i = 0; i < A.length; i++) if (A[i] !== B[i]) return false;
+function normalizeQosVerificationPolicy(policy: QosVerificationPolicy): {
+  allowedManifestDigests: Uint8Array[];
+  expectedPcrs: Record<QosIdentityPcrIndex, Uint8Array>;
+} {
+  if (
+    !policy ||
+    !Array.isArray(policy.allowedManifestSha256) ||
+    policy.allowedManifestSha256.length === 0
+  ) {
+    throw new Error(
+      "QOS verification policy must allow at least one manifest SHA-256 digest",
+    );
+  }
+
+  const allowedManifestDigests = policy.allowedManifestSha256.map(
+    (digest, index) =>
+      decodeFixedHex(digest, SHA256_LENGTH, `allowedManifestSha256[${index}]`),
+  );
+  const expectedPcrs = {} as Record<QosIdentityPcrIndex, Uint8Array>;
+  for (const index of [0, 1, 2, 3] as const) {
+    expectedPcrs[index] = decodeFixedHex(
+      policy.expectedPcrs?.[index],
+      SHA384_LENGTH,
+      `expectedPcrs[${index}]`,
+    );
+  }
+
+  return { allowedManifestDigests, expectedPcrs };
+}
+
+function validateQosAttestationDocument(
+  attestationDoc: AwsNitroAttestationDocument,
+): void {
+  if (
+    typeof attestationDoc.module_id !== "string" ||
+    attestationDoc.module_id.length === 0
+  ) {
+    throw new Error("AWS Nitro attestation document has an invalid module_id");
+  }
+  if (attestationDoc.digest !== "SHA384") {
+    throw new Error(
+      `AWS Nitro attestation document must use SHA384, got ${String(attestationDoc.digest)}`,
+    );
+  }
+  if (
+    !Number.isSafeInteger(attestationDoc.timestamp) ||
+    attestationDoc.timestamp <= 0
+  ) {
+    throw new Error("AWS Nitro attestation document has an invalid timestamp");
+  }
+  if (attestationDoc.nonce !== null && attestationDoc.nonce !== undefined) {
+    throw new Error("QOS attestation document must not contain a nonce");
+  }
+  if (
+    !attestationDoc.pcrs ||
+    typeof attestationDoc.pcrs !== "object" ||
+    Object.keys(attestationDoc.pcrs).length !== QOS_ATTESTABLE_PCR_COUNT
+  ) {
+    throw new Error(
+      `QOS attestation document must contain exactly ${QOS_ATTESTABLE_PCR_COUNT} PCRs`,
+    );
+  }
+}
+
+function getAttestationPcr(
+  attestationDoc: AwsNitroAttestationDocument,
+  index: number,
+): Uint8Array {
+  const value = attestationDoc.pcrs?.[index];
+  if (value === undefined) {
+    throw new Error(`AWS Nitro attestation document is missing PCR${index}`);
+  }
+  const pcr = asBytes(value, `attestation document PCR${index}`);
+  if (pcr.length !== SHA384_LENGTH) {
+    throw new Error(
+      `AWS Nitro attestation document PCR${index} must be ${SHA384_LENGTH} bytes, got ${pcr.length}`,
+    );
+  }
+  return pcr;
+}
+
+function decodeFixedHex(
+  value: unknown,
+  expectedBytes: number,
+  label: string,
+): Uint8Array {
+  if (
+    typeof value !== "string" ||
+    !new RegExp(`^[0-9a-fA-F]{${expectedBytes * 2}}$`).test(value)
+  ) {
+    throw new Error(`${label} must be a ${expectedBytes}-byte hex string`);
+  }
+  return uint8ArrayFromHexString(value.toLowerCase());
+}
+
+function asBytes(value: unknown, label: string): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  throw new Error(`${label} must be a byte string`);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return uint8ArrayToHexString(bytes).toLowerCase();
+}
+
+function bytesEq(a: Uint8Array, b: Uint8Array) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
   return true;
 }

--- a/packages/crypto/src/proof.ts
+++ b/packages/crypto/src/proof.ts
@@ -5,7 +5,7 @@ import {
 import type { v1AppProof, v1BootProof } from "@turnkey/sdk-types";
 import { p256 } from "@noble/curves/p256";
 import { sha256, sha384 } from "@noble/hashes/sha2";
-import * as CBOR from "cbor-js";
+import CBOR from "cbor-js";
 import * as x509 from "@peculiar/x509";
 import { AWS_ROOT_CERT_PEM, AWS_ROOT_CERT_SHA256 } from "./constants";
 
@@ -26,7 +26,11 @@ export type QosIdentityPcrIndex = 0 | 1 | 2 | 3;
  * from the boot proof or from the service being verified.
  */
 export type QosVerificationPolicy = {
-  /** SHA-256 digests of complete, independently approved QOS manifests. */
+  /**
+   * Semantic QOS manifest hashes from `VersionedManifest::manifest_hash()`.
+   * These are the 32 bytes committed in the Nitro attestation `user_data`,
+   * not SHA-256 of the raw serialized Borsh manifest.
+   */
   allowedManifestSha256: readonly string[];
   /** Expected SHA-384 PCR0 through PCR3 measurements. */
   expectedPcrs: Readonly<Record<QosIdentityPcrIndex, string>>;
@@ -114,16 +118,19 @@ export async function verify(
   appProof: v1AppProof,
   bootProof: v1BootProof,
 ): Promise<void> {
-  await verifyProofPair(appProof, bootProof);
+  await verifyProofPair(appProof, bootProof, true);
 }
 
 /**
  * Verifies an app proof and boot proof pair against an independently trusted
  * QOS deployment policy.
  *
- * In addition to {@link verify}, this pins the complete QOS manifest digest,
- * checks PCR0 through PCR3, requires the complete attestable PCR bank, and
- * verifies the QOS live manifest/Ephemeral Key commitment in PCR17.
+ * This verifies the core App Proof, AWS attestation, and Ephemeral-key chain,
+ * pins the semantic QOS manifest hash committed in `user_data`, checks PCR0
+ * through PCR3, requires the complete attestable PCR bank, and verifies the
+ * QOS live manifest/Ephemeral Key commitment in PCR17. Because the semantic
+ * hash is independently pinned, this path does not use the legacy
+ * SHA-256(raw serialized manifest) compatibility check from {@link verify}.
  */
 export async function verifyWithQosPolicy(
   appProof: v1AppProof,
@@ -134,6 +141,7 @@ export async function verifyWithQosPolicy(
   const { attestationDoc, manifestDigest } = await verifyProofPair(
     appProof,
     bootProof,
+    false,
   );
 
   if (
@@ -215,6 +223,7 @@ export function computeQosLiveManifestCommitmentPcr(
 async function verifyProofPair(
   appProof: v1AppProof,
   bootProof: v1BootProof,
+  verifyLegacySerializedManifestHash: boolean,
 ): Promise<VerifiedProofPair> {
   // 1. Verify App Proof
   verifyAppProofSignature(appProof);
@@ -246,17 +255,32 @@ async function verifyProofPair(
     appProofTimestampMs,
   );
 
-  // Verify manifest digest
-  const decodedBootProofManifest = Uint8Array.from(
-    atob(bootProof.qosManifestB64)
-      .split("")
-      .map((c) => c.charCodeAt(0)),
+  const manifestDigest = asBytes(
+    attestationDoc.user_data,
+    "attestation document user_data manifest hash",
   );
-  const manifestDigest = sha256(decodedBootProofManifest);
-  if (!bytesEq(manifestDigest, attestationDoc.user_data)) {
+  if (manifestDigest.length !== SHA256_LENGTH) {
     throw new Error(
-      `attestationDoc's user_data doesn't match the hash of the manifest. attestationDoc.user_data: ${attestationDoc.user_data} , manifest digest: ${manifestDigest}`,
+      `QOS attestation user_data manifest hash must be ${SHA256_LENGTH} bytes, got ${manifestDigest.length}`,
     );
+  }
+
+  // Preserve the original reference verifier's behavior for older proof
+  // fixtures. Current QOS releases commit the semantic
+  // `VersionedManifest::manifest_hash()` in user_data; the policy-aware path
+  // pins that value directly and must not substitute SHA-256(raw Borsh bytes).
+  if (verifyLegacySerializedManifestHash) {
+    const decodedBootProofManifest = Uint8Array.from(
+      atob(bootProof.qosManifestB64)
+        .split("")
+        .map((c) => c.charCodeAt(0)),
+    );
+    const serializedManifestDigest = sha256(decodedBootProofManifest);
+    if (!bytesEq(serializedManifestDigest, manifestDigest)) {
+      throw new Error(
+        `attestationDoc's user_data doesn't match the hash of the manifest. attestationDoc.user_data: ${manifestDigest} , manifest digest: ${serializedManifestDigest}`,
+      );
+    }
   }
 
   // 3. Verify that all the ephemeral public keys match: app proof, boot proof structure, actual attestation doc
@@ -450,7 +474,7 @@ function normalizeQosVerificationPolicy(policy: QosVerificationPolicy): {
     policy.allowedManifestSha256.length === 0
   ) {
     throw new Error(
-      "QOS verification policy must allow at least one manifest SHA-256 digest",
+      "QOS verification policy must allow at least one semantic manifest hash",
     );
   }
 


### PR DESCRIPTION
## Summary & Motivation

`@turnkey/crypto.verify()` intentionally stops at a reference-grade proof
chain. It also uses the legacy SHA-256(raw serialized manifest) binding, while
current QOS commits the semantic `VersionedManifest::manifest_hash()` in the
Nitro attestation `user_data` and PCR17.

This draft adds an additive `verifyWithQosPolicy()` API for relying parties
that already distribute independent release trust material. It:

- pins allowed semantic QOS manifest hashes from signed attestation
  `user_data` (not SHA-256 of raw Borsh bytes);
- pins PCR0 through PCR3;
- validates the QOS attestation shape (`SHA384`, module ID, timestamp, no
  nonce);
- requires the complete PCR0-31 bank;
- recomputes and verifies the live manifest/Ephemeral Key commitment in
  PCR17; and
- preserves the existing `verify()` behavior for compatibility.

It also exports `computeQosLiveManifestCommitmentPcr()` and documents that
policy values must not be learned from the proof or service being verified.
The `cbor-js` import is corrected so COSE verification works in the built ESM
package as well as in Jest/CommonJS.

The PCR17 construction mirrors
`qos_nsm::nitro::expected_manifest_commitment_pcr(ManifestCommitmentKind::Live, ...)`
from QOS 0.13.0. The test vector was cross-checked byte-for-byte against that
Rust implementation.

### Draft questions

- This proposal pins the independently approved semantic manifest hash instead
  of introducing a browser-side Borsh/JSON manifest-envelope parser. Is that
  the preferred first API, or should this PR also parse and verify
  manifest-envelope approvals?
- The existing TypeScript fixtures contain only PCR0-15 and predate the live
  PCR17 commitment. The new verifier deliberately rejects them. A current QOS
  live-attestation fixture would allow a positive end-to-end policy test in
  addition to the Rust parity vector and fail-closed legacy-fixture test.
- Should this lower-level policy API remain in `@turnkey/crypto`, or should
  known Turnkey production release policies live in a separate package?

## How I Tested These Changes

- `pnpm --filter @turnkey/crypto test --runInBand` (56 tests passed)
- `pnpm --filter @turnkey/crypto typecheck`
- `pnpm --filter @turnkey/crypto build`
- built ESM import smoke test for `verifyCoseSign1Sig()`
- Prettier check for all changed files
- cross-language PCR17 vector against `qos_nsm = 0.13.0`

## Did you add a changeset?

Yes, a minor changeset for the additive `@turnkey/crypto` API.
