### PR TITLE
target orgId returned from get accounts

### DIFF
--- a/packages/core/src/__clients__/core.ts
+++ b/packages/core/src/__clients__/core.ts
@@ -1745,8 +1745,17 @@ export class TurnkeyClient {
           );
         }
 
+        const subOrganizationId = signupRes.organizationId;
+        if (!subOrganizationId) {
+          throw new TurnkeyError(
+            `Failed to retrieve sub-organization ID after OTP sign up`,
+            TurnkeyErrorCodes.OTP_SIGNUP_ERROR,
+          );
+        }
+
         const otpRes = await this.loginWithOtp({
           verificationToken,
+          organizationId: subOrganizationId,
           ...(invalidateExisting && { invalidateExisting }),
           ...(sessionKey && { sessionKey }),
           ...(sessionProfileId && { sessionProfileId }),
@@ -1868,6 +1877,7 @@ export class TurnkeyClient {
         } else {
           const loginRes = await this.loginWithOtp({
             verificationToken,
+            organizationId: subOrganizationId,
             ...(invalidateExisting && { invalidateExisting }),
             ...(sessionKey && { sessionKey }),
             ...(sessionProfileId && { sessionProfileId }),
@@ -1954,6 +1964,7 @@ export class TurnkeyClient {
           const loginRes = await this.loginWithOauth({
             oidcToken,
             publicKey,
+            organizationId: subOrganizationId,
             ...(invalidateExisting && { invalidateExisting }),
             ...(sessionKey && { sessionKey }),
             ...(sessionProfileId && { sessionProfileId }),
@@ -2157,9 +2168,18 @@ export class TurnkeyClient {
           );
         }
 
+        const subOrganizationId = signupRes.organizationId;
+        if (!subOrganizationId) {
+          throw new TurnkeyError(
+            `Failed to retrieve sub-organization ID after OAuth sign up`,
+            TurnkeyErrorCodes.OAUTH_SIGNUP_ERROR,
+          );
+        }
+
         const oauthRes = await this.loginWithOauth({
           oidcToken,
           publicKey: publicKey!,
+          organizationId: subOrganizationId,
           ...(sessionKey && { sessionKey }),
           ...(sessionProfileId && { sessionProfileId }),
         });


### PR DESCRIPTION
## Summary & Motivation

auth Proxy's behavior for `get_accounts` is to return the newest sub-org. Some users have multiple verified duplicate sub-orgs, but were previously relying on this behavior to successfully log in

when we switched to using attested stamps for login, we stopped passing the `orgId` returned by `get_accounts`. Instead, we fell back to our internal "figure it out" logic, where the parent org is targeted and we resolve the sub-org internally

the problem is that this logic errors when there are multiple matching/duplicate sub-orgs

so basically users with duplicate verified sub-orgs are currently borked, even though they were able to log in before this change!

this fixes that :)


