### PR TITLE
Retry the export submission only on the Turnkey activity-conflict error

### DIFF
--- a/examples/key-management/programmable-credential-access/src/index.ts
+++ b/examples/key-management/programmable-credential-access/src/index.ts
@@ -1,6 +1,10 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
-import { Turnkey, TurnkeyApiClient } from "@turnkey/sdk-server";
+import {
+  Turnkey,
+  TurnkeyApiClient,
+  TurnkeyRequestError,
+} from "@turnkey/sdk-server";
 import { generateP256KeyPair } from "@turnkey/crypto";
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
@@ -132,12 +136,21 @@ async function main() {
   // other registers as an approval vote. If the two submissions race to
   // create the activity, the loser gets a conflict error and its retry lands
   // as the approval.
+  // The losing side of the race fails with gRPC ALREADY_EXISTS (code 6):
+  // "an activity with the same fingerprint already exists". Only that error
+  // is safe to retry; anything else (auth, validation, rate limits) is a
+  // real failure.
+  const isConflictError = (error: unknown) =>
+    error instanceof TurnkeyRequestError && error.code === 6;
   const submitAsAgent = async (agent: TurnkeyApiClient, label: string) => {
     try {
       const result = await agent.submitExportSecrets(proposal);
       console.log(`${label} submitted: ${result.status}`);
       return result;
-    } catch (_) {
+    } catch (error) {
+      if (!isConflictError(error)) {
+        throw error;
+      }
       const result = await agent.submitExportSecrets(proposal);
       console.log(
         `${label} submitted (after conflict retry): ${result.status}`,


### PR DESCRIPTION
Addresses [this review comment](https://github.com/tkhq/sdk/pull/1488#discussion_r3865654784) on #1488: the bare `catch` in the programmable-credential-access example retried every failure as if it were the create-activity race, which would duplicate requests on auth/validation/rate-limit/server errors and mask the original error.

The retry is now gated on the specific conflict response. Verified against the live API that the losing side of the race throws `TurnkeyRequestError` with gRPC code 6 (`ALREADY_EXISTS`) and message `failed to insert activity: 23505 — an activity with the same fingerprint already exists`; everything else is rethrown.

Ran the example end-to-end after the change — it hit the race live, retried through the guarded path, and completed the consensus export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)