### PR TITLE
Extract activity fingerprint construction into a @turnkey/crypto helper

### DIFF
--- a/.changeset/activity-fingerprint-helper.md
+++ b/.changeset/activity-fingerprint-helper.md
@@ -1,0 +1,6 @@
+---
+"@turnkey/crypto": minor
+"@turnkey/sdk-server": patch
+---
+
+Add `computeActivityFingerprint` to `@turnkey/crypto`, deriving the `sha256:<hex>` activity fingerprint from a request body. `createExportSecretsProposal` now uses it instead of building the string inline.

--- a/packages/crypto/src/__tests__/crypto-test.ts
+++ b/packages/crypto/src/__tests__/crypto-test.ts
@@ -18,6 +18,7 @@ import {
   verifySessionJwtSignature,
   verifyOtpVerificationToken,
   fromDerSignature,
+  computeActivityFingerprint,
 } from "../";
 
 // Mock data for testing
@@ -446,6 +447,46 @@ describe("Turnkey Crypto Primitives", () => {
         /invalid tag for s/,
       );
     });
+  });
+});
+
+describe("computeActivityFingerprint", () => {
+  test("matches sha256: + hex digest of the exact request bytes", () => {
+    const body = JSON.stringify({
+      type: "ACTIVITY_TYPE_EXPORT_SECRETS",
+      timestampMs: "1700000000000",
+      organizationId: "9c4dfaa6-fd39-4b40-8ec8-2e0d5ac0a1cb",
+    });
+
+    const expected = `sha256:${Buffer.from(
+      sha256(new TextEncoder().encode(body)),
+    ).toString("hex")}`;
+
+    expect(computeActivityFingerprint(body)).toBe(expected);
+  });
+
+  test("is stable and 71 characters of lowercase hex", () => {
+    const body = '{"type":"ACTIVITY_TYPE_EXPORT_SECRETS"}';
+    const fingerprint = computeActivityFingerprint(body);
+
+    expect(fingerprint).toBe(computeActivityFingerprint(body));
+    expect(fingerprint).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("is byte-sensitive: whitespace changes the fingerprint", () => {
+    expect(computeActivityFingerprint('{"a":1}')).not.toBe(
+      computeActivityFingerprint('{"a": 1}'),
+    );
+  });
+
+  test("hashes UTF-8 bytes, not UTF-16 code units", () => {
+    // "é" is two bytes in UTF-8; a code-unit hash would differ from this.
+    const body = '{"name":"café"}';
+    const expected = `sha256:${Buffer.from(
+      sha256(new TextEncoder().encode(body)),
+    ).toString("hex")}`;
+
+    expect(computeActivityFingerprint(body)).toBe(expected);
   });
 });
 

--- a/packages/crypto/src/turnkey.ts
+++ b/packages/crypto/src/turnkey.ts
@@ -54,6 +54,10 @@ interface EncryptWalletToBundleParams {
   dangerouslyOverrideSignerPublicKey?: string; // Optional override for signer key
 }
 
+// Server-side format for activity fingerprints: the hash name, then the hex
+// digest. Only SHA-256 is used today.
+const ACTIVITY_FINGERPRINT_PREFIX = "sha256:";
+
 export enum Enclave {
   NOTARIZER = "notarizer",
   SIGNER = "signer",
@@ -321,6 +325,26 @@ export const decryptSecretBundle = async ({
   });
 
   return new TextDecoder().decode(decryptedData);
+};
+
+/**
+ * Computes the activity fingerprint for a Turnkey request body.
+ *
+ * The fingerprint is how the server identifies an activity independently of
+ * who submitted it, so any party holding the exact request bytes can derive
+ * it locally — to look up an activity they did not submit, or to check that
+ * co-signers of a consensus activity are all voting on the same bytes.
+ *
+ * Byte-sensitive by design: the digest is taken over `requestBody` as given,
+ * so a re-serialized body (different key order or whitespace) yields a
+ * different fingerprint and, server-side, a different activity.
+ *
+ * @param {string} requestBody - The exact serialized request body that is (or was) submitted.
+ * @returns {string} - The fingerprint, formatted as "sha256:<hex digest>".
+ */
+export const computeActivityFingerprint = (requestBody: string): string => {
+  const digest = sha256(new TextEncoder().encode(requestBody));
+  return `${ACTIVITY_FINGERPRINT_PREFIX}${uint8ArrayToHexString(digest)}`;
 };
 
 /**

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -47,7 +47,6 @@
     "codegen": "node scripts/codegen.js"
   },
   "dependencies": {
-    "@noble/hashes": "1.8.0",
     "@turnkey/api-key-stamper": "workspace:*",
     "@turnkey/crypto": "workspace:*",
     "@turnkey/http": "workspace:*",

--- a/packages/sdk-server/src/sdk-client.ts
+++ b/packages/sdk-server/src/sdk-client.ts
@@ -10,11 +10,11 @@ import {
   type v1InitImportSecretsResult,
 } from "@turnkey/sdk-types";
 import {
+  computeActivityFingerprint,
   decryptSecretBundle,
   encryptSecretToBundle,
   generateP256KeyPair,
 } from "@turnkey/crypto";
-import { sha256 } from "@noble/hashes/sha256";
 
 import { fetch } from "./universal";
 import { VERSION } from "./__generated__/version";
@@ -421,10 +421,7 @@ export class TurnkeyApiClient extends TurnkeyServerClient {
       },
     };
     const body = JSON.stringify(request);
-
-    const fingerprint = `sha256:${Buffer.from(
-      sha256(new TextEncoder().encode(body)),
-    ).toString("hex")}`;
+    const fingerprint = computeActivityFingerprint(body);
 
     return {
       body,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4825,9 +4825,6 @@ importers:
 
   packages/sdk-server:
     dependencies:
-      '@noble/hashes':
-        specifier: 1.8.0
-        version: 1.8.0
       '@turnkey/api-key-stamper':
         specifier: workspace:*
         version: link:../api-key-stamper


### PR DESCRIPTION
Stacked on #1479 (based on `zeke/secrets-sdk`, not `main` — the call site does not exist on `main` yet).

Follows up on [this review thread](https://github.com/tkhq/sdk/pull/1479#discussion_r3787020736): `createExportSecretsProposal` built the activity fingerprint inline with a string-templated `sha256:` prefix, which was a new pattern in this repo — nothing else computes an activity fingerprint client-side.

## What changed

- `@turnkey/crypto` gains `computeActivityFingerprint(requestBody: string): string`, returning `sha256:<hex digest>` over the exact request bytes. The prefix now lives in one named constant instead of being interpolated at the call site.
- `createExportSecretsProposal` calls it instead of hashing inline.
- Uses `uint8ArrayToHexString` rather than `Buffer.from(...).toString("hex")`, so the primitive works unchanged in the browser.
- Drops `@noble/hashes` from `@turnkey/sdk-server` — it was added for this one call and is now unused there.

## Why it belongs in crypto

The fingerprint is what lets a party who did not submit an activity look it up, and what lets co-signers confirm they are voting on the same bytes. That makes it a primitive rather than an export-secrets detail.

## Tests

Four unit tests in `packages/crypto/src/__tests__/crypto-test.ts`: digest agreement with the server format, stability plus `sha256:` + 64 lowercase hex shape, byte-sensitivity (whitespace changes the fingerprint), and UTF-8 rather than UTF-16 hashing.

`pnpm --filter @turnkey/crypto test` passes (58 tests); `@turnkey/sdk-server` typechecks; `pnpm install --frozen-lockfile` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)