### PR TITLE
Add export-path-policies example

### DIFF
--- a/examples/key-management/export-path-policies/.env.local.example
+++ b/examples/key-management/export-path-policies/.env.local.example
@@ -1,0 +1,4 @@
+BASE_URL=https://api.turnkey.com
+ORGANIZATION_ID="<Turnkey organization ID>"
+API_PUBLIC_KEY="<Turnkey API public key>"
+API_PRIVATE_KEY="<Turnkey API private key>"

--- a/examples/key-management/export-path-policies/README.md
+++ b/examples/key-management/export-path-policies/README.md
@@ -1,0 +1,89 @@
+# Example: `export-path-policies`
+
+This example shows how to restrict wallet account exports by derivation path.
+It uses the `wallet_account.path_indexes` and `wallet_account.path_hardened`
+policy fields with `EXPORT_WALLET_ACCOUNT`.
+
+The script uses a root API key. It creates a non-root API-only user and a
+wallet with accounts on three derivation paths. It then verifies:
+
+1. with no policy in place, the tester user is denied (baseline);
+2. an ALLOW policy scoped to `m/8797555'/*'/3'/*'` (via `path_indexes` /
+   `path_hardened`) permits only the in-subtree account, whose export bundle
+   is decrypted locally;
+3. accounts outside the subtree are denied;
+4. an explicit DENY written against `path_indexes` wins over a broad ALLOW;
+5. a policy that references an unsupported field (`wallet_account.path`) is
+   rejected at creation time.
+
+Use a fresh organization: existing policies can change the results above. The
+script does not delete what it creates, and it prints each resource ID.
+
+## Getting started
+
+### 1/ Cloning the example
+
+Make sure you have `Node.js` installed locally; we recommend using Node v18+.
+
+```bash
+$ git clone https://github.com/tkhq/sdk
+$ cd sdk/
+$ corepack enable  # Install `pnpm`
+$ pnpm install -r  # Install dependencies
+$ pnpm run build-all  # Compile source code
+$ cd examples/key-management/export-path-policies/
+```
+
+### 2/ Setting up Turnkey
+
+The first step is to set up your Turnkey organization and account. By
+following the [Quickstart](https://docs.turnkey.com/getting-started/quickstart)
+guide, you should have:
+
+- A public/private API key pair for Turnkey
+- An organization ID
+
+Once you've gathered these values, add them to a new `.env.local` file. Notice
+that your API private key should be securely managed and **_never_** be
+committed to git.
+
+```bash
+$ cp .env.local.example .env.local
+```
+
+Now open `.env.local` and add the missing environment variables:
+
+- `API_PUBLIC_KEY`
+- `API_PRIVATE_KEY`
+- `BASE_URL`
+- `ORGANIZATION_ID`
+
+### 3/ Running the script
+
+```bash
+$ pnpm start
+```
+
+Sample output:
+
+```
+Created tester user with id: 93c0bedd-fd5c-413c-92fb-bd4d95d43c86
+Created wallet with id: 899c4411-2d5b-52f5-beb6-de2d501589eb
+- m/8797555'/0'/0'    030dc5e09c5082890533d41e1595cc3d42f8882f934d62fb81f53d1c8d840f038b
+- m/8797555'/0'/3'/0' 02ea98bfbce4bd8eda77d1d3fcbcfce4ce5919b77e8a092dc93a104235dfba6b90
+- m/44'/60'/0'/0/0    0x214Cc1a3DA4780Fa34e38dbFb7Ce9132A8a42513
+Export of 02ea98bfbce4… denied as expected: Turnkey error 7: You don't have sufficient permissions to take this action. […] "message":"No policies evaluated to outcome: Allow","policyEvaluations":[] […]
+Created subtree ALLOW policy with id: abffd94d-9167-4ab7-b9f4-73c427bab0b5
+Exported the subtree account (decrypted a 64-character private key) ✅
+Export of 030dc5e09c50… denied as expected: Turnkey error 7: […] "policyEvaluations":[{"policyId":"abffd94d-…","outcome":"OUTCOME_DENY_IMPLICIT"}] […]
+Export of 0x214Cc1a3DA… denied as expected: Turnkey error 7: […] "policyEvaluations":[{"policyId":"abffd94d-…","outcome":"OUTCOME_DENY_IMPLICIT"}] […]
+Exported the Ethereum account under the broad ALLOW ✅
+Export of 0x214Cc1a3DA… denied as expected: Turnkey error 7: […] "message":"The following policies denied this action: cd889eab-…","policyEvaluations":[{"policyId":"abffd94d-…","outcome":"OUTCOME_DENY_IMPLICIT"},{"policyId":"bd73d310-…","outcome":"OUTCOME_ALLOW"},{"policyId":"cd889eab-…","outcome":"OUTCOME_DENY_EXPLICIT"}] […]
+Exported the identity account (the DENY does not match it) ✅
+Policy on wallet_account.path rejected as expected: Turnkey error 3: invalid policy condition: Expression cannot be evaluated: field does not exist: path (Details: [])
+All checks passed ✅
+```
+
+Note: the long denial details and addresses are shortened with `…` above. The
+real output includes the full `PolicyEnginePermissionError` payload, which
+lists each policy's evaluation outcome.

--- a/examples/key-management/export-path-policies/package.json
+++ b/examples/key-management/export-path-policies/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@turnkey/example-export-path-policies",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "pnpm tsx src/index.ts",
+    "clean": "rimraf ./dist ./.cache",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@turnkey/crypto": "workspace:*",
+    "@turnkey/sdk-server": "workspace:*",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/examples/key-management/export-path-policies/src/index.ts
+++ b/examples/key-management/export-path-policies/src/index.ts
@@ -1,0 +1,194 @@
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { Turnkey } from "@turnkey/sdk-server";
+import { generateP256KeyPair, decryptExportBundle } from "@turnkey/crypto";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+// Gate wallet account exports on the account's derivation path with the
+// wallet_account.path_indexes / wallet_account.path_hardened policy fields.
+// Use a fresh organization: existing policies can change the results below.
+async function main() {
+  const organizationId = process.env.ORGANIZATION_ID!;
+  const apiBaseUrl = process.env.BASE_URL!;
+  const suffix = Date.now();
+
+  const root = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: process.env.API_PUBLIC_KEY!,
+    apiPrivateKey: process.env.API_PRIVATE_KEY!,
+    defaultOrganizationId: organizationId,
+  }).apiClient();
+
+  // 0/ Create a non-root tester user. Non-root users can do nothing until a
+  // policy allows them to.
+  const testerKeyPair = generateP256KeyPair();
+  const { userIds } = await root.createUsers({
+    users: [
+      {
+        userName: `tester-${suffix}`,
+        apiKeys: [
+          {
+            apiKeyName: "tester-key",
+            publicKey: testerKeyPair.publicKey,
+            curveType: "API_KEY_CURVE_P256",
+          },
+        ],
+        authenticators: [],
+        oauthProviders: [],
+        userTags: [],
+      },
+    ],
+  });
+  const [userId] = userIds;
+  console.log(`Created tester user with id: ${userId}`);
+
+  const tester = new Turnkey({
+    apiBaseUrl,
+    apiPublicKey: testerKeyPair.publicKey,
+    apiPrivateKey: testerKeyPair.privateKey,
+    defaultOrganizationId: organizationId,
+  }).apiClient();
+
+  // 1/ Create a wallet with accounts on three derivation paths: two fully
+  // hardened paths of different depths, and a standard Ethereum path with
+  // non-hardened components.
+  const { walletId, addresses } = await root.createWallet({
+    walletName: `wallet-${suffix}`,
+    accounts: [
+      {
+        curve: "CURVE_SECP256K1",
+        pathFormat: "PATH_FORMAT_BIP32",
+        path: "m/8797555'/0'/0'",
+        addressFormat: "ADDRESS_FORMAT_COMPRESSED",
+      },
+      {
+        curve: "CURVE_SECP256K1",
+        pathFormat: "PATH_FORMAT_BIP32",
+        path: "m/8797555'/0'/3'/0'",
+        addressFormat: "ADDRESS_FORMAT_COMPRESSED",
+      },
+      {
+        curve: "CURVE_SECP256K1",
+        pathFormat: "PATH_FORMAT_BIP32",
+        path: "m/44'/60'/0'/0/0",
+        addressFormat: "ADDRESS_FORMAT_ETHEREUM",
+      },
+    ],
+  });
+  const identityAddress = addresses[0]!;
+  const subtreeAddress = addresses[1]!;
+  const ethereumAddress = addresses[2]!;
+  console.log(`Created wallet with id: ${walletId}`);
+  console.log(`- m/8797555'/0'/0'    ${identityAddress}`);
+  console.log(`- m/8797555'/0'/3'/0' ${subtreeAddress}`);
+  console.log(`- m/44'/60'/0'/0/0    ${ethereumAddress}`);
+
+  // Exports are encrypted to this local target key; decryptExportBundle also
+  // verifies the bundle's enclave signature.
+  const targetKeyPair = generateP256KeyPair();
+  const exportAccount = async (address: string) => {
+    const { exportBundle } = await tester.exportWalletAccount({
+      address,
+      targetPublicKey: targetKeyPair.publicKeyUncompressed,
+    });
+    return decryptExportBundle({
+      exportBundle,
+      embeddedKey: targetKeyPair.privateKey,
+      organizationId,
+      returnMnemonic: false,
+    });
+  };
+  const expectExportDenied = async (address: string) => {
+    try {
+      await exportAccount(address);
+    } catch (error: unknown) {
+      console.log(
+        `Export of ${address} denied as expected: ${(error as Error).message}`,
+      );
+      return;
+    }
+    throw new Error(`export of ${address} should have been denied`);
+  };
+
+  // 2/ With no policy in place, the tester cannot export anything.
+  await expectExportDenied(subtreeAddress);
+
+  // 3/ Allow the tester to export only accounts in the fully hardened subtree
+  // m/8797555'/*'/3'/*'.
+  const { policyId } = await root.createPolicy({
+    policyName: "Allow exports from the hardened subtree",
+    effect: "EFFECT_ALLOW",
+    consensus: `approvers.any(u, u.id == '${userId}')`,
+    condition:
+      `activity.kind == 'EXPORT_WALLET_ACCOUNT'` +
+      ` && wallet_account.path_indexes.count() == 4` +
+      ` && wallet_account.path_indexes[0] == 8797555` +
+      ` && wallet_account.path_indexes[2] == 3` +
+      ` && wallet_account.path_hardened.all(h, h == true)`,
+    notes: "",
+  });
+  console.log(`Created subtree ALLOW policy with id: ${policyId}`);
+
+  // 4/ The in-subtree account can now be exported and decrypted locally...
+  const subtreeKey = await exportAccount(subtreeAddress);
+  console.log(
+    `Exported the subtree account (decrypted a ${subtreeKey.length}-character private key) ✅`,
+  );
+
+  // 5/ ...but the other accounts still cannot: wrong depth for one, wrong
+  // subtree and non-hardened components for the other.
+  await expectExportDenied(identityAddress);
+  await expectExportDenied(ethereumAddress);
+
+  // 6/ A broad allow admits the Ethereum account...
+  await root.createPolicy({
+    policyName: "Allow all exports for the tester",
+    effect: "EFFECT_ALLOW",
+    consensus: `approvers.any(u, u.id == '${userId}')`,
+    condition: `activity.kind == 'EXPORT_WALLET_ACCOUNT'`,
+    notes: "",
+  });
+  await exportAccount(ethereumAddress);
+  console.log(`Exported the Ethereum account under the broad ALLOW ✅`);
+
+  // 7/ ...until an explicit DENY on its coin type wins over the allow. The
+  // identity account stays exportable because the deny does not match it.
+  await root.createPolicy({
+    policyName: "Deny exporting Ethereum (coin type 60) accounts",
+    effect: "EFFECT_DENY",
+    consensus: `approvers.any(u, u.id == '${userId}')`,
+    condition:
+      `activity.kind == 'EXPORT_WALLET_ACCOUNT'` +
+      ` && wallet_account.path_indexes[1] == 60`,
+    notes: "",
+  });
+  await expectExportDenied(ethereumAddress);
+  await exportAccount(identityAddress);
+  console.log(`Exported the identity account (the DENY does not match it) ✅`);
+
+  // 8/ The raw path string is not a policy field (paths contain apostrophes,
+  // which policy string literals cannot express) — referencing it is rejected
+  // at policy creation time.
+  try {
+    await root.createPolicy({
+      policyName: "Refers to an unsupported field",
+      effect: "EFFECT_ALLOW",
+      consensus: `approvers.any(u, u.id == '${userId}')`,
+      condition: `wallet_account.path == ''`,
+      notes: "",
+    });
+  } catch (error: unknown) {
+    console.log(
+      `Policy on wallet_account.path rejected as expected: ${(error as Error).message}`,
+    );
+    console.log("All checks passed ✅");
+    return;
+  }
+  throw new Error("policy on wallet_account.path should have been rejected");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/key-management/export-path-policies/tsconfig.json
+++ b/examples/key-management/export-path-policies/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./.cache/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3699,6 +3699,18 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
 
+  examples/key-management/export-path-policies:
+    dependencies:
+      '@turnkey/crypto':
+        specifier: workspace:*
+        version: link:../../../packages/crypto
+      '@turnkey/sdk-server':
+        specifier: workspace:*
+        version: link:../../../packages/sdk-server
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.6.1
+
   examples/key-management/import-export-with-iframe-stamper:
     dependencies:
       '@turnkey/iframe-stamper':


### PR DESCRIPTION
## Summary & Motivation

$title

This PR adds a new example (`examples/key-management/export-path-policies`) that demonstrates usage of derivation-path-based policy fields for `EXPORT_WALLET_ACCOUNT`. Specifically, we now expose the fields `wallet_account.path_indexes` (BIP32 path indexes with the hardening bit stripped) and `wallet_account.path_hardened` (per-component hardening flags).

The script creates a non-root tester user and a wallet with accounts on three derivation paths, then walks through:

1. baseline: the tester is denied with no policy in place;
2. an ALLOW policy scoped to the hardened subtree `m/8797555'/*'/3'/*'` (via `path_indexes` / `path_hardened`) allows only the in-subtree account
3. accounts _outside_ the subtree stay denied (`OUTCOME_DENY_IMPLICIT` on the path policy);
4. an explicit DENY on `path_indexes[1] == 60` wins over a broad export ALLOW (`OUTCOME_DENY_EXPLICIT`);
5. a policy referencing an unsupported field (`wallet_account.path`) is rejected at creation time.

FYI this script assumes a fresh (parent) organization. An org's existing policies would potentially change the allow/deny outcomes (the example's README calls this out).

A companion docs PR (tkhq/docs#805) documents the new fields and adds policy examples.

## How I Tested These Changes
locally

## Did you add a changeset?
N/A
