### PR TITLE
Update SDK swap activities to create V2 and execute V3

### DIFF
--- a/.changeset/modern-swaps-arrive.md
+++ b/.changeset/modern-swaps-arrive.md
@@ -1,0 +1,9 @@
+---
+"@turnkey/core": minor
+"@turnkey/sdk-browser": minor
+"@turnkey/sdk-server": minor
+"@turnkey/sdk-types": minor
+"@turnkey/http": minor
+---
+
+Use the latest public swap activities. `createSwapQuote` now submits V2, and `executeSwap` now submits V3. Both inputs support an optional `destinationAddress` for cross-protocol swaps. Also sync the public API types from mono v2026.8.4.

--- a/examples/defi/execute-swap/.env.local.example
+++ b/examples/defi/execute-swap/.env.local.example
@@ -6,5 +6,7 @@ SIGN_WITH="<Turnkey Wallet Account Address>"
 # CAIP-19 asset IDs (Solana mainnet SOL -> USDC)
 FROM_TOKEN="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
 TO_TOKEN="solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+# Optional raw destination address. This value is required for a cross-protocol swap.
+DESTINATION_ADDRESS=""
 # Base units (lamports for SOL): 5000000 = 0.005 SOL
 AMOUNT="5000000"

--- a/examples/defi/execute-swap/README.md
+++ b/examples/defi/execute-swap/README.md
@@ -2,15 +2,15 @@
 
 > **Closed beta:** Turnkey Swap is currently in closed beta. Your organization must be allowlisted (with the relevant swap feature flags enabled) before this example will work.
 
-This example uses the typed `createSwapQuote`, `executeSwap`, and `getSwapStatus` wrapper methods from `@turnkey/sdk-server` to create a quote, execute it, and poll until the swap completes or fails.
+This example uses the typed swap methods from `@turnkey/sdk-server`. It submits create-swap-quote V2 and execute-swap V3 activities.
 
 By default it is configured for Solana mainnet SOL → USDC. Token pair and amount are driven by env vars (`FROM_TOKEN` / `TO_TOKEN` as CAIP-19 asset IDs, `AMOUNT` in base units), so you can point it at other supported pairs without code changes.
 
 The script will:
 
-1. Call `createSwapQuote` with `signWith`, CAIP-19 tokens, amount, and slippage
+1. Call `createSwapQuote` (V2) with the tokens, amount, slippage, and optional destination address
 2. Prompt whether to use Turnkey gas sponsorship
-3. Call `executeSwap` (V2) bound to the selected quote’s `quoteId`, including `quotedOutputAmount` and `minOutputAmount`
+3. Call `executeSwap` (V3) with the selected quote and the same destination address
 4. Poll `getSwapStatus` with the returned `swapRequestId` until `COMPLETED` or a terminal failure
 
 ---
@@ -60,7 +60,8 @@ Fill in the following values:
 - `SIGN_WITH` — Turnkey wallet account address used as `signWith` on `createSwapQuote` (signer is derived from the quote on execute)
 - `FROM_TOKEN` — CAIP-19 input asset ID
 - `TO_TOKEN` — CAIP-19 output asset ID
-- `AMOUNT` — input amount in base units (e.g. lamports for SOL)
+- `DESTINATION_ADDRESS` — optional raw output address. Set this value for a cross-protocol swap.
+- `AMOUNT` — input amount in base units (for example, lamports for SOL)
 
 The example defaults to Solana mainnet SOL → USDC with `AMOUNT=5000000` (0.005 SOL).
 

--- a/examples/defi/execute-swap/src/index.ts
+++ b/examples/defi/execute-swap/src/index.ts
@@ -21,12 +21,17 @@ export async function main() {
   const inputToken = requireEnv("FROM_TOKEN");
   const outputToken = requireEnv("TO_TOKEN");
   const inputAmount = requireEnv("AMOUNT");
+  const destinationAddress =
+    process.env.DESTINATION_ADDRESS?.trim() || undefined;
   const turnkey = getTurnkeyClient();
   const apiClient = turnkey.apiClient();
 
   console.log(`\nUsing wallet: ${signWith}`);
   console.log(`Swap: ${inputToken} -> ${outputToken}`);
   console.log(`Amount (base units): ${inputAmount}\n`);
+  if (destinationAddress) {
+    console.log(`Destination address: ${destinationAddress}\n`);
+  }
 
   const { sponsored } = await prompts({
     type: "confirm",
@@ -35,7 +40,7 @@ export async function main() {
     initial: true,
   });
 
-  console.log("Fetching swap quotes via CREATE_SWAP_QUOTE...");
+  console.log("Fetching swap quotes via CREATE_SWAP_QUOTE_V2...");
   const quoteResponse = await apiClient.createSwapQuote({
     organizationId,
     signWith,
@@ -43,6 +48,7 @@ export async function main() {
     outputToken,
     inputAmount,
     slippageBps: SLIPPAGE_BPS,
+    destinationAddress,
   });
 
   if (!quoteResponse.quotes?.length) {
@@ -64,7 +70,7 @@ export async function main() {
     );
   }
   console.log(
-    `\nExecuting quote ${selectedQuote.quoteId} via EXECUTE_SWAP_V2...\n`,
+    `\nExecuting quote ${selectedQuote.quoteId} via EXECUTE_SWAP_V3...\n`,
   );
 
   const executeResponse = await apiClient.executeSwap({
@@ -76,6 +82,7 @@ export async function main() {
     quotedOutputAmount: selectedQuote.outputAmount,
     minOutputAmount: selectedQuote.minOutputAmount,
     sponsor: sponsored,
+    destinationAddress,
   });
 
   const swapRequestId = executeResponse.swapRequestId;

--- a/examples/defi/execute-swap/src/index.ts
+++ b/examples/defi/execute-swap/src/index.ts
@@ -48,7 +48,7 @@ export async function main() {
     outputToken,
     inputAmount,
     slippageBps: SLIPPAGE_BPS,
-    destinationAddress,
+    ...(destinationAddress ? { destinationAddress } : {}),
   });
 
   if (!quoteResponse.quotes?.length) {
@@ -82,7 +82,7 @@ export async function main() {
     quotedOutputAmount: selectedQuote.outputAmount,
     minOutputAmount: selectedQuote.minOutputAmount,
     sponsor: sponsored,
-    destinationAddress,
+    ...(destinationAddress ? { destinationAddress } : {}),
   });
 
   const swapRequestId = executeResponse.swapRequestId;

--- a/packages/core/scripts/codegen.js
+++ b/packages/core/scripts/codegen.js
@@ -113,9 +113,14 @@ const VERSIONED_ACTIVITY_TYPES = {
     "v1VerifyOtpIntent",
     "v1VerifyOtpResult",
   ],
+  ACTIVITY_TYPE_CREATE_SWAP_QUOTE: [
+    "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+    "v1CreateSwapQuoteIntentV2",
+    "v1CreateSwapQuoteResult",
+  ],
   ACTIVITY_TYPE_EXECUTE_SWAP: [
-    "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
-    "v1ExecuteSwapIntentV2",
+    "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
+    "v1ExecuteSwapIntentV3",
     "v1ExecuteSwapResult",
   ],
 };

--- a/packages/core/src/__generated__/sdk-client-base.ts
+++ b/packages/core/src/__generated__/sdk-client-base.ts
@@ -437,6 +437,53 @@ export class TurnkeySDKClientBase {
     return data as TResponseType;
   }
 
+  getActivePolicies = async (
+    input: SdkTypes.TGetActivePoliciesBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetActivePoliciesResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_active_policies",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetActivePolicies = async (
+    input: SdkTypes.TGetActivePoliciesBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_active_policies";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getActivity = async (
     input: SdkTypes.TGetActivityBody,
     stampWith?: StamperType,
@@ -2068,6 +2115,53 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getVelocityControl = async (
+    input: SdkTypes.TGetVelocityControlBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TGetVelocityControlResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/get_velocity_control",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampGetVelocityControl = async (
+    input: SdkTypes.TGetVelocityControlBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_velocity_control";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getWallet = async (
     input: SdkTypes.TGetWalletBody,
     stampWith?: StamperType,
@@ -3171,6 +3265,53 @@ export class TurnkeySDKClientBase {
 
     const session = await this.storageManager?.getActiveSession();
     const fullUrl = this.config.apiBaseUrl + "/public/v1/query/list_users";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  listVelocityControls = async (
+    input: SdkTypes.TListVelocityControlsBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TListVelocityControlsResponse> => {
+    const session = await this.storageManager?.getActiveSession();
+    return this.request(
+      "/public/v1/query/list_velocity_controls",
+      {
+        ...input,
+        organizationId:
+          input.organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+      },
+      stampWith,
+    );
+  };
+
+  stampListVelocityControls = async (
+    input: SdkTypes.TListVelocityControlsBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const session = await this.storageManager?.getActiveSession();
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/list_velocity_controls";
     const body = {
       ...input,
       organizationId:
@@ -4587,7 +4728,7 @@ export class TurnkeySDKClientBase {
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
         generateAppProofs: generateAppProofs ?? false,
-        type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
+        type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
       },
       "createSwapQuoteResult",
       stampWith,
@@ -4613,7 +4754,7 @@ export class TurnkeySDKClientBase {
       organizationId:
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
-      type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
+      type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4903,6 +5044,64 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_USERS_V4",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  createVelocityControl = async (
+    input: SdkTypes.TCreateVelocityControlBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TCreateVelocityControlResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/create_velocity_control",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+      },
+      "createVelocityControlResult",
+      stampWith,
+    );
+  };
+
+  stampCreateVelocityControl = async (
+    input: SdkTypes.TCreateVelocityControlBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_velocity_control";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -6074,6 +6273,64 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  deleteVelocityControl = async (
+    input: SdkTypes.TDeleteVelocityControlBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TDeleteVelocityControlResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/delete_velocity_control",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+      },
+      "deleteVelocityControlResult",
+      stampWith,
+    );
+  };
+
+  stampDeleteVelocityControl = async (
+    input: SdkTypes.TDeleteVelocityControlBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/delete_velocity_control";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   deleteWalletAccounts = async (
     input: SdkTypes.TDeleteWalletAccountsBody,
     stampWith?: StamperType,
@@ -6612,7 +6869,7 @@ export class TurnkeySDKClientBase {
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
         generateAppProofs: generateAppProofs ?? false,
-        type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        type: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
       },
       "executeSwapResult",
       stampWith,
@@ -6637,7 +6894,7 @@ export class TurnkeySDKClientBase {
       organizationId:
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
-      type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+      type: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -7156,6 +7413,64 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await activeStamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  initImportSecrets = async (
+    input: SdkTypes.TInitImportSecretsBody,
+    stampWith?: StamperType,
+  ): Promise<SdkTypes.TInitImportSecretsResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+
+    //@ts-ignore - generateAppProofs does not exist on all request types, so we ignore the type error here for those that are missing it
+    const generateAppProofs = input?.generateAppProofs ?? false;
+    const session = await this.storageManager?.getActiveSession();
+
+    return this.activity(
+      "/public/v1/submit/init_import_secrets",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        generateAppProofs: generateAppProofs ?? false,
+        type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
+      },
+      "initImportSecretsResult",
+      stampWith,
+    );
+  };
+
+  stampInitImportSecrets = async (
+    input: SdkTypes.TInitImportSecretsBody,
+    stampWith?: StamperType,
+  ): Promise<TSignedRequest | undefined> => {
+    const activeStamper = this.getStamper(stampWith);
+    if (!activeStamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const session = await this.storageManager?.getActiveSession();
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/init_import_secrets";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/core/src/__inputs__/public_api.swagger.json
+++ b/packages/core/src/__inputs__/public_api.swagger.json
@@ -72,6 +72,38 @@
   "consumes": ["application/json"],
   "produces": ["application/json"],
   "paths": {
+    "/public/v1/query/get_active_policies": {
+      "post": {
+        "summary": "Get active policies",
+        "description": "For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active.",
+        "operationId": "PublicApiService_GetActivePolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["Policies"]
+      }
+    },
     "/public/v1/query/get_activity": {
       "post": {
         "summary": "Get activity",
@@ -1192,6 +1224,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/get_velocity_control": {
+      "post": {
+        "summary": "Get velocity control",
+        "description": "Get details about a velocity control.",
+        "operationId": "PublicApiService_GetVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/get_wallet": {
       "post": {
         "summary": "Get wallet",
@@ -1960,6 +2024,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/list_velocity_controls": {
+      "post": {
+        "summary": "List velocity controls",
+        "description": "List all velocity controls within an organization.",
+        "operationId": "PublicApiService_ListVelocityControls",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/list_verified_suborgs": {
       "post": {
         "summary": "Get verified sub-organizations",
@@ -1994,7 +2090,7 @@
     },
     "/public/v1/query/list_wallet_accounts": {
       "post": {
-        "summary": "List wallets accounts",
+        "summary": "List wallet accounts",
         "description": "List all accounts within a wallet.",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
@@ -2952,6 +3048,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/create_velocity_control": {
+      "post": {
+        "summary": "Create velocity control",
+        "description": "Create a new velocity control.",
+        "operationId": "PublicApiService_CreateVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/create_wallet": {
       "post": {
         "summary": "Create wallet",
@@ -3592,6 +3720,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/delete_velocity_control": {
+      "post": {
+        "summary": "Delete velocity control",
+        "description": "Delete an existing velocity control.",
+        "operationId": "PublicApiService_DeleteVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/delete_wallet_accounts": {
       "post": {
         "summary": "Delete wallet accounts",
@@ -4230,6 +4390,38 @@
           }
         ],
         "tags": ["Private Keys"]
+      }
+    },
+    "/public/v1/submit/init_import_secrets": {
+      "post": {
+        "summary": "Init import secrets",
+        "description": "Initialize secret imports by generating Ingress Encryption Target Keys.",
+        "operationId": "PublicApiService_InitImportSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1InitImportSecretsRequest"
+            }
+          }
+        ],
+        "tags": ["Secrets"]
       }
     },
     "/public/v1/submit/init_import_wallet": {
@@ -5732,6 +5924,26 @@
       },
       "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
+    "billingUpdatePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
+    "billingUpdatePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -6011,6 +6223,32 @@
       "type": "string",
       "enum": ["ACCESS_TYPE_WEB", "ACCESS_TYPE_API", "ACCESS_TYPE_ALL"]
     },
+    "v1ActivePolicyStatus": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for the organization the policy belongs to."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "Unique identifier for a given policy."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the policy is currently active. A policy without a time window is always active."
+        },
+        "timeExpr": {
+          "type": "string",
+          "description": "The policy's time expression, absent when the policy has no time window."
+        },
+        "error": {
+          "type": "string",
+          "description": "Set when the policy's time expression could not be evaluated; the policy is reported inactive."
+        }
+      },
+      "required": ["organizationId", "policyId", "active"]
+    },
     "v1Activity": {
       "type": "object",
       "properties": {
@@ -6276,7 +6514,12 @@
         "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
         "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
         "ACTIVITY_TYPE_IMPORT_SECRETS",
-        "ACTIVITY_TYPE_EXPORT_SECRETS"
+        "ACTIVITY_TYPE_EXPORT_SECRETS",
+        "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V3"
       ]
     },
     "v1AddressFormat": {
@@ -6564,6 +6807,13 @@
         "stable": {
           "type": "boolean",
           "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
+        },
+        "earnProviders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1EarnProvider"
+          },
+          "description": "Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn."
         }
       }
     },
@@ -8590,6 +8840,36 @@
       },
       "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
     },
+    "v1CreateSwapQuoteIntentV2": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
     "v1CreateSwapQuoteRequest": {
       "type": "object",
       "properties": {
@@ -9137,6 +9417,61 @@
         }
       },
       "required": ["userIds"]
+    },
+    "v1CreateVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": ["name", "dataSource", "aggregation", "identifier"]
+    },
+    "v1CreateVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
     },
     "v1CreateWalletAccountsIntent": {
       "type": "object",
@@ -10208,6 +10543,48 @@
       },
       "required": ["userIds"]
     },
+    "v1DeleteVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
+    "v1DeleteVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
     "v1DeleteWalletAccountsIntent": {
       "type": "object",
       "properties": {
@@ -10380,6 +10757,10 @@
         "lastUpdatedTime": {
           "$ref": "#/definitions/externaldatav1Timestamp",
           "description": "Last time this deployment was updated"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/v1ProvisioningState",
+          "description": "Current quorum-key provisioning state for this deployment"
         }
       },
       "required": [
@@ -10622,6 +11003,22 @@
         "clientFeeWallet": {
           "type": "string",
           "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        },
+        "exposures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EarnVaultExposure"
+          },
+          "description": "The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho)."
         }
       }
     },
@@ -10802,6 +11199,47 @@
         "curator": {
           "type": "string",
           "description": "Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave)."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        }
+      }
+    },
+    "v1EarnVaultExposure": {
+      "type": "object",
+      "properties": {
+        "marketId": {
+          "type": "string",
+          "description": "Provider-specific identifier for the market (the Morpho Blue market id)."
+        },
+        "collateralSymbol": {
+          "type": "string",
+          "description": "Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market."
+        },
+        "collateralCaip19": {
+          "type": "string",
+          "description": "CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market."
+        },
+        "lltvPct": {
+          "type": "string",
+          "description": "The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%)."
+        },
+        "supplied": {
+          "type": "string",
+          "description": "Assets the vault supplies to this market, in raw on-chain units of the underlying asset."
+        },
+        "display": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead."
+        },
+        "sharePct": {
+          "type": "string",
+          "description": "This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%)."
         }
       }
     },
@@ -11272,7 +11710,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -11318,7 +11758,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11386,7 +11828,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11560,7 +12004,9 @@
             "eip155:143",
             "eip155:10143",
             "eip155:42161",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11703,6 +12149,64 @@
         "gasStationNonce": {
           "type": "string",
           "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
+    "v1ExecuteSwapIntentV3": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
         }
       },
       "required": [
@@ -12143,6 +12647,35 @@
         "FIAT_ON_RAMP_PROVIDER_COINBASE",
         "FIAT_ON_RAMP_PROVIDER_MOONPAY"
       ]
+    },
+    "v1GetActivePoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetActivePoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "statuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ActivePolicyStatus"
+          },
+          "description": "The active/inactive status of every policy in the organization."
+        },
+        "evaluatedAtMs": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy."
+        }
+      },
+      "required": ["statuses", "evaluatedAtMs"]
     },
     "v1GetActivitiesRequest": {
       "type": "object",
@@ -12684,7 +13217,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -13399,6 +13934,27 @@
       },
       "required": ["users"]
     },
+    "v1GetVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["organizationId", "velocityControlId"]
+    },
+    "v1GetVelocityControlResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControl": {
+          "$ref": "#/definitions/v1VelocityControl"
+        }
+      },
+      "required": ["velocityControl"]
+    },
     "v1GetVerifiedSubOrgIdsRequest": {
       "type": "object",
       "properties": {
@@ -13532,6 +14088,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14020,6 +14578,27 @@
       },
       "required": ["encryptionSuite", "numSecrets"]
     },
+    "v1InitImportSecretsRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_INIT_IMPORT_SECRETS"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1InitImportSecretsIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
     "v1InitImportSecretsResult": {
       "type": "object",
       "properties": {
@@ -14082,7 +14661,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14120,7 +14699,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14167,7 +14746,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14266,7 +14845,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14317,7 +14896,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14372,7 +14951,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -15060,6 +15639,21 @@
         },
         "exportSecretsIntent": {
           "$ref": "#/definitions/v1ExportSecretsIntent"
+        },
+        "createVelocityControlIntent": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "deleteVelocityControlIntent": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "updatePaymentMethodIntent": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodIntent"
+        },
+        "createSwapQuoteIntentV2": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntentV2"
+        },
+        "executeSwapIntentV3": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV3"
         }
       }
     },
@@ -15185,6 +15779,10 @@
         "caip19": {
           "type": "string",
           "description": "Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier."
+        },
+        "includeExposure": {
+          "type": "boolean",
+          "description": "When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views."
         }
       },
       "required": ["organizationId"]
@@ -15329,7 +15927,9 @@
             "eip155:42431",
             "eip155:421614",
             "eip155:56",
-            "eip155:97"
+            "eip155:97",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "EVM CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -15526,6 +16126,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -15570,6 +16172,34 @@
         }
       },
       "required": ["userTags"]
+    },
+    "v1ListVelocityControlsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "paginationOptions": {
+          "$ref": "#/definitions/v1Pagination"
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1ListVelocityControlsResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControl"
+          }
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo"
+        }
+      },
+      "required": ["velocityControls", "pageInfo"]
     },
     "v1ListWebhookEndpointsRequest": {
       "type": "object",
@@ -16516,6 +17146,14 @@
         }
       }
     },
+    "v1ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "PROVISIONING_STATE_PENDING",
+        "PROVISIONING_STATE_AWAITING_PROVISION",
+        "PROVISIONING_STATE_PROVISIONED"
+      ]
+    },
     "v1PublicKeyCredentialWithAttestation": {
       "type": "object",
       "properties": {
@@ -17268,6 +17906,15 @@
         },
         "exportSecretsResult": {
           "$ref": "#/definitions/v1ExportSecretsResult"
+        },
+        "createVelocityControlResult": {
+          "$ref": "#/definitions/v1CreateVelocityControlResult"
+        },
+        "deleteVelocityControlResult": {
+          "$ref": "#/definitions/v1DeleteVelocityControlResult"
+        },
+        "updatePaymentMethodResult": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodResult"
         }
       }
     },
@@ -20927,6 +21574,261 @@
           "type": "string"
         }
       }
+    },
+    "v1VelocityControl": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string",
+          "description": "Unique identifier for the Velocity Control."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Identifier of the Organization that owns the Velocity Control."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was created."
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was last updated."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": [
+        "velocityControlId",
+        "organizationId",
+        "name",
+        "dataSource",
+        "aggregation",
+        "createdAt",
+        "updatedAt",
+        "identifier"
+      ]
+    },
+    "v1VelocityControlAggregation": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "$ref": "#/definitions/v1VelocityControlAggregationMethod",
+          "description": "Method that aggregates matching data points."
+        },
+        "operator": {
+          "$ref": "#/definitions/v1VelocityControlAggregationOperator",
+          "description": "Comparison between the aggregate and the threshold."
+        },
+        "threshold": {
+          "type": "string",
+          "description": "Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits."
+        },
+        "window": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindow",
+          "description": "Time window for the aggregation."
+        },
+        "groupBy": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupBy",
+          "description": "Scope that partitions matching data before aggregation."
+        }
+      },
+      "required": ["method", "operator", "threshold", "window", "groupBy"]
+    },
+    "v1VelocityControlAggregationGroupBy": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByOrganization",
+          "description": "Uses one shared bucket for the Organization."
+        },
+        "user": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByUser",
+          "description": "Uses one bucket for each User."
+        },
+        "wallet": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByWallet",
+          "description": "Uses one bucket for each Wallet."
+        }
+      }
+    },
+    "v1VelocityControlAggregationGroupByOrganization": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByUser": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByWallet": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationMethod": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM",
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT"
+      ]
+    },
+    "v1VelocityControlAggregationOperator": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN"
+      ]
+    },
+    "v1VelocityControlAggregationWindow": {
+      "type": "object",
+      "properties": {
+        "rolling": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowRolling",
+          "description": "Uses a rolling time window."
+        },
+        "infinite": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowInfinite",
+          "description": "Uses all matching data without a time limit."
+        }
+      }
+    },
+    "v1VelocityControlAggregationWindowInfinite": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationWindowRolling": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the rolling window, in seconds, as a base-10 integer string."
+        }
+      },
+      "required": ["duration"]
+    },
+    "v1VelocityControlDataSource": {
+      "type": "object",
+      "properties": {
+        "chainAssetTransfer": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransfer",
+          "description": "Uses transfers of the listed on-chain assets as input data."
+        },
+        "activityExecution": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecution",
+          "description": "Uses executed Turnkey activities as input data."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecution": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecutionFilter",
+          "description": "Filters activity executions by type."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecutionFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose executions are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceChainAssetTransfer": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferDefinition"
+          },
+          "description": "Assets whose transfers are included in the data source."
+        },
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferFilter",
+          "description": "Filters asset transfers by activity type."
+        },
+        "phase": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhase",
+          "description": "Selects when to measure an asset transfer."
+        }
+      },
+      "required": ["definition"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferDefinition": {
+      "type": "object",
+      "properties": {
+        "caip19": {
+          "type": "string",
+          "description": "CAIP-19 identifier for the asset."
+        },
+        "decimals": {
+          "type": "string",
+          "description": "Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset."
+        }
+      },
+      "required": ["caip19", "decimals"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose asset transfers are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceFilterActivity": {
+      "type": "object",
+      "properties": {
+        "activityType": {
+          "type": "string",
+          "description": "Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`."
+        }
+      },
+      "required": ["activityType"]
+    },
+    "v1VelocityControlDataSourcePhase": {
+      "type": "object",
+      "properties": {
+        "signature": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSignature",
+          "description": "Measures the transfer when Turnkey signs the transaction and returns it to the user."
+        },
+        "submission": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSubmission",
+          "description": "Reserved for future use. Measures the transfer after the transaction lands on chain."
+        }
+      }
+    },
+    "v1VelocityControlDataSourcePhaseSignature": {
+      "type": "object"
+    },
+    "v1VelocityControlDataSourcePhaseSubmission": {
+      "type": "object"
     },
     "v1VerifyOtpIntent": {
       "type": "object",

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.client.ts
@@ -10,6 +10,10 @@ import {
 } from "../../../../../base";
 import { VERSION } from "../../../../../version";
 import type {
+  TGetActivePoliciesBody,
+  TGetActivePoliciesResponse,
+} from "./public_api.fetcher";
+import type {
   TGetActivityBody,
   TGetActivityResponse,
 } from "./public_api.fetcher";
@@ -142,6 +146,10 @@ import type {
   TGetTvcQosVersionsResponse,
 } from "./public_api.fetcher";
 import type { TGetUserBody, TGetUserResponse } from "./public_api.fetcher";
+import type {
+  TGetVelocityControlBody,
+  TGetVelocityControlResponse,
+} from "./public_api.fetcher";
 import type { TGetWalletBody, TGetWalletResponse } from "./public_api.fetcher";
 import type {
   TGetWalletAccountBody,
@@ -232,6 +240,10 @@ import type {
   TListUserTagsResponse,
 } from "./public_api.fetcher";
 import type { TGetUsersBody, TGetUsersResponse } from "./public_api.fetcher";
+import type {
+  TListVelocityControlsBody,
+  TListVelocityControlsResponse,
+} from "./public_api.fetcher";
 import type {
   TGetVerifiedSubOrgIdsBody,
   TGetVerifiedSubOrgIdsResponse,
@@ -366,6 +378,10 @@ import type {
   TCreateUsersResponse,
 } from "./public_api.fetcher";
 import type {
+  TCreateVelocityControlBody,
+  TCreateVelocityControlResponse,
+} from "./public_api.fetcher";
+import type {
   TCreateWalletBody,
   TCreateWalletResponse,
 } from "./public_api.fetcher";
@@ -444,6 +460,10 @@ import type {
 import type {
   TDeleteUsersBody,
   TDeleteUsersResponse,
+} from "./public_api.fetcher";
+import type {
+  TDeleteVelocityControlBody,
+  TDeleteVelocityControlResponse,
 } from "./public_api.fetcher";
 import type {
   TDeleteWalletAccountsBody,
@@ -729,7 +749,7 @@ export class TurnkeyClient {
         [stamp.stampHeaderName]: stamp.stampHeaderValue,
       },
       body: stringifiedBody,
-      redirect: "follow",
+      redirect: "error",
     });
 
     if (!response.ok) {
@@ -746,6 +766,38 @@ export class TurnkeyClient {
     const data = await response.json();
     return data as TResponseType;
   }
+
+  /**
+   * For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active.
+   *
+   * Sign the provided `TGetActivePoliciesBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_active_policies).
+   *
+   * See also {@link stampGetActivePolicies}.
+   */
+  getActivePolicies = async (
+    input: TGetActivePoliciesBody,
+  ): Promise<TGetActivePoliciesResponse> => {
+    return this.request("/public/v1/query/get_active_policies", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetActivePoliciesBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetActivePolicies}.
+   */
+  stampGetActivePolicies = async (
+    input: TGetActivePoliciesBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/query/get_active_policies";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
 
   /**
    * Get details about an activity.
@@ -1898,6 +1950,38 @@ export class TurnkeyClient {
   };
 
   /**
+   * Get details about a velocity control.
+   *
+   * Sign the provided `TGetVelocityControlBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_velocity_control).
+   *
+   * See also {@link stampGetVelocityControl}.
+   */
+  getVelocityControl = async (
+    input: TGetVelocityControlBody,
+  ): Promise<TGetVelocityControlResponse> => {
+    return this.request("/public/v1/query/get_velocity_control", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TGetVelocityControlBody` by using the client's `stamp` function.
+   *
+   * See also {@link GetVelocityControl}.
+   */
+  stampGetVelocityControl = async (
+    input: TGetVelocityControlBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/query/get_velocity_control";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * Get details about a wallet.
    *
    * Sign the provided `TGetWalletBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/get_wallet).
@@ -2637,6 +2721,38 @@ export class TurnkeyClient {
    */
   stampGetUsers = async (input: TGetUsersBody): Promise<TSignedRequest> => {
     const fullUrl = this.config.baseUrl + "/public/v1/query/list_users";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * List all velocity controls within an organization.
+   *
+   * Sign the provided `TListVelocityControlsBody` with the client's `stamp` function, and submit the request (POST /public/v1/query/list_velocity_controls).
+   *
+   * See also {@link stampListVelocityControls}.
+   */
+  listVelocityControls = async (
+    input: TListVelocityControlsBody,
+  ): Promise<TListVelocityControlsResponse> => {
+    return this.request("/public/v1/query/list_velocity_controls", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TListVelocityControlsBody` by using the client's `stamp` function.
+   *
+   * See also {@link ListVelocityControls}.
+   */
+  stampListVelocityControls = async (
+    input: TListVelocityControlsBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/query/list_velocity_controls";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {
@@ -3722,6 +3838,38 @@ export class TurnkeyClient {
   };
 
   /**
+   * Create a new velocity control.
+   *
+   * Sign the provided `TCreateVelocityControlBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_velocity_control).
+   *
+   * See also {@link stampCreateVelocityControl}.
+   */
+  createVelocityControl = async (
+    input: TCreateVelocityControlBody,
+  ): Promise<TCreateVelocityControlResponse> => {
+    return this.request("/public/v1/submit/create_velocity_control", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TCreateVelocityControlBody` by using the client's `stamp` function.
+   *
+   * See also {@link CreateVelocityControl}.
+   */
+  stampCreateVelocityControl = async (
+    input: TCreateVelocityControlBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/submit/create_velocity_control";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
    * Create a wallet and derive addresses.
    *
    * Sign the provided `TCreateWalletBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/create_wallet).
@@ -4353,6 +4501,38 @@ export class TurnkeyClient {
     input: TDeleteUsersBody,
   ): Promise<TSignedRequest> => {
     const fullUrl = this.config.baseUrl + "/public/v1/submit/delete_users";
+    const body = JSON.stringify(input);
+    const stamp = await this.stamper.stamp(body);
+    return {
+      body: body,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  /**
+   * Delete an existing velocity control.
+   *
+   * Sign the provided `TDeleteVelocityControlBody` with the client's `stamp` function, and submit the request (POST /public/v1/submit/delete_velocity_control).
+   *
+   * See also {@link stampDeleteVelocityControl}.
+   */
+  deleteVelocityControl = async (
+    input: TDeleteVelocityControlBody,
+  ): Promise<TDeleteVelocityControlResponse> => {
+    return this.request("/public/v1/submit/delete_velocity_control", input);
+  };
+
+  /**
+   * Produce a `SignedRequest` from `TDeleteVelocityControlBody` by using the client's `stamp` function.
+   *
+   * See also {@link DeleteVelocityControl}.
+   */
+  stampDeleteVelocityControl = async (
+    input: TDeleteVelocityControlBody,
+  ): Promise<TSignedRequest> => {
+    const fullUrl =
+      this.config.baseUrl + "/public/v1/submit/delete_velocity_control";
     const body = JSON.stringify(input);
     const stamp = await this.stamper.stamp(body);
     return {

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.fetcher.ts
@@ -8,6 +8,58 @@ import {
 import type { operations } from "./public_api.types";
 
 /**
+ * `POST /public/v1/query/get_active_policies`
+ */
+export type TGetActivePoliciesResponse =
+  operations["PublicApiService_GetActivePolicies"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_active_policies`
+ */
+export type TGetActivePoliciesInput = { body: TGetActivePoliciesBody };
+
+/**
+ * `POST /public/v1/query/get_active_policies`
+ */
+export type TGetActivePoliciesBody =
+  operations["PublicApiService_GetActivePolicies"]["parameters"]["body"]["body"];
+
+/**
+ * Get active policies
+ *
+ * For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active.
+ *
+ * `POST /public/v1/query/get_active_policies`
+ */
+export const getActivePolicies = (input: TGetActivePoliciesInput) =>
+  request<
+    TGetActivePoliciesResponse,
+    TGetActivePoliciesBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/query/get_active_policies",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetActivePolicies` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetActivePolicies}
+ */
+export const signGetActivePolicies = (
+  input: TGetActivePoliciesInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetActivePoliciesBody, never, never>({
+    uri: "/public/v1/query/get_active_policies",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/query/get_activity`
  */
 export type TGetActivityResponse =
@@ -1854,6 +1906,58 @@ export const signGetUser = (
   });
 
 /**
+ * `POST /public/v1/query/get_velocity_control`
+ */
+export type TGetVelocityControlResponse =
+  operations["PublicApiService_GetVelocityControl"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/get_velocity_control`
+ */
+export type TGetVelocityControlInput = { body: TGetVelocityControlBody };
+
+/**
+ * `POST /public/v1/query/get_velocity_control`
+ */
+export type TGetVelocityControlBody =
+  operations["PublicApiService_GetVelocityControl"]["parameters"]["body"]["body"];
+
+/**
+ * Get velocity control
+ *
+ * Get details about a velocity control.
+ *
+ * `POST /public/v1/query/get_velocity_control`
+ */
+export const getVelocityControl = (input: TGetVelocityControlInput) =>
+  request<
+    TGetVelocityControlResponse,
+    TGetVelocityControlBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/query/get_velocity_control",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `GetVelocityControl` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link GetVelocityControl}
+ */
+export const signGetVelocityControl = (
+  input: TGetVelocityControlInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TGetVelocityControlBody, never, never>({
+    uri: "/public/v1/query/get_velocity_control",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/query/get_wallet`
  */
 export type TGetWalletResponse =
@@ -3050,6 +3154,58 @@ export const signGetUsers = (
   });
 
 /**
+ * `POST /public/v1/query/list_velocity_controls`
+ */
+export type TListVelocityControlsResponse =
+  operations["PublicApiService_ListVelocityControls"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/query/list_velocity_controls`
+ */
+export type TListVelocityControlsInput = { body: TListVelocityControlsBody };
+
+/**
+ * `POST /public/v1/query/list_velocity_controls`
+ */
+export type TListVelocityControlsBody =
+  operations["PublicApiService_ListVelocityControls"]["parameters"]["body"]["body"];
+
+/**
+ * List velocity controls
+ *
+ * List all velocity controls within an organization.
+ *
+ * `POST /public/v1/query/list_velocity_controls`
+ */
+export const listVelocityControls = (input: TListVelocityControlsInput) =>
+  request<
+    TListVelocityControlsResponse,
+    TListVelocityControlsBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/query/list_velocity_controls",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `ListVelocityControls` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link ListVelocityControls}
+ */
+export const signListVelocityControls = (
+  input: TListVelocityControlsInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TListVelocityControlsBody, never, never>({
+    uri: "/public/v1/query/list_velocity_controls",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/query/list_verified_suborgs`
  */
 export type TGetVerifiedSubOrgIdsResponse =
@@ -3119,7 +3275,7 @@ export type TGetWalletAccountsBody =
   operations["PublicApiService_GetWalletAccounts"]["parameters"]["body"]["body"];
 
 /**
- * List wallets accounts
+ * List wallet accounts
  *
  * List all accounts within a wallet.
  *
@@ -4756,6 +4912,58 @@ export const signCreateUsers = (
   });
 
 /**
+ * `POST /public/v1/submit/create_velocity_control`
+ */
+export type TCreateVelocityControlResponse =
+  operations["PublicApiService_CreateVelocityControl"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/create_velocity_control`
+ */
+export type TCreateVelocityControlInput = { body: TCreateVelocityControlBody };
+
+/**
+ * `POST /public/v1/submit/create_velocity_control`
+ */
+export type TCreateVelocityControlBody =
+  operations["PublicApiService_CreateVelocityControl"]["parameters"]["body"]["body"];
+
+/**
+ * Create velocity control
+ *
+ * Create a new velocity control.
+ *
+ * `POST /public/v1/submit/create_velocity_control`
+ */
+export const createVelocityControl = (input: TCreateVelocityControlInput) =>
+  request<
+    TCreateVelocityControlResponse,
+    TCreateVelocityControlBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/submit/create_velocity_control",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `CreateVelocityControl` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link CreateVelocityControl}
+ */
+export const signCreateVelocityControl = (
+  input: TCreateVelocityControlInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TCreateVelocityControlBody, never, never>({
+    uri: "/public/v1/submit/create_velocity_control",
+    body: input.body,
+    options,
+  });
+
+/**
  * `POST /public/v1/submit/create_wallet`
  */
 export type TCreateWalletResponse =
@@ -5763,6 +5971,58 @@ export const signDeleteUsers = (
 ) =>
   signedRequest<TDeleteUsersBody, never, never>({
     uri: "/public/v1/submit/delete_users",
+    body: input.body,
+    options,
+  });
+
+/**
+ * `POST /public/v1/submit/delete_velocity_control`
+ */
+export type TDeleteVelocityControlResponse =
+  operations["PublicApiService_DeleteVelocityControl"]["responses"]["200"]["schema"];
+
+/**
+ * `POST /public/v1/submit/delete_velocity_control`
+ */
+export type TDeleteVelocityControlInput = { body: TDeleteVelocityControlBody };
+
+/**
+ * `POST /public/v1/submit/delete_velocity_control`
+ */
+export type TDeleteVelocityControlBody =
+  operations["PublicApiService_DeleteVelocityControl"]["parameters"]["body"]["body"];
+
+/**
+ * Delete velocity control
+ *
+ * Delete an existing velocity control.
+ *
+ * `POST /public/v1/submit/delete_velocity_control`
+ */
+export const deleteVelocityControl = (input: TDeleteVelocityControlInput) =>
+  request<
+    TDeleteVelocityControlResponse,
+    TDeleteVelocityControlBody,
+    never,
+    never,
+    never
+  >({
+    uri: "/public/v1/submit/delete_velocity_control",
+    method: "POST",
+    body: input.body,
+  });
+
+/**
+ * Request a WebAuthn assertion and return a signed `DeleteVelocityControl` request, ready to be POSTed to Turnkey.
+ *
+ * See {@link DeleteVelocityControl}
+ */
+export const signDeleteVelocityControl = (
+  input: TDeleteVelocityControlInput,
+  options?: TurnkeyCredentialRequestOptions,
+) =>
+  signedRequest<TDeleteVelocityControlBody, never, never>({
+    uri: "/public/v1/submit/delete_velocity_control",
     body: input.body,
     options,
   });

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.swagger.json
@@ -72,6 +72,38 @@
   "consumes": ["application/json"],
   "produces": ["application/json"],
   "paths": {
+    "/public/v1/query/get_active_policies": {
+      "post": {
+        "summary": "Get active policies",
+        "description": "For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active.",
+        "operationId": "PublicApiService_GetActivePolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["Policies"]
+      }
+    },
     "/public/v1/query/get_activity": {
       "post": {
         "summary": "Get activity",
@@ -1256,6 +1288,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/get_velocity_control": {
+      "post": {
+        "summary": "Get velocity control",
+        "description": "Get details about a velocity control.",
+        "operationId": "PublicApiService_GetVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/get_wallet": {
       "post": {
         "summary": "Get wallet",
@@ -2024,6 +2088,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/list_velocity_controls": {
+      "post": {
+        "summary": "List velocity controls",
+        "description": "List all velocity controls within an organization.",
+        "operationId": "PublicApiService_ListVelocityControls",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/list_verified_suborgs": {
       "post": {
         "summary": "Get verified sub-organizations",
@@ -2058,7 +2154,7 @@
     },
     "/public/v1/query/list_wallet_accounts": {
       "post": {
-        "summary": "List wallets accounts",
+        "summary": "List wallet accounts",
         "description": "List all accounts within a wallet.",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
@@ -3112,6 +3208,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/create_velocity_control": {
+      "post": {
+        "summary": "Create velocity control",
+        "description": "Create a new velocity control.",
+        "operationId": "PublicApiService_CreateVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/create_wallet": {
       "post": {
         "summary": "Create wallet",
@@ -3750,6 +3878,38 @@
           }
         ],
         "tags": ["Users"]
+      }
+    },
+    "/public/v1/submit/delete_velocity_control": {
+      "post": {
+        "summary": "Delete velocity control",
+        "description": "Delete an existing velocity control.",
+        "operationId": "PublicApiService_DeleteVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
       }
     },
     "/public/v1/submit/delete_wallet_accounts": {
@@ -6084,6 +6244,26 @@
       },
       "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
+    "billingUpdatePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
+    "billingUpdatePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -6363,6 +6543,32 @@
       "type": "string",
       "enum": ["ACCESS_TYPE_WEB", "ACCESS_TYPE_API", "ACCESS_TYPE_ALL"]
     },
+    "v1ActivePolicyStatus": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for the organization the policy belongs to."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "Unique identifier for a given policy."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the policy is currently active. A policy without a time window is always active."
+        },
+        "timeExpr": {
+          "type": "string",
+          "description": "The policy's time expression, absent when the policy has no time window."
+        },
+        "error": {
+          "type": "string",
+          "description": "Set when the policy's time expression could not be evaluated; the policy is reported inactive."
+        }
+      },
+      "required": ["organizationId", "policyId", "active"]
+    },
     "v1Activity": {
       "type": "object",
       "properties": {
@@ -6628,7 +6834,12 @@
         "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
         "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
         "ACTIVITY_TYPE_IMPORT_SECRETS",
-        "ACTIVITY_TYPE_EXPORT_SECRETS"
+        "ACTIVITY_TYPE_EXPORT_SECRETS",
+        "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V3"
       ]
     },
     "v1AddressFormat": {
@@ -6916,6 +7127,13 @@
         "stable": {
           "type": "boolean",
           "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
+        },
+        "earnProviders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1EarnProvider"
+          },
+          "description": "Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn."
         }
       }
     },
@@ -8966,6 +9184,36 @@
       },
       "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
     },
+    "v1CreateSwapQuoteIntentV2": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
     "v1CreateSwapQuoteRequest": {
       "type": "object",
       "properties": {
@@ -9561,6 +9809,61 @@
         }
       },
       "required": ["userIds"]
+    },
+    "v1CreateVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": ["name", "dataSource", "aggregation", "identifier"]
+    },
+    "v1CreateVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
     },
     "v1CreateWalletAccountsIntent": {
       "type": "object",
@@ -10632,6 +10935,48 @@
       },
       "required": ["userIds"]
     },
+    "v1DeleteVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
+    "v1DeleteVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
     "v1DeleteWalletAccountsIntent": {
       "type": "object",
       "properties": {
@@ -10804,6 +11149,10 @@
         "lastUpdatedTime": {
           "$ref": "#/definitions/externaldatav1Timestamp",
           "description": "Last time this deployment was updated"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/v1ProvisioningState",
+          "description": "Current quorum-key provisioning state for this deployment"
         }
       },
       "required": [
@@ -11046,6 +11395,22 @@
         "clientFeeWallet": {
           "type": "string",
           "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        },
+        "exposures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EarnVaultExposure"
+          },
+          "description": "The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho)."
         }
       }
     },
@@ -11226,6 +11591,47 @@
         "curator": {
           "type": "string",
           "description": "Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave)."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        }
+      }
+    },
+    "v1EarnVaultExposure": {
+      "type": "object",
+      "properties": {
+        "marketId": {
+          "type": "string",
+          "description": "Provider-specific identifier for the market (the Morpho Blue market id)."
+        },
+        "collateralSymbol": {
+          "type": "string",
+          "description": "Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market."
+        },
+        "collateralCaip19": {
+          "type": "string",
+          "description": "CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market."
+        },
+        "lltvPct": {
+          "type": "string",
+          "description": "The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%)."
+        },
+        "supplied": {
+          "type": "string",
+          "description": "Assets the vault supplies to this market, in raw on-chain units of the underlying asset."
+        },
+        "display": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead."
+        },
+        "sharePct": {
+          "type": "string",
+          "description": "This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%)."
         }
       }
     },
@@ -11696,7 +12102,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -11766,7 +12174,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11834,7 +12244,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -12008,7 +12420,9 @@
             "eip155:143",
             "eip155:10143",
             "eip155:42161",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -12151,6 +12565,64 @@
         "gasStationNonce": {
           "type": "string",
           "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
+    "v1ExecuteSwapIntentV3": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
         }
       },
       "required": [
@@ -12591,6 +13063,35 @@
         "FIAT_ON_RAMP_PROVIDER_COINBASE",
         "FIAT_ON_RAMP_PROVIDER_MOONPAY"
       ]
+    },
+    "v1GetActivePoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetActivePoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "statuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ActivePolicyStatus"
+          },
+          "description": "The active/inactive status of every policy in the organization."
+        },
+        "evaluatedAtMs": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy."
+        }
+      },
+      "required": ["statuses", "evaluatedAtMs"]
     },
     "v1GetActivitiesRequest": {
       "type": "object",
@@ -13132,7 +13633,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -13788,15 +14291,18 @@
         "attestationDocument": {
           "type": "string",
           "format": "byte",
-          "description": "The attestation document of the provisioning enclave in a TVC deployment."
+          "description": "The attestation document of the provisioning enclave. Present only when a deployment is awaiting provisioning."
         },
         "manifestEnvelope": {
           "type": "string",
           "format": "byte",
-          "description": "The manifest envelope containing the TVC deployment's manifest and signatures."
+          "description": "The manifest envelope containing the TVC deployment's manifest and signatures. Present only when a deployment is awaiting provisioning."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/v1ProvisioningState",
+          "description": "Current provisioning state."
         }
-      },
-      "required": ["attestationDocument", "manifestEnvelope"]
+      }
     },
     "v1GetTvcDeploymentRequest": {
       "type": "object",
@@ -13896,6 +14402,27 @@
         }
       },
       "required": ["users"]
+    },
+    "v1GetVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["organizationId", "velocityControlId"]
+    },
+    "v1GetVelocityControlResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControl": {
+          "$ref": "#/definitions/v1VelocityControl"
+        }
+      },
+      "required": ["velocityControl"]
     },
     "v1GetVerifiedSubOrgIdsRequest": {
       "type": "object",
@@ -14030,6 +14557,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14601,7 +15130,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14639,7 +15168,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14686,7 +15215,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14785,7 +15314,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14836,7 +15365,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14891,7 +15420,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -15579,6 +16108,21 @@
         },
         "exportSecretsIntent": {
           "$ref": "#/definitions/v1ExportSecretsIntent"
+        },
+        "createVelocityControlIntent": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "deleteVelocityControlIntent": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "updatePaymentMethodIntent": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodIntent"
+        },
+        "createSwapQuoteIntentV2": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntentV2"
+        },
+        "executeSwapIntentV3": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV3"
         }
       }
     },
@@ -15765,6 +16309,10 @@
         "caip19": {
           "type": "string",
           "description": "Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier."
+        },
+        "includeExposure": {
+          "type": "boolean",
+          "description": "When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views."
         }
       },
       "required": ["organizationId"]
@@ -15909,7 +16457,9 @@
             "eip155:42431",
             "eip155:421614",
             "eip155:56",
-            "eip155:97"
+            "eip155:97",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "EVM CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -16106,6 +16656,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -16150,6 +16702,34 @@
         }
       },
       "required": ["userTags"]
+    },
+    "v1ListVelocityControlsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "paginationOptions": {
+          "$ref": "#/definitions/v1Pagination"
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1ListVelocityControlsResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControl"
+          }
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo"
+        }
+      },
+      "required": ["velocityControls", "pageInfo"]
     },
     "v1ListWebhookEndpointsRequest": {
       "type": "object",
@@ -17187,6 +17767,14 @@
         }
       }
     },
+    "v1ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "PROVISIONING_STATE_PENDING",
+        "PROVISIONING_STATE_AWAITING_PROVISION",
+        "PROVISIONING_STATE_PROVISIONED"
+      ]
+    },
     "v1PublicKeyCredentialWithAttestation": {
       "type": "object",
       "properties": {
@@ -17969,6 +18557,15 @@
         },
         "exportSecretsResult": {
           "$ref": "#/definitions/v1ExportSecretsResult"
+        },
+        "createVelocityControlResult": {
+          "$ref": "#/definitions/v1CreateVelocityControlResult"
+        },
+        "deleteVelocityControlResult": {
+          "$ref": "#/definitions/v1DeleteVelocityControlResult"
+        },
+        "updatePaymentMethodResult": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodResult"
         }
       }
     },
@@ -21664,6 +22261,261 @@
           "type": "string"
         }
       }
+    },
+    "v1VelocityControl": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string",
+          "description": "Unique identifier for the Velocity Control."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Identifier of the Organization that owns the Velocity Control."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was created."
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was last updated."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": [
+        "velocityControlId",
+        "organizationId",
+        "name",
+        "dataSource",
+        "aggregation",
+        "createdAt",
+        "updatedAt",
+        "identifier"
+      ]
+    },
+    "v1VelocityControlAggregation": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "$ref": "#/definitions/v1VelocityControlAggregationMethod",
+          "description": "Method that aggregates matching data points."
+        },
+        "operator": {
+          "$ref": "#/definitions/v1VelocityControlAggregationOperator",
+          "description": "Comparison between the aggregate and the threshold."
+        },
+        "threshold": {
+          "type": "string",
+          "description": "Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits."
+        },
+        "window": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindow",
+          "description": "Time window for the aggregation."
+        },
+        "groupBy": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupBy",
+          "description": "Scope that partitions matching data before aggregation."
+        }
+      },
+      "required": ["method", "operator", "threshold", "window", "groupBy"]
+    },
+    "v1VelocityControlAggregationGroupBy": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByOrganization",
+          "description": "Uses one shared bucket for the Organization."
+        },
+        "user": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByUser",
+          "description": "Uses one bucket for each User."
+        },
+        "wallet": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByWallet",
+          "description": "Uses one bucket for each Wallet."
+        }
+      }
+    },
+    "v1VelocityControlAggregationGroupByOrganization": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByUser": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByWallet": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationMethod": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM",
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT"
+      ]
+    },
+    "v1VelocityControlAggregationOperator": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN"
+      ]
+    },
+    "v1VelocityControlAggregationWindow": {
+      "type": "object",
+      "properties": {
+        "rolling": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowRolling",
+          "description": "Uses a rolling time window."
+        },
+        "infinite": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowInfinite",
+          "description": "Uses all matching data without a time limit."
+        }
+      }
+    },
+    "v1VelocityControlAggregationWindowInfinite": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationWindowRolling": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the rolling window, in seconds, as a base-10 integer string."
+        }
+      },
+      "required": ["duration"]
+    },
+    "v1VelocityControlDataSource": {
+      "type": "object",
+      "properties": {
+        "chainAssetTransfer": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransfer",
+          "description": "Uses transfers of the listed on-chain assets as input data."
+        },
+        "activityExecution": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecution",
+          "description": "Uses executed Turnkey activities as input data."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecution": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecutionFilter",
+          "description": "Filters activity executions by type."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecutionFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose executions are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceChainAssetTransfer": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferDefinition"
+          },
+          "description": "Assets whose transfers are included in the data source."
+        },
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferFilter",
+          "description": "Filters asset transfers by activity type."
+        },
+        "phase": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhase",
+          "description": "Selects when to measure an asset transfer."
+        }
+      },
+      "required": ["definition"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferDefinition": {
+      "type": "object",
+      "properties": {
+        "caip19": {
+          "type": "string",
+          "description": "CAIP-19 identifier for the asset."
+        },
+        "decimals": {
+          "type": "string",
+          "description": "Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset."
+        }
+      },
+      "required": ["caip19", "decimals"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose asset transfers are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceFilterActivity": {
+      "type": "object",
+      "properties": {
+        "activityType": {
+          "type": "string",
+          "description": "Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`."
+        }
+      },
+      "required": ["activityType"]
+    },
+    "v1VelocityControlDataSourcePhase": {
+      "type": "object",
+      "properties": {
+        "signature": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSignature",
+          "description": "Measures the transfer when Turnkey signs the transaction and returns it to the user."
+        },
+        "submission": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSubmission",
+          "description": "Reserved for future use. Measures the transfer after the transaction lands on chain."
+        }
+      }
+    },
+    "v1VelocityControlDataSourcePhaseSignature": {
+      "type": "object"
+    },
+    "v1VelocityControlDataSourcePhaseSubmission": {
+      "type": "object"
     },
     "v1VerifyOtpIntent": {
       "type": "object",

--- a/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
+++ b/packages/http/src/__generated__/services/coordinator/public/v1/public_api.types.ts
@@ -4,6 +4,10 @@
  */
 
 export type paths = {
+  "/public/v1/query/get_active_policies": {
+    /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+    post: operations["PublicApiService_GetActivePolicies"];
+  };
   "/public/v1/query/get_activity": {
     /** Get details about an activity. */
     post: operations["PublicApiService_GetActivity"];
@@ -152,6 +156,10 @@ export type paths = {
     /** Get details about a user. */
     post: operations["PublicApiService_GetUser"];
   };
+  "/public/v1/query/get_velocity_control": {
+    /** Get details about a velocity control. */
+    post: operations["PublicApiService_GetVelocityControl"];
+  };
   "/public/v1/query/get_wallet": {
     /** Get details about a wallet. */
     post: operations["PublicApiService_GetWallet"];
@@ -247,6 +255,10 @@ export type paths = {
   "/public/v1/query/list_users": {
     /** List all users within an organization. */
     post: operations["PublicApiService_GetUsers"];
+  };
+  "/public/v1/query/list_velocity_controls": {
+    /** List all velocity controls within an organization. */
+    post: operations["PublicApiService_ListVelocityControls"];
   };
   "/public/v1/query/list_verified_suborgs": {
     /** Get all email or phone verified suborg IDs associated given a parent org ID. */
@@ -384,6 +396,10 @@ export type paths = {
     /** Create users in an existing organization. Each user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateUsers"];
   };
+  "/public/v1/submit/create_velocity_control": {
+    /** Create a new velocity control. */
+    post: operations["PublicApiService_CreateVelocityControl"];
+  };
   "/public/v1/submit/create_wallet": {
     /** Create a wallet and derive addresses. */
     post: operations["PublicApiService_CreateWallet"];
@@ -463,6 +479,10 @@ export type paths = {
   "/public/v1/submit/delete_users": {
     /** Delete users within an organization. */
     post: operations["PublicApiService_DeleteUsers"];
+  };
+  "/public/v1/submit/delete_velocity_control": {
+    /** Delete an existing velocity control. */
+    post: operations["PublicApiService_DeleteVelocityControl"];
   };
   "/public/v1/submit/delete_wallet_accounts": {
     /** Delete wallet accounts for an organization. */
@@ -797,6 +817,14 @@ export type definitions = {
     /** @description The email address associated with the payment method. */
     cardHolderEmail: string;
   };
+  billingUpdatePaymentMethodIntent: {
+    /** @description The email that will receive invoices for the payment method. */
+    paymentEmail: string;
+  };
+  billingUpdatePaymentMethodResult: {
+    /** @description The email address associated with the payment method. */
+    paymentEmail: string;
+  };
   datav1Tag: {
     /** @description Unique identifier for a given Tag. */
     tagId: string;
@@ -904,6 +932,18 @@ export type definitions = {
   };
   /** @enum {string} */
   v1AccessType: "ACCESS_TYPE_WEB" | "ACCESS_TYPE_API" | "ACCESS_TYPE_ALL";
+  v1ActivePolicyStatus: {
+    /** @description Unique identifier for the organization the policy belongs to. */
+    organizationId: string;
+    /** @description Unique identifier for a given policy. */
+    policyId: string;
+    /** @description Whether the policy is currently active. A policy without a time window is always active. */
+    active: boolean;
+    /** @description The policy's time expression, absent when the policy has no time window. */
+    timeExpr?: string;
+    /** @description Set when the policy's time expression could not be evaluated; the policy is reported inactive. */
+    error?: string;
+  };
   v1Activity: {
     /** @description Unique identifier for a given Activity object. */
     id: string;
@@ -1106,7 +1146,12 @@ export type definitions = {
     | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
     | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
     | "ACTIVITY_TYPE_IMPORT_SECRETS"
-    | "ACTIVITY_TYPE_EXPORT_SECRETS";
+    | "ACTIVITY_TYPE_EXPORT_SECRETS"
+    | "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V3";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1258,6 +1303,8 @@ export type definitions = {
     name?: string;
     /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
     stable?: boolean;
+    /** @description Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn. */
+    earnProviders?: definitions["v1EarnProvider"][];
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -2068,6 +2115,20 @@ export type definitions = {
     /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
     slippageBps?: string;
   };
+  v1CreateSwapQuoteIntentV2: {
+    /** @description Wallet account address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
+  };
   v1CreateSwapQuoteRequest: {
     /** @enum {string} */
     type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
@@ -2313,6 +2374,29 @@ export type definitions = {
   v1CreateUsersResult: {
     /** @description A list of User IDs. */
     userIds: string[];
+  };
+  v1CreateVelocityControlIntent: {
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1CreateVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateVelocityControlResult: {
+    velocityControlId: string;
   };
   v1CreateWalletAccountsIntent: {
     /** @description Unique identifier for a given Wallet. */
@@ -2737,6 +2821,22 @@ export type definitions = {
     /** @description A list of User IDs. */
     userIds: string[];
   };
+  v1DeleteVelocityControlIntent: {
+    velocityControlId: string;
+  };
+  v1DeleteVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1DeleteVelocityControlResult: {
+    velocityControlId: string;
+  };
   v1DeleteWalletAccountsIntent: {
     /** @description List of unique identifiers for wallet accounts within an organization */
     walletAccountIds: string[];
@@ -2810,6 +2910,8 @@ export type definitions = {
     desiredReplicas: number;
     /** @description Last time this deployment was updated */
     lastUpdatedTime: definitions["externaldatav1Timestamp"];
+    /** @description Current quorum-key provisioning state for this deployment */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1DisableAuthProxyIntent: { [key: string]: unknown };
   v1DisableAuthProxyResult: { [key: string]: unknown };
@@ -2924,6 +3026,12 @@ export type definitions = {
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
     /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
     clientFeeWallet?: string;
+    /** @description Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho). */
+    exposures?: definitions["v1EarnVaultExposure"][];
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3008,6 +3116,26 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
+    /** @description Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+  };
+  v1EarnVaultExposure: {
+    /** @description Provider-specific identifier for the market (the Morpho Blue market id). */
+    marketId?: string;
+    /** @description Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market. */
+    collateralSymbol?: string;
+    /** @description CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market. */
+    collateralCaip19?: string;
+    /** @description The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%). */
+    lltvPct?: string;
+    /** @description Assets the vault supplies to this market, in raw on-chain units of the underlying asset. */
+    supplied?: string;
+    /** @description Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead. */
+    display?: definitions["v1EarnValueDisplay"];
+    /** @description This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%). */
+    sharePct?: string;
   };
   v1EarnWithdrawIntent: {
     /** @description Address of the deployed Earn wrapper holding the position to withdraw from, from ListEarnPositions. Must be one of the org's deployed wrappers. */
@@ -3237,7 +3365,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -3278,7 +3408,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -3321,7 +3453,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
     sponsor?: boolean;
     /** @description Outer transaction nonce. Omit to auto-fetch. */
@@ -3405,7 +3539,9 @@ export type definitions = {
       | "eip155:143"
       | "eip155:10143"
       | "eip155:42161"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Outer transaction nonce. Omit to auto-fetch. */
     nonce?: string;
     /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
@@ -3468,6 +3604,30 @@ export type definitions = {
     recentBlockhash?: string;
     /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
     gasStationNonce?: string;
+  };
+  v1ExecuteSwapIntentV3: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
   };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
@@ -3684,6 +3844,19 @@ export type definitions = {
   v1FiatOnRampProvider:
     | "FIAT_ON_RAMP_PROVIDER_COINBASE"
     | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
+  v1GetActivePoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetActivePoliciesResponse: {
+    /** @description The active/inactive status of every policy in the organization. */
+    statuses: definitions["v1ActivePolicyStatus"][];
+    /**
+     * Format: uint64
+     * @description The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy.
+     */
+    evaluatedAtMs: string;
+  };
   v1GetActivitiesRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3926,7 +4099,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -4193,14 +4368,16 @@ export type definitions = {
   v1GetTvcDeploymentProvisioningDetailsResponse: {
     /**
      * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
+     * @description The attestation document of the provisioning enclave. Present only when a deployment is awaiting provisioning.
      */
-    attestationDocument: string;
+    attestationDocument?: string;
     /**
      * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
+     * @description The manifest envelope containing the TVC deployment's manifest and signatures. Present only when a deployment is awaiting provisioning.
      */
-    manifestEnvelope: string;
+    manifestEnvelope?: string;
+    /** @description Current provisioning state. */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4239,6 +4416,13 @@ export type definitions = {
   v1GetUsersResponse: {
     /** @description A list of users. */
     users: definitions["v1User"][];
+  };
+  v1GetVelocityControlRequest: {
+    organizationId: string;
+    velocityControlId: string;
+  };
+  v1GetVelocityControlResponse: {
+    velocityControl: definitions["v1VelocityControl"];
   };
   v1GetVerifiedSubOrgIdsRequest: {
     /** @description Unique identifier for the parent organization. This is used to find sub-organizations within it. */
@@ -4308,6 +4492,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4537,7 +4723,7 @@ export type definitions = {
     importBundle: string;
   };
   v1InitOtpAuthIntent: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4555,7 +4741,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV2: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4580,7 +4766,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4627,7 +4813,7 @@ export type definitions = {
     otpId: string;
   };
   v1InitOtpIntent: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4654,7 +4840,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV2: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4683,7 +4869,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4940,6 +5126,11 @@ export type definitions = {
     createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
     importSecretsIntent?: definitions["v1ImportSecretsIntent"];
     exportSecretsIntent?: definitions["v1ExportSecretsIntent"];
+    createVelocityControlIntent?: definitions["v1CreateVelocityControlIntent"];
+    deleteVelocityControlIntent?: definitions["v1DeleteVelocityControlIntent"];
+    updatePaymentMethodIntent?: definitions["billingUpdatePaymentMethodIntent"];
+    createSwapQuoteIntentV2?: definitions["v1CreateSwapQuoteIntentV2"];
+    executeSwapIntentV3?: definitions["v1ExecuteSwapIntentV3"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -5013,6 +5204,8 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier. */
     caip19?: string;
+    /** @description When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views. */
+    includeExposure?: boolean;
   };
   v1ListEarnEnabledVaultsResponse: {
     /** @description The organization's deployed wrappers. */
@@ -5079,7 +5272,9 @@ export type definitions = {
       | "eip155:42431"
       | "eip155:421614"
       | "eip155:56"
-      | "eip155:97";
+      | "eip155:97"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Cursor-based pagination options. Cursors are opaque and valid only for the same address and CAIP-2 query. */
     paginationOptions?: definitions["v1Pagination"];
   };
@@ -5166,6 +5361,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -5180,6 +5377,14 @@ export type definitions = {
   v1ListUserTagsResponse: {
     /** @description A list of user tags. */
     userTags: definitions["datav1Tag"][];
+  };
+  v1ListVelocityControlsRequest: {
+    organizationId: string;
+    paginationOptions?: definitions["v1Pagination"];
+  };
+  v1ListVelocityControlsResponse: {
+    velocityControls: definitions["v1VelocityControl"][];
+    pageInfo: definitions["v1PageInfo"];
   };
   v1ListWebhookEndpointsRequest: {
     /** @description Unique identifier for a given Organization. */
@@ -5596,6 +5801,11 @@ export type definitions = {
     privateKeyId?: string;
     addresses?: definitions["immutableactivityv1Address"][];
   };
+  /** @enum {string} */
+  v1ProvisioningState:
+    | "PROVISIONING_STATE_PENDING"
+    | "PROVISIONING_STATE_AWAITING_PROVISION"
+    | "PROVISIONING_STATE_PROVISIONED";
   v1PublicKeyCredentialWithAttestation: {
     id: string;
     /** @enum {string} */
@@ -5877,6 +6087,9 @@ export type definitions = {
     createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
     importSecretsResult?: definitions["v1ImportSecretsResult"];
     exportSecretsResult?: definitions["v1ExportSecretsResult"];
+    createVelocityControlResult?: definitions["v1CreateVelocityControlResult"];
+    deleteVelocityControlResult?: definitions["v1DeleteVelocityControlResult"];
+    updatePaymentMethodResult?: definitions["billingUpdatePaymentMethodResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -7386,6 +7599,113 @@ export type definitions = {
   v1ValidateTvcImageResponse: {
     resolvedImageDigest?: string;
   };
+  v1VelocityControl: {
+    /** @description Unique identifier for the Velocity Control. */
+    velocityControlId: string;
+    /** @description Identifier of the Organization that owns the Velocity Control. */
+    organizationId: string;
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Time when the Velocity Control was created. */
+    createdAt: definitions["externaldatav1Timestamp"];
+    /** @description Time when the Velocity Control was last updated. */
+    updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1VelocityControlAggregation: {
+    /** @description Method that aggregates matching data points. */
+    method: definitions["v1VelocityControlAggregationMethod"];
+    /** @description Comparison between the aggregate and the threshold. */
+    operator: definitions["v1VelocityControlAggregationOperator"];
+    /** @description Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits. */
+    threshold: string;
+    /** @description Time window for the aggregation. */
+    window: definitions["v1VelocityControlAggregationWindow"];
+    /** @description Scope that partitions matching data before aggregation. */
+    groupBy: definitions["v1VelocityControlAggregationGroupBy"];
+  };
+  v1VelocityControlAggregationGroupBy: {
+    /** @description Uses one shared bucket for the Organization. */
+    organization?: definitions["v1VelocityControlAggregationGroupByOrganization"];
+    /** @description Uses one bucket for each User. */
+    user?: definitions["v1VelocityControlAggregationGroupByUser"];
+    /** @description Uses one bucket for each Wallet. */
+    wallet?: definitions["v1VelocityControlAggregationGroupByWallet"];
+  };
+  v1VelocityControlAggregationGroupByOrganization: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByUser: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByWallet: { [key: string]: unknown };
+  /** @enum {string} */
+  v1VelocityControlAggregationMethod:
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM"
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT";
+  /** @enum {string} */
+  v1VelocityControlAggregationOperator:
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN";
+  v1VelocityControlAggregationWindow: {
+    /** @description Uses a rolling time window. */
+    rolling?: definitions["v1VelocityControlAggregationWindowRolling"];
+    /** @description Uses all matching data without a time limit. */
+    infinite?: definitions["v1VelocityControlAggregationWindowInfinite"];
+  };
+  v1VelocityControlAggregationWindowInfinite: { [key: string]: unknown };
+  v1VelocityControlAggregationWindowRolling: {
+    /** @description Duration of the rolling window, in seconds, as a base-10 integer string. */
+    duration: string;
+  };
+  v1VelocityControlDataSource: {
+    /** @description Uses transfers of the listed on-chain assets as input data. */
+    chainAssetTransfer?: definitions["v1VelocityControlDataSourceChainAssetTransfer"];
+    /** @description Uses executed Turnkey activities as input data. */
+    activityExecution?: definitions["v1VelocityControlDataSourceActivityExecution"];
+  };
+  v1VelocityControlDataSourceActivityExecution: {
+    /** @description Filters activity executions by type. */
+    filter?: definitions["v1VelocityControlDataSourceActivityExecutionFilter"];
+  };
+  v1VelocityControlDataSourceActivityExecutionFilter: {
+    /** @description Activity types whose executions are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceChainAssetTransfer: {
+    /** @description Assets whose transfers are included in the data source. */
+    definition: definitions["v1VelocityControlDataSourceChainAssetTransferDefinition"][];
+    /** @description Filters asset transfers by activity type. */
+    filter?: definitions["v1VelocityControlDataSourceChainAssetTransferFilter"];
+    /** @description Selects when to measure an asset transfer. */
+    phase?: definitions["v1VelocityControlDataSourcePhase"];
+  };
+  v1VelocityControlDataSourceChainAssetTransferDefinition: {
+    /** @description CAIP-19 identifier for the asset. */
+    caip19: string;
+    /** @description Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset. */
+    decimals: string;
+  };
+  v1VelocityControlDataSourceChainAssetTransferFilter: {
+    /** @description Activity types whose asset transfers are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceFilterActivity: {
+    /** @description Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`. */
+    activityType: string;
+  };
+  v1VelocityControlDataSourcePhase: {
+    /** @description Measures the transfer when Turnkey signs the transaction and returns it to the user. */
+    signature?: definitions["v1VelocityControlDataSourcePhaseSignature"];
+    /** @description Reserved for future use. Measures the transfer after the transaction lands on chain. */
+    submission?: definitions["v1VelocityControlDataSourcePhaseSubmission"];
+  };
+  v1VelocityControlDataSourcePhaseSignature: { [key: string]: unknown };
+  v1VelocityControlDataSourcePhaseSubmission: { [key: string]: unknown };
   v1VerifyOtpIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -7559,6 +7879,24 @@ export type definitions = {
 };
 
 export type operations = {
+  /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+  PublicApiService_GetActivePolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetActivePoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetActivePoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about an activity. */
   PublicApiService_GetActivity: {
     parameters: {
@@ -8225,6 +8563,24 @@ export type operations = {
       };
     };
   };
+  /** Get details about a velocity control. */
+  PublicApiService_GetVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1GetVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetVelocityControlResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a wallet. */
   PublicApiService_GetWallet: {
     parameters: {
@@ -8650,6 +9006,24 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetUsersResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** List all velocity controls within an organization. */
+  PublicApiService_ListVelocityControls: {
+    parameters: {
+      body: {
+        body: definitions["v1ListVelocityControlsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ListVelocityControlsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -9269,6 +9643,24 @@ export type operations = {
       };
     };
   };
+  /** Create a new velocity control. */
+  PublicApiService_CreateVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a wallet and derive addresses. */
   PublicApiService_CreateWallet: {
     parameters: {
@@ -9616,6 +10008,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteUsersRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an existing velocity control. */
+  PublicApiService_DeleteVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteVelocityControlRequest"];
       };
     };
     responses: {

--- a/packages/sdk-browser/scripts/codegen.js
+++ b/packages/sdk-browser/scripts/codegen.js
@@ -41,8 +41,27 @@ const VERSIONED_ACTIVITY_TYPES = {
     "ACTIVITY_TYPE_CREATE_OAUTH_PROVIDERS_V2",
   ACTIVITY_TYPE_ETH_SEND_TRANSACTION: "ACTIVITY_TYPE_ETH_SEND_TRANSACTION_V2",
   ACTIVITY_TYPE_SOL_SEND_TRANSACTION: "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2",
-  ACTIVITY_TYPE_EXECUTE_SWAP: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+  ACTIVITY_TYPE_CREATE_SWAP_QUOTE: {
+    activityType: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+    intentType: "v1CreateSwapQuoteIntentV2",
+  },
+  ACTIVITY_TYPE_EXECUTE_SWAP: {
+    activityType: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
+    intentType: "v1ExecuteSwapIntentV3",
+  },
 };
+
+/**
+ * @param {string | { activityType: string, intentType?: string } | undefined} entry
+ * @returns {{ activityType: string | undefined, intentType: string | undefined }}
+ */
+function resolveVersionedActivity(entry) {
+  if (!entry) return { activityType: undefined, intentType: undefined };
+  if (typeof entry === "string") {
+    return { activityType: entry, intentType: undefined };
+  }
+  return entry;
+}
 
 const METHODS_WITH_ONLY_OPTIONAL_PARAMETERS = [
   "getActivities",
@@ -174,6 +193,12 @@ const generateApiTypesFromSwagger = async (swaggerSpec, targetPath) => {
     }
 
     const parameterList = operation["parameters"] ?? [];
+    const unversionedActivityType = `ACTIVITY_TYPE_${operationNameWithoutNamespace
+      .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+      .toUpperCase()}`;
+    const { intentType: versionedIntentType } = resolveVersionedActivity(
+      VERSIONED_ACTIVITY_TYPES[unversionedActivityType],
+    );
 
     let responseValue = "void";
     if (methodType === "command") {
@@ -196,7 +221,9 @@ const generateApiTypesFromSwagger = async (swaggerSpec, targetPath) => {
 
     let bodyValue = "{}";
     if (["activityDecision", "command"].includes(methodType)) {
-      bodyValue = `operations["${operationId}"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams`;
+      bodyValue = versionedIntentType
+        ? `definitions["${versionedIntentType}"] & commandOverrideParams`
+        : `operations["${operationId}"]["parameters"]["body"]["body"]["parameters"] & commandOverrideParams`;
     } else if (methodType === "query") {
       bodyValue = `Omit<operations["${operationId}"]["parameters"]["body"]["body"], "organizationId"> & queryOverrideParams`;
     }
@@ -441,8 +468,9 @@ export class TurnkeySDKClientBase {
     const unversionedActivityType = `ACTIVITY_TYPE_${operationNameWithoutNamespace
       .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
       .toUpperCase()}`;
-    const versionedActivityType =
-      VERSIONED_ACTIVITY_TYPES[unversionedActivityType];
+    const { activityType: versionedActivityType } = resolveVersionedActivity(
+      VERSIONED_ACTIVITY_TYPES[unversionedActivityType],
+    );
 
     if (methodType === "query") {
       codeBuffer.push(

--- a/packages/sdk-browser/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-browser/src/__generated__/sdk-client-base.ts
@@ -153,6 +153,48 @@ export class TurnkeySDKClientBase {
     } as TResponseType;
   }
 
+  getActivePolicies = async (
+    input: SdkApiTypes.TGetActivePoliciesBody,
+  ): Promise<SdkApiTypes.TGetActivePoliciesResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_active_policies", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetActivePolicies = async (
+    input: SdkApiTypes.TGetActivePoliciesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_active_policies";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getActivity = async (
     input: SdkApiTypes.TGetActivityBody,
   ): Promise<SdkApiTypes.TGetActivityResponse> => {
@@ -1609,6 +1651,48 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getVelocityControl = async (
+    input: SdkApiTypes.TGetVelocityControlBody,
+  ): Promise<SdkApiTypes.TGetVelocityControlResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/get_velocity_control", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampGetVelocityControl = async (
+    input: SdkApiTypes.TGetVelocityControlBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_velocity_control";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getWallet = async (
     input: SdkApiTypes.TGetWalletBody,
   ): Promise<SdkApiTypes.TGetWalletResponse> => {
@@ -2592,6 +2676,48 @@ export class TurnkeySDKClientBase {
     const sessionData = await getStorageValue(StorageKeys.Session);
     const session = sessionData ? parseSession(sessionData) : null;
     const fullUrl = this.config.apiBaseUrl + "/public/v1/query/list_users";
+    const body = {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  listVelocityControls = async (
+    input: SdkApiTypes.TListVelocityControlsBody,
+  ): Promise<SdkApiTypes.TListVelocityControlsResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    return this.request("/public/v1/query/list_velocity_controls", {
+      ...input,
+      organizationId:
+        input.organizationId ??
+        session?.organizationId ??
+        this.config.organizationId,
+    });
+  };
+
+  stampListVelocityControls = async (
+    input: SdkApiTypes.TListVelocityControlsBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/list_velocity_controls";
     const body = {
       ...input,
       organizationId:
@@ -3858,7 +3984,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
-        type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
+        type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
       },
       "createSwapQuoteResult",
     );
@@ -3882,7 +4008,7 @@ export class TurnkeySDKClientBase {
       organizationId:
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
-      type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
+      type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4142,6 +4268,58 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_USERS_V4",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  createVelocityControl = async (
+    input: SdkApiTypes.TCreateVelocityControlBody,
+  ): Promise<SdkApiTypes.TCreateVelocityControlResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/create_velocity_control",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+      },
+      "createVelocityControlResult",
+    );
+  };
+
+  stampCreateVelocityControl = async (
+    input: SdkApiTypes.TCreateVelocityControlBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_velocity_control";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -5193,6 +5371,58 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  deleteVelocityControl = async (
+    input: SdkApiTypes.TDeleteVelocityControlBody,
+  ): Promise<SdkApiTypes.TDeleteVelocityControlResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/delete_velocity_control",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+      },
+      "deleteVelocityControlResult",
+    );
+  };
+
+  stampDeleteVelocityControl = async (
+    input: SdkApiTypes.TDeleteVelocityControlBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/delete_velocity_control";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   deleteWalletAccounts = async (
     input: SdkApiTypes.TDeleteWalletAccountsBody,
   ): Promise<SdkApiTypes.TDeleteWalletAccountsResponse> => {
@@ -5725,7 +5955,7 @@ export class TurnkeySDKClientBase {
           session?.organizationId ??
           this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
-        type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        type: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
       },
       "executeSwapResult",
     );
@@ -5748,7 +5978,7 @@ export class TurnkeySDKClientBase {
       organizationId:
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
-      type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+      type: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -6213,6 +6443,58 @@ export class TurnkeySDKClientBase {
         organizationId ?? session?.organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  initImportSecrets = async (
+    input: SdkApiTypes.TInitImportSecretsBody,
+  ): Promise<SdkApiTypes.TInitImportSecretsResponse> => {
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/init_import_secrets",
+      {
+        parameters: rest,
+        organizationId:
+          organizationId ??
+          session?.organizationId ??
+          this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
+      },
+      "initImportSecretsResult",
+    );
+  };
+
+  stampInitImportSecrets = async (
+    input: SdkApiTypes.TInitImportSecretsBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const sessionData = await getStorageValue(StorageKeys.Session);
+    const session = sessionData ? parseSession(sessionData) : null;
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/init_import_secrets";
+    const bodyWithType = {
+      parameters,
+      organizationId:
+        organizationId ?? session?.organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/sdk-browser/src/__generated__/sdk_api_types.ts
+++ b/packages/sdk-browser/src/__generated__/sdk_api_types.ts
@@ -7,6 +7,17 @@ import type {
   commandOverrideParams,
 } from "../__types__/base";
 
+export type TGetActivePoliciesResponse =
+  operations["PublicApiService_GetActivePolicies"]["responses"]["200"]["schema"];
+
+export type TGetActivePoliciesInput = { body: TGetActivePoliciesBody };
+
+export type TGetActivePoliciesBody = Omit<
+  operations["PublicApiService_GetActivePolicies"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetActivityResponse =
   operations["PublicApiService_GetActivity"]["responses"]["200"]["schema"];
 
@@ -404,6 +415,17 @@ export type TGetUserBody = Omit<
 > &
   queryOverrideParams;
 
+export type TGetVelocityControlResponse =
+  operations["PublicApiService_GetVelocityControl"]["responses"]["200"]["schema"];
+
+export type TGetVelocityControlInput = { body: TGetVelocityControlBody };
+
+export type TGetVelocityControlBody = Omit<
+  operations["PublicApiService_GetVelocityControl"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetWalletResponse =
   operations["PublicApiService_GetWallet"]["responses"]["200"]["schema"];
 
@@ -678,6 +700,17 @@ export type TGetUsersBody = Omit<
 > &
   queryOverrideParams;
 
+export type TListVelocityControlsResponse =
+  operations["PublicApiService_ListVelocityControls"]["responses"]["200"]["schema"];
+
+export type TListVelocityControlsInput = { body: TListVelocityControlsBody };
+
+export type TListVelocityControlsBody = Omit<
+  operations["PublicApiService_ListVelocityControls"]["parameters"]["body"]["body"],
+  "organizationId"
+> &
+  queryOverrideParams;
+
 export type TGetVerifiedSubOrgIdsResponse =
   operations["PublicApiService_GetVerifiedSubOrgIds"]["responses"]["200"]["schema"];
 
@@ -948,9 +981,8 @@ export type TCreateSwapQuoteResponse =
 
 export type TCreateSwapQuoteInput = { body: TCreateSwapQuoteBody };
 
-export type TCreateSwapQuoteBody =
-  operations["PublicApiService_CreateSwapQuote"]["parameters"]["body"]["body"]["parameters"] &
-    commandOverrideParams;
+export type TCreateSwapQuoteBody = definitions["v1CreateSwapQuoteIntentV2"] &
+  commandOverrideParams;
 
 export type TCreateTvcAppResponse =
   operations["PublicApiService_CreateTvcApp"]["responses"]["200"]["schema"]["activity"]["result"]["createTvcAppResult"] &
@@ -1002,6 +1034,16 @@ export type TCreateUsersInput = { body: TCreateUsersBody };
 
 export type TCreateUsersBody =
   operations["PublicApiService_CreateUsers"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TCreateVelocityControlResponse =
+  operations["PublicApiService_CreateVelocityControl"]["responses"]["200"]["schema"]["activity"]["result"]["createVelocityControlResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TCreateVelocityControlInput = { body: TCreateVelocityControlBody };
+
+export type TCreateVelocityControlBody =
+  operations["PublicApiService_CreateVelocityControl"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TCreateWalletResponse =
@@ -1212,6 +1254,16 @@ export type TDeleteUsersBody =
   operations["PublicApiService_DeleteUsers"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
+export type TDeleteVelocityControlResponse =
+  operations["PublicApiService_DeleteVelocityControl"]["responses"]["200"]["schema"]["activity"]["result"]["deleteVelocityControlResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TDeleteVelocityControlInput = { body: TDeleteVelocityControlBody };
+
+export type TDeleteVelocityControlBody =
+  operations["PublicApiService_DeleteVelocityControl"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
 export type TDeleteWalletAccountsResponse =
   operations["PublicApiService_DeleteWalletAccounts"]["responses"]["200"]["schema"]["activity"]["result"]["deleteWalletAccountsResult"] &
     definitions["v1ActivityResponse"];
@@ -1318,9 +1370,8 @@ export type TExecuteSwapResponse =
 
 export type TExecuteSwapInput = { body: TExecuteSwapBody };
 
-export type TExecuteSwapBody =
-  operations["PublicApiService_ExecuteSwap"]["parameters"]["body"]["body"]["parameters"] &
-    commandOverrideParams;
+export type TExecuteSwapBody = definitions["v1ExecuteSwapIntentV3"] &
+  commandOverrideParams;
 
 export type TExportPrivateKeyResponse =
   operations["PublicApiService_ExportPrivateKey"]["responses"]["200"]["schema"]["activity"]["result"]["exportPrivateKeyResult"] &
@@ -1410,6 +1461,16 @@ export type TInitImportPrivateKeyInput = { body: TInitImportPrivateKeyBody };
 
 export type TInitImportPrivateKeyBody =
   operations["PublicApiService_InitImportPrivateKey"]["parameters"]["body"]["body"]["parameters"] &
+    commandOverrideParams;
+
+export type TInitImportSecretsResponse =
+  operations["PublicApiService_InitImportSecrets"]["responses"]["200"]["schema"]["activity"]["result"]["initImportSecretsResult"] &
+    definitions["v1ActivityResponse"];
+
+export type TInitImportSecretsInput = { body: TInitImportSecretsBody };
+
+export type TInitImportSecretsBody =
+  operations["PublicApiService_InitImportSecrets"]["parameters"]["body"]["body"]["parameters"] &
     commandOverrideParams;
 
 export type TInitImportWalletResponse =

--- a/packages/sdk-browser/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-browser/src/__inputs__/public_api.swagger.json
@@ -72,6 +72,38 @@
   "consumes": ["application/json"],
   "produces": ["application/json"],
   "paths": {
+    "/public/v1/query/get_active_policies": {
+      "post": {
+        "summary": "Get active policies",
+        "description": "For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active.",
+        "operationId": "PublicApiService_GetActivePolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["Policies"]
+      }
+    },
     "/public/v1/query/get_activity": {
       "post": {
         "summary": "Get activity",
@@ -1192,6 +1224,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/get_velocity_control": {
+      "post": {
+        "summary": "Get velocity control",
+        "description": "Get details about a velocity control.",
+        "operationId": "PublicApiService_GetVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/get_wallet": {
       "post": {
         "summary": "Get wallet",
@@ -1960,6 +2024,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/list_velocity_controls": {
+      "post": {
+        "summary": "List velocity controls",
+        "description": "List all velocity controls within an organization.",
+        "operationId": "PublicApiService_ListVelocityControls",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/list_verified_suborgs": {
       "post": {
         "summary": "Get verified sub-organizations",
@@ -1994,7 +2090,7 @@
     },
     "/public/v1/query/list_wallet_accounts": {
       "post": {
-        "summary": "List wallets accounts",
+        "summary": "List wallet accounts",
         "description": "List all accounts within a wallet.",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
@@ -2952,6 +3048,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/create_velocity_control": {
+      "post": {
+        "summary": "Create velocity control",
+        "description": "Create a new velocity control.",
+        "operationId": "PublicApiService_CreateVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/create_wallet": {
       "post": {
         "summary": "Create wallet",
@@ -3592,6 +3720,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/delete_velocity_control": {
+      "post": {
+        "summary": "Delete velocity control",
+        "description": "Delete an existing velocity control.",
+        "operationId": "PublicApiService_DeleteVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/delete_wallet_accounts": {
       "post": {
         "summary": "Delete wallet accounts",
@@ -4230,6 +4390,38 @@
           }
         ],
         "tags": ["Private Keys"]
+      }
+    },
+    "/public/v1/submit/init_import_secrets": {
+      "post": {
+        "summary": "Init import secrets",
+        "description": "Initialize secret imports by generating Ingress Encryption Target Keys.",
+        "operationId": "PublicApiService_InitImportSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1InitImportSecretsRequest"
+            }
+          }
+        ],
+        "tags": ["Secrets"]
       }
     },
     "/public/v1/submit/init_import_wallet": {
@@ -5732,6 +5924,26 @@
       },
       "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
+    "billingUpdatePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
+    "billingUpdatePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -6011,6 +6223,32 @@
       "type": "string",
       "enum": ["ACCESS_TYPE_WEB", "ACCESS_TYPE_API", "ACCESS_TYPE_ALL"]
     },
+    "v1ActivePolicyStatus": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for the organization the policy belongs to."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "Unique identifier for a given policy."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the policy is currently active. A policy without a time window is always active."
+        },
+        "timeExpr": {
+          "type": "string",
+          "description": "The policy's time expression, absent when the policy has no time window."
+        },
+        "error": {
+          "type": "string",
+          "description": "Set when the policy's time expression could not be evaluated; the policy is reported inactive."
+        }
+      },
+      "required": ["organizationId", "policyId", "active"]
+    },
     "v1Activity": {
       "type": "object",
       "properties": {
@@ -6276,7 +6514,12 @@
         "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
         "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
         "ACTIVITY_TYPE_IMPORT_SECRETS",
-        "ACTIVITY_TYPE_EXPORT_SECRETS"
+        "ACTIVITY_TYPE_EXPORT_SECRETS",
+        "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V3"
       ]
     },
     "v1AddressFormat": {
@@ -6564,6 +6807,13 @@
         "stable": {
           "type": "boolean",
           "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
+        },
+        "earnProviders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1EarnProvider"
+          },
+          "description": "Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn."
         }
       }
     },
@@ -8590,6 +8840,36 @@
       },
       "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
     },
+    "v1CreateSwapQuoteIntentV2": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
     "v1CreateSwapQuoteRequest": {
       "type": "object",
       "properties": {
@@ -9137,6 +9417,61 @@
         }
       },
       "required": ["userIds"]
+    },
+    "v1CreateVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": ["name", "dataSource", "aggregation", "identifier"]
+    },
+    "v1CreateVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
     },
     "v1CreateWalletAccountsIntent": {
       "type": "object",
@@ -10208,6 +10543,48 @@
       },
       "required": ["userIds"]
     },
+    "v1DeleteVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
+    "v1DeleteVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
     "v1DeleteWalletAccountsIntent": {
       "type": "object",
       "properties": {
@@ -10380,6 +10757,10 @@
         "lastUpdatedTime": {
           "$ref": "#/definitions/externaldatav1Timestamp",
           "description": "Last time this deployment was updated"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/v1ProvisioningState",
+          "description": "Current quorum-key provisioning state for this deployment"
         }
       },
       "required": [
@@ -10622,6 +11003,22 @@
         "clientFeeWallet": {
           "type": "string",
           "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        },
+        "exposures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EarnVaultExposure"
+          },
+          "description": "The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho)."
         }
       }
     },
@@ -10802,6 +11199,47 @@
         "curator": {
           "type": "string",
           "description": "Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave)."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        }
+      }
+    },
+    "v1EarnVaultExposure": {
+      "type": "object",
+      "properties": {
+        "marketId": {
+          "type": "string",
+          "description": "Provider-specific identifier for the market (the Morpho Blue market id)."
+        },
+        "collateralSymbol": {
+          "type": "string",
+          "description": "Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market."
+        },
+        "collateralCaip19": {
+          "type": "string",
+          "description": "CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market."
+        },
+        "lltvPct": {
+          "type": "string",
+          "description": "The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%)."
+        },
+        "supplied": {
+          "type": "string",
+          "description": "Assets the vault supplies to this market, in raw on-chain units of the underlying asset."
+        },
+        "display": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead."
+        },
+        "sharePct": {
+          "type": "string",
+          "description": "This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%)."
         }
       }
     },
@@ -11272,7 +11710,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -11318,7 +11758,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11386,7 +11828,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11560,7 +12004,9 @@
             "eip155:143",
             "eip155:10143",
             "eip155:42161",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11703,6 +12149,64 @@
         "gasStationNonce": {
           "type": "string",
           "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
+    "v1ExecuteSwapIntentV3": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
         }
       },
       "required": [
@@ -12143,6 +12647,35 @@
         "FIAT_ON_RAMP_PROVIDER_COINBASE",
         "FIAT_ON_RAMP_PROVIDER_MOONPAY"
       ]
+    },
+    "v1GetActivePoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetActivePoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "statuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ActivePolicyStatus"
+          },
+          "description": "The active/inactive status of every policy in the organization."
+        },
+        "evaluatedAtMs": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy."
+        }
+      },
+      "required": ["statuses", "evaluatedAtMs"]
     },
     "v1GetActivitiesRequest": {
       "type": "object",
@@ -12684,7 +13217,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -13399,6 +13934,27 @@
       },
       "required": ["users"]
     },
+    "v1GetVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["organizationId", "velocityControlId"]
+    },
+    "v1GetVelocityControlResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControl": {
+          "$ref": "#/definitions/v1VelocityControl"
+        }
+      },
+      "required": ["velocityControl"]
+    },
     "v1GetVerifiedSubOrgIdsRequest": {
       "type": "object",
       "properties": {
@@ -13532,6 +14088,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14020,6 +14578,27 @@
       },
       "required": ["encryptionSuite", "numSecrets"]
     },
+    "v1InitImportSecretsRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_INIT_IMPORT_SECRETS"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1InitImportSecretsIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
     "v1InitImportSecretsResult": {
       "type": "object",
       "properties": {
@@ -14082,7 +14661,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14120,7 +14699,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14167,7 +14746,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14266,7 +14845,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14317,7 +14896,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14372,7 +14951,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -15060,6 +15639,21 @@
         },
         "exportSecretsIntent": {
           "$ref": "#/definitions/v1ExportSecretsIntent"
+        },
+        "createVelocityControlIntent": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "deleteVelocityControlIntent": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "updatePaymentMethodIntent": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodIntent"
+        },
+        "createSwapQuoteIntentV2": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntentV2"
+        },
+        "executeSwapIntentV3": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV3"
         }
       }
     },
@@ -15185,6 +15779,10 @@
         "caip19": {
           "type": "string",
           "description": "Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier."
+        },
+        "includeExposure": {
+          "type": "boolean",
+          "description": "When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views."
         }
       },
       "required": ["organizationId"]
@@ -15329,7 +15927,9 @@
             "eip155:42431",
             "eip155:421614",
             "eip155:56",
-            "eip155:97"
+            "eip155:97",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "EVM CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -15526,6 +16126,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -15570,6 +16172,34 @@
         }
       },
       "required": ["userTags"]
+    },
+    "v1ListVelocityControlsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "paginationOptions": {
+          "$ref": "#/definitions/v1Pagination"
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1ListVelocityControlsResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControl"
+          }
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo"
+        }
+      },
+      "required": ["velocityControls", "pageInfo"]
     },
     "v1ListWebhookEndpointsRequest": {
       "type": "object",
@@ -16516,6 +17146,14 @@
         }
       }
     },
+    "v1ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "PROVISIONING_STATE_PENDING",
+        "PROVISIONING_STATE_AWAITING_PROVISION",
+        "PROVISIONING_STATE_PROVISIONED"
+      ]
+    },
     "v1PublicKeyCredentialWithAttestation": {
       "type": "object",
       "properties": {
@@ -17268,6 +17906,15 @@
         },
         "exportSecretsResult": {
           "$ref": "#/definitions/v1ExportSecretsResult"
+        },
+        "createVelocityControlResult": {
+          "$ref": "#/definitions/v1CreateVelocityControlResult"
+        },
+        "deleteVelocityControlResult": {
+          "$ref": "#/definitions/v1DeleteVelocityControlResult"
+        },
+        "updatePaymentMethodResult": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodResult"
         }
       }
     },
@@ -20927,6 +21574,261 @@
           "type": "string"
         }
       }
+    },
+    "v1VelocityControl": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string",
+          "description": "Unique identifier for the Velocity Control."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Identifier of the Organization that owns the Velocity Control."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was created."
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was last updated."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": [
+        "velocityControlId",
+        "organizationId",
+        "name",
+        "dataSource",
+        "aggregation",
+        "createdAt",
+        "updatedAt",
+        "identifier"
+      ]
+    },
+    "v1VelocityControlAggregation": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "$ref": "#/definitions/v1VelocityControlAggregationMethod",
+          "description": "Method that aggregates matching data points."
+        },
+        "operator": {
+          "$ref": "#/definitions/v1VelocityControlAggregationOperator",
+          "description": "Comparison between the aggregate and the threshold."
+        },
+        "threshold": {
+          "type": "string",
+          "description": "Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits."
+        },
+        "window": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindow",
+          "description": "Time window for the aggregation."
+        },
+        "groupBy": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupBy",
+          "description": "Scope that partitions matching data before aggregation."
+        }
+      },
+      "required": ["method", "operator", "threshold", "window", "groupBy"]
+    },
+    "v1VelocityControlAggregationGroupBy": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByOrganization",
+          "description": "Uses one shared bucket for the Organization."
+        },
+        "user": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByUser",
+          "description": "Uses one bucket for each User."
+        },
+        "wallet": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByWallet",
+          "description": "Uses one bucket for each Wallet."
+        }
+      }
+    },
+    "v1VelocityControlAggregationGroupByOrganization": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByUser": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByWallet": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationMethod": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM",
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT"
+      ]
+    },
+    "v1VelocityControlAggregationOperator": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN"
+      ]
+    },
+    "v1VelocityControlAggregationWindow": {
+      "type": "object",
+      "properties": {
+        "rolling": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowRolling",
+          "description": "Uses a rolling time window."
+        },
+        "infinite": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowInfinite",
+          "description": "Uses all matching data without a time limit."
+        }
+      }
+    },
+    "v1VelocityControlAggregationWindowInfinite": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationWindowRolling": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the rolling window, in seconds, as a base-10 integer string."
+        }
+      },
+      "required": ["duration"]
+    },
+    "v1VelocityControlDataSource": {
+      "type": "object",
+      "properties": {
+        "chainAssetTransfer": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransfer",
+          "description": "Uses transfers of the listed on-chain assets as input data."
+        },
+        "activityExecution": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecution",
+          "description": "Uses executed Turnkey activities as input data."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecution": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecutionFilter",
+          "description": "Filters activity executions by type."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecutionFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose executions are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceChainAssetTransfer": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferDefinition"
+          },
+          "description": "Assets whose transfers are included in the data source."
+        },
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferFilter",
+          "description": "Filters asset transfers by activity type."
+        },
+        "phase": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhase",
+          "description": "Selects when to measure an asset transfer."
+        }
+      },
+      "required": ["definition"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferDefinition": {
+      "type": "object",
+      "properties": {
+        "caip19": {
+          "type": "string",
+          "description": "CAIP-19 identifier for the asset."
+        },
+        "decimals": {
+          "type": "string",
+          "description": "Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset."
+        }
+      },
+      "required": ["caip19", "decimals"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose asset transfers are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceFilterActivity": {
+      "type": "object",
+      "properties": {
+        "activityType": {
+          "type": "string",
+          "description": "Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`."
+        }
+      },
+      "required": ["activityType"]
+    },
+    "v1VelocityControlDataSourcePhase": {
+      "type": "object",
+      "properties": {
+        "signature": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSignature",
+          "description": "Measures the transfer when Turnkey signs the transaction and returns it to the user."
+        },
+        "submission": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSubmission",
+          "description": "Reserved for future use. Measures the transfer after the transaction lands on chain."
+        }
+      }
+    },
+    "v1VelocityControlDataSourcePhaseSignature": {
+      "type": "object"
+    },
+    "v1VelocityControlDataSourcePhaseSubmission": {
+      "type": "object"
     },
     "v1VerifyOtpIntent": {
       "type": "object",

--- a/packages/sdk-browser/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-browser/src/__inputs__/public_api.types.ts
@@ -4,6 +4,10 @@
  */
 
 export type paths = {
+  "/public/v1/query/get_active_policies": {
+    /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+    post: operations["PublicApiService_GetActivePolicies"];
+  };
   "/public/v1/query/get_activity": {
     /** Get details about an activity. */
     post: operations["PublicApiService_GetActivity"];
@@ -152,6 +156,10 @@ export type paths = {
     /** Get details about a user. */
     post: operations["PublicApiService_GetUser"];
   };
+  "/public/v1/query/get_velocity_control": {
+    /** Get details about a velocity control. */
+    post: operations["PublicApiService_GetVelocityControl"];
+  };
   "/public/v1/query/get_wallet": {
     /** Get details about a wallet. */
     post: operations["PublicApiService_GetWallet"];
@@ -247,6 +255,10 @@ export type paths = {
   "/public/v1/query/list_users": {
     /** List all users within an organization. */
     post: operations["PublicApiService_GetUsers"];
+  };
+  "/public/v1/query/list_velocity_controls": {
+    /** List all velocity controls within an organization. */
+    post: operations["PublicApiService_ListVelocityControls"];
   };
   "/public/v1/query/list_verified_suborgs": {
     /** Get all email or phone verified suborg IDs associated given a parent org ID. */
@@ -384,6 +396,10 @@ export type paths = {
     /** Create users in an existing organization. Each user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateUsers"];
   };
+  "/public/v1/submit/create_velocity_control": {
+    /** Create a new velocity control. */
+    post: operations["PublicApiService_CreateVelocityControl"];
+  };
   "/public/v1/submit/create_wallet": {
     /** Create a wallet and derive addresses. */
     post: operations["PublicApiService_CreateWallet"];
@@ -463,6 +479,10 @@ export type paths = {
   "/public/v1/submit/delete_users": {
     /** Delete users within an organization. */
     post: operations["PublicApiService_DeleteUsers"];
+  };
+  "/public/v1/submit/delete_velocity_control": {
+    /** Delete an existing velocity control. */
+    post: operations["PublicApiService_DeleteVelocityControl"];
   };
   "/public/v1/submit/delete_wallet_accounts": {
     /** Delete wallet accounts for an organization. */
@@ -797,6 +817,14 @@ export type definitions = {
     /** @description The email address associated with the payment method. */
     cardHolderEmail: string;
   };
+  billingUpdatePaymentMethodIntent: {
+    /** @description The email that will receive invoices for the payment method. */
+    paymentEmail: string;
+  };
+  billingUpdatePaymentMethodResult: {
+    /** @description The email address associated with the payment method. */
+    paymentEmail: string;
+  };
   datav1Tag: {
     /** @description Unique identifier for a given Tag. */
     tagId: string;
@@ -904,6 +932,18 @@ export type definitions = {
   };
   /** @enum {string} */
   v1AccessType: "ACCESS_TYPE_WEB" | "ACCESS_TYPE_API" | "ACCESS_TYPE_ALL";
+  v1ActivePolicyStatus: {
+    /** @description Unique identifier for the organization the policy belongs to. */
+    organizationId: string;
+    /** @description Unique identifier for a given policy. */
+    policyId: string;
+    /** @description Whether the policy is currently active. A policy without a time window is always active. */
+    active: boolean;
+    /** @description The policy's time expression, absent when the policy has no time window. */
+    timeExpr?: string;
+    /** @description Set when the policy's time expression could not be evaluated; the policy is reported inactive. */
+    error?: string;
+  };
   v1Activity: {
     /** @description Unique identifier for a given Activity object. */
     id: string;
@@ -1106,7 +1146,12 @@ export type definitions = {
     | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
     | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
     | "ACTIVITY_TYPE_IMPORT_SECRETS"
-    | "ACTIVITY_TYPE_EXPORT_SECRETS";
+    | "ACTIVITY_TYPE_EXPORT_SECRETS"
+    | "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V3";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1258,6 +1303,8 @@ export type definitions = {
     name?: string;
     /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
     stable?: boolean;
+    /** @description Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn. */
+    earnProviders?: definitions["v1EarnProvider"][];
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -2068,6 +2115,20 @@ export type definitions = {
     /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
     slippageBps?: string;
   };
+  v1CreateSwapQuoteIntentV2: {
+    /** @description Wallet account address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
+  };
   v1CreateSwapQuoteRequest: {
     /** @enum {string} */
     type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
@@ -2313,6 +2374,29 @@ export type definitions = {
   v1CreateUsersResult: {
     /** @description A list of User IDs. */
     userIds: string[];
+  };
+  v1CreateVelocityControlIntent: {
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1CreateVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateVelocityControlResult: {
+    velocityControlId: string;
   };
   v1CreateWalletAccountsIntent: {
     /** @description Unique identifier for a given Wallet. */
@@ -2737,6 +2821,22 @@ export type definitions = {
     /** @description A list of User IDs. */
     userIds: string[];
   };
+  v1DeleteVelocityControlIntent: {
+    velocityControlId: string;
+  };
+  v1DeleteVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1DeleteVelocityControlResult: {
+    velocityControlId: string;
+  };
   v1DeleteWalletAccountsIntent: {
     /** @description List of unique identifiers for wallet accounts within an organization */
     walletAccountIds: string[];
@@ -2810,6 +2910,8 @@ export type definitions = {
     desiredReplicas: number;
     /** @description Last time this deployment was updated */
     lastUpdatedTime: definitions["externaldatav1Timestamp"];
+    /** @description Current quorum-key provisioning state for this deployment */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1DisableAuthProxyIntent: { [key: string]: unknown };
   v1DisableAuthProxyResult: { [key: string]: unknown };
@@ -2924,6 +3026,12 @@ export type definitions = {
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
     /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
     clientFeeWallet?: string;
+    /** @description Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho). */
+    exposures?: definitions["v1EarnVaultExposure"][];
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3008,6 +3116,26 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
+    /** @description Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+  };
+  v1EarnVaultExposure: {
+    /** @description Provider-specific identifier for the market (the Morpho Blue market id). */
+    marketId?: string;
+    /** @description Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market. */
+    collateralSymbol?: string;
+    /** @description CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market. */
+    collateralCaip19?: string;
+    /** @description The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%). */
+    lltvPct?: string;
+    /** @description Assets the vault supplies to this market, in raw on-chain units of the underlying asset. */
+    supplied?: string;
+    /** @description Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead. */
+    display?: definitions["v1EarnValueDisplay"];
+    /** @description This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%). */
+    sharePct?: string;
   };
   v1EarnWithdrawIntent: {
     /** @description Address of the deployed Earn wrapper holding the position to withdraw from, from ListEarnPositions. Must be one of the org's deployed wrappers. */
@@ -3237,7 +3365,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -3278,7 +3408,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -3321,7 +3453,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
     sponsor?: boolean;
     /** @description Outer transaction nonce. Omit to auto-fetch. */
@@ -3405,7 +3539,9 @@ export type definitions = {
       | "eip155:143"
       | "eip155:10143"
       | "eip155:42161"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Outer transaction nonce. Omit to auto-fetch. */
     nonce?: string;
     /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
@@ -3468,6 +3604,30 @@ export type definitions = {
     recentBlockhash?: string;
     /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
     gasStationNonce?: string;
+  };
+  v1ExecuteSwapIntentV3: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
   };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
@@ -3684,6 +3844,19 @@ export type definitions = {
   v1FiatOnRampProvider:
     | "FIAT_ON_RAMP_PROVIDER_COINBASE"
     | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
+  v1GetActivePoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetActivePoliciesResponse: {
+    /** @description The active/inactive status of every policy in the organization. */
+    statuses: definitions["v1ActivePolicyStatus"][];
+    /**
+     * Format: uint64
+     * @description The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy.
+     */
+    evaluatedAtMs: string;
+  };
   v1GetActivitiesRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3926,7 +4099,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -4193,14 +4368,16 @@ export type definitions = {
   v1GetTvcDeploymentProvisioningDetailsResponse: {
     /**
      * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
+     * @description The attestation document of the provisioning enclave. Present only when a deployment is awaiting provisioning.
      */
-    attestationDocument: string;
+    attestationDocument?: string;
     /**
      * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
+     * @description The manifest envelope containing the TVC deployment's manifest and signatures. Present only when a deployment is awaiting provisioning.
      */
-    manifestEnvelope: string;
+    manifestEnvelope?: string;
+    /** @description Current provisioning state. */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4239,6 +4416,13 @@ export type definitions = {
   v1GetUsersResponse: {
     /** @description A list of users. */
     users: definitions["v1User"][];
+  };
+  v1GetVelocityControlRequest: {
+    organizationId: string;
+    velocityControlId: string;
+  };
+  v1GetVelocityControlResponse: {
+    velocityControl: definitions["v1VelocityControl"];
   };
   v1GetVerifiedSubOrgIdsRequest: {
     /** @description Unique identifier for the parent organization. This is used to find sub-organizations within it. */
@@ -4308,6 +4492,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4537,7 +4723,7 @@ export type definitions = {
     importBundle: string;
   };
   v1InitOtpAuthIntent: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4555,7 +4741,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV2: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4580,7 +4766,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4627,7 +4813,7 @@ export type definitions = {
     otpId: string;
   };
   v1InitOtpIntent: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4654,7 +4840,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV2: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4683,7 +4869,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4940,6 +5126,11 @@ export type definitions = {
     createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
     importSecretsIntent?: definitions["v1ImportSecretsIntent"];
     exportSecretsIntent?: definitions["v1ExportSecretsIntent"];
+    createVelocityControlIntent?: definitions["v1CreateVelocityControlIntent"];
+    deleteVelocityControlIntent?: definitions["v1DeleteVelocityControlIntent"];
+    updatePaymentMethodIntent?: definitions["billingUpdatePaymentMethodIntent"];
+    createSwapQuoteIntentV2?: definitions["v1CreateSwapQuoteIntentV2"];
+    executeSwapIntentV3?: definitions["v1ExecuteSwapIntentV3"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -5013,6 +5204,8 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier. */
     caip19?: string;
+    /** @description When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views. */
+    includeExposure?: boolean;
   };
   v1ListEarnEnabledVaultsResponse: {
     /** @description The organization's deployed wrappers. */
@@ -5079,7 +5272,9 @@ export type definitions = {
       | "eip155:42431"
       | "eip155:421614"
       | "eip155:56"
-      | "eip155:97";
+      | "eip155:97"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Cursor-based pagination options. Cursors are opaque and valid only for the same address and CAIP-2 query. */
     paginationOptions?: definitions["v1Pagination"];
   };
@@ -5166,6 +5361,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -5180,6 +5377,14 @@ export type definitions = {
   v1ListUserTagsResponse: {
     /** @description A list of user tags. */
     userTags: definitions["datav1Tag"][];
+  };
+  v1ListVelocityControlsRequest: {
+    organizationId: string;
+    paginationOptions?: definitions["v1Pagination"];
+  };
+  v1ListVelocityControlsResponse: {
+    velocityControls: definitions["v1VelocityControl"][];
+    pageInfo: definitions["v1PageInfo"];
   };
   v1ListWebhookEndpointsRequest: {
     /** @description Unique identifier for a given Organization. */
@@ -5596,6 +5801,11 @@ export type definitions = {
     privateKeyId?: string;
     addresses?: definitions["immutableactivityv1Address"][];
   };
+  /** @enum {string} */
+  v1ProvisioningState:
+    | "PROVISIONING_STATE_PENDING"
+    | "PROVISIONING_STATE_AWAITING_PROVISION"
+    | "PROVISIONING_STATE_PROVISIONED";
   v1PublicKeyCredentialWithAttestation: {
     id: string;
     /** @enum {string} */
@@ -5877,6 +6087,9 @@ export type definitions = {
     createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
     importSecretsResult?: definitions["v1ImportSecretsResult"];
     exportSecretsResult?: definitions["v1ExportSecretsResult"];
+    createVelocityControlResult?: definitions["v1CreateVelocityControlResult"];
+    deleteVelocityControlResult?: definitions["v1DeleteVelocityControlResult"];
+    updatePaymentMethodResult?: definitions["billingUpdatePaymentMethodResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -7386,6 +7599,113 @@ export type definitions = {
   v1ValidateTvcImageResponse: {
     resolvedImageDigest?: string;
   };
+  v1VelocityControl: {
+    /** @description Unique identifier for the Velocity Control. */
+    velocityControlId: string;
+    /** @description Identifier of the Organization that owns the Velocity Control. */
+    organizationId: string;
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Time when the Velocity Control was created. */
+    createdAt: definitions["externaldatav1Timestamp"];
+    /** @description Time when the Velocity Control was last updated. */
+    updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1VelocityControlAggregation: {
+    /** @description Method that aggregates matching data points. */
+    method: definitions["v1VelocityControlAggregationMethod"];
+    /** @description Comparison between the aggregate and the threshold. */
+    operator: definitions["v1VelocityControlAggregationOperator"];
+    /** @description Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits. */
+    threshold: string;
+    /** @description Time window for the aggregation. */
+    window: definitions["v1VelocityControlAggregationWindow"];
+    /** @description Scope that partitions matching data before aggregation. */
+    groupBy: definitions["v1VelocityControlAggregationGroupBy"];
+  };
+  v1VelocityControlAggregationGroupBy: {
+    /** @description Uses one shared bucket for the Organization. */
+    organization?: definitions["v1VelocityControlAggregationGroupByOrganization"];
+    /** @description Uses one bucket for each User. */
+    user?: definitions["v1VelocityControlAggregationGroupByUser"];
+    /** @description Uses one bucket for each Wallet. */
+    wallet?: definitions["v1VelocityControlAggregationGroupByWallet"];
+  };
+  v1VelocityControlAggregationGroupByOrganization: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByUser: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByWallet: { [key: string]: unknown };
+  /** @enum {string} */
+  v1VelocityControlAggregationMethod:
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM"
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT";
+  /** @enum {string} */
+  v1VelocityControlAggregationOperator:
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN";
+  v1VelocityControlAggregationWindow: {
+    /** @description Uses a rolling time window. */
+    rolling?: definitions["v1VelocityControlAggregationWindowRolling"];
+    /** @description Uses all matching data without a time limit. */
+    infinite?: definitions["v1VelocityControlAggregationWindowInfinite"];
+  };
+  v1VelocityControlAggregationWindowInfinite: { [key: string]: unknown };
+  v1VelocityControlAggregationWindowRolling: {
+    /** @description Duration of the rolling window, in seconds, as a base-10 integer string. */
+    duration: string;
+  };
+  v1VelocityControlDataSource: {
+    /** @description Uses transfers of the listed on-chain assets as input data. */
+    chainAssetTransfer?: definitions["v1VelocityControlDataSourceChainAssetTransfer"];
+    /** @description Uses executed Turnkey activities as input data. */
+    activityExecution?: definitions["v1VelocityControlDataSourceActivityExecution"];
+  };
+  v1VelocityControlDataSourceActivityExecution: {
+    /** @description Filters activity executions by type. */
+    filter?: definitions["v1VelocityControlDataSourceActivityExecutionFilter"];
+  };
+  v1VelocityControlDataSourceActivityExecutionFilter: {
+    /** @description Activity types whose executions are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceChainAssetTransfer: {
+    /** @description Assets whose transfers are included in the data source. */
+    definition: definitions["v1VelocityControlDataSourceChainAssetTransferDefinition"][];
+    /** @description Filters asset transfers by activity type. */
+    filter?: definitions["v1VelocityControlDataSourceChainAssetTransferFilter"];
+    /** @description Selects when to measure an asset transfer. */
+    phase?: definitions["v1VelocityControlDataSourcePhase"];
+  };
+  v1VelocityControlDataSourceChainAssetTransferDefinition: {
+    /** @description CAIP-19 identifier for the asset. */
+    caip19: string;
+    /** @description Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset. */
+    decimals: string;
+  };
+  v1VelocityControlDataSourceChainAssetTransferFilter: {
+    /** @description Activity types whose asset transfers are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceFilterActivity: {
+    /** @description Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`. */
+    activityType: string;
+  };
+  v1VelocityControlDataSourcePhase: {
+    /** @description Measures the transfer when Turnkey signs the transaction and returns it to the user. */
+    signature?: definitions["v1VelocityControlDataSourcePhaseSignature"];
+    /** @description Reserved for future use. Measures the transfer after the transaction lands on chain. */
+    submission?: definitions["v1VelocityControlDataSourcePhaseSubmission"];
+  };
+  v1VelocityControlDataSourcePhaseSignature: { [key: string]: unknown };
+  v1VelocityControlDataSourcePhaseSubmission: { [key: string]: unknown };
   v1VerifyOtpIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -7559,6 +7879,24 @@ export type definitions = {
 };
 
 export type operations = {
+  /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+  PublicApiService_GetActivePolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetActivePoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetActivePoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about an activity. */
   PublicApiService_GetActivity: {
     parameters: {
@@ -8225,6 +8563,24 @@ export type operations = {
       };
     };
   };
+  /** Get details about a velocity control. */
+  PublicApiService_GetVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1GetVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetVelocityControlResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a wallet. */
   PublicApiService_GetWallet: {
     parameters: {
@@ -8650,6 +9006,24 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetUsersResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** List all velocity controls within an organization. */
+  PublicApiService_ListVelocityControls: {
+    parameters: {
+      body: {
+        body: definitions["v1ListVelocityControlsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ListVelocityControlsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -9269,6 +9643,24 @@ export type operations = {
       };
     };
   };
+  /** Create a new velocity control. */
+  PublicApiService_CreateVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a wallet and derive addresses. */
   PublicApiService_CreateWallet: {
     parameters: {
@@ -9616,6 +10008,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteUsersRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an existing velocity control. */
+  PublicApiService_DeleteVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteVelocityControlRequest"];
       };
     };
     responses: {

--- a/packages/sdk-server/scripts/codegen.js
+++ b/packages/sdk-server/scripts/codegen.js
@@ -44,9 +44,8 @@ const VERSIONED_ACTIVITY_TYPES = {
     activityType: "ACTIVITY_TYPE_SOL_SEND_TRANSACTION_V2",
     typeVersion: "V2",
   },
-  // Endpoint is execute_swap / ExecuteSwap; sdk-types emits TExecuteSwapBody
-  // (not TExecuteSwapV2Body). Only the activity type enum is V2.
-  ACTIVITY_TYPE_EXECUTE_SWAP: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+  ACTIVITY_TYPE_CREATE_SWAP_QUOTE: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+  ACTIVITY_TYPE_EXECUTE_SWAP: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
 };
 
 /**

--- a/packages/sdk-server/src/__generated__/sdk-client-base.ts
+++ b/packages/sdk-server/src/__generated__/sdk-client-base.ts
@@ -142,6 +142,38 @@ export class TurnkeySDKClientBase {
     } as TResponseType;
   }
 
+  getActivePolicies = async (
+    input: SdkApiTypes.TGetActivePoliciesBody,
+  ): Promise<SdkApiTypes.TGetActivePoliciesResponse> => {
+    return this.request("/public/v1/query/get_active_policies", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetActivePolicies = async (
+    input: SdkApiTypes.TGetActivePoliciesBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_active_policies";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getActivity = async (
     input: SdkApiTypes.TGetActivityBody,
   ): Promise<SdkApiTypes.TGetActivityResponse> => {
@@ -1248,6 +1280,38 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  getVelocityControl = async (
+    input: SdkApiTypes.TGetVelocityControlBody,
+  ): Promise<SdkApiTypes.TGetVelocityControlResponse> => {
+    return this.request("/public/v1/query/get_velocity_control", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampGetVelocityControl = async (
+    input: SdkApiTypes.TGetVelocityControlBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/get_velocity_control";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   getWallet = async (
     input: SdkApiTypes.TGetWalletBody,
   ): Promise<SdkApiTypes.TGetWalletResponse> => {
@@ -1994,6 +2058,38 @@ export class TurnkeySDKClientBase {
     }
 
     const fullUrl = this.config.apiBaseUrl + "/public/v1/query/list_users";
+    const body = {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    };
+
+    const stringifiedBody = JSON.stringify(body);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  listVelocityControls = async (
+    input: SdkApiTypes.TListVelocityControlsBody,
+  ): Promise<SdkApiTypes.TListVelocityControlsResponse> => {
+    return this.request("/public/v1/query/list_velocity_controls", {
+      ...input,
+      organizationId: input.organizationId ?? this.config.organizationId,
+    });
+  };
+
+  stampListVelocityControls = async (
+    input: SdkApiTypes.TListVelocityControlsBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/query/list_velocity_controls";
     const body = {
       ...input,
       organizationId: input.organizationId ?? this.config.organizationId,
@@ -3003,7 +3099,7 @@ export class TurnkeySDKClientBase {
         parameters: rest,
         organizationId: organizationId ?? this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
-        type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
+        type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
       },
       "createSwapQuoteResult",
     );
@@ -3023,7 +3119,7 @@ export class TurnkeySDKClientBase {
       parameters,
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
-      type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
+      type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -3233,6 +3329,48 @@ export class TurnkeySDKClientBase {
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_CREATE_USERS_V4",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  createVelocityControl = async (
+    input: SdkApiTypes.TCreateVelocityControlBody,
+  ): Promise<SdkApiTypes.TCreateVelocityControlResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/create_velocity_control",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+      },
+      "createVelocityControlResult",
+    );
+  };
+
+  stampCreateVelocityControl = async (
+    input: SdkApiTypes.TCreateVelocityControlBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/create_velocity_control";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4084,6 +4222,48 @@ export class TurnkeySDKClientBase {
     };
   };
 
+  deleteVelocityControl = async (
+    input: SdkApiTypes.TDeleteVelocityControlBody,
+  ): Promise<SdkApiTypes.TDeleteVelocityControlResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/delete_velocity_control",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+      },
+      "deleteVelocityControlResult",
+    );
+  };
+
+  stampDeleteVelocityControl = async (
+    input: SdkApiTypes.TDeleteVelocityControlBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/delete_velocity_control";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
   deleteWalletAccounts = async (
     input: SdkApiTypes.TDeleteWalletAccountsBody,
   ): Promise<SdkApiTypes.TDeleteWalletAccountsResponse> => {
@@ -4510,7 +4690,7 @@ export class TurnkeySDKClientBase {
         parameters: rest,
         organizationId: organizationId ?? this.config.organizationId,
         timestampMs: timestampMs ?? String(Date.now()),
-        type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+        type: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
       },
       "executeSwapResult",
     );
@@ -4529,7 +4709,7 @@ export class TurnkeySDKClientBase {
       parameters,
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
-      type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
+      type: "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);
@@ -4904,6 +5084,48 @@ export class TurnkeySDKClientBase {
       organizationId: organizationId ?? this.config.organizationId,
       timestampMs: timestampMs ?? String(Date.now()),
       type: "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
+    };
+
+    const stringifiedBody = JSON.stringify(bodyWithType);
+    const stamp = await this.stamper.stamp(stringifiedBody);
+    return {
+      body: stringifiedBody,
+      stamp: stamp,
+      url: fullUrl,
+    };
+  };
+
+  initImportSecrets = async (
+    input: SdkApiTypes.TInitImportSecretsBody,
+  ): Promise<SdkApiTypes.TInitImportSecretsResponse> => {
+    const { organizationId, timestampMs, ...rest } = input;
+    return this.command(
+      "/public/v1/submit/init_import_secrets",
+      {
+        parameters: rest,
+        organizationId: organizationId ?? this.config.organizationId,
+        timestampMs: timestampMs ?? String(Date.now()),
+        type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
+      },
+      "initImportSecretsResult",
+    );
+  };
+
+  stampInitImportSecrets = async (
+    input: SdkApiTypes.TInitImportSecretsBody,
+  ): Promise<TSignedRequest | undefined> => {
+    if (!this.stamper) {
+      return undefined;
+    }
+
+    const { organizationId, timestampMs, ...parameters } = input;
+    const fullUrl =
+      this.config.apiBaseUrl + "/public/v1/submit/init_import_secrets";
+    const bodyWithType = {
+      parameters,
+      organizationId: organizationId ?? this.config.organizationId,
+      timestampMs: timestampMs ?? String(Date.now()),
+      type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
     };
 
     const stringifiedBody = JSON.stringify(bodyWithType);

--- a/packages/sdk-server/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-server/src/__inputs__/public_api.swagger.json
@@ -72,6 +72,38 @@
   "consumes": ["application/json"],
   "produces": ["application/json"],
   "paths": {
+    "/public/v1/query/get_active_policies": {
+      "post": {
+        "summary": "Get active policies",
+        "description": "For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active.",
+        "operationId": "PublicApiService_GetActivePolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["Policies"]
+      }
+    },
     "/public/v1/query/get_activity": {
       "post": {
         "summary": "Get activity",
@@ -1192,6 +1224,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/get_velocity_control": {
+      "post": {
+        "summary": "Get velocity control",
+        "description": "Get details about a velocity control.",
+        "operationId": "PublicApiService_GetVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/get_wallet": {
       "post": {
         "summary": "Get wallet",
@@ -1960,6 +2024,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/list_velocity_controls": {
+      "post": {
+        "summary": "List velocity controls",
+        "description": "List all velocity controls within an organization.",
+        "operationId": "PublicApiService_ListVelocityControls",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/list_verified_suborgs": {
       "post": {
         "summary": "Get verified sub-organizations",
@@ -1994,7 +2090,7 @@
     },
     "/public/v1/query/list_wallet_accounts": {
       "post": {
-        "summary": "List wallets accounts",
+        "summary": "List wallet accounts",
         "description": "List all accounts within a wallet.",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
@@ -2952,6 +3048,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/create_velocity_control": {
+      "post": {
+        "summary": "Create velocity control",
+        "description": "Create a new velocity control.",
+        "operationId": "PublicApiService_CreateVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/create_wallet": {
       "post": {
         "summary": "Create wallet",
@@ -3592,6 +3720,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/delete_velocity_control": {
+      "post": {
+        "summary": "Delete velocity control",
+        "description": "Delete an existing velocity control.",
+        "operationId": "PublicApiService_DeleteVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/delete_wallet_accounts": {
       "post": {
         "summary": "Delete wallet accounts",
@@ -4230,6 +4390,38 @@
           }
         ],
         "tags": ["Private Keys"]
+      }
+    },
+    "/public/v1/submit/init_import_secrets": {
+      "post": {
+        "summary": "Init import secrets",
+        "description": "Initialize secret imports by generating Ingress Encryption Target Keys.",
+        "operationId": "PublicApiService_InitImportSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1InitImportSecretsRequest"
+            }
+          }
+        ],
+        "tags": ["Secrets"]
       }
     },
     "/public/v1/submit/init_import_wallet": {
@@ -5732,6 +5924,26 @@
       },
       "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
+    "billingUpdatePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
+    "billingUpdatePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -6011,6 +6223,32 @@
       "type": "string",
       "enum": ["ACCESS_TYPE_WEB", "ACCESS_TYPE_API", "ACCESS_TYPE_ALL"]
     },
+    "v1ActivePolicyStatus": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for the organization the policy belongs to."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "Unique identifier for a given policy."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the policy is currently active. A policy without a time window is always active."
+        },
+        "timeExpr": {
+          "type": "string",
+          "description": "The policy's time expression, absent when the policy has no time window."
+        },
+        "error": {
+          "type": "string",
+          "description": "Set when the policy's time expression could not be evaluated; the policy is reported inactive."
+        }
+      },
+      "required": ["organizationId", "policyId", "active"]
+    },
     "v1Activity": {
       "type": "object",
       "properties": {
@@ -6276,7 +6514,12 @@
         "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
         "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
         "ACTIVITY_TYPE_IMPORT_SECRETS",
-        "ACTIVITY_TYPE_EXPORT_SECRETS"
+        "ACTIVITY_TYPE_EXPORT_SECRETS",
+        "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V3"
       ]
     },
     "v1AddressFormat": {
@@ -6564,6 +6807,13 @@
         "stable": {
           "type": "boolean",
           "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
+        },
+        "earnProviders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1EarnProvider"
+          },
+          "description": "Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn."
         }
       }
     },
@@ -8590,6 +8840,36 @@
       },
       "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
     },
+    "v1CreateSwapQuoteIntentV2": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
     "v1CreateSwapQuoteRequest": {
       "type": "object",
       "properties": {
@@ -9137,6 +9417,61 @@
         }
       },
       "required": ["userIds"]
+    },
+    "v1CreateVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": ["name", "dataSource", "aggregation", "identifier"]
+    },
+    "v1CreateVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
     },
     "v1CreateWalletAccountsIntent": {
       "type": "object",
@@ -10208,6 +10543,48 @@
       },
       "required": ["userIds"]
     },
+    "v1DeleteVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
+    "v1DeleteVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
     "v1DeleteWalletAccountsIntent": {
       "type": "object",
       "properties": {
@@ -10380,6 +10757,10 @@
         "lastUpdatedTime": {
           "$ref": "#/definitions/externaldatav1Timestamp",
           "description": "Last time this deployment was updated"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/v1ProvisioningState",
+          "description": "Current quorum-key provisioning state for this deployment"
         }
       },
       "required": [
@@ -10622,6 +11003,22 @@
         "clientFeeWallet": {
           "type": "string",
           "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        },
+        "exposures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EarnVaultExposure"
+          },
+          "description": "The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho)."
         }
       }
     },
@@ -10802,6 +11199,47 @@
         "curator": {
           "type": "string",
           "description": "Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave)."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        }
+      }
+    },
+    "v1EarnVaultExposure": {
+      "type": "object",
+      "properties": {
+        "marketId": {
+          "type": "string",
+          "description": "Provider-specific identifier for the market (the Morpho Blue market id)."
+        },
+        "collateralSymbol": {
+          "type": "string",
+          "description": "Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market."
+        },
+        "collateralCaip19": {
+          "type": "string",
+          "description": "CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market."
+        },
+        "lltvPct": {
+          "type": "string",
+          "description": "The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%)."
+        },
+        "supplied": {
+          "type": "string",
+          "description": "Assets the vault supplies to this market, in raw on-chain units of the underlying asset."
+        },
+        "display": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead."
+        },
+        "sharePct": {
+          "type": "string",
+          "description": "This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%)."
         }
       }
     },
@@ -11272,7 +11710,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -11318,7 +11758,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11386,7 +11828,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11560,7 +12004,9 @@
             "eip155:143",
             "eip155:10143",
             "eip155:42161",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11703,6 +12149,64 @@
         "gasStationNonce": {
           "type": "string",
           "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
+    "v1ExecuteSwapIntentV3": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
         }
       },
       "required": [
@@ -12143,6 +12647,35 @@
         "FIAT_ON_RAMP_PROVIDER_COINBASE",
         "FIAT_ON_RAMP_PROVIDER_MOONPAY"
       ]
+    },
+    "v1GetActivePoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetActivePoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "statuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ActivePolicyStatus"
+          },
+          "description": "The active/inactive status of every policy in the organization."
+        },
+        "evaluatedAtMs": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy."
+        }
+      },
+      "required": ["statuses", "evaluatedAtMs"]
     },
     "v1GetActivitiesRequest": {
       "type": "object",
@@ -12684,7 +13217,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -13399,6 +13934,27 @@
       },
       "required": ["users"]
     },
+    "v1GetVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["organizationId", "velocityControlId"]
+    },
+    "v1GetVelocityControlResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControl": {
+          "$ref": "#/definitions/v1VelocityControl"
+        }
+      },
+      "required": ["velocityControl"]
+    },
     "v1GetVerifiedSubOrgIdsRequest": {
       "type": "object",
       "properties": {
@@ -13532,6 +14088,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14020,6 +14578,27 @@
       },
       "required": ["encryptionSuite", "numSecrets"]
     },
+    "v1InitImportSecretsRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_INIT_IMPORT_SECRETS"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1InitImportSecretsIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
     "v1InitImportSecretsResult": {
       "type": "object",
       "properties": {
@@ -14082,7 +14661,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14120,7 +14699,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14167,7 +14746,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14266,7 +14845,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14317,7 +14896,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14372,7 +14951,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -15060,6 +15639,21 @@
         },
         "exportSecretsIntent": {
           "$ref": "#/definitions/v1ExportSecretsIntent"
+        },
+        "createVelocityControlIntent": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "deleteVelocityControlIntent": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "updatePaymentMethodIntent": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodIntent"
+        },
+        "createSwapQuoteIntentV2": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntentV2"
+        },
+        "executeSwapIntentV3": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV3"
         }
       }
     },
@@ -15185,6 +15779,10 @@
         "caip19": {
           "type": "string",
           "description": "Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier."
+        },
+        "includeExposure": {
+          "type": "boolean",
+          "description": "When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views."
         }
       },
       "required": ["organizationId"]
@@ -15329,7 +15927,9 @@
             "eip155:42431",
             "eip155:421614",
             "eip155:56",
-            "eip155:97"
+            "eip155:97",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "EVM CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -15526,6 +16126,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -15570,6 +16172,34 @@
         }
       },
       "required": ["userTags"]
+    },
+    "v1ListVelocityControlsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "paginationOptions": {
+          "$ref": "#/definitions/v1Pagination"
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1ListVelocityControlsResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControl"
+          }
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo"
+        }
+      },
+      "required": ["velocityControls", "pageInfo"]
     },
     "v1ListWebhookEndpointsRequest": {
       "type": "object",
@@ -16516,6 +17146,14 @@
         }
       }
     },
+    "v1ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "PROVISIONING_STATE_PENDING",
+        "PROVISIONING_STATE_AWAITING_PROVISION",
+        "PROVISIONING_STATE_PROVISIONED"
+      ]
+    },
     "v1PublicKeyCredentialWithAttestation": {
       "type": "object",
       "properties": {
@@ -17268,6 +17906,15 @@
         },
         "exportSecretsResult": {
           "$ref": "#/definitions/v1ExportSecretsResult"
+        },
+        "createVelocityControlResult": {
+          "$ref": "#/definitions/v1CreateVelocityControlResult"
+        },
+        "deleteVelocityControlResult": {
+          "$ref": "#/definitions/v1DeleteVelocityControlResult"
+        },
+        "updatePaymentMethodResult": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodResult"
         }
       }
     },
@@ -20927,6 +21574,261 @@
           "type": "string"
         }
       }
+    },
+    "v1VelocityControl": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string",
+          "description": "Unique identifier for the Velocity Control."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Identifier of the Organization that owns the Velocity Control."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was created."
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was last updated."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": [
+        "velocityControlId",
+        "organizationId",
+        "name",
+        "dataSource",
+        "aggregation",
+        "createdAt",
+        "updatedAt",
+        "identifier"
+      ]
+    },
+    "v1VelocityControlAggregation": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "$ref": "#/definitions/v1VelocityControlAggregationMethod",
+          "description": "Method that aggregates matching data points."
+        },
+        "operator": {
+          "$ref": "#/definitions/v1VelocityControlAggregationOperator",
+          "description": "Comparison between the aggregate and the threshold."
+        },
+        "threshold": {
+          "type": "string",
+          "description": "Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits."
+        },
+        "window": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindow",
+          "description": "Time window for the aggregation."
+        },
+        "groupBy": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupBy",
+          "description": "Scope that partitions matching data before aggregation."
+        }
+      },
+      "required": ["method", "operator", "threshold", "window", "groupBy"]
+    },
+    "v1VelocityControlAggregationGroupBy": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByOrganization",
+          "description": "Uses one shared bucket for the Organization."
+        },
+        "user": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByUser",
+          "description": "Uses one bucket for each User."
+        },
+        "wallet": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByWallet",
+          "description": "Uses one bucket for each Wallet."
+        }
+      }
+    },
+    "v1VelocityControlAggregationGroupByOrganization": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByUser": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByWallet": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationMethod": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM",
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT"
+      ]
+    },
+    "v1VelocityControlAggregationOperator": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN"
+      ]
+    },
+    "v1VelocityControlAggregationWindow": {
+      "type": "object",
+      "properties": {
+        "rolling": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowRolling",
+          "description": "Uses a rolling time window."
+        },
+        "infinite": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowInfinite",
+          "description": "Uses all matching data without a time limit."
+        }
+      }
+    },
+    "v1VelocityControlAggregationWindowInfinite": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationWindowRolling": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the rolling window, in seconds, as a base-10 integer string."
+        }
+      },
+      "required": ["duration"]
+    },
+    "v1VelocityControlDataSource": {
+      "type": "object",
+      "properties": {
+        "chainAssetTransfer": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransfer",
+          "description": "Uses transfers of the listed on-chain assets as input data."
+        },
+        "activityExecution": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecution",
+          "description": "Uses executed Turnkey activities as input data."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecution": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecutionFilter",
+          "description": "Filters activity executions by type."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecutionFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose executions are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceChainAssetTransfer": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferDefinition"
+          },
+          "description": "Assets whose transfers are included in the data source."
+        },
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferFilter",
+          "description": "Filters asset transfers by activity type."
+        },
+        "phase": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhase",
+          "description": "Selects when to measure an asset transfer."
+        }
+      },
+      "required": ["definition"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferDefinition": {
+      "type": "object",
+      "properties": {
+        "caip19": {
+          "type": "string",
+          "description": "CAIP-19 identifier for the asset."
+        },
+        "decimals": {
+          "type": "string",
+          "description": "Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset."
+        }
+      },
+      "required": ["caip19", "decimals"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose asset transfers are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceFilterActivity": {
+      "type": "object",
+      "properties": {
+        "activityType": {
+          "type": "string",
+          "description": "Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`."
+        }
+      },
+      "required": ["activityType"]
+    },
+    "v1VelocityControlDataSourcePhase": {
+      "type": "object",
+      "properties": {
+        "signature": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSignature",
+          "description": "Measures the transfer when Turnkey signs the transaction and returns it to the user."
+        },
+        "submission": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSubmission",
+          "description": "Reserved for future use. Measures the transfer after the transaction lands on chain."
+        }
+      }
+    },
+    "v1VelocityControlDataSourcePhaseSignature": {
+      "type": "object"
+    },
+    "v1VelocityControlDataSourcePhaseSubmission": {
+      "type": "object"
     },
     "v1VerifyOtpIntent": {
       "type": "object",

--- a/packages/sdk-server/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-server/src/__inputs__/public_api.types.ts
@@ -4,6 +4,10 @@
  */
 
 export type paths = {
+  "/public/v1/query/get_active_policies": {
+    /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+    post: operations["PublicApiService_GetActivePolicies"];
+  };
   "/public/v1/query/get_activity": {
     /** Get details about an activity. */
     post: operations["PublicApiService_GetActivity"];
@@ -152,6 +156,10 @@ export type paths = {
     /** Get details about a user. */
     post: operations["PublicApiService_GetUser"];
   };
+  "/public/v1/query/get_velocity_control": {
+    /** Get details about a velocity control. */
+    post: operations["PublicApiService_GetVelocityControl"];
+  };
   "/public/v1/query/get_wallet": {
     /** Get details about a wallet. */
     post: operations["PublicApiService_GetWallet"];
@@ -247,6 +255,10 @@ export type paths = {
   "/public/v1/query/list_users": {
     /** List all users within an organization. */
     post: operations["PublicApiService_GetUsers"];
+  };
+  "/public/v1/query/list_velocity_controls": {
+    /** List all velocity controls within an organization. */
+    post: operations["PublicApiService_ListVelocityControls"];
   };
   "/public/v1/query/list_verified_suborgs": {
     /** Get all email or phone verified suborg IDs associated given a parent org ID. */
@@ -384,6 +396,10 @@ export type paths = {
     /** Create users in an existing organization. Each user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateUsers"];
   };
+  "/public/v1/submit/create_velocity_control": {
+    /** Create a new velocity control. */
+    post: operations["PublicApiService_CreateVelocityControl"];
+  };
   "/public/v1/submit/create_wallet": {
     /** Create a wallet and derive addresses. */
     post: operations["PublicApiService_CreateWallet"];
@@ -463,6 +479,10 @@ export type paths = {
   "/public/v1/submit/delete_users": {
     /** Delete users within an organization. */
     post: operations["PublicApiService_DeleteUsers"];
+  };
+  "/public/v1/submit/delete_velocity_control": {
+    /** Delete an existing velocity control. */
+    post: operations["PublicApiService_DeleteVelocityControl"];
   };
   "/public/v1/submit/delete_wallet_accounts": {
     /** Delete wallet accounts for an organization. */
@@ -797,6 +817,14 @@ export type definitions = {
     /** @description The email address associated with the payment method. */
     cardHolderEmail: string;
   };
+  billingUpdatePaymentMethodIntent: {
+    /** @description The email that will receive invoices for the payment method. */
+    paymentEmail: string;
+  };
+  billingUpdatePaymentMethodResult: {
+    /** @description The email address associated with the payment method. */
+    paymentEmail: string;
+  };
   datav1Tag: {
     /** @description Unique identifier for a given Tag. */
     tagId: string;
@@ -904,6 +932,18 @@ export type definitions = {
   };
   /** @enum {string} */
   v1AccessType: "ACCESS_TYPE_WEB" | "ACCESS_TYPE_API" | "ACCESS_TYPE_ALL";
+  v1ActivePolicyStatus: {
+    /** @description Unique identifier for the organization the policy belongs to. */
+    organizationId: string;
+    /** @description Unique identifier for a given policy. */
+    policyId: string;
+    /** @description Whether the policy is currently active. A policy without a time window is always active. */
+    active: boolean;
+    /** @description The policy's time expression, absent when the policy has no time window. */
+    timeExpr?: string;
+    /** @description Set when the policy's time expression could not be evaluated; the policy is reported inactive. */
+    error?: string;
+  };
   v1Activity: {
     /** @description Unique identifier for a given Activity object. */
     id: string;
@@ -1106,7 +1146,12 @@ export type definitions = {
     | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
     | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
     | "ACTIVITY_TYPE_IMPORT_SECRETS"
-    | "ACTIVITY_TYPE_EXPORT_SECRETS";
+    | "ACTIVITY_TYPE_EXPORT_SECRETS"
+    | "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V3";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1258,6 +1303,8 @@ export type definitions = {
     name?: string;
     /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
     stable?: boolean;
+    /** @description Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn. */
+    earnProviders?: definitions["v1EarnProvider"][];
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -2068,6 +2115,20 @@ export type definitions = {
     /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
     slippageBps?: string;
   };
+  v1CreateSwapQuoteIntentV2: {
+    /** @description Wallet account address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
+  };
   v1CreateSwapQuoteRequest: {
     /** @enum {string} */
     type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
@@ -2313,6 +2374,29 @@ export type definitions = {
   v1CreateUsersResult: {
     /** @description A list of User IDs. */
     userIds: string[];
+  };
+  v1CreateVelocityControlIntent: {
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1CreateVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateVelocityControlResult: {
+    velocityControlId: string;
   };
   v1CreateWalletAccountsIntent: {
     /** @description Unique identifier for a given Wallet. */
@@ -2737,6 +2821,22 @@ export type definitions = {
     /** @description A list of User IDs. */
     userIds: string[];
   };
+  v1DeleteVelocityControlIntent: {
+    velocityControlId: string;
+  };
+  v1DeleteVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1DeleteVelocityControlResult: {
+    velocityControlId: string;
+  };
   v1DeleteWalletAccountsIntent: {
     /** @description List of unique identifiers for wallet accounts within an organization */
     walletAccountIds: string[];
@@ -2810,6 +2910,8 @@ export type definitions = {
     desiredReplicas: number;
     /** @description Last time this deployment was updated */
     lastUpdatedTime: definitions["externaldatav1Timestamp"];
+    /** @description Current quorum-key provisioning state for this deployment */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1DisableAuthProxyIntent: { [key: string]: unknown };
   v1DisableAuthProxyResult: { [key: string]: unknown };
@@ -2924,6 +3026,12 @@ export type definitions = {
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
     /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
     clientFeeWallet?: string;
+    /** @description Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho). */
+    exposures?: definitions["v1EarnVaultExposure"][];
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3008,6 +3116,26 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
+    /** @description Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+  };
+  v1EarnVaultExposure: {
+    /** @description Provider-specific identifier for the market (the Morpho Blue market id). */
+    marketId?: string;
+    /** @description Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market. */
+    collateralSymbol?: string;
+    /** @description CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market. */
+    collateralCaip19?: string;
+    /** @description The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%). */
+    lltvPct?: string;
+    /** @description Assets the vault supplies to this market, in raw on-chain units of the underlying asset. */
+    supplied?: string;
+    /** @description Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead. */
+    display?: definitions["v1EarnValueDisplay"];
+    /** @description This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%). */
+    sharePct?: string;
   };
   v1EarnWithdrawIntent: {
     /** @description Address of the deployed Earn wrapper holding the position to withdraw from, from ListEarnPositions. Must be one of the org's deployed wrappers. */
@@ -3237,7 +3365,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -3278,7 +3408,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -3321,7 +3453,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
     sponsor?: boolean;
     /** @description Outer transaction nonce. Omit to auto-fetch. */
@@ -3405,7 +3539,9 @@ export type definitions = {
       | "eip155:143"
       | "eip155:10143"
       | "eip155:42161"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Outer transaction nonce. Omit to auto-fetch. */
     nonce?: string;
     /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
@@ -3468,6 +3604,30 @@ export type definitions = {
     recentBlockhash?: string;
     /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
     gasStationNonce?: string;
+  };
+  v1ExecuteSwapIntentV3: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
   };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
@@ -3684,6 +3844,19 @@ export type definitions = {
   v1FiatOnRampProvider:
     | "FIAT_ON_RAMP_PROVIDER_COINBASE"
     | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
+  v1GetActivePoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetActivePoliciesResponse: {
+    /** @description The active/inactive status of every policy in the organization. */
+    statuses: definitions["v1ActivePolicyStatus"][];
+    /**
+     * Format: uint64
+     * @description The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy.
+     */
+    evaluatedAtMs: string;
+  };
   v1GetActivitiesRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3926,7 +4099,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -4193,14 +4368,16 @@ export type definitions = {
   v1GetTvcDeploymentProvisioningDetailsResponse: {
     /**
      * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
+     * @description The attestation document of the provisioning enclave. Present only when a deployment is awaiting provisioning.
      */
-    attestationDocument: string;
+    attestationDocument?: string;
     /**
      * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
+     * @description The manifest envelope containing the TVC deployment's manifest and signatures. Present only when a deployment is awaiting provisioning.
      */
-    manifestEnvelope: string;
+    manifestEnvelope?: string;
+    /** @description Current provisioning state. */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4239,6 +4416,13 @@ export type definitions = {
   v1GetUsersResponse: {
     /** @description A list of users. */
     users: definitions["v1User"][];
+  };
+  v1GetVelocityControlRequest: {
+    organizationId: string;
+    velocityControlId: string;
+  };
+  v1GetVelocityControlResponse: {
+    velocityControl: definitions["v1VelocityControl"];
   };
   v1GetVerifiedSubOrgIdsRequest: {
     /** @description Unique identifier for the parent organization. This is used to find sub-organizations within it. */
@@ -4308,6 +4492,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4537,7 +4723,7 @@ export type definitions = {
     importBundle: string;
   };
   v1InitOtpAuthIntent: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4555,7 +4741,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV2: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4580,7 +4766,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4627,7 +4813,7 @@ export type definitions = {
     otpId: string;
   };
   v1InitOtpIntent: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4654,7 +4840,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV2: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4683,7 +4869,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4940,6 +5126,11 @@ export type definitions = {
     createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
     importSecretsIntent?: definitions["v1ImportSecretsIntent"];
     exportSecretsIntent?: definitions["v1ExportSecretsIntent"];
+    createVelocityControlIntent?: definitions["v1CreateVelocityControlIntent"];
+    deleteVelocityControlIntent?: definitions["v1DeleteVelocityControlIntent"];
+    updatePaymentMethodIntent?: definitions["billingUpdatePaymentMethodIntent"];
+    createSwapQuoteIntentV2?: definitions["v1CreateSwapQuoteIntentV2"];
+    executeSwapIntentV3?: definitions["v1ExecuteSwapIntentV3"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -5013,6 +5204,8 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier. */
     caip19?: string;
+    /** @description When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views. */
+    includeExposure?: boolean;
   };
   v1ListEarnEnabledVaultsResponse: {
     /** @description The organization's deployed wrappers. */
@@ -5079,7 +5272,9 @@ export type definitions = {
       | "eip155:42431"
       | "eip155:421614"
       | "eip155:56"
-      | "eip155:97";
+      | "eip155:97"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Cursor-based pagination options. Cursors are opaque and valid only for the same address and CAIP-2 query. */
     paginationOptions?: definitions["v1Pagination"];
   };
@@ -5166,6 +5361,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -5180,6 +5377,14 @@ export type definitions = {
   v1ListUserTagsResponse: {
     /** @description A list of user tags. */
     userTags: definitions["datav1Tag"][];
+  };
+  v1ListVelocityControlsRequest: {
+    organizationId: string;
+    paginationOptions?: definitions["v1Pagination"];
+  };
+  v1ListVelocityControlsResponse: {
+    velocityControls: definitions["v1VelocityControl"][];
+    pageInfo: definitions["v1PageInfo"];
   };
   v1ListWebhookEndpointsRequest: {
     /** @description Unique identifier for a given Organization. */
@@ -5596,6 +5801,11 @@ export type definitions = {
     privateKeyId?: string;
     addresses?: definitions["immutableactivityv1Address"][];
   };
+  /** @enum {string} */
+  v1ProvisioningState:
+    | "PROVISIONING_STATE_PENDING"
+    | "PROVISIONING_STATE_AWAITING_PROVISION"
+    | "PROVISIONING_STATE_PROVISIONED";
   v1PublicKeyCredentialWithAttestation: {
     id: string;
     /** @enum {string} */
@@ -5877,6 +6087,9 @@ export type definitions = {
     createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
     importSecretsResult?: definitions["v1ImportSecretsResult"];
     exportSecretsResult?: definitions["v1ExportSecretsResult"];
+    createVelocityControlResult?: definitions["v1CreateVelocityControlResult"];
+    deleteVelocityControlResult?: definitions["v1DeleteVelocityControlResult"];
+    updatePaymentMethodResult?: definitions["billingUpdatePaymentMethodResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -7386,6 +7599,113 @@ export type definitions = {
   v1ValidateTvcImageResponse: {
     resolvedImageDigest?: string;
   };
+  v1VelocityControl: {
+    /** @description Unique identifier for the Velocity Control. */
+    velocityControlId: string;
+    /** @description Identifier of the Organization that owns the Velocity Control. */
+    organizationId: string;
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Time when the Velocity Control was created. */
+    createdAt: definitions["externaldatav1Timestamp"];
+    /** @description Time when the Velocity Control was last updated. */
+    updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1VelocityControlAggregation: {
+    /** @description Method that aggregates matching data points. */
+    method: definitions["v1VelocityControlAggregationMethod"];
+    /** @description Comparison between the aggregate and the threshold. */
+    operator: definitions["v1VelocityControlAggregationOperator"];
+    /** @description Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits. */
+    threshold: string;
+    /** @description Time window for the aggregation. */
+    window: definitions["v1VelocityControlAggregationWindow"];
+    /** @description Scope that partitions matching data before aggregation. */
+    groupBy: definitions["v1VelocityControlAggregationGroupBy"];
+  };
+  v1VelocityControlAggregationGroupBy: {
+    /** @description Uses one shared bucket for the Organization. */
+    organization?: definitions["v1VelocityControlAggregationGroupByOrganization"];
+    /** @description Uses one bucket for each User. */
+    user?: definitions["v1VelocityControlAggregationGroupByUser"];
+    /** @description Uses one bucket for each Wallet. */
+    wallet?: definitions["v1VelocityControlAggregationGroupByWallet"];
+  };
+  v1VelocityControlAggregationGroupByOrganization: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByUser: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByWallet: { [key: string]: unknown };
+  /** @enum {string} */
+  v1VelocityControlAggregationMethod:
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM"
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT";
+  /** @enum {string} */
+  v1VelocityControlAggregationOperator:
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN";
+  v1VelocityControlAggregationWindow: {
+    /** @description Uses a rolling time window. */
+    rolling?: definitions["v1VelocityControlAggregationWindowRolling"];
+    /** @description Uses all matching data without a time limit. */
+    infinite?: definitions["v1VelocityControlAggregationWindowInfinite"];
+  };
+  v1VelocityControlAggregationWindowInfinite: { [key: string]: unknown };
+  v1VelocityControlAggregationWindowRolling: {
+    /** @description Duration of the rolling window, in seconds, as a base-10 integer string. */
+    duration: string;
+  };
+  v1VelocityControlDataSource: {
+    /** @description Uses transfers of the listed on-chain assets as input data. */
+    chainAssetTransfer?: definitions["v1VelocityControlDataSourceChainAssetTransfer"];
+    /** @description Uses executed Turnkey activities as input data. */
+    activityExecution?: definitions["v1VelocityControlDataSourceActivityExecution"];
+  };
+  v1VelocityControlDataSourceActivityExecution: {
+    /** @description Filters activity executions by type. */
+    filter?: definitions["v1VelocityControlDataSourceActivityExecutionFilter"];
+  };
+  v1VelocityControlDataSourceActivityExecutionFilter: {
+    /** @description Activity types whose executions are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceChainAssetTransfer: {
+    /** @description Assets whose transfers are included in the data source. */
+    definition: definitions["v1VelocityControlDataSourceChainAssetTransferDefinition"][];
+    /** @description Filters asset transfers by activity type. */
+    filter?: definitions["v1VelocityControlDataSourceChainAssetTransferFilter"];
+    /** @description Selects when to measure an asset transfer. */
+    phase?: definitions["v1VelocityControlDataSourcePhase"];
+  };
+  v1VelocityControlDataSourceChainAssetTransferDefinition: {
+    /** @description CAIP-19 identifier for the asset. */
+    caip19: string;
+    /** @description Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset. */
+    decimals: string;
+  };
+  v1VelocityControlDataSourceChainAssetTransferFilter: {
+    /** @description Activity types whose asset transfers are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceFilterActivity: {
+    /** @description Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`. */
+    activityType: string;
+  };
+  v1VelocityControlDataSourcePhase: {
+    /** @description Measures the transfer when Turnkey signs the transaction and returns it to the user. */
+    signature?: definitions["v1VelocityControlDataSourcePhaseSignature"];
+    /** @description Reserved for future use. Measures the transfer after the transaction lands on chain. */
+    submission?: definitions["v1VelocityControlDataSourcePhaseSubmission"];
+  };
+  v1VelocityControlDataSourcePhaseSignature: { [key: string]: unknown };
+  v1VelocityControlDataSourcePhaseSubmission: { [key: string]: unknown };
   v1VerifyOtpIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -7559,6 +7879,24 @@ export type definitions = {
 };
 
 export type operations = {
+  /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+  PublicApiService_GetActivePolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetActivePoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetActivePoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about an activity. */
   PublicApiService_GetActivity: {
     parameters: {
@@ -8225,6 +8563,24 @@ export type operations = {
       };
     };
   };
+  /** Get details about a velocity control. */
+  PublicApiService_GetVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1GetVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetVelocityControlResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a wallet. */
   PublicApiService_GetWallet: {
     parameters: {
@@ -8650,6 +9006,24 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetUsersResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** List all velocity controls within an organization. */
+  PublicApiService_ListVelocityControls: {
+    parameters: {
+      body: {
+        body: definitions["v1ListVelocityControlsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ListVelocityControlsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -9269,6 +9643,24 @@ export type operations = {
       };
     };
   };
+  /** Create a new velocity control. */
+  PublicApiService_CreateVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a wallet and derive addresses. */
   PublicApiService_CreateWallet: {
     parameters: {
@@ -9616,6 +10008,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteUsersRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an existing velocity control. */
+  PublicApiService_DeleteVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteVelocityControlRequest"];
       };
     };
     responses: {

--- a/packages/sdk-types/scripts/codegen.js
+++ b/packages/sdk-types/scripts/codegen.js
@@ -114,9 +114,14 @@ const VERSIONED_ACTIVITY_TYPES = {
     "v1VerifyOtpIntentV2",
     "v1VerifyOtpResultV2",
   ],
+  ACTIVITY_TYPE_CREATE_SWAP_QUOTE: [
+    "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+    "v1CreateSwapQuoteIntentV2",
+    "v1CreateSwapQuoteResult",
+  ],
   ACTIVITY_TYPE_EXECUTE_SWAP: [
-    "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
-    "v1ExecuteSwapIntentV2",
+    "ACTIVITY_TYPE_EXECUTE_SWAP_V3",
+    "v1ExecuteSwapIntentV3",
     "v1ExecuteSwapResult",
   ],
 };

--- a/packages/sdk-types/src/__generated__/types.ts
+++ b/packages/sdk-types/src/__generated__/types.ts
@@ -472,6 +472,16 @@ export type billingSetPaymentMethodResult = {
   cardHolderEmail: string;
 };
 
+export type billingUpdatePaymentMethodIntent = {
+  /** The email that will receive invoices for the payment method. */
+  paymentEmail: string;
+};
+
+export type billingUpdatePaymentMethodResult = {
+  /** The email address associated with the payment method. */
+  paymentEmail: string;
+};
+
 export type datav1Tag = {
   /** Unique identifier for a given Tag. */
   tagId: string;
@@ -579,6 +589,19 @@ export type v1AccessType =
   | "ACCESS_TYPE_WEB"
   | "ACCESS_TYPE_API"
   | "ACCESS_TYPE_ALL";
+
+export type v1ActivePolicyStatus = {
+  /** Unique identifier for the organization the policy belongs to. */
+  organizationId: string;
+  /** Unique identifier for a given policy. */
+  policyId: string;
+  /** Whether the policy is currently active. A policy without a time window is always active. */
+  active: boolean;
+  /** The policy's time expression, absent when the policy has no time window. */
+  timeExpr?: string;
+  /** Set when the policy's time expression could not be evaluated; the policy is reported inactive. */
+  error?: string;
+};
 
 export type v1Activity = {
   /** Unique identifier for a given Activity object. */
@@ -783,7 +806,12 @@ export type v1ActivityType =
   | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
   | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
   | "ACTIVITY_TYPE_IMPORT_SECRETS"
-  | "ACTIVITY_TYPE_EXPORT_SECRETS";
+  | "ACTIVITY_TYPE_EXPORT_SECRETS"
+  | "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"
+  | "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"
+  | "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD"
+  | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2"
+  | "ACTIVITY_TYPE_EXECUTE_SWAP_V3";
 
 export type v1ApiKey = {
   /** A User credential that can be used to authenticate to Turnkey. */
@@ -868,6 +896,8 @@ export type v1AssetMetadata = {
   name?: string;
   /** Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
   stable?: boolean;
+  /** Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn. */
+  earnProviders?: v1EarnProvider[];
 };
 
 export type v1AuthenticationMethod = {
@@ -1675,6 +1705,21 @@ export type v1CreateSwapQuoteIntent = {
   slippageBps?: string;
 };
 
+export type v1CreateSwapQuoteIntentV2 = {
+  /** Wallet account address used to price the executable provider quote. Private Key identifiers are not supported. */
+  signWith: string;
+  /** CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+  inputToken: string;
+  /** CAIP-19 asset ID for the output asset. */
+  outputToken: string;
+  /** Base-unit amount of the input asset. */
+  inputAmount: string;
+  /** Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+  slippageBps?: string;
+  /** Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+  destinationAddress?: string;
+};
+
 export type v1CreateSwapQuoteRequest = {
   type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
   /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
@@ -1896,6 +1941,31 @@ export type v1CreateUsersRequest = {
 export type v1CreateUsersResult = {
   /** A list of User IDs. */
   userIds: string[];
+};
+
+export type v1CreateVelocityControlIntent = {
+  /** Human-readable name for the Velocity Control. */
+  name: string;
+  /** Data source for the Velocity Control. */
+  dataSource: v1VelocityControlDataSource;
+  /** Aggregation expression that the Velocity Control evaluates. */
+  aggregation: v1VelocityControlAggregation;
+  /** Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+  identifier: string;
+};
+
+export type v1CreateVelocityControlRequest = {
+  type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1CreateVelocityControlIntent;
+  generateAppProofs?: boolean;
+};
+
+export type v1CreateVelocityControlResult = {
+  velocityControlId: string;
 };
 
 export type v1CreateWalletAccountsIntent = {
@@ -2360,6 +2430,24 @@ export type v1DeleteUsersResult = {
   userIds: string[];
 };
 
+export type v1DeleteVelocityControlIntent = {
+  velocityControlId: string;
+};
+
+export type v1DeleteVelocityControlRequest = {
+  type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1DeleteVelocityControlIntent;
+  generateAppProofs?: boolean;
+};
+
+export type v1DeleteVelocityControlResult = {
+  velocityControlId: string;
+};
+
 export type v1DeleteWalletAccountsIntent = {
   /** List of unique identifiers for wallet accounts within an organization */
   walletAccountIds: string[];
@@ -2433,6 +2521,8 @@ export type v1DeploymentStatus = {
   desiredReplicas: number;
   /** Last time this deployment was updated */
   lastUpdatedTime: externaldatav1Timestamp;
+  /** Current quorum-key provisioning state for this deployment */
+  provisioningState?: v1ProvisioningState;
 };
 
 export type v1DisableAuthProxyIntent = {};
@@ -2548,6 +2638,12 @@ export type v1EarnEnabledVault = {
   claimableClientFeeDisplay?: v1EarnValueDisplay;
   /** The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
   clientFeeWallet?: string;
+  /** Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it. */
+  liquidity?: string;
+  /** Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+  liquidityDisplay?: v1EarnValueDisplay;
+  /** The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho). */
+  exposures?: v1EarnVaultExposure[];
 };
 
 export type v1EarnPosition = {
@@ -2638,6 +2734,27 @@ export type v1EarnVault = {
   name?: string;
   /** Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
   curator?: string;
+  /** Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it. */
+  liquidity?: string;
+  /** Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+  liquidityDisplay?: v1EarnValueDisplay;
+};
+
+export type v1EarnVaultExposure = {
+  /** Provider-specific identifier for the market (the Morpho Blue market id). */
+  marketId?: string;
+  /** Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market. */
+  collateralSymbol?: string;
+  /** CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market. */
+  collateralCaip19?: string;
+  /** The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%). */
+  lltvPct?: string;
+  /** Assets the vault supplies to this market, in raw on-chain units of the underlying asset. */
+  supplied?: string;
+  /** Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead. */
+  display?: v1EarnValueDisplay;
+  /** This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%). */
+  sharePct?: string;
 };
 
 export type v1EarnWithdrawIntent = {
@@ -2873,7 +2990,9 @@ export type v1EthSendRawTransactionIntent = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
 };
 
 export type v1EthSendRawTransactionResult = {
@@ -2903,7 +3022,9 @@ export type v1EthSendTransactionIntent = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Recipient address as a hex string with 0x prefix. */
   to: string;
   /** Amount of native asset to send in wei. */
@@ -2944,7 +3065,9 @@ export type v1EthSendTransactionIntentV2 = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
   sponsor?: boolean;
   /** Outer transaction nonce. Omit to auto-fetch. */
@@ -3027,7 +3150,9 @@ export type v1EthUndelegate7702Intent = {
     | "eip155:143"
     | "eip155:10143"
     | "eip155:42161"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Outer transaction nonce. Omit to auto-fetch. */
   nonce?: string;
   /** Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
@@ -3093,6 +3218,31 @@ export type v1ExecuteSwapIntentV2 = {
   recentBlockhash?: string;
   /** Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
   gasStationNonce?: string;
+};
+
+export type v1ExecuteSwapIntentV3 = {
+  /** Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+  quoteId: string;
+  /** CAIP-19 asset ID for the input asset. */
+  inputToken: string;
+  /** Exact base-unit amount of the input asset committed by the quote. */
+  inputAmount: string;
+  /** CAIP-19 asset ID for the output asset. */
+  outputToken: string;
+  /** Exact quoted base-unit output amount committed by the quote. */
+  quotedOutputAmount: string;
+  /** Exact minimum base-unit output committed by the quote. */
+  minOutputAmount: string;
+  /** Whether the quoted transaction is sponsored. */
+  sponsor: boolean;
+  /** Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+  evmNonce?: string;
+  /** Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+  recentBlockhash?: string;
+  /** Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+  gasStationNonce?: string;
+  /** Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+  destinationAddress?: string;
 };
 
 export type v1ExecuteSwapRequest = {
@@ -3321,6 +3471,18 @@ export type v1FiatOnRampPaymentMethod =
 export type v1FiatOnRampProvider =
   | "FIAT_ON_RAMP_PROVIDER_COINBASE"
   | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
+
+export type v1GetActivePoliciesRequest = {
+  /** Unique identifier for a given organization. */
+  organizationId: string;
+};
+
+export type v1GetActivePoliciesResponse = {
+  /** The active/inactive status of every policy in the organization. */
+  statuses: v1ActivePolicyStatus[];
+  /** The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy. */
+  evaluatedAtMs: string;
+};
 
 export type v1GetActivitiesRequest = {
   /** Unique identifier for a given organization. */
@@ -3581,7 +3743,9 @@ export type v1GetNoncesRequest = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Whether to fetch the standard on-chain nonce. */
   nonce?: boolean;
   /** Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -3907,6 +4071,15 @@ export type v1GetUsersResponse = {
   users: v1User[];
 };
 
+export type v1GetVelocityControlRequest = {
+  organizationId: string;
+  velocityControlId: string;
+};
+
+export type v1GetVelocityControlResponse = {
+  velocityControl: v1VelocityControl;
+};
+
 export type v1GetVerifiedSubOrgIdsRequest = {
   /** Unique identifier for the parent organization. This is used to find sub-organizations within it. */
   organizationId: string;
@@ -3978,6 +4151,8 @@ export type v1GetWalletAddressBalancesRequest = {
     | "eip155:4217"
     | "eip155:42431"
     | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -4192,6 +4367,15 @@ export type v1InitImportSecretsIntent = {
   numSecrets: number;
 };
 
+export type v1InitImportSecretsRequest = {
+  type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS";
+  /** Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+  timestampMs: string;
+  /** Unique identifier for a given Organization. */
+  organizationId: string;
+  parameters: v1InitImportSecretsIntent;
+};
+
 export type v1InitImportSecretsResult = {
   /** Enclave ingress target keys along with metadata specific to the encryption suite. For enclave encrypt v1 this will be ServerTargetMsgV1. */
   enclaveTargetMessages: string[];
@@ -4218,7 +4402,7 @@ export type v1InitImportWalletResult = {
 };
 
 export type v1InitOtpAuthIntent = {
-  /** Enum to specify whether to send OTP via SMS or email */
+  /** Enum to specify whether to send OTP via SMS, email, or WhatsApp */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -4237,7 +4421,7 @@ export type v1InitOtpAuthIntent = {
 };
 
 export type v1InitOtpAuthIntentV2 = {
-  /** Enum to specify whether to send OTP via SMS or email */
+  /** Enum to specify whether to send OTP via SMS, email, or WhatsApp */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -4260,7 +4444,7 @@ export type v1InitOtpAuthIntentV2 = {
 };
 
 export type v1InitOtpAuthIntentV3 = {
-  /** Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+  /** Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -4307,7 +4491,7 @@ export type v1InitOtpAuthResultV2 = {
 };
 
 export type v1InitOtpIntent = {
-  /** Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+  /** Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -4332,7 +4516,7 @@ export type v1InitOtpIntent = {
 };
 
 export type v1InitOtpIntentV2 = {
-  /** Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+  /** Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -4359,7 +4543,7 @@ export type v1InitOtpIntentV2 = {
 };
 
 export type v1InitOtpIntentV3 = {
-  /** Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+  /** Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -4609,6 +4793,11 @@ export type v1Intent = {
   createSwapQuoteIntent?: v1CreateSwapQuoteIntent;
   importSecretsIntent?: v1ImportSecretsIntent;
   exportSecretsIntent?: v1ExportSecretsIntent;
+  createVelocityControlIntent?: v1CreateVelocityControlIntent;
+  deleteVelocityControlIntent?: v1DeleteVelocityControlIntent;
+  updatePaymentMethodIntent?: billingUpdatePaymentMethodIntent;
+  createSwapQuoteIntentV2?: v1CreateSwapQuoteIntentV2;
+  executeSwapIntentV3?: v1ExecuteSwapIntentV3;
 };
 
 export type v1InvitationParams = {
@@ -4665,6 +4854,8 @@ export type v1ListEarnEnabledVaultsRequest = {
   provider?: v1EarnProvider;
   /** Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier. */
   caip19?: string;
+  /** When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views. */
+  includeExposure?: boolean;
 };
 
 export type v1ListEarnEnabledVaultsResponse = {
@@ -4736,7 +4927,9 @@ export type v1ListEthTransactionHistoryRequest = {
     | "eip155:42431"
     | "eip155:421614"
     | "eip155:56"
-    | "eip155:97";
+    | "eip155:97"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Cursor-based pagination options. Cursors are opaque and valid only for the same address and CAIP-2 query. */
   paginationOptions?: v1Pagination;
 };
@@ -4829,6 +5022,8 @@ export type v1ListSupportedAssetsRequest = {
     | "eip155:4217"
     | "eip155:42431"
     | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -4846,6 +5041,16 @@ export type v1ListUserTagsRequest = {
 export type v1ListUserTagsResponse = {
   /** A list of user tags. */
   userTags: datav1Tag[];
+};
+
+export type v1ListVelocityControlsRequest = {
+  organizationId: string;
+  paginationOptions?: v1Pagination;
+};
+
+export type v1ListVelocityControlsResponse = {
+  velocityControls: v1VelocityControl[];
+  pageInfo: v1PageInfo;
 };
 
 export type v1ListWebhookEndpointsRequest = {
@@ -5228,6 +5433,11 @@ export type v1PrivateKeyResult = {
   addresses?: immutableactivityv1Address[];
 };
 
+export type v1ProvisioningState =
+  | "PROVISIONING_STATE_PENDING"
+  | "PROVISIONING_STATE_AWAITING_PROVISION"
+  | "PROVISIONING_STATE_PROVISIONED";
+
 export type v1PublicKeyCredentialWithAttestation = {
   id: string;
   type: "public-key";
@@ -5509,6 +5719,9 @@ export type v1Result = {
   createSwapQuoteResult?: v1CreateSwapQuoteResult;
   importSecretsResult?: v1ImportSecretsResult;
   exportSecretsResult?: v1ExportSecretsResult;
+  createVelocityControlResult?: v1CreateVelocityControlResult;
+  deleteVelocityControlResult?: v1DeleteVelocityControlResult;
+  updatePaymentMethodResult?: billingUpdatePaymentMethodResult;
 };
 
 export type v1RevertChainEntry = {
@@ -7055,6 +7268,126 @@ export type v1ValidateTvcImageResponse = {
   resolvedImageDigest?: string;
 };
 
+export type v1VelocityControl = {
+  /** Unique identifier for the Velocity Control. */
+  velocityControlId: string;
+  /** Identifier of the Organization that owns the Velocity Control. */
+  organizationId: string;
+  /** Human-readable name for the Velocity Control. */
+  name: string;
+  /** Data source for the Velocity Control. */
+  dataSource: v1VelocityControlDataSource;
+  /** Aggregation expression that the Velocity Control evaluates. */
+  aggregation: v1VelocityControlAggregation;
+  /** Time when the Velocity Control was created. */
+  createdAt: externaldatav1Timestamp;
+  /** Time when the Velocity Control was last updated. */
+  updatedAt: externaldatav1Timestamp;
+  /** Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+  identifier: string;
+};
+
+export type v1VelocityControlAggregation = {
+  /** Method that aggregates matching data points. */
+  method: v1VelocityControlAggregationMethod;
+  /** Comparison between the aggregate and the threshold. */
+  operator: v1VelocityControlAggregationOperator;
+  /** Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits. */
+  threshold: string;
+  /** Time window for the aggregation. */
+  window: v1VelocityControlAggregationWindow;
+  /** Scope that partitions matching data before aggregation. */
+  groupBy: v1VelocityControlAggregationGroupBy;
+};
+
+export type v1VelocityControlAggregationGroupBy = {
+  /** Uses one shared bucket for the Organization. */
+  organization?: v1VelocityControlAggregationGroupByOrganization;
+  /** Uses one bucket for each User. */
+  user?: v1VelocityControlAggregationGroupByUser;
+  /** Uses one bucket for each Wallet. */
+  wallet?: v1VelocityControlAggregationGroupByWallet;
+};
+
+export type v1VelocityControlAggregationGroupByOrganization = {};
+export type v1VelocityControlAggregationGroupByUser = {};
+export type v1VelocityControlAggregationGroupByWallet = {};
+export type v1VelocityControlAggregationMethod =
+  | "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM"
+  | "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT";
+
+export type v1VelocityControlAggregationOperator =
+  | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN"
+  | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL"
+  | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL"
+  | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL"
+  | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN";
+
+export type v1VelocityControlAggregationWindow = {
+  /** Uses a rolling time window. */
+  rolling?: v1VelocityControlAggregationWindowRolling;
+  /** Uses all matching data without a time limit. */
+  infinite?: v1VelocityControlAggregationWindowInfinite;
+};
+
+export type v1VelocityControlAggregationWindowInfinite = {};
+export type v1VelocityControlAggregationWindowRolling = {
+  /** Duration of the rolling window, in seconds, as a base-10 integer string. */
+  duration: string;
+};
+
+export type v1VelocityControlDataSource = {
+  /** Uses transfers of the listed on-chain assets as input data. */
+  chainAssetTransfer?: v1VelocityControlDataSourceChainAssetTransfer;
+  /** Uses executed Turnkey activities as input data. */
+  activityExecution?: v1VelocityControlDataSourceActivityExecution;
+};
+
+export type v1VelocityControlDataSourceActivityExecution = {
+  /** Filters activity executions by type. */
+  filter?: v1VelocityControlDataSourceActivityExecutionFilter;
+};
+
+export type v1VelocityControlDataSourceActivityExecutionFilter = {
+  /** Activity types whose executions are included. */
+  activity?: v1VelocityControlDataSourceFilterActivity[];
+};
+
+export type v1VelocityControlDataSourceChainAssetTransfer = {
+  /** Assets whose transfers are included in the data source. */
+  definition: v1VelocityControlDataSourceChainAssetTransferDefinition[];
+  /** Filters asset transfers by activity type. */
+  filter?: v1VelocityControlDataSourceChainAssetTransferFilter;
+  /** Selects when to measure an asset transfer. */
+  phase?: v1VelocityControlDataSourcePhase;
+};
+
+export type v1VelocityControlDataSourceChainAssetTransferDefinition = {
+  /** CAIP-19 identifier for the asset. */
+  caip19: string;
+  /** Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset. */
+  decimals: string;
+};
+
+export type v1VelocityControlDataSourceChainAssetTransferFilter = {
+  /** Activity types whose asset transfers are included. */
+  activity?: v1VelocityControlDataSourceFilterActivity[];
+};
+
+export type v1VelocityControlDataSourceFilterActivity = {
+  /** Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`. */
+  activityType: string;
+};
+
+export type v1VelocityControlDataSourcePhase = {
+  /** Measures the transfer when Turnkey signs the transaction and returns it to the user. */
+  signature?: v1VelocityControlDataSourcePhaseSignature;
+  /** Reserved for future use. Measures the transfer after the transaction lands on chain. */
+  submission?: v1VelocityControlDataSourcePhaseSubmission;
+};
+
+export type v1VelocityControlDataSourcePhaseSignature = {};
+export type v1VelocityControlDataSourcePhaseSubmission = {};
 export type v1VerifyOtpIntent = {
   /** ID representing the result of an init OTP activity. */
   otpId: string;
@@ -7188,6 +7521,19 @@ export type v1WebhookSubscriptionParams = {
 };
 
 // --- API Types from Swagger Paths ---
+export type TGetActivePoliciesResponse = {
+  /** The active/inactive status of every policy in the organization. */
+  statuses: v1ActivePolicyStatus[];
+  /** The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy. */
+  evaluatedAtMs: string;
+};
+
+export type TGetActivePoliciesBody = {
+  organizationId?: string;
+};
+
+export type TGetActivePoliciesInput = { body: TGetActivePoliciesBody };
+
 export type TGetActivityResponse = {
   /** An action that can be taken within the Turnkey infrastructure. */
   activity: v1Activity;
@@ -7458,7 +7804,9 @@ export type TGetNoncesBody = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Whether to fetch the standard on-chain nonce. */
   nonce?: boolean;
   /** Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -7728,6 +8076,17 @@ export type TGetUserBody = {
 
 export type TGetUserInput = { body: TGetUserBody };
 
+export type TGetVelocityControlResponse = {
+  velocityControl: v1VelocityControl;
+};
+
+export type TGetVelocityControlBody = {
+  organizationId?: string;
+  velocityControlId: string;
+};
+
+export type TGetVelocityControlInput = { body: TGetVelocityControlBody };
+
 export type TGetWalletResponse = {
   /** A collection of deterministically generated cryptographic public / private key pairs that share a common seed. */
   wallet: v1Wallet;
@@ -7785,6 +8144,8 @@ export type TGetWalletAddressBalancesBody = {
     | "eip155:4217"
     | "eip155:42431"
     | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -7833,6 +8194,8 @@ export type TListEarnEnabledVaultsBody = {
   provider?: v1EarnProvider;
   /** Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier. */
   caip19?: string;
+  /** When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views. */
+  includeExposure?: boolean;
 };
 
 export type TListEarnEnabledVaultsInput = { body: TListEarnEnabledVaultsBody };
@@ -7909,7 +8272,9 @@ export type TListEthTransactionHistoryBody = {
     | "eip155:42431"
     | "eip155:421614"
     | "eip155:56"
-    | "eip155:97";
+    | "eip155:97"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Cursor-based pagination options. Cursors are opaque and valid only for the same address and CAIP-2 query. */
   paginationOptions?: v1Pagination;
 };
@@ -8065,6 +8430,8 @@ export type TListSupportedAssetsBody = {
     | "eip155:4217"
     | "eip155:42431"
     | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630"
     | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
 };
@@ -8116,6 +8483,18 @@ export type TGetUsersBody = {
 };
 
 export type TGetUsersInput = { body: TGetUsersBody };
+
+export type TListVelocityControlsResponse = {
+  velocityControls: v1VelocityControl[];
+  pageInfo: v1PageInfo;
+};
+
+export type TListVelocityControlsBody = {
+  organizationId?: string;
+  paginationOptions?: v1Pagination;
+};
+
+export type TListVelocityControlsInput = { body: TListVelocityControlsBody };
 
 export type TGetVerifiedSubOrgIdsResponse = {
   /** List of unique identifiers for the matching sub-organizations. */
@@ -8621,7 +9000,7 @@ export type TCreateSwapQuoteResponse = {
 export type TCreateSwapQuoteBody = {
   timestampMs?: string;
   organizationId?: string;
-  /** Wallet account or Private Key address used to price the executable provider quote. Private Key identifiers are not supported. */
+  /** Wallet account address used to price the executable provider quote. Private Key identifiers are not supported. */
   signWith: string;
   /** CAIP-19 asset ID for the input asset. The chain is derived from this value. */
   inputToken: string;
@@ -8631,6 +9010,8 @@ export type TCreateSwapQuoteBody = {
   inputAmount: string;
   /** Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
   slippageBps?: string;
+  /** Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+  destinationAddress?: string;
   generateAppProofs?: boolean;
 };
 
@@ -8772,6 +9153,27 @@ export type TCreateUsersBody = {
 };
 
 export type TCreateUsersInput = { body: TCreateUsersBody };
+
+export type TCreateVelocityControlResponse = {
+  activity: v1Activity;
+  velocityControlId: string;
+};
+
+export type TCreateVelocityControlBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  /** Human-readable name for the Velocity Control. */
+  name: string;
+  /** Data source for the Velocity Control. */
+  dataSource: v1VelocityControlDataSource;
+  /** Aggregation expression that the Velocity Control evaluates. */
+  aggregation: v1VelocityControlAggregation;
+  /** Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+  identifier: string;
+  generateAppProofs?: boolean;
+};
+
+export type TCreateVelocityControlInput = { body: TCreateVelocityControlBody };
 
 export type TCreateWalletResponse = {
   activity: v1Activity;
@@ -9130,6 +9532,20 @@ export type TDeleteUsersBody = {
 
 export type TDeleteUsersInput = { body: TDeleteUsersBody };
 
+export type TDeleteVelocityControlResponse = {
+  activity: v1Activity;
+  velocityControlId: string;
+};
+
+export type TDeleteVelocityControlBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  velocityControlId: string;
+  generateAppProofs?: boolean;
+};
+
+export type TDeleteVelocityControlInput = { body: TDeleteVelocityControlBody };
+
 export type TDeleteWalletAccountsResponse = {
   activity: v1Activity;
   /** A list of wallet account unique identifiers that were removed */
@@ -9354,7 +9770,9 @@ export type TEthUndelegate7702Body = {
     | "eip155:143"
     | "eip155:10143"
     | "eip155:42161"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Outer transaction nonce. Omit to auto-fetch. */
   nonce?: string;
   /** Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
@@ -9401,6 +9819,8 @@ export type TExecuteSwapBody = {
   recentBlockhash?: string;
   /** Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
   gasStationNonce?: string;
+  /** Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+  destinationAddress?: string;
   generateAppProofs?: boolean;
 };
 
@@ -9604,6 +10024,23 @@ export type TInitImportPrivateKeyBody = {
 
 export type TInitImportPrivateKeyInput = { body: TInitImportPrivateKeyBody };
 
+export type TInitImportSecretsResponse = {
+  activity: v1Activity;
+  /** Enclave ingress target keys along with metadata specific to the encryption suite. For enclave encrypt v1 this will be ServerTargetMsgV1. */
+  enclaveTargetMessages: string[];
+};
+
+export type TInitImportSecretsBody = {
+  timestampMs?: string;
+  organizationId?: string;
+  /** Transport encryption suite used for ingress secrets. */
+  encryptionSuite: v1TransportEncryptionSuite;
+  /** The number of secrets the user intends to import. */
+  numSecrets: number;
+};
+
+export type TInitImportSecretsInput = { body: TInitImportSecretsBody };
+
 export type TInitImportWalletResponse = {
   activity: v1Activity;
   /** Import bundle containing a public key and signature to use for importing client data. */
@@ -9631,7 +10068,7 @@ export type TInitOtpResponse = {
 export type TInitOtpBody = {
   timestampMs?: string;
   organizationId?: string;
-  /** Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+  /** Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -9669,7 +10106,7 @@ export type TInitOtpAuthResponse = {
 export type TInitOtpAuthBody = {
   timestampMs?: string;
   organizationId?: string;
-  /** Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+  /** Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
   otpType: string;
   /** Email or phone number to send the OTP code to */
   contact: string;
@@ -10546,7 +10983,9 @@ export type TEthSendTransactionBody = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Recipient address as a hex string with 0x prefix. */
   to: string;
   /** Amount of native asset to send in wei. */
@@ -10598,7 +11037,9 @@ export type TEthSendTransactionV2Body = {
     | "eip155:42161"
     | "eip155:4217"
     | "eip155:42431"
-    | "eip155:421614";
+    | "eip155:421614"
+    | "eip155:4663"
+    | "eip155:46630";
   /** Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
   sponsor?: boolean;
   /** Outer transaction nonce. Omit to auto-fetch. */

--- a/packages/sdk-types/src/__inputs__/public_api.swagger.json
+++ b/packages/sdk-types/src/__inputs__/public_api.swagger.json
@@ -72,6 +72,38 @@
   "consumes": ["application/json"],
   "produces": ["application/json"],
   "paths": {
+    "/public/v1/query/get_active_policies": {
+      "post": {
+        "summary": "Get active policies",
+        "description": "For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active.",
+        "operationId": "PublicApiService_GetActivePolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetActivePoliciesRequest"
+            }
+          }
+        ],
+        "tags": ["Policies"]
+      }
+    },
     "/public/v1/query/get_activity": {
       "post": {
         "summary": "Get activity",
@@ -1192,6 +1224,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/get_velocity_control": {
+      "post": {
+        "summary": "Get velocity control",
+        "description": "Get details about a velocity control.",
+        "operationId": "PublicApiService_GetVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/get_wallet": {
       "post": {
         "summary": "Get wallet",
@@ -1960,6 +2024,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/query/list_velocity_controls": {
+      "post": {
+        "summary": "List velocity controls",
+        "description": "List all velocity controls within an organization.",
+        "operationId": "PublicApiService_ListVelocityControls",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListVelocityControlsRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/query/list_verified_suborgs": {
       "post": {
         "summary": "Get verified sub-organizations",
@@ -1994,7 +2090,7 @@
     },
     "/public/v1/query/list_wallet_accounts": {
       "post": {
-        "summary": "List wallets accounts",
+        "summary": "List wallet accounts",
         "description": "List all accounts within a wallet.",
         "operationId": "PublicApiService_GetWalletAccounts",
         "responses": {
@@ -2952,6 +3048,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/create_velocity_control": {
+      "post": {
+        "summary": "Create velocity control",
+        "description": "Create a new velocity control.",
+        "operationId": "PublicApiService_CreateVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/create_wallet": {
       "post": {
         "summary": "Create wallet",
@@ -3592,6 +3720,38 @@
         "tags": ["Users"]
       }
     },
+    "/public/v1/submit/delete_velocity_control": {
+      "post": {
+        "summary": "Delete velocity control",
+        "description": "Delete an existing velocity control.",
+        "operationId": "PublicApiService_DeleteVelocityControl",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DeleteVelocityControlRequest"
+            }
+          }
+        ],
+        "tags": ["Velocity Controls"]
+      }
+    },
     "/public/v1/submit/delete_wallet_accounts": {
       "post": {
         "summary": "Delete wallet accounts",
@@ -4230,6 +4390,38 @@
           }
         ],
         "tags": ["Private Keys"]
+      }
+    },
+    "/public/v1/submit/init_import_secrets": {
+      "post": {
+        "summary": "Init import secrets",
+        "description": "Initialize secret imports by generating Ingress Encryption Target Keys.",
+        "operationId": "PublicApiService_InitImportSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ActivityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1InitImportSecretsRequest"
+            }
+          }
+        ],
+        "tags": ["Secrets"]
       }
     },
     "/public/v1/submit/init_import_wallet": {
@@ -5732,6 +5924,26 @@
       },
       "required": ["lastFour", "cardHolderName", "cardHolderEmail"]
     },
+    "billingUpdatePaymentMethodIntent": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email that will receive invoices for the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
+    "billingUpdatePaymentMethodResult": {
+      "type": "object",
+      "properties": {
+        "paymentEmail": {
+          "type": "string",
+          "description": "The email address associated with the payment method."
+        }
+      },
+      "required": ["paymentEmail"]
+    },
     "datav1Tag": {
       "type": "object",
       "properties": {
@@ -6011,6 +6223,32 @@
       "type": "string",
       "enum": ["ACCESS_TYPE_WEB", "ACCESS_TYPE_API", "ACCESS_TYPE_ALL"]
     },
+    "v1ActivePolicyStatus": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for the organization the policy belongs to."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "Unique identifier for a given policy."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the policy is currently active. A policy without a time window is always active."
+        },
+        "timeExpr": {
+          "type": "string",
+          "description": "The policy's time expression, absent when the policy has no time window."
+        },
+        "error": {
+          "type": "string",
+          "description": "Set when the policy's time expression could not be evaluated; the policy is reported inactive."
+        }
+      },
+      "required": ["organizationId", "policyId", "active"]
+    },
     "v1Activity": {
       "type": "object",
       "properties": {
@@ -6276,7 +6514,12 @@
         "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
         "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
         "ACTIVITY_TYPE_IMPORT_SECRETS",
-        "ACTIVITY_TYPE_EXPORT_SECRETS"
+        "ACTIVITY_TYPE_EXPORT_SECRETS",
+        "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL",
+        "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD",
+        "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2",
+        "ACTIVITY_TYPE_EXECUTE_SWAP_V3"
       ]
     },
     "v1AddressFormat": {
@@ -6564,6 +6807,13 @@
         "stable": {
           "type": "boolean",
           "description": "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."
+        },
+        "earnProviders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1EarnProvider"
+          },
+          "description": "Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn."
         }
       }
     },
@@ -8590,6 +8840,36 @@
       },
       "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
     },
+    "v1CreateSwapQuoteIntentV2": {
+      "type": "object",
+      "properties": {
+        "signWith": {
+          "type": "string",
+          "description": "Wallet account address used to price the executable provider quote. Private Key identifiers are not supported."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset. The chain is derived from this value."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Base-unit amount of the input asset."
+        },
+        "slippageBps": {
+          "type": "string",
+          "description": "Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
+        }
+      },
+      "required": ["signWith", "inputToken", "outputToken", "inputAmount"]
+    },
     "v1CreateSwapQuoteRequest": {
       "type": "object",
       "properties": {
@@ -9137,6 +9417,61 @@
         }
       },
       "required": ["userIds"]
+    },
+    "v1CreateVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": ["name", "dataSource", "aggregation", "identifier"]
+    },
+    "v1CreateVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1CreateVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
     },
     "v1CreateWalletAccountsIntent": {
       "type": "object",
@@ -10208,6 +10543,48 @@
       },
       "required": ["userIds"]
     },
+    "v1DeleteVelocityControlIntent": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
+    "v1DeleteVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "generateAppProofs": {
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
+    "v1DeleteVelocityControlResult": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["velocityControlId"]
+    },
     "v1DeleteWalletAccountsIntent": {
       "type": "object",
       "properties": {
@@ -10380,6 +10757,10 @@
         "lastUpdatedTime": {
           "$ref": "#/definitions/externaldatav1Timestamp",
           "description": "Last time this deployment was updated"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/v1ProvisioningState",
+          "description": "Current quorum-key provisioning state for this deployment"
         }
       },
       "required": [
@@ -10622,6 +11003,22 @@
         "clientFeeWallet": {
           "type": "string",
           "description": "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        },
+        "exposures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EarnVaultExposure"
+          },
+          "description": "The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho)."
         }
       }
     },
@@ -10802,6 +11199,47 @@
         "curator": {
           "type": "string",
           "description": "Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave)."
+        },
+        "liquidity": {
+          "type": "string",
+          "description": "Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it."
+        },
+        "liquidityDisplay": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."
+        }
+      }
+    },
+    "v1EarnVaultExposure": {
+      "type": "object",
+      "properties": {
+        "marketId": {
+          "type": "string",
+          "description": "Provider-specific identifier for the market (the Morpho Blue market id)."
+        },
+        "collateralSymbol": {
+          "type": "string",
+          "description": "Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market."
+        },
+        "collateralCaip19": {
+          "type": "string",
+          "description": "CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market."
+        },
+        "lltvPct": {
+          "type": "string",
+          "description": "The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%)."
+        },
+        "supplied": {
+          "type": "string",
+          "description": "Assets the vault supplies to this market, in raw on-chain units of the underlying asset."
+        },
+        "display": {
+          "$ref": "#/definitions/v1EarnValueDisplay",
+          "description": "Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead."
+        },
+        "sharePct": {
+          "type": "string",
+          "description": "This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%)."
         }
       }
     },
@@ -11272,7 +11710,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         }
@@ -11318,7 +11758,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11386,7 +11828,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11560,7 +12004,9 @@
             "eip155:143",
             "eip155:10143",
             "eip155:42161",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -11703,6 +12149,64 @@
         "gasStationNonce": {
           "type": "string",
           "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        }
+      },
+      "required": [
+        "quoteId",
+        "inputToken",
+        "inputAmount",
+        "outputToken",
+        "quotedOutputAmount",
+        "minOutputAmount",
+        "sponsor"
+      ]
+    },
+    "v1ExecuteSwapIntentV3": {
+      "type": "object",
+      "properties": {
+        "quoteId": {
+          "type": "string",
+          "description": "Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied."
+        },
+        "inputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the input asset."
+        },
+        "inputAmount": {
+          "type": "string",
+          "description": "Exact base-unit amount of the input asset committed by the quote."
+        },
+        "outputToken": {
+          "type": "string",
+          "description": "CAIP-19 asset ID for the output asset."
+        },
+        "quotedOutputAmount": {
+          "type": "string",
+          "description": "Exact quoted base-unit output amount committed by the quote."
+        },
+        "minOutputAmount": {
+          "type": "string",
+          "description": "Exact minimum base-unit output committed by the quote."
+        },
+        "sponsor": {
+          "type": "boolean",
+          "description": "Whether the quoted transaction is sponsored."
+        },
+        "evmNonce": {
+          "type": "string",
+          "description": "Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "recentBlockhash": {
+          "type": "string",
+          "description": "Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch."
+        },
+        "gasStationNonce": {
+          "type": "string",
+          "description": "Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported."
         }
       },
       "required": [
@@ -12143,6 +12647,35 @@
         "FIAT_ON_RAMP_PROVIDER_COINBASE",
         "FIAT_ON_RAMP_PROVIDER_MOONPAY"
       ]
+    },
+    "v1GetActivePoliciesRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given organization."
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1GetActivePoliciesResponse": {
+      "type": "object",
+      "properties": {
+        "statuses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ActivePolicyStatus"
+          },
+          "description": "The active/inactive status of every policy in the organization."
+        },
+        "evaluatedAtMs": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy."
+        }
+      },
+      "required": ["statuses", "evaluatedAtMs"]
     },
     "v1GetActivitiesRequest": {
       "type": "object",
@@ -12684,7 +13217,9 @@
             "eip155:42161",
             "eip155:4217",
             "eip155:42431",
-            "eip155:421614"
+            "eip155:421614",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -13399,6 +13934,27 @@
       },
       "required": ["users"]
     },
+    "v1GetVelocityControlRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "velocityControlId": {
+          "type": "string"
+        }
+      },
+      "required": ["organizationId", "velocityControlId"]
+    },
+    "v1GetVelocityControlResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControl": {
+          "$ref": "#/definitions/v1VelocityControl"
+        }
+      },
+      "required": ["velocityControl"]
+    },
     "v1GetVerifiedSubOrgIdsRequest": {
       "type": "object",
       "properties": {
@@ -13532,6 +14088,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -14020,6 +14578,27 @@
       },
       "required": ["encryptionSuite", "numSecrets"]
     },
+    "v1InitImportSecretsRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ACTIVITY_TYPE_INIT_IMPORT_SECRETS"]
+        },
+        "timestampMs": {
+          "type": "string",
+          "description": "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Unique identifier for a given Organization."
+        },
+        "parameters": {
+          "$ref": "#/definitions/v1InitImportSecretsIntent"
+        }
+      },
+      "required": ["type", "timestampMs", "organizationId", "parameters"]
+    },
     "v1InitImportSecretsResult": {
       "type": "object",
       "properties": {
@@ -14082,7 +14661,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14120,7 +14699,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Enum to specify whether to send OTP via SMS or email"
+          "description": "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
         },
         "contact": {
           "type": "string",
@@ -14167,7 +14746,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14266,7 +14845,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14317,7 +14896,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -14372,7 +14951,7 @@
       "properties": {
         "otpType": {
           "type": "string",
-          "description": "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+          "description": "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
         },
         "contact": {
           "type": "string",
@@ -15060,6 +15639,21 @@
         },
         "exportSecretsIntent": {
           "$ref": "#/definitions/v1ExportSecretsIntent"
+        },
+        "createVelocityControlIntent": {
+          "$ref": "#/definitions/v1CreateVelocityControlIntent"
+        },
+        "deleteVelocityControlIntent": {
+          "$ref": "#/definitions/v1DeleteVelocityControlIntent"
+        },
+        "updatePaymentMethodIntent": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodIntent"
+        },
+        "createSwapQuoteIntentV2": {
+          "$ref": "#/definitions/v1CreateSwapQuoteIntentV2"
+        },
+        "executeSwapIntentV3": {
+          "$ref": "#/definitions/v1ExecuteSwapIntentV3"
         }
       }
     },
@@ -15185,6 +15779,10 @@
         "caip19": {
           "type": "string",
           "description": "Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier."
+        },
+        "includeExposure": {
+          "type": "boolean",
+          "description": "When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views."
         }
       },
       "required": ["organizationId"]
@@ -15329,7 +15927,9 @@
             "eip155:42431",
             "eip155:421614",
             "eip155:56",
-            "eip155:97"
+            "eip155:97",
+            "eip155:4663",
+            "eip155:46630"
           ],
           "description": "EVM CAIP-2 chain ID (e.g., 'eip155:1' for Ethereum mainnet)."
         },
@@ -15526,6 +16126,8 @@
             "eip155:4217",
             "eip155:42431",
             "eip155:421614",
+            "eip155:4663",
+            "eip155:46630",
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
           ],
@@ -15570,6 +16172,34 @@
         }
       },
       "required": ["userTags"]
+    },
+    "v1ListVelocityControlsRequest": {
+      "type": "object",
+      "properties": {
+        "organizationId": {
+          "type": "string"
+        },
+        "paginationOptions": {
+          "$ref": "#/definitions/v1Pagination"
+        }
+      },
+      "required": ["organizationId"]
+    },
+    "v1ListVelocityControlsResponse": {
+      "type": "object",
+      "properties": {
+        "velocityControls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControl"
+          }
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/v1PageInfo"
+        }
+      },
+      "required": ["velocityControls", "pageInfo"]
     },
     "v1ListWebhookEndpointsRequest": {
       "type": "object",
@@ -16516,6 +17146,14 @@
         }
       }
     },
+    "v1ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "PROVISIONING_STATE_PENDING",
+        "PROVISIONING_STATE_AWAITING_PROVISION",
+        "PROVISIONING_STATE_PROVISIONED"
+      ]
+    },
     "v1PublicKeyCredentialWithAttestation": {
       "type": "object",
       "properties": {
@@ -17268,6 +17906,15 @@
         },
         "exportSecretsResult": {
           "$ref": "#/definitions/v1ExportSecretsResult"
+        },
+        "createVelocityControlResult": {
+          "$ref": "#/definitions/v1CreateVelocityControlResult"
+        },
+        "deleteVelocityControlResult": {
+          "$ref": "#/definitions/v1DeleteVelocityControlResult"
+        },
+        "updatePaymentMethodResult": {
+          "$ref": "#/definitions/billingUpdatePaymentMethodResult"
         }
       }
     },
@@ -20927,6 +21574,261 @@
           "type": "string"
         }
       }
+    },
+    "v1VelocityControl": {
+      "type": "object",
+      "properties": {
+        "velocityControlId": {
+          "type": "string",
+          "description": "Unique identifier for the Velocity Control."
+        },
+        "organizationId": {
+          "type": "string",
+          "description": "Identifier of the Organization that owns the Velocity Control."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Velocity Control."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/v1VelocityControlDataSource",
+          "description": "Data source for the Velocity Control."
+        },
+        "aggregation": {
+          "$ref": "#/definitions/v1VelocityControlAggregation",
+          "description": "Aggregation expression that the Velocity Control evaluates."
+        },
+        "createdAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was created."
+        },
+        "updatedAt": {
+          "$ref": "#/definitions/externaldatav1Timestamp",
+          "description": "Time when the Velocity Control was last updated."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Identifier for the Velocity Control. Policies reference it as `controls.\u003cidentifier\u003e`. It must be unique within the Organization."
+        }
+      },
+      "required": [
+        "velocityControlId",
+        "organizationId",
+        "name",
+        "dataSource",
+        "aggregation",
+        "createdAt",
+        "updatedAt",
+        "identifier"
+      ]
+    },
+    "v1VelocityControlAggregation": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "$ref": "#/definitions/v1VelocityControlAggregationMethod",
+          "description": "Method that aggregates matching data points."
+        },
+        "operator": {
+          "$ref": "#/definitions/v1VelocityControlAggregationOperator",
+          "description": "Comparison between the aggregate and the threshold."
+        },
+        "threshold": {
+          "type": "string",
+          "description": "Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits."
+        },
+        "window": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindow",
+          "description": "Time window for the aggregation."
+        },
+        "groupBy": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupBy",
+          "description": "Scope that partitions matching data before aggregation."
+        }
+      },
+      "required": ["method", "operator", "threshold", "window", "groupBy"]
+    },
+    "v1VelocityControlAggregationGroupBy": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByOrganization",
+          "description": "Uses one shared bucket for the Organization."
+        },
+        "user": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByUser",
+          "description": "Uses one bucket for each User."
+        },
+        "wallet": {
+          "$ref": "#/definitions/v1VelocityControlAggregationGroupByWallet",
+          "description": "Uses one bucket for each Wallet."
+        }
+      }
+    },
+    "v1VelocityControlAggregationGroupByOrganization": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByUser": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationGroupByWallet": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationMethod": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM",
+        "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT"
+      ]
+    },
+    "v1VelocityControlAggregationOperator": {
+      "type": "string",
+      "enum": [
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL",
+        "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN"
+      ]
+    },
+    "v1VelocityControlAggregationWindow": {
+      "type": "object",
+      "properties": {
+        "rolling": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowRolling",
+          "description": "Uses a rolling time window."
+        },
+        "infinite": {
+          "$ref": "#/definitions/v1VelocityControlAggregationWindowInfinite",
+          "description": "Uses all matching data without a time limit."
+        }
+      }
+    },
+    "v1VelocityControlAggregationWindowInfinite": {
+      "type": "object"
+    },
+    "v1VelocityControlAggregationWindowRolling": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the rolling window, in seconds, as a base-10 integer string."
+        }
+      },
+      "required": ["duration"]
+    },
+    "v1VelocityControlDataSource": {
+      "type": "object",
+      "properties": {
+        "chainAssetTransfer": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransfer",
+          "description": "Uses transfers of the listed on-chain assets as input data."
+        },
+        "activityExecution": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecution",
+          "description": "Uses executed Turnkey activities as input data."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecution": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceActivityExecutionFilter",
+          "description": "Filters activity executions by type."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceActivityExecutionFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose executions are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceChainAssetTransfer": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferDefinition"
+          },
+          "description": "Assets whose transfers are included in the data source."
+        },
+        "filter": {
+          "$ref": "#/definitions/v1VelocityControlDataSourceChainAssetTransferFilter",
+          "description": "Filters asset transfers by activity type."
+        },
+        "phase": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhase",
+          "description": "Selects when to measure an asset transfer."
+        }
+      },
+      "required": ["definition"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferDefinition": {
+      "type": "object",
+      "properties": {
+        "caip19": {
+          "type": "string",
+          "description": "CAIP-19 identifier for the asset."
+        },
+        "decimals": {
+          "type": "string",
+          "description": "Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset."
+        }
+      },
+      "required": ["caip19", "decimals"]
+    },
+    "v1VelocityControlDataSourceChainAssetTransferFilter": {
+      "type": "object",
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VelocityControlDataSourceFilterActivity"
+          },
+          "description": "Activity types whose asset transfers are included."
+        }
+      }
+    },
+    "v1VelocityControlDataSourceFilterActivity": {
+      "type": "object",
+      "properties": {
+        "activityType": {
+          "type": "string",
+          "description": "Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`."
+        }
+      },
+      "required": ["activityType"]
+    },
+    "v1VelocityControlDataSourcePhase": {
+      "type": "object",
+      "properties": {
+        "signature": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSignature",
+          "description": "Measures the transfer when Turnkey signs the transaction and returns it to the user."
+        },
+        "submission": {
+          "$ref": "#/definitions/v1VelocityControlDataSourcePhaseSubmission",
+          "description": "Reserved for future use. Measures the transfer after the transaction lands on chain."
+        }
+      }
+    },
+    "v1VelocityControlDataSourcePhaseSignature": {
+      "type": "object"
+    },
+    "v1VelocityControlDataSourcePhaseSubmission": {
+      "type": "object"
     },
     "v1VerifyOtpIntent": {
       "type": "object",

--- a/packages/sdk-types/src/__inputs__/public_api.types.ts
+++ b/packages/sdk-types/src/__inputs__/public_api.types.ts
@@ -4,6 +4,10 @@
  */
 
 export type paths = {
+  "/public/v1/query/get_active_policies": {
+    /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+    post: operations["PublicApiService_GetActivePolicies"];
+  };
   "/public/v1/query/get_activity": {
     /** Get details about an activity. */
     post: operations["PublicApiService_GetActivity"];
@@ -152,6 +156,10 @@ export type paths = {
     /** Get details about a user. */
     post: operations["PublicApiService_GetUser"];
   };
+  "/public/v1/query/get_velocity_control": {
+    /** Get details about a velocity control. */
+    post: operations["PublicApiService_GetVelocityControl"];
+  };
   "/public/v1/query/get_wallet": {
     /** Get details about a wallet. */
     post: operations["PublicApiService_GetWallet"];
@@ -247,6 +255,10 @@ export type paths = {
   "/public/v1/query/list_users": {
     /** List all users within an organization. */
     post: operations["PublicApiService_GetUsers"];
+  };
+  "/public/v1/query/list_velocity_controls": {
+    /** List all velocity controls within an organization. */
+    post: operations["PublicApiService_ListVelocityControls"];
   };
   "/public/v1/query/list_verified_suborgs": {
     /** Get all email or phone verified suborg IDs associated given a parent org ID. */
@@ -384,6 +396,10 @@ export type paths = {
     /** Create users in an existing organization. Each user must have at least one valid credential: an API key, an authenticator, an OAuth provider, or an email or phone number with a login method enabled on the organization (email, email OTP, or SMS). */
     post: operations["PublicApiService_CreateUsers"];
   };
+  "/public/v1/submit/create_velocity_control": {
+    /** Create a new velocity control. */
+    post: operations["PublicApiService_CreateVelocityControl"];
+  };
   "/public/v1/submit/create_wallet": {
     /** Create a wallet and derive addresses. */
     post: operations["PublicApiService_CreateWallet"];
@@ -463,6 +479,10 @@ export type paths = {
   "/public/v1/submit/delete_users": {
     /** Delete users within an organization. */
     post: operations["PublicApiService_DeleteUsers"];
+  };
+  "/public/v1/submit/delete_velocity_control": {
+    /** Delete an existing velocity control. */
+    post: operations["PublicApiService_DeleteVelocityControl"];
   };
   "/public/v1/submit/delete_wallet_accounts": {
     /** Delete wallet accounts for an organization. */
@@ -797,6 +817,14 @@ export type definitions = {
     /** @description The email address associated with the payment method. */
     cardHolderEmail: string;
   };
+  billingUpdatePaymentMethodIntent: {
+    /** @description The email that will receive invoices for the payment method. */
+    paymentEmail: string;
+  };
+  billingUpdatePaymentMethodResult: {
+    /** @description The email address associated with the payment method. */
+    paymentEmail: string;
+  };
   datav1Tag: {
     /** @description Unique identifier for a given Tag. */
     tagId: string;
@@ -904,6 +932,18 @@ export type definitions = {
   };
   /** @enum {string} */
   v1AccessType: "ACCESS_TYPE_WEB" | "ACCESS_TYPE_API" | "ACCESS_TYPE_ALL";
+  v1ActivePolicyStatus: {
+    /** @description Unique identifier for the organization the policy belongs to. */
+    organizationId: string;
+    /** @description Unique identifier for a given policy. */
+    policyId: string;
+    /** @description Whether the policy is currently active. A policy without a time window is always active. */
+    active: boolean;
+    /** @description The policy's time expression, absent when the policy has no time window. */
+    timeExpr?: string;
+    /** @description Set when the policy's time expression could not be evaluated; the policy is reported inactive. */
+    error?: string;
+  };
   v1Activity: {
     /** @description Unique identifier for a given Activity object. */
     id: string;
@@ -1106,7 +1146,12 @@ export type definitions = {
     | "ACTIVITY_TYPE_EXECUTE_SWAP_V2"
     | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE"
     | "ACTIVITY_TYPE_IMPORT_SECRETS"
-    | "ACTIVITY_TYPE_EXPORT_SECRETS";
+    | "ACTIVITY_TYPE_EXPORT_SECRETS"
+    | "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL"
+    | "ACTIVITY_TYPE_UPDATE_PAYMENT_METHOD"
+    | "ACTIVITY_TYPE_CREATE_SWAP_QUOTE_V2"
+    | "ACTIVITY_TYPE_EXECUTE_SWAP_V3";
   /** @enum {string} */
   v1AddressFormat:
     | "ADDRESS_FORMAT_UNCOMPRESSED"
@@ -1258,6 +1303,8 @@ export type definitions = {
     name?: string;
     /** @description Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing). */
     stable?: boolean;
+    /** @description Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn. */
+    earnProviders?: definitions["v1EarnProvider"][];
   };
   v1Attestation: {
     /** @description The cbor encoded then base64 url encoded id of the credential. */
@@ -2068,6 +2115,20 @@ export type definitions = {
     /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
     slippageBps?: string;
   };
+  v1CreateSwapQuoteIntentV2: {
+    /** @description Wallet account address used to price the executable provider quote. Private Key identifiers are not supported. */
+    signWith: string;
+    /** @description CAIP-19 asset ID for the input asset. The chain is derived from this value. */
+    inputToken: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Base-unit amount of the input asset. */
+    inputAmount: string;
+    /** @description Provider-neutral maximum allowed slippage in basis points. Turnkey converts this value to each provider's request format. When omitted, each provider applies its default slippage behavior. */
+    slippageBps?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
+  };
   v1CreateSwapQuoteRequest: {
     /** @enum {string} */
     type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE";
@@ -2313,6 +2374,29 @@ export type definitions = {
   v1CreateUsersResult: {
     /** @description A list of User IDs. */
     userIds: string[];
+  };
+  v1CreateVelocityControlIntent: {
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1CreateVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_CREATE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1CreateVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1CreateVelocityControlResult: {
+    velocityControlId: string;
   };
   v1CreateWalletAccountsIntent: {
     /** @description Unique identifier for a given Wallet. */
@@ -2737,6 +2821,22 @@ export type definitions = {
     /** @description A list of User IDs. */
     userIds: string[];
   };
+  v1DeleteVelocityControlIntent: {
+    velocityControlId: string;
+  };
+  v1DeleteVelocityControlRequest: {
+    /** @enum {string} */
+    type: "ACTIVITY_TYPE_DELETE_VELOCITY_CONTROL";
+    /** @description Timestamp (in milliseconds) of the request, used to verify liveness of user requests. */
+    timestampMs: string;
+    /** @description Unique identifier for a given Organization. */
+    organizationId: string;
+    parameters: definitions["v1DeleteVelocityControlIntent"];
+    generateAppProofs?: boolean;
+  };
+  v1DeleteVelocityControlResult: {
+    velocityControlId: string;
+  };
   v1DeleteWalletAccountsIntent: {
     /** @description List of unique identifiers for wallet accounts within an organization */
     walletAccountIds: string[];
@@ -2810,6 +2910,8 @@ export type definitions = {
     desiredReplicas: number;
     /** @description Last time this deployment was updated */
     lastUpdatedTime: definitions["externaldatav1Timestamp"];
+    /** @description Current quorum-key provisioning state for this deployment */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1DisableAuthProxyIntent: { [key: string]: unknown };
   v1DisableAuthProxyResult: { [key: string]: unknown };
@@ -2924,6 +3026,12 @@ export type definitions = {
     claimableClientFeeDisplay?: definitions["v1EarnValueDisplay"];
     /** @description The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries. */
     clientFeeWallet?: string;
+    /** @description Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+    /** @description The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho). */
+    exposures?: definitions["v1EarnVaultExposure"][];
   };
   v1EarnPosition: {
     /** @description Address of the underlying yield vault. */
@@ -3008,6 +3116,26 @@ export type definitions = {
     name?: string;
     /** @description Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave). */
     curator?: string;
+    /** @description Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it. */
+    liquidity?: string;
+    /** @description Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead. */
+    liquidityDisplay?: definitions["v1EarnValueDisplay"];
+  };
+  v1EarnVaultExposure: {
+    /** @description Provider-specific identifier for the market (the Morpho Blue market id). */
+    marketId?: string;
+    /** @description Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market. */
+    collateralSymbol?: string;
+    /** @description CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market. */
+    collateralCaip19?: string;
+    /** @description The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%). */
+    lltvPct?: string;
+    /** @description Assets the vault supplies to this market, in raw on-chain units of the underlying asset. */
+    supplied?: string;
+    /** @description Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead. */
+    display?: definitions["v1EarnValueDisplay"];
+    /** @description This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%). */
+    sharePct?: string;
   };
   v1EarnWithdrawIntent: {
     /** @description Address of the deployed Earn wrapper holding the position to withdraw from, from ListEarnPositions. Must be one of the org's deployed wrappers. */
@@ -3237,7 +3365,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
   };
   v1EthSendRawTransactionRequest: {
     /** @enum {string} */
@@ -3278,7 +3408,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Recipient address as a hex string with 0x prefix. */
     to: string;
     /** @description Amount of native asset to send in wei. */
@@ -3321,7 +3453,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to sponsor this transaction via Gas Station. If false or unset, the EOA pays gas. A single call uses EIP-1559; multiple calls use EIP-7702 batch execution via Gas Station. */
     sponsor?: boolean;
     /** @description Outer transaction nonce. Omit to auto-fetch. */
@@ -3405,7 +3539,9 @@ export type definitions = {
       | "eip155:143"
       | "eip155:10143"
       | "eip155:42161"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Outer transaction nonce. Omit to auto-fetch. */
     nonce?: string;
     /** @description Maximum amount of gas for the undelegation transaction. Omit to use the fixed undelegation gas limit. */
@@ -3468,6 +3604,30 @@ export type definitions = {
     recentBlockhash?: string;
     /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
     gasStationNonce?: string;
+  };
+  v1ExecuteSwapIntentV3: {
+    /** @description Quote identifier returned by create_swap_quote. Execution is bound to this quote; the signer is derived from the quote and must not be resupplied. */
+    quoteId: string;
+    /** @description CAIP-19 asset ID for the input asset. */
+    inputToken: string;
+    /** @description Exact base-unit amount of the input asset committed by the quote. */
+    inputAmount: string;
+    /** @description CAIP-19 asset ID for the output asset. */
+    outputToken: string;
+    /** @description Exact quoted base-unit output amount committed by the quote. */
+    quotedOutputAmount: string;
+    /** @description Exact minimum base-unit output committed by the quote. */
+    minOutputAmount: string;
+    /** @description Whether the quoted transaction is sponsored. */
+    sponsor: boolean;
+    /** @description Exact EVM sender (EOA account) nonce. Valid only for a non-sponsored EVM swap. Honored for already-delegated (Type-2) batch swaps and single-call swaps; ignored for not-yet-delegated EIP-7702 (Type-4) batches where the outer nonce is derived from the authorization. Prefer gas_station_nonce for batch replay protection and use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    evmNonce?: string;
+    /** @description Exact Solana recent blockhash. Valid only for a Solana swap, including sponsored swaps. Omit to auto-fetch. */
+    recentBlockhash?: string;
+    /** @description Exact gas station delegate contract nonce used in the BatchExecution EIP-712 message. Valid for sponsored EVM swaps and non-sponsored EVM swaps that execute as a multi-call batch (for example ERC-20 approve + swap). This is the replay-protection nonce for gas-station batches; use the nonces endpoint to fetch it. Omit to auto-fetch. */
+    gasStationNonce?: string;
+    /** @description Raw public address that receives the output asset. Required for cross-protocol swaps. The address must match the output token protocol. Wallet account IDs, private key IDs, and CAIP account or asset identifiers are not supported. */
+    destinationAddress?: string;
   };
   v1ExecuteSwapRequest: {
     /** @enum {string} */
@@ -3684,6 +3844,19 @@ export type definitions = {
   v1FiatOnRampProvider:
     | "FIAT_ON_RAMP_PROVIDER_COINBASE"
     | "FIAT_ON_RAMP_PROVIDER_MOONPAY";
+  v1GetActivePoliciesRequest: {
+    /** @description Unique identifier for a given organization. */
+    organizationId: string;
+  };
+  v1GetActivePoliciesResponse: {
+    /** @description The active/inactive status of every policy in the organization. */
+    statuses: definitions["v1ActivePolicyStatus"][];
+    /**
+     * Format: uint64
+     * @description The enclave's trusted timestamp (Unix epoch milliseconds) used to evaluate every policy.
+     */
+    evaluatedAtMs: string;
+  };
   v1GetActivitiesRequest: {
     /** @description Unique identifier for a given organization. */
     organizationId: string;
@@ -3926,7 +4099,9 @@ export type definitions = {
       | "eip155:42161"
       | "eip155:4217"
       | "eip155:42431"
-      | "eip155:421614";
+      | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Whether to fetch the standard on-chain nonce. */
     nonce?: boolean;
     /** @description Whether to fetch the gas station nonce used for sponsored transactions. */
@@ -4193,14 +4368,16 @@ export type definitions = {
   v1GetTvcDeploymentProvisioningDetailsResponse: {
     /**
      * Format: byte
-     * @description The attestation document of the provisioning enclave in a TVC deployment.
+     * @description The attestation document of the provisioning enclave. Present only when a deployment is awaiting provisioning.
      */
-    attestationDocument: string;
+    attestationDocument?: string;
     /**
      * Format: byte
-     * @description The manifest envelope containing the TVC deployment's manifest and signatures.
+     * @description The manifest envelope containing the TVC deployment's manifest and signatures. Present only when a deployment is awaiting provisioning.
      */
-    manifestEnvelope: string;
+    manifestEnvelope?: string;
+    /** @description Current provisioning state. */
+    provisioningState?: definitions["v1ProvisioningState"];
   };
   v1GetTvcDeploymentRequest: {
     /** @description Unique identifier for a given organization. */
@@ -4239,6 +4416,13 @@ export type definitions = {
   v1GetUsersResponse: {
     /** @description A list of users. */
     users: definitions["v1User"][];
+  };
+  v1GetVelocityControlRequest: {
+    organizationId: string;
+    velocityControlId: string;
+  };
+  v1GetVelocityControlResponse: {
+    velocityControl: definitions["v1VelocityControl"];
   };
   v1GetVerifiedSubOrgIdsRequest: {
     /** @description Unique identifier for the parent organization. This is used to find sub-organizations within it. */
@@ -4308,6 +4492,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -4537,7 +4723,7 @@ export type definitions = {
     importBundle: string;
   };
   v1InitOtpAuthIntent: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4555,7 +4741,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV2: {
-    /** @description Enum to specify whether to send OTP via SMS or email */
+    /** @description Enum to specify whether to send OTP via SMS, email, or WhatsApp */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4580,7 +4766,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpAuthIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4627,7 +4813,7 @@ export type definitions = {
     otpId: string;
   };
   v1InitOtpIntent: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4654,7 +4840,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV2: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4683,7 +4869,7 @@ export type definitions = {
     replyToEmailAddress?: string;
   };
   v1InitOtpIntentV3: {
-    /** @description Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL */
+    /** @description Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP */
     otpType: string;
     /** @description Email or phone number to send the OTP code to */
     contact: string;
@@ -4940,6 +5126,11 @@ export type definitions = {
     createSwapQuoteIntent?: definitions["v1CreateSwapQuoteIntent"];
     importSecretsIntent?: definitions["v1ImportSecretsIntent"];
     exportSecretsIntent?: definitions["v1ExportSecretsIntent"];
+    createVelocityControlIntent?: definitions["v1CreateVelocityControlIntent"];
+    deleteVelocityControlIntent?: definitions["v1DeleteVelocityControlIntent"];
+    updatePaymentMethodIntent?: definitions["billingUpdatePaymentMethodIntent"];
+    createSwapQuoteIntentV2?: definitions["v1CreateSwapQuoteIntentV2"];
+    executeSwapIntentV3?: definitions["v1ExecuteSwapIntentV3"];
   };
   v1Invitation: {
     /** @description Unique identifier for a given Invitation object. */
@@ -5013,6 +5204,8 @@ export type definitions = {
     provider?: definitions["v1EarnProvider"];
     /** @description Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier. */
     caip19?: string;
+    /** @description When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views. */
+    includeExposure?: boolean;
   };
   v1ListEarnEnabledVaultsResponse: {
     /** @description The organization's deployed wrappers. */
@@ -5079,7 +5272,9 @@ export type definitions = {
       | "eip155:42431"
       | "eip155:421614"
       | "eip155:56"
-      | "eip155:97";
+      | "eip155:97"
+      | "eip155:4663"
+      | "eip155:46630";
     /** @description Cursor-based pagination options. Cursors are opaque and valid only for the same address and CAIP-2 query. */
     paginationOptions?: definitions["v1Pagination"];
   };
@@ -5166,6 +5361,8 @@ export type definitions = {
       | "eip155:4217"
       | "eip155:42431"
       | "eip155:421614"
+      | "eip155:4663"
+      | "eip155:46630"
       | "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
       | "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
   };
@@ -5180,6 +5377,14 @@ export type definitions = {
   v1ListUserTagsResponse: {
     /** @description A list of user tags. */
     userTags: definitions["datav1Tag"][];
+  };
+  v1ListVelocityControlsRequest: {
+    organizationId: string;
+    paginationOptions?: definitions["v1Pagination"];
+  };
+  v1ListVelocityControlsResponse: {
+    velocityControls: definitions["v1VelocityControl"][];
+    pageInfo: definitions["v1PageInfo"];
   };
   v1ListWebhookEndpointsRequest: {
     /** @description Unique identifier for a given Organization. */
@@ -5596,6 +5801,11 @@ export type definitions = {
     privateKeyId?: string;
     addresses?: definitions["immutableactivityv1Address"][];
   };
+  /** @enum {string} */
+  v1ProvisioningState:
+    | "PROVISIONING_STATE_PENDING"
+    | "PROVISIONING_STATE_AWAITING_PROVISION"
+    | "PROVISIONING_STATE_PROVISIONED";
   v1PublicKeyCredentialWithAttestation: {
     id: string;
     /** @enum {string} */
@@ -5877,6 +6087,9 @@ export type definitions = {
     createSwapQuoteResult?: definitions["v1CreateSwapQuoteResult"];
     importSecretsResult?: definitions["v1ImportSecretsResult"];
     exportSecretsResult?: definitions["v1ExportSecretsResult"];
+    createVelocityControlResult?: definitions["v1CreateVelocityControlResult"];
+    deleteVelocityControlResult?: definitions["v1DeleteVelocityControlResult"];
+    updatePaymentMethodResult?: definitions["billingUpdatePaymentMethodResult"];
   };
   v1RevertChainEntry: {
     /** @description The contract address where the revert occurred. */
@@ -7386,6 +7599,113 @@ export type definitions = {
   v1ValidateTvcImageResponse: {
     resolvedImageDigest?: string;
   };
+  v1VelocityControl: {
+    /** @description Unique identifier for the Velocity Control. */
+    velocityControlId: string;
+    /** @description Identifier of the Organization that owns the Velocity Control. */
+    organizationId: string;
+    /** @description Human-readable name for the Velocity Control. */
+    name: string;
+    /** @description Data source for the Velocity Control. */
+    dataSource: definitions["v1VelocityControlDataSource"];
+    /** @description Aggregation expression that the Velocity Control evaluates. */
+    aggregation: definitions["v1VelocityControlAggregation"];
+    /** @description Time when the Velocity Control was created. */
+    createdAt: definitions["externaldatav1Timestamp"];
+    /** @description Time when the Velocity Control was last updated. */
+    updatedAt: definitions["externaldatav1Timestamp"];
+    /** @description Identifier for the Velocity Control. Policies reference it as `controls.<identifier>`. It must be unique within the Organization. */
+    identifier: string;
+  };
+  v1VelocityControlAggregation: {
+    /** @description Method that aggregates matching data points. */
+    method: definitions["v1VelocityControlAggregationMethod"];
+    /** @description Comparison between the aggregate and the threshold. */
+    operator: definitions["v1VelocityControlAggregationOperator"];
+    /** @description Non-negative base-10 decimal string with at most 38 total digits and 18 fractional digits. */
+    threshold: string;
+    /** @description Time window for the aggregation. */
+    window: definitions["v1VelocityControlAggregationWindow"];
+    /** @description Scope that partitions matching data before aggregation. */
+    groupBy: definitions["v1VelocityControlAggregationGroupBy"];
+  };
+  v1VelocityControlAggregationGroupBy: {
+    /** @description Uses one shared bucket for the Organization. */
+    organization?: definitions["v1VelocityControlAggregationGroupByOrganization"];
+    /** @description Uses one bucket for each User. */
+    user?: definitions["v1VelocityControlAggregationGroupByUser"];
+    /** @description Uses one bucket for each Wallet. */
+    wallet?: definitions["v1VelocityControlAggregationGroupByWallet"];
+  };
+  v1VelocityControlAggregationGroupByOrganization: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByUser: { [key: string]: unknown };
+  v1VelocityControlAggregationGroupByWallet: { [key: string]: unknown };
+  /** @enum {string} */
+  v1VelocityControlAggregationMethod:
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_SUM"
+    | "VELOCITY_CONTROL_AGGREGATION_METHOD_COUNT";
+  /** @enum {string} */
+  v1VelocityControlAggregationOperator:
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_LESS_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN_OR_EQUAL"
+    | "VELOCITY_CONTROL_AGGREGATION_OPERATOR_GREATER_THAN";
+  v1VelocityControlAggregationWindow: {
+    /** @description Uses a rolling time window. */
+    rolling?: definitions["v1VelocityControlAggregationWindowRolling"];
+    /** @description Uses all matching data without a time limit. */
+    infinite?: definitions["v1VelocityControlAggregationWindowInfinite"];
+  };
+  v1VelocityControlAggregationWindowInfinite: { [key: string]: unknown };
+  v1VelocityControlAggregationWindowRolling: {
+    /** @description Duration of the rolling window, in seconds, as a base-10 integer string. */
+    duration: string;
+  };
+  v1VelocityControlDataSource: {
+    /** @description Uses transfers of the listed on-chain assets as input data. */
+    chainAssetTransfer?: definitions["v1VelocityControlDataSourceChainAssetTransfer"];
+    /** @description Uses executed Turnkey activities as input data. */
+    activityExecution?: definitions["v1VelocityControlDataSourceActivityExecution"];
+  };
+  v1VelocityControlDataSourceActivityExecution: {
+    /** @description Filters activity executions by type. */
+    filter?: definitions["v1VelocityControlDataSourceActivityExecutionFilter"];
+  };
+  v1VelocityControlDataSourceActivityExecutionFilter: {
+    /** @description Activity types whose executions are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceChainAssetTransfer: {
+    /** @description Assets whose transfers are included in the data source. */
+    definition: definitions["v1VelocityControlDataSourceChainAssetTransferDefinition"][];
+    /** @description Filters asset transfers by activity type. */
+    filter?: definitions["v1VelocityControlDataSourceChainAssetTransferFilter"];
+    /** @description Selects when to measure an asset transfer. */
+    phase?: definitions["v1VelocityControlDataSourcePhase"];
+  };
+  v1VelocityControlDataSourceChainAssetTransferDefinition: {
+    /** @description CAIP-19 identifier for the asset. */
+    caip19: string;
+    /** @description Base-10 integer string from 0 through 255 that specifies the number of decimal places for the asset. */
+    decimals: string;
+  };
+  v1VelocityControlDataSourceChainAssetTransferFilter: {
+    /** @description Activity types whose asset transfers are included. */
+    activity?: definitions["v1VelocityControlDataSourceFilterActivity"][];
+  };
+  v1VelocityControlDataSourceFilterActivity: {
+    /** @description Name of an activity type to include, such as `ACTIVITY_TYPE_SOL_SEND_TRANSACTION`. */
+    activityType: string;
+  };
+  v1VelocityControlDataSourcePhase: {
+    /** @description Measures the transfer when Turnkey signs the transaction and returns it to the user. */
+    signature?: definitions["v1VelocityControlDataSourcePhaseSignature"];
+    /** @description Reserved for future use. Measures the transfer after the transaction lands on chain. */
+    submission?: definitions["v1VelocityControlDataSourcePhaseSubmission"];
+  };
+  v1VelocityControlDataSourcePhaseSignature: { [key: string]: unknown };
+  v1VelocityControlDataSourcePhaseSubmission: { [key: string]: unknown };
   v1VerifyOtpIntent: {
     /** @description ID representing the result of an init OTP activity. */
     otpId: string;
@@ -7559,6 +7879,24 @@ export type definitions = {
 };
 
 export type operations = {
+  /** For each policy in an organization, report whether it is currently active based on the enclave's trusted timestamp and the policy's time window (if any). Policies without a time field are always active. */
+  PublicApiService_GetActivePolicies: {
+    parameters: {
+      body: {
+        body: definitions["v1GetActivePoliciesRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetActivePoliciesResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about an activity. */
   PublicApiService_GetActivity: {
     parameters: {
@@ -8225,6 +8563,24 @@ export type operations = {
       };
     };
   };
+  /** Get details about a velocity control. */
+  PublicApiService_GetVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1GetVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1GetVelocityControlResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Get details about a wallet. */
   PublicApiService_GetWallet: {
     parameters: {
@@ -8650,6 +9006,24 @@ export type operations = {
       /** A successful response. */
       200: {
         schema: definitions["v1GetUsersResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** List all velocity controls within an organization. */
+  PublicApiService_ListVelocityControls: {
+    parameters: {
+      body: {
+        body: definitions["v1ListVelocityControlsRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ListVelocityControlsResponse"];
       };
       /** An unexpected error response. */
       default: {
@@ -9269,6 +9643,24 @@ export type operations = {
       };
     };
   };
+  /** Create a new velocity control. */
+  PublicApiService_CreateVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1CreateVelocityControlRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
   /** Create a wallet and derive addresses. */
   PublicApiService_CreateWallet: {
     parameters: {
@@ -9616,6 +10008,24 @@ export type operations = {
     parameters: {
       body: {
         body: definitions["v1DeleteUsersRequest"];
+      };
+    };
+    responses: {
+      /** A successful response. */
+      200: {
+        schema: definitions["v1ActivityResponse"];
+      };
+      /** An unexpected error response. */
+      default: {
+        schema: definitions["rpcStatus"];
+      };
+    };
+  };
+  /** Delete an existing velocity control. */
+  PublicApiService_DeleteVelocityControl: {
+    parameters: {
+      body: {
+        body: definitions["v1DeleteVelocityControlRequest"];
       };
     };
     responses: {


### PR DESCRIPTION
## Summary & Motivation

Update the swap SDK methods to use the latest public activities:

- `createSwapQuote` now submits `CREATE_SWAP_QUOTE_V2`.
- `executeSwap` now submits `EXECUTE_SWAP_V3`.
- Both inputs accept an optional `destinationAddress` for cross-protocol swaps.
- Sync the public Swagger and TypeScript API artifacts from mono `v2026.8.4`.
- Update the execute-swap example and documentation to use the new versions.

## How I Tested These Changes

- `pnpm --filter @turnkey/core --filter @turnkey/sdk-browser --filter @turnkey/sdk-server --filter @turnkey/sdk-types --filter @turnkey/http run typecheck`
- `pnpm --filter @turnkey/example-execute-swap typecheck`
- `git diff --check`

## Did you add a changeset?

Yes. `.changeset/modern-swaps-arrive.md` adds minor releases for the five affected packages.
