### PR TITLE
chore: release JS SDK 2026.9.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,12 +21,10 @@
     "@turnkey/solana-usdc-swap",
     "@turnkey/wallet-auth-*",
     "magic-link-auth",
-    "oauth-cross-platform-mobile",
     "with-0x",
     "with-delegated-client-side",
     "with-export-and-sign-escrow",
     "with-lifi",
-    "with-react-native-wallet-kit",
     "with-x",
     "with-x402"
   ]

--- a/.changeset/modern-swaps-arrive.md
+++ b/.changeset/modern-swaps-arrive.md
@@ -1,9 +1,0 @@
----
-"@turnkey/core": minor
-"@turnkey/sdk-browser": minor
-"@turnkey/sdk-server": minor
-"@turnkey/sdk-types": minor
-"@turnkey/http": minor
----
-
-Use the latest public swap activities. `createSwapQuote` now submits V2, and `executeSwap` now submits V3. Both inputs support an optional `destinationAddress` for cross-protocol swaps. Also sync the public API types from mono v2026.8.4.

--- a/.changeset/uae-phone-code.md
+++ b/.changeset/uae-phone-code.md
@@ -1,6 +1,0 @@
----
-"@turnkey/react-wallet-kit": patch
-"@turnkey/sdk-react": patch
----
-
-Add United Arab Emirates (+971) to the supported phone country codes.

--- a/packages/api-key-stamper/CHANGELOG.md
+++ b/packages/api-key-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/api-key-stamper
 
+## 0.6.14
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @turnkey/crypto@2.12.1
+
 ## 0.6.13
 
 ### Patch Changes

--- a/packages/api-key-stamper/package.json
+++ b/packages/api-key-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/api-key-stamper",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @turnkey/bitcoin
 
+## 0.1.9
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-browser@8.4.0
+  - @turnkey/sdk-server@8.4.0
+
 ## 0.1.8
 
 ### Patch Changes

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/bitcoin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @turnkey/core
 
+## 2.9.0
+
+### Minor Changes
+
+- [#1506](https://github.com/tkhq/sdk/pull/1506) [`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f) Thanks [@Bijan-Massoumi](https://github.com/Bijan-Massoumi)! - Use the latest public swap activities. `createSwapQuote` now submits V2, and `executeSwap` now submits V3. Both inputs support an optional `destinationAddress` for cross-protocol swaps. Also sync the public API types from mono v2026.8.4.
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/sdk-types@1.7.0
+  - @turnkey/http@6.4.0
+  - @turnkey/crypto@2.12.1
+  - @turnkey/react-native-passkey-stamper@1.2.23
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 2.8.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/core",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "A core JavaScript web and React Native package for interfacing with Turnkey's infrastructure.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/__generated__/version.ts
+++ b/packages/core/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/core@2.8.1";
+export const VERSION = "@turnkey/core@2.9.0";

--- a/packages/cosmjs/CHANGELOG.md
+++ b/packages/cosmjs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/cosmjs
 
+## 0.8.41
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-browser@8.4.0
+  - @turnkey/sdk-server@8.4.0
+  - @turnkey/http@6.4.0
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 0.8.40
 
 ### Patch Changes

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/cosmjs",
-  "version": "0.8.40",
+  "version": "0.8.41",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/crypto
 
+## 2.12.1
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/sdk-types@1.7.0
+
 ## 2.12.0
 
 ### Minor Changes

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/crypto",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/CHANGELOG.md
+++ b/packages/eip-1193-provider/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/eip-1193-provider
 
+## 3.4.40
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-browser@8.4.0
+  - @turnkey/http@6.4.0
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 3.4.39
 
 ### Patch Changes

--- a/packages/eip-1193-provider/package.json
+++ b/packages/eip-1193-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/eip-1193-provider",
-  "version": "3.4.39",
+  "version": "3.4.40",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/eip-1193-provider/src/version.ts
+++ b/packages/eip-1193-provider/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/eip-1193-provider@3.4.39";
+export const VERSION = "@turnkey/eip-1193-provider@3.4.40";

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/ethers
 
+## 1.3.40
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-browser@8.4.0
+  - @turnkey/sdk-server@8.4.0
+  - @turnkey/http@6.4.0
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 1.3.39
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/ethers",
-  "version": "1.3.39",
+  "version": "1.3.40",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/gas-station/CHANGELOG.md
+++ b/packages/gas-station/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/gas-station
 
+## 15.0.0
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/sdk-server@8.4.0
+
 ## 14.0.0
 
 ### Patch Changes

--- a/packages/gas-station/package.json
+++ b/packages/gas-station/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/gas-station",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Turnkey Gas Station SDK for EIP-7702 delegated execution",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/http
 
+## 6.4.0
+
+### Minor Changes
+
+- [#1506](https://github.com/tkhq/sdk/pull/1506) [`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f) Thanks [@Bijan-Massoumi](https://github.com/Bijan-Massoumi)! - Use the latest public swap activities. `createSwapQuote` now submits V2, and `executeSwap` now submits V3. Both inputs support an optional `destinationAddress` for cross-protocol swaps. Also sync the public API types from mono v2026.8.4.
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 6.3.0
 
 ### Minor Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/http",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/http@6.3.0";
+export const VERSION = "@turnkey/http@6.4.0";

--- a/packages/indexed-db-stamper/CHANGELOG.md
+++ b/packages/indexed-db-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/indexed-db-stamper
 
+## 1.3.8
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/sdk-types@1.7.0
+
 ## 1.3.7
 
 ### Patch Changes

--- a/packages/indexed-db-stamper/package.json
+++ b/packages/indexed-db-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/indexed-db-stamper",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/react-native-passkey-stamper/CHANGELOG.md
+++ b/packages/react-native-passkey-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/react-native-passkey-stamper
 
+## 1.2.23
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/http@6.4.0
+
 ## 1.2.22
 
 ### Patch Changes

--- a/packages/react-native-passkey-stamper/package.json
+++ b/packages/react-native-passkey-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-native-passkey-stamper",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/react-native-wallet-kit/CHANGELOG.md
+++ b/packages/react-native-wallet-kit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/react-native-wallet-kit
 
+## 2.3.4
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-types@1.7.0
+  - @turnkey/crypto@2.12.1
+  - @turnkey/react-native-passkey-stamper@1.2.23
+
 ## 2.3.3
 
 ### Patch Changes

--- a/packages/react-native-wallet-kit/package.json
+++ b/packages/react-native-wallet-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-native-wallet-kit",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "The easiest and most powerful way to integrate Turnkey's Embedded Wallets into your React Native applications.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react-wallet-kit/CHANGELOG.md
+++ b/packages/react-wallet-kit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/react-wallet-kit
 
+## 2.4.4
+
+### Patch Changes
+
+- [#1509](https://github.com/tkhq/sdk/pull/1509) [`2511465`](https://github.com/tkhq/sdk/commit/25114656b9a4024f5dcbcb8819b3833b4100e8b5) Author [@truham](https://github.com/truham) - Add United Arab Emirates (+971) to the supported phone country codes.
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-types@1.7.0
+
 ## 2.4.3
 
 ### Patch Changes

--- a/packages/react-wallet-kit/package.json
+++ b/packages/react-wallet-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/react-wallet-kit",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "The easiest and most powerful way to integrate Turnkey's Embedded Wallets into your React applications.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk-browser/CHANGELOG.md
+++ b/packages/sdk-browser/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @turnkey/sdk-browser
 
+## 8.4.0
+
+### Minor Changes
+
+- [#1506](https://github.com/tkhq/sdk/pull/1506) [`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f) Thanks [@Bijan-Massoumi](https://github.com/Bijan-Massoumi)! - Use the latest public swap activities. `createSwapQuote` now submits V2, and `executeSwap` now submits V3. Both inputs support an optional `destinationAddress` for cross-protocol swaps. Also sync the public API types from mono v2026.8.4.
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/sdk-types@1.7.0
+  - @turnkey/http@6.4.0
+  - @turnkey/crypto@2.12.1
+  - @turnkey/indexed-db-stamper@1.3.8
+  - @turnkey/wallet-stamper@1.1.26
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 8.3.0
 
 ### Minor Changes

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-browser",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-browser/src/__generated__/version.ts
+++ b/packages/sdk-browser/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-browser@8.3.0";
+export const VERSION = "@turnkey/sdk-browser@8.4.0";

--- a/packages/sdk-react-native/CHANGELOG.md
+++ b/packages/sdk-react-native/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/sdk-react-native
 
+## 1.5.30
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/http@6.4.0
+  - @turnkey/crypto@2.12.1
+  - @turnkey/react-native-passkey-stamper@1.2.23
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 1.5.29
 
 ### Patch Changes

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react-native",
-  "version": "1.5.29",
+  "version": "1.5.30",
   "description": "React Native SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @turnkey/sdk-react
 
+## 6.0.9
+
+### Patch Changes
+
+- [#1509](https://github.com/tkhq/sdk/pull/1509) [`2511465`](https://github.com/tkhq/sdk/commit/25114656b9a4024f5dcbcb8819b3833b4100e8b5) Author [@truham](https://github.com/truham) - Add United Arab Emirates (+971) to the supported phone country codes.
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/sdk-browser@8.4.0
+  - @turnkey/sdk-server@8.4.0
+  - @turnkey/sdk-types@1.7.0
+  - @turnkey/crypto@2.12.1
+  - @turnkey/wallet-stamper@1.1.26
+
 ## 6.0.8
 
 ### Patch Changes

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-react",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/CHANGELOG.md
+++ b/packages/sdk-server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @turnkey/sdk-server
 
+## 8.4.0
+
+### Minor Changes
+
+- [#1506](https://github.com/tkhq/sdk/pull/1506) [`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f) Thanks [@Bijan-Massoumi](https://github.com/Bijan-Massoumi)! - Use the latest public swap activities. `createSwapQuote` now submits V2, and `executeSwap` now submits V3. Both inputs support an optional `destinationAddress` for cross-protocol swaps. Also sync the public API types from mono v2026.8.4.
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/sdk-types@1.7.0
+  - @turnkey/http@6.4.0
+  - @turnkey/crypto@2.12.1
+  - @turnkey/wallet-stamper@1.1.26
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 8.3.0
 
 ### Minor Changes

--- a/packages/sdk-server/package.json
+++ b/packages/sdk-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-server",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/sdk-server/src/__generated__/version.ts
+++ b/packages/sdk-server/src/__generated__/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "@turnkey/sdk-server@8.3.0";
+export const VERSION = "@turnkey/sdk-server@8.4.0";

--- a/packages/sdk-types/CHANGELOG.md
+++ b/packages/sdk-types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @turnkey/sdk-types
 
+## 1.7.0
+
+### Minor Changes
+
+- [#1506](https://github.com/tkhq/sdk/pull/1506) [`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f) Thanks [@Bijan-Massoumi](https://github.com/Bijan-Massoumi)! - Use the latest public swap activities. `createSwapQuote` now submits V2, and `executeSwap` now submits V3. Both inputs support an optional `destinationAddress` for cross-protocol swaps. Also sync the public API types from mono v2026.8.4.
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/sdk-types",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @turnkey/solana
 
+## 1.1.40
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-browser@8.4.0
+  - @turnkey/sdk-server@8.4.0
+  - @turnkey/http@6.4.0
+
 ## 1.1.39
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/solana",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/spark/CHANGELOG.md
+++ b/packages/spark/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @turnkey/spark
 
+## 0.3.9
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-server@8.4.0
+
 ## 0.3.8
 
 ### Patch Changes

--- a/packages/spark/package.json
+++ b/packages/spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/spark",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/telegram-cloud-storage-stamper/CHANGELOG.md
+++ b/packages/telegram-cloud-storage-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/telegram-cloud-storage-stamper
 
+## 2.1.15
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 2.1.14
 
 ### Patch Changes

--- a/packages/telegram-cloud-storage-stamper/package.json
+++ b/packages/telegram-cloud-storage-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/telegram-cloud-storage-stamper",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/viem/CHANGELOG.md
+++ b/packages/viem/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @turnkey/viem
 
+## 0.14.40
+
+### Patch Changes
+
+- Updated dependencies [[`8e25b38`](https://github.com/tkhq/sdk/commit/8e25b3886c4cb8d9646fdf8473735e96ebed556f)]:
+  - @turnkey/core@2.9.0
+  - @turnkey/sdk-browser@8.4.0
+  - @turnkey/sdk-server@8.4.0
+  - @turnkey/http@6.4.0
+  - @turnkey/api-key-stamper@0.6.14
+
 ## 0.14.39
 
 ### Patch Changes

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/viem",
-  "version": "0.14.39",
+  "version": "0.14.40",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/wallet-stamper/CHANGELOG.md
+++ b/packages/wallet-stamper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @turnkey/wallet-stamper
 
+## 1.1.26
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @turnkey/crypto@2.12.1
+
 ## 1.1.25
 
 ### Patch Changes

--- a/packages/wallet-stamper/package.json
+++ b/packages/wallet-stamper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turnkey/wallet-stamper",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run [`pnpm changeset`](https://pnpm.io/using-changesets#adding-new-changesets). `pnpm changeset` will generate a file where you should write a human friendly message about the changes. Note how this ([example](https://github.com/tkhq/sdk/blob/b409cd06790f011bf939adcf0755499b8e7497ae/.changeset/extra-http-exports.md?plain=1#L1)) includes the package name (should be auto added by the command) along with the type of [semver change (major.minor.patch)](https://semver.org/) (which you should set).

These changes will be used at release time to determine what packages to publish and how to bump their version. For more context see [this comment](https://github.com/tkhq/sdk/pull/67#issuecomment-1568838440).
